### PR TITLE
build: Add a Flatpak manifest

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 *.snap
+.flatpak-builder

--- a/build-aux/flatpak/org.qelectrotech.QElectroTech.json
+++ b/build-aux/flatpak/org.qelectrotech.QElectroTech.json
@@ -1,0 +1,37 @@
+{
+  "id": "org.qelectrotech.QElectroTech",
+  "runtime": "org.kde.Platform",
+  "runtime-version": "5.14",
+  "sdk": "org.kde.Sdk",
+  "command": "qelectrotech",
+  "rename-desktop-file": "qelectrotech.desktop",
+  "rename-appdata-file": "qelectrotech",
+  "rename-icon": "qelectrotech",
+  "copy-icon": true,
+  "finish-args": [
+    "--socket=wayland",
+    "--socket=x11",
+    "--device=dri",
+    "--share=ipc",
+    "--filesystem=host"
+  ],
+  "modules": [
+    {
+      "name": "qelectrotech",
+      "buildsystem": "qmake",
+      "post-install": [
+        "mv /app/share/mime/packages/qelectrotech.xml /app/share/mime/packages/org.qelectrotech.QElectroTech.xml"
+      ],
+      "sources": [
+        {
+          "type": "dir",
+          "path": "../.."
+        },
+        {
+          "type": "patch",
+          "path": "patches/0001-build-Fix-the-installation-paths.patch"
+        }
+      ]
+    }
+  ]
+}

--- a/build-aux/flatpak/patches/0001-build-Fix-the-installation-paths.patch
+++ b/build-aux/flatpak/patches/0001-build-Fix-the-installation-paths.patch
@@ -1,0 +1,44 @@
+From 579ee22f1d2bef560ec90d324a0e476b81faf495 Mon Sep 17 00:00:00 2001
+From: Mathieu Bridon <mathieu@hashbang.fr>
+Date: Tue, 7 Jan 2020 14:39:08 +0100
+Subject: [PATCH] build: Fix the installation paths
+
+---
+ qelectrotech.pro | 14 +++++++-------
+ 1 file changed, 7 insertions(+), 7 deletions(-)
+
+diff --git a/qelectrotech.pro b/qelectrotech.pro
+index 07e51fb..2a86b91 100644
+--- a/qelectrotech.pro
++++ b/qelectrotech.pro
+@@ -5,20 +5,20 @@
+ # Chemins utilises pour la compilation et l'installation de QET
+ unix {
+ 	# Chemins UNIX
+-	COMPIL_PREFIX              = '/usr/local/'
+-	INSTALL_PREFIX             = '/usr/local/'
++	COMPIL_PREFIX              = '/app/'
++	INSTALL_PREFIX             = '/app/'
+ 	QET_BINARY_PATH            = 'bin/'
+ 	QET_COMMON_COLLECTION_PATH = 'share/qelectrotech/elements/'
+ 	QET_COMMON_TBT_PATH        = 'share/qelectrotech/titleblocks/'
+ 	QET_LANG_PATH              = 'share/qelectrotech/lang/'
+ 	QET_EXAMPLES_PATH          = 'share/qelectrotech/examples/'
+-	QET_LICENSE_PATH           = 'doc/qelectrotech/'
+-	QET_MIME_XML_PATH          = '../share/mime/application/'
+-	QET_MIME_DESKTOP_PATH      = '../share/mimelnk/application/'
+-	QET_MIME_PACKAGE_PATH      = '../share/mime/packages/'
++	QET_LICENSE_PATH           = 'share/doc/qelectrotech/'
++	QET_MIME_XML_PATH          = 'share/mime/application/'
++	QET_MIME_DESKTOP_PATH      = 'share/mimelnk/application/'
++	QET_MIME_PACKAGE_PATH      = 'share/mime/packages/'
+ 	QET_DESKTOP_PATH           = 'share/applications/'
+ 	QET_ICONS_PATH             = 'share/icons/hicolor/'
+-	QET_MAN_PATH               = 'man/'
++	QET_MAN_PATH               = 'share/man/'
+ 	QET_APPDATA_PATH           = 'share/appdata'
+ }
+ win32 {
+-- 
+2.24.1
+


### PR DESCRIPTION
This allows building the master branch of QElectroTech with a simple
command:

$ flatpak-builder _build build-aux/flatpak/org.qelectrotech.QElectroTech.json

---

For those who don't know Flatpak much, here are a few additional instructions.

1. you need to install Flatpak, Flatpak Builder and configure the Flathub remote: https://flatpak.org/setup/
2. you will need to install the KDE platform and sdk to build;
3. to make rebuilds faster you want to use the `--ccache` and `--force-clean` options;
4. once the app is built, you need to export it to a local repo, configure that local repo, then install from that repo; this can be automated with the `--install` and `--user` options;

All in all, the following two commands should do the right thing:

```
$ flatpak install flathub org.kde.Platform//5.14 org.kde.Sdk//5.14
$ flatpak-builder --force-clean --ccache --user --install _build build-aux/flatpak/org.qelectrotech.QElectroTech.json
```

If this is merged, we can look at having automatic builds in your CI, published to a development repo, etc…

And then I can help you send the next release to Flathub if you're interested. :slightly_smiling_face: