### PR TITLE
Fix dxf export for copied conductors

### DIFF
--- a/sources/exportdialog.cpp
+++ b/sources/exportdialog.cpp
@@ -578,12 +578,14 @@ void ExportDialog::generateDxf(Diagram *diagram, int width, int height, bool kee
 	}
 
 	//Draw conductors
-	foreach(Conductor *cond, list_conductors) {
-		foreach(ConductorSegment *segment, cond -> segmentsList()) {
-			qreal x1 = (segment -> firstPoint().x()) * Createdxf::xScale;
-			qreal y1 = Createdxf::sheetHeight - (segment -> firstPoint().y() * Createdxf::yScale);
-			qreal x2 = (segment -> secondPoint().x()) * Createdxf::xScale;
-			qreal y2 = Createdxf::sheetHeight - (segment -> secondPoint().y() * Createdxf::yScale);
+    foreach(Conductor *cond, list_conductors) {
+        qreal cx = cond->pos().x();
+        qreal cy = cond->pos().y();
+        foreach(ConductorSegment *segment, cond -> segmentsList()) {
+            qreal x1 = (cx + segment -> firstPoint().x()) * Createdxf::xScale;
+            qreal y1 = Createdxf::sheetHeight - ((cy + segment -> firstPoint().y()) * Createdxf::yScale);
+            qreal x2 = (cx + segment -> secondPoint().x()) * Createdxf::xScale;
+            qreal y2 = Createdxf::sheetHeight - ((cy + segment -> secondPoint().y()) * Createdxf::yScale);
 			Createdxf::drawLine(file_path, x1, y1, x2, y2, 0);
 		}
 		//Draw conductor text item


### PR DESCRIPTION
When exporting as DXF a drawing with conductors that had been copied, all the copies appeared in the same location as the original, so visually they disappeared.
This minor modification fixes that problem.

There are still (at least) a couple of problems with DXF export:
1. The frame/border is offset incorrectly
2. Text that has been auto-sized to fit in a cell is exported at original size and overflows