### PR TITLE
flatpak: Properly rename the appdata file

### DIFF
--- a/build-aux/flatpak/org.qelectrotech.QElectroTech.json
+++ b/build-aux/flatpak/org.qelectrotech.QElectroTech.json
@@ -5,7 +5,7 @@
   "sdk": "org.kde.Sdk",
   "command": "qelectrotech",
   "rename-desktop-file": "qelectrotech.desktop",
-  "rename-appdata-file": "qelectrotech",
+  "rename-appdata-file": "qelectrotech.appdata.xml",
   "rename-icon": "qelectrotech",
   "copy-icon": true,
   "finish-args": [


### PR DESCRIPTION
Adding the full file name was required, just like for renaming the
desktop files, unlike for renaming the icons.