### PR TITLE
add option to change the maximum number of parts

### DIFF
--- a/lang/qet_ar.ts
+++ b/lang/qet_ar.ts
@@ -7148,7 +7148,7 @@ les conditions requises ne sont pas valides</source>
     </message>
     <message>
         <location filename="../sources/editor/qetelementeditor.cpp" line="1489"/>
-        <source>Trop de primitives, liste non générée.</source>
+        <source>Trop de primitives, liste non générée: </source>
         <translation>عدد كبير من الأوليات , قائمة غير مُحدثة.</translation>
     </message>
     <message>

--- a/lang/qet_be.ts
+++ b/lang/qet_be.ts
@@ -7101,7 +7101,7 @@ les conditions requises ne sont pas valides</source>
     </message>
     <message>
         <location filename="../sources/editor/qetelementeditor.cpp" line="1489"/>
-        <source>Trop de primitives, liste non générée.</source>
+        <source>Trop de primitives, liste non générée: </source>
         <translation>Te veel onderdelen, lijst niet gemaakt.</translation>
     </message>
     <message>

--- a/lang/qet_ca.ts
+++ b/lang/qet_ca.ts
@@ -7104,7 +7104,7 @@ Les condicions requerides no són vàlides</translation>
     </message>
     <message>
         <location filename="../sources/editor/qetelementeditor.cpp" line="1489"/>
-        <source>Trop de primitives, liste non générée.</source>
+        <source>Trop de primitives, liste non générée: </source>
         <translation>No s&apos;ha pogut generar la llista.</translation>
     </message>
     <message>

--- a/lang/qet_cs.ts
+++ b/lang/qet_cs.ts
@@ -7083,7 +7083,7 @@ podmínky nejsou platné</translation>
     </message>
     <message>
         <location filename="../sources/editor/qetelementeditor.cpp" line="1489"/>
-        <source>Trop de primitives, liste non générée.</source>
+        <source>Trop de primitives, liste non générée: </source>
         <translation>Příliš jednoduché. Seznam nebyl vytvořen.</translation>
     </message>
     <message>

--- a/lang/qet_da.ts
+++ b/lang/qet_da.ts
@@ -7095,7 +7095,7 @@ betingelser ikke gyldig</translation>
     </message>
     <message>
         <location filename="../sources/editor/qetelementeditor.cpp" line="1489"/>
-        <source>Trop de primitives, liste non générée.</source>
+        <source>Trop de primitives, liste non générée: </source>
         <translation>For mange dele, liste genereres ikke.</translation>
     </message>
     <message>

--- a/lang/qet_de.ts
+++ b/lang/qet_de.ts
@@ -7162,7 +7162,7 @@ les conditions requises ne sont pas valides</source>
     </message>
     <message>
         <location filename="../sources/editor/qetelementeditor.cpp" line="1489"/>
-        <source>Trop de primitives, liste non générée.</source>
+        <source>Trop de primitives, liste non générée: </source>
         <translation>Zu viele Stammfunktionen. Liste nicht generiert.</translation>
     </message>
     <message>

--- a/lang/qet_el.ts
+++ b/lang/qet_el.ts
@@ -7080,7 +7080,7 @@ les conditions requises ne sont pas valides</source>
     </message>
     <message>
         <location filename="../sources/editor/qetelementeditor.cpp" line="1489"/>
-        <source>Trop de primitives, liste non générée.</source>
+        <source>Trop de primitives, liste non générée: </source>
         <translation>Πάρα πολλά βασικά στοιχεία, η λίστα δεν δημιουργήθηκε.</translation>
     </message>
     <message>

--- a/lang/qet_en.ts
+++ b/lang/qet_en.ts
@@ -7056,7 +7056,7 @@ the conditions are not valid</translation>
     </message>
     <message>
         <location filename="../sources/editor/qetelementeditor.cpp" line="1489"/>
-        <source>Trop de primitives, liste non générée.</source>
+        <source>Trop de primitives, liste non générée: </source>
         <translation>Too much parts, list not rendered.</translation>
     </message>
     <message>

--- a/lang/qet_es.ts
+++ b/lang/qet_es.ts
@@ -7056,7 +7056,7 @@ Las condiciones requeridas no son validas</translation>
     </message>
     <message>
         <location filename="../sources/editor/qetelementeditor.cpp" line="1489"/>
-        <source>Trop de primitives, liste non générée.</source>
+        <source>Trop de primitives, liste non générée: </source>
         <translation>Demasiado primitivas, lista no generada.</translation>
     </message>
     <message>

--- a/lang/qet_fi.ts
+++ b/lang/qet_fi.ts
@@ -5577,7 +5577,7 @@ les conditions requises ne sont pas valides</source>
     </message>
     <message>
         <location filename="../sources/editor/qetelementeditor.cpp" line="1382"/>
-        <source>Trop de primitives, liste non générée.</source>
+        <source>Trop de primitives, liste non générée: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/lang/qet_fr.ts
+++ b/lang/qet_fr.ts
@@ -7113,7 +7113,7 @@ les conditions requises ne sont pas valides</source>
     </message>
     <message>
         <location filename="../sources/editor/qetelementeditor.cpp" line="1489"/>
-        <source>Trop de primitives, liste non générée.</source>
+        <source>Trop de primitives, liste non générée: </source>
         <translation></translation>
     </message>
     <message>

--- a/lang/qet_hr.ts
+++ b/lang/qet_hr.ts
@@ -7083,7 +7083,7 @@ les conditions requises ne sont pas valides</source>
     </message>
     <message>
         <location filename="../sources/editor/qetelementeditor.cpp" line="1489"/>
-        <source>Trop de primitives, liste non générée.</source>
+        <source>Trop de primitives, liste non générée: </source>
         <translation>Previše dijelova, lista nije stvorena.</translation>
     </message>
     <message>

--- a/lang/qet_hu.ts
+++ b/lang/qet_hu.ts
@@ -7163,7 +7163,7 @@ les conditions requises ne sont pas valides</source>
     </message>
     <message>
         <location filename="../sources/editor/qetelementeditor.cpp" line="1489"/>
-        <source>Trop de primitives, liste non générée.</source>
+        <source>Trop de primitives, liste non générée: </source>
         <translation>Túl sok alkatrész, a lista nincs feldolgozva.</translation>
     </message>
     <message>

--- a/lang/qet_it.ts
+++ b/lang/qet_it.ts
@@ -7079,7 +7079,7 @@ le condizioni richieste non sono validi</translation>
     </message>
     <message>
         <location filename="../sources/editor/qetelementeditor.cpp" line="1489"/>
-        <source>Trop de primitives, liste non générée.</source>
+        <source>Trop de primitives, liste non générée: </source>
         <translation>Troppe parti, lista non generata.</translation>
     </message>
     <message>

--- a/lang/qet_nl.ts
+++ b/lang/qet_nl.ts
@@ -7063,7 +7063,7 @@ de voorwaarden zijn ongeldig</translation>
     </message>
     <message>
         <location filename="../sources/editor/qetelementeditor.cpp" line="1489"/>
-        <source>Trop de primitives, liste non générée.</source>
+        <source>Trop de primitives, liste non générée: </source>
         <translation>Te veel onderdelen, lijst is niet gemaakt.</translation>
     </message>
     <message>

--- a/lang/qet_no.ts
+++ b/lang/qet_no.ts
@@ -4697,7 +4697,7 @@ les conditions requises ne sont pas valides</source>
     </message>
     <message>
         <location filename="../sources/editor/qetelementeditor.cpp" line="1313"/>
-        <source>Trop de primitives, liste non générée.</source>
+        <source>Trop de primitives, liste non générée: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/lang/qet_pl.ts
+++ b/lang/qet_pl.ts
@@ -7104,7 +7104,7 @@ wymagane warunki nie zostały spełnione</translation>
     </message>
     <message>
         <location filename="../sources/editor/qetelementeditor.cpp" line="1489"/>
-        <source>Trop de primitives, liste non générée.</source>
+        <source>Trop de primitives, liste non générée: </source>
         <translation>Zbyt wiele części, lista nie jest generowana.</translation>
     </message>
     <message>

--- a/lang/qet_pt.ts
+++ b/lang/qet_pt.ts
@@ -7079,7 +7079,7 @@ les conditions requises ne sont pas valides</source>
     </message>
     <message>
         <location filename="../sources/editor/qetelementeditor.cpp" line="1489"/>
-        <source>Trop de primitives, liste non générée.</source>
+        <source>Trop de primitives, liste non générée: </source>
         <translation>Demasiados objectos, lista não gerada.</translation>
     </message>
     <message>

--- a/lang/qet_pt_br.ts
+++ b/lang/qet_pt_br.ts
@@ -7158,7 +7158,7 @@ as condições não são válidas</translation>
     </message>
     <message>
         <location filename="../sources/editor/qetelementeditor.cpp" line="1489"/>
-        <source>Trop de primitives, liste non générée.</source>
+        <source>Trop de primitives, liste non générée: </source>
         <translation>Demasiados objetos, lista não gerada.</translation>
     </message>
     <message>

--- a/lang/qet_ro.ts
+++ b/lang/qet_ro.ts
@@ -7088,7 +7088,7 @@ condițiile nu sunt valide</translation>
     </message>
     <message>
         <location filename="../sources/editor/qetelementeditor.cpp" line="1489"/>
-        <source>Trop de primitives, liste non générée.</source>
+        <source>Trop de primitives, liste non générée: </source>
         <translation>Prea multe componente, lista nu a fost randată.</translation>
     </message>
     <message>

--- a/lang/qet_ru.ts
+++ b/lang/qet_ru.ts
@@ -7007,7 +7007,7 @@ les conditions requises ne sont pas valides</source>
     </message>
     <message>
         <location filename="../sources/editor/qetelementeditor.cpp" line="1489"/>
-        <source>Trop de primitives, liste non générée.</source>
+        <source>Trop de primitives, liste non générée: </source>
         <translation>Слишком много частей, список не создан.</translation>
     </message>
     <message>

--- a/lang/qet_sl.ts
+++ b/lang/qet_sl.ts
@@ -7080,7 +7080,7 @@ les conditions requises ne sont pas valides</source>
     </message>
     <message>
         <location filename="../sources/editor/qetelementeditor.cpp" line="1489"/>
-        <source>Trop de primitives, liste non générée.</source>
+        <source>Trop de primitives, liste non générée: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/lang/qet_sr.ts
+++ b/lang/qet_sr.ts
@@ -7074,7 +7074,7 @@ les conditions requises ne sont pas valides</source>
     </message>
     <message>
         <location filename="../sources/editor/qetelementeditor.cpp" line="1489"/>
-        <source>Trop de primitives, liste non générée.</source>
+        <source>Trop de primitives, liste non générée: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/lang/qet_tr.ts
+++ b/lang/qet_tr.ts
@@ -7175,7 +7175,7 @@ les conditions requises ne sont pas valides</source>
     </message>
     <message>
         <location filename="../sources/editor/qetelementeditor.cpp" line="1489"/>
-        <source>Trop de primitives, liste non générée.</source>
+        <source>Trop de primitives, liste non générée: </source>
         <translation>Çok fazla öncül var, liste oluşturulmadı.</translation>
     </message>
     <message>

--- a/lang/qet_zh.ts
+++ b/lang/qet_zh.ts
@@ -7062,7 +7062,7 @@ les conditions requises ne sont pas valides</source>
     </message>
     <message>
         <location filename="../sources/editor/qetelementeditor.cpp" line="1489"/>
-        <source>Trop de primitives, liste non générée.</source>
+        <source>Trop de primitives, liste non générée: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/sources/editor/qetelementeditor.cpp
+++ b/sources/editor/qetelementeditor.cpp
@@ -57,13 +57,6 @@
 #include <QModelIndex>
 #include <utility>
 
-/*
-	Nombre maximum de primitives affichees par la "liste des parties"
-	Au-dela, un petit message est affiche, indiquant que ce nombre a ete depasse
-	et que la liste ne sera donc pas mise a jour.
-*/
-#define QET_MAX_PARTS_IN_ELEMENT_EDITOR_LIST 200
-
 /**
 	Constructeur
 	@param parent QWidget parent
@@ -1464,7 +1457,9 @@ void QETElementEditor::slot_createPartsList()
 	// on ne construit plus la liste a partir de 200 primitives
 	// c'est ingerable : la maj de la liste prend trop de temps et le resultat
 	// est inexploitable
-	if (qgis.count() <= QET_MAX_PARTS_IN_ELEMENT_EDITOR_LIST) {
+    QSettings settings;
+    int maxParts = settings.value("elementeditor/max-parts-element-editor-list", 200).toInt();
+    if (qgis.count() <= maxParts) {
 		for (int j = qgis.count() - 1 ; j >= 0 ; -- j) {
 			QGraphicsItem *qgi = qgis[j];
 			if (CustomElementPart *cep = dynamic_cast<CustomElementPart *>(qgi)) {
@@ -1486,7 +1481,7 @@ void QETElementEditor::slot_createPartsList()
 		}
 	}
 	else {
-		m_parts_list -> addItem(new QListWidgetItem(tr("Trop de primitives, liste non générée.")));
+        m_parts_list -> addItem(new QListWidgetItem(tr("Trop de primitives, liste non générée: ") + QString::number(qgis.count())));
 	}
 	m_parts_list -> blockSignals(false);
 }
@@ -1497,10 +1492,12 @@ void QETElementEditor::slot_createPartsList()
 void QETElementEditor::slot_updatePartsList()
 {
 	int items_count = m_elmt_scene -> items().count();
+    QSettings settings;
+    int maxParts = settings.value("elementeditor/max-parts-element-editor-list", 200).toInt();
 	if (m_parts_list -> count() != items_count) {
 		slot_createPartsList();
 	}
-	else if (items_count <= QET_MAX_PARTS_IN_ELEMENT_EDITOR_LIST) {
+    else if (items_count <= maxParts) {
 		m_parts_list -> blockSignals(true);
 		int i = 0;
 		QList<QGraphicsItem *> items = m_elmt_scene -> zItems();

--- a/sources/ui/configpage/generalconfigurationpage.cpp
+++ b/sources/ui/configpage/generalconfigurationpage.cpp
@@ -93,6 +93,12 @@ GeneralConfigurationPage::GeneralConfigurationPage(QWidget *parent) :
 	
 	ui->m_highlight_integrated_elements->setChecked(settings.value("diagrameditor/highlight-integrated-elements", true).toBool());
 	ui->m_default_elements_info->setPlainText(settings.value("elementeditor/default-informations", "").toString());
+    /*
+        Nombre maximum de primitives affichees par la "liste des parties"
+        Au-dela, un petit message est affiche, indiquant que ce nombre a ete depasse
+        et que la liste ne sera donc pas mise a jour.
+    */
+    ui->MaxPartsElementEditorList_sb->setValue(settings.value("elementeditor/max-parts-element-editor-list", 200).toInt());
 	
 	QString path = settings.value("elements-collections/common-collection-path", "default").toString();
 	if (path != "default")
@@ -150,6 +156,7 @@ void GeneralConfigurationPage::applyConf()
 
 		//ELEMENT EDITOR
 	settings.setValue("elementeditor/default-informations", ui->m_default_elements_info->toPlainText());
+    settings.setValue("elementeditor/max-parts-element-editor-list", ui->MaxPartsElementEditorList_sb->value());
 
 		//DIAGRAM VIEW
 	settings.setValue("diagramview/gestures", ui->m_use_gesture_trackpad->isChecked());
@@ -396,4 +403,15 @@ void GeneralConfigurationPage::on_m_indi_text_font_pb_clicked()
 							font.styleName() + ")";
 		ui->m_indi_text_font_pb->setText(fontInfos);
 	}
+}
+
+void GeneralConfigurationPage::on_MaxPartsElementEditorList_sb_valueChanged(int value)
+{
+    if (value > 500) {
+        ui->MaxPartsElementEditorList_sb->setToolTip(tr("To high values might lead to crashes of the application."));
+        ui->MaxPartsElementEditorList_sb->setStyleSheet("background-color: orange");
+    } else {
+        ui->MaxPartsElementEditorList_sb->setToolTip("");
+        ui->MaxPartsElementEditorList_sb->setStyleSheet("");
+    }
 }

--- a/sources/ui/configpage/generalconfigurationpage.h
+++ b/sources/ui/configpage/generalconfigurationpage.h
@@ -44,6 +44,7 @@ class GeneralConfigurationPage : public ConfigPage
 		void on_m_custom_elmt_path_cb_currentIndexChanged(int index);
 		void on_m_custom_tbt_path_cb_currentIndexChanged(int index);
 		void on_m_indi_text_font_pb_clicked();
+        void on_MaxPartsElementEditorList_sb_valueChanged(int value);
 
 	private:
 		void fillLang();

--- a/sources/ui/configpage/generalconfigurationpage.ui
+++ b/sources/ui/configpage/generalconfigurationpage.ui
@@ -6,18 +6,18 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>727</width>
-    <height>510</height>
+    <width>899</width>
+    <height>695</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>Form</string>
   </property>
-  <layout class="QGridLayout" name="gridLayout_5">
-   <item row="0" column="0">
+  <layout class="QVBoxLayout" name="verticalLayout_6">
+   <item>
     <widget class="QTabWidget" name="tabWidget">
      <property name="currentIndex">
-      <number>4</number>
+      <number>5</number>
      </property>
      <widget class="QWidget" name="tab_3">
       <attribute name="title">
@@ -793,6 +793,63 @@ Vous pouvez spécifier ici la valeur par défaut de ce champ pour les éléments
        </item>
        <item>
         <spacer name="verticalSpacer_5">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>40</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+      </layout>
+     </widget>
+     <widget class="QWidget" name="Editor">
+      <attribute name="title">
+       <string>Editor</string>
+      </attribute>
+      <layout class="QVBoxLayout" name="verticalLayout_7">
+       <item>
+        <layout class="QHBoxLayout" name="horizontalLayout">
+         <item>
+          <widget class="QLabel" name="label_2">
+           <property name="text">
+            <string>Max. parts in Element Editor List</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <spacer name="horizontalSpacer_8">
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>40</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+         <item>
+          <widget class="QSpinBox" name="MaxPartsElementEditorList_sb">
+           <property name="minimum">
+            <number>1</number>
+           </property>
+           <property name="maximum">
+            <number>10000</number>
+           </property>
+           <property name="value">
+            <number>200</number>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+       <item>
+        <spacer name="verticalSpacer_6">
          <property name="orientation">
           <enum>Qt::Vertical</enum>
          </property>


### PR DESCRIPTION
I had a few times when importing a dxf that I don't see the elements in the list, because there are too many. In this patch I implemented a new property which holds that number and the user can change it to show all. What do you think?

If you increase the number in the settings above 500 the spinbox gets orange and a tooltip describes the risks of increasing that number.
At the moment I just created a new page in the settings, because I did not find the right place for it.

Problems:
- when applying the settings, the list gets not updated. How this can be achieved? At the moment you have to change the selection to update the list.