### PR TITLE
ElementEditor: always clear m_cep_list in StyleEditor::setPart bugfix 0197

### DIFF
--- a/sources/editor/styleeditor.cpp
+++ b/sources/editor/styleeditor.cpp
@@ -479,6 +479,7 @@ void StyleEditor::updateForm()
  */
 bool StyleEditor::setPart(CustomElementPart *new_part) {
 	m_part_list.clear();
+	m_cep_list.clear();
 
 	if (!new_part)
 	{


### PR DESCRIPTION
Please, could you correct my first commit?
Thank you