### PR TITLE
Elementeditor: remove redundant calls to StyleEditor::setPart

### DIFF
--- a/sources/editor/arceditor.cpp
+++ b/sources/editor/arceditor.cpp
@@ -109,7 +109,6 @@ bool ArcEditor::setPart(CustomElementPart *new_part)
 			disconnectChangeConnections();
 
 		part = nullptr;
-		style_ -> setPart(nullptr);
 		return(true);
 	}
 
@@ -119,7 +118,6 @@ bool ArcEditor::setPart(CustomElementPart *new_part)
 		if (part)
 			disconnectChangeConnections();
 		part = part_arc;
-		style_ -> setPart(part);
 		updateForm();
 		setUpChangeConnections();
 		return(true);

--- a/sources/editor/ellipseeditor.cpp
+++ b/sources/editor/ellipseeditor.cpp
@@ -98,7 +98,6 @@ bool EllipseEditor::setPart(CustomElementPart *new_part)
 		if (part)
 			disconnectChangeConnections();
 		part = nullptr;
-		style_ -> setPart(nullptr);
 		return(true);
 	}
 	if (PartEllipse *part_ellipse = dynamic_cast<PartEllipse *>(new_part))
@@ -107,7 +106,6 @@ bool EllipseEditor::setPart(CustomElementPart *new_part)
 		if (part)
 			disconnectChangeConnections();
 		part = part_ellipse;
-		style_ -> setPart(part);
 		updateForm();
 		setUpChangeConnections();
 		return(true);

--- a/sources/editor/lineeditor.cpp
+++ b/sources/editor/lineeditor.cpp
@@ -125,7 +125,6 @@ bool LineEditor::setPart(CustomElementPart *new_part)
 			disconnectChangeConnections();
 		}
 		part = nullptr;
-		style_ -> setPart(nullptr);
 		return(true);
 	}
 	if (PartLine *part_line = dynamic_cast<PartLine *>(new_part))
@@ -136,7 +135,6 @@ bool LineEditor::setPart(CustomElementPart *new_part)
 			disconnectChangeConnections();
 		}
 		part = part_line;
-		style_ -> setPart(part);
 		updateForm();
 		setUpChangeConnections();
 		return(true);

--- a/sources/editor/ui/polygoneditor.cpp
+++ b/sources/editor/ui/polygoneditor.cpp
@@ -80,7 +80,6 @@ bool PolygonEditor::setPart(CustomElementPart *new_part)
 			disconnectChangeConnections();
 		}
 		m_part = nullptr;
-		m_style -> setPart(nullptr);
 		return(true);
 	}
 	if (PartPolygon *part_polygon = dynamic_cast<PartPolygon *>(new_part))
@@ -91,7 +90,6 @@ bool PolygonEditor::setPart(CustomElementPart *new_part)
 			disconnectChangeConnections();
 		}
 		m_part = part_polygon;
-		m_style -> setPart(m_part);
 		updateForm();
 		setUpChangeConnections();
 		return(true);

--- a/sources/editor/ui/rectangleeditor.cpp
+++ b/sources/editor/ui/rectangleeditor.cpp
@@ -77,7 +77,6 @@ bool RectangleEditor::setPart(CustomElementPart *part)
 			disconnectChangeConnections();
 		}
 		m_part = nullptr;
-		m_style->setPart(nullptr);
 		return(true);
 	}
 	
@@ -91,7 +90,6 @@ bool RectangleEditor::setPart(CustomElementPart *part)
 			disconnectChangeConnections();
 		}
 		m_part = part_rectangle;
-		m_style->setPart(m_part);
 		updateForm();
 		setUpChangeConnections();
 		return(true);


### PR DESCRIPTION
During bug fix 0197 it is discovered that part editors make redundant calls to style editor.
Thanks