### PR TITLE
when model is not yet loaded, but the element editor should be opened…

### DIFF
--- a/sources/ElementsCollection/elementscollectionwidget.cpp
+++ b/sources/ElementsCollection/elementscollectionwidget.cpp
@@ -123,7 +123,8 @@ void ElementsCollectionWidget::setCurrentLocation(const ElementsLocation &locati
 	if (!location.exist())
 		return;
 	
-	m_tree_view->setCurrentIndex(m_model->indexFromLocation(location));
+    if (m_model)
+        m_tree_view->setCurrentIndex(m_model->indexFromLocation(location));
 }
 
 void ElementsCollectionWidget::leaveEvent(QEvent *event)


### PR DESCRIPTION
…, a segmentation fault occurs. Do not set current index when m_model is not yet loaded