### PR TITLE
Add file .gitmessage.txt

### DIFF
--- a/.gitmessage.txt
+++ b/.gitmessage.txt
@@ -1,0 +1,35 @@
+Subject: Capitalized, short, summary, imperative
+
+     Body of commit message is a few lines of text, explaining things
+in more detail, possibly giving some background about the issue being
+fixed, etc etc.
+     The body of the commit message can be several paragraphs, and
+please do proper word-wrap and keep columns shorter than about 74
+characters or so. That way "git log" will show things nicely even when
+it's indented.
+     Make sure you explain your solution and why you're doing what
+you're doing, as opposed to describing what you're doing. Reviewers
+and your future self can read the patch, but might not understand why
+a particular solution was implemented.
+#
+# Subject line:
+# * Begin all subject lines with a capital letter
+# * Do not end the subject line with a period
+# * Limit the subject line to 50 characters
+# * Use the imperative mood in the subject line
+#    A properly formed Git commit subject line should
+#    always be able to complete the following sentence:
+#    - If applied, this commit will your subject line here
+#
+#    eg:
+#       If applied, this commit will
+#        - Remove deprecated methods
+#        - Update qelectrotech gui
+#        - Add file autonumber.h
+#        - Add feature autonumber
+#
+# Separate subject from body with a blank line
+#
+# Wrap the body at 74 characters/line
+# Use the body to explain what and why vs. how
+#


### PR DESCRIPTION
Git will use ths file as the default initial message when you commit.

for use run this instruction:
git config --local commit.template .gitmessage.txt

https://qelectrotech.org/forum/misc.php?action=pun_attachment&item=1452&preview

In essence, the intention is to use the commits for the change-log for that we need to use tools like a template.
Of course this is just a start, and i would like to get extra info for the definitive file.

So please make your comment.