### PR TITLE
use pkgconfig for sqlite3

### DIFF
--- a/qelectrotech.pro
+++ b/qelectrotech.pro
@@ -220,14 +220,14 @@ UI_SOURCES_DIR = sources/ui/
 UI_HEADERS_DIR = sources/ui/
 
 # Configuration de la compilation
-CONFIG += c++17 debug_and_release warn_on
+CONFIG += c++17 debug_and_release warn_on link_pkgconfig
 
 # Nom du binaire genere par la compilation
 TARGET = qelectrotech
 
 # Ajustement des bibliotheques utilisees lors de l'edition des liens
 unix:QMAKE_LIBS_THREAD -= -lpthread
-unix|win32: LIBS += -lsqlite3
+unix|win32: PKGCONFIG += sqlite3
 
 # Enable C++17
 QMAKE_CXXFLAGS += -std=c++17


### PR DESCRIPTION
To detected early, and use propre build/link flags

Without library
```
$ qmake-qt5 *pro
Project ERROR: sqlite3 development package not found
```

With, build passes and
```
$ ldd qelectrotech
	linux-vdso.so.1 (0x00007ffed41e9000)
	libsqlite3.so.0 => /lib64/libsqlite3.so.0 (0x00007f39d0e3d000)
...
```