### PR TITLE
Update qet_en.ts

### DIFF
--- a/lang/qet_en.ts
+++ b/lang/qet_en.ts
@@ -51,7 +51,7 @@
     <message>
         <location filename="../sources/ui/aboutqetdialog.ui" line="449"/>
         <source>log</source>
-        <translation></translation>
+        <translation>Log</translation>
     </message>
     <message>
         <location filename="../sources/ui/aboutqetdialog.cpp" line="58"/>


### PR DESCRIPTION
The first letter of the word needs to be in upper case to align with the rest of the menu.