### PR TITLE
Modifications to SaveFile-Dialog for "Save As PDF"

### DIFF
--- a/sources/print/projectprintwindow.cpp
+++ b/sources/print/projectprintwindow.cpp
@@ -95,13 +95,13 @@ void ProjectPrintWindow::launchDialog(QETProject *project, QPrinter::OutputForma
 QString ProjectPrintWindow::docName(QETProject *project)
 {
 	QString doc_name;
-	if (!project->title().isEmpty()) {
-		doc_name = project->title();
-	} else if (!project->filePath().isEmpty()) {
-		doc_name = QFileInfo(project->filePath()).baseName();
+    if (!project->filePath().isEmpty()) {
+        doc_name = QFileInfo(project->filePath()).baseName();
+    } else if (!project->title().isEmpty()) {
+        doc_name = project->title();
+        doc_name = QET::stringToFileName(doc_name);
 	}
 
-	doc_name = QET::stringToFileName(doc_name);
 	if (doc_name.isEmpty()) {
 		doc_name = tr("projet", "string used to generate a filename");
 	}
@@ -666,7 +666,7 @@ QList<Diagram *> ProjectPrintWindow::selectedDiagram() const
 
 void ProjectPrintWindow::exportToPDF()
 {
-	auto file_name = QFileDialog::getSaveFileName(this, tr("Exporter sous : "), m_printer->outputFileName(), tr("Fichier (*.pdf)"));
+    auto file_name = QFileDialog::getSaveFileName(this, tr("Exporter sous : "), m_printer->outputFileName(), tr("Fichier (*.pdf)"));
 	if (file_name.isEmpty()) {
 		return;
 	}

--- a/sources/ui/borderpropertieswidget.ui
+++ b/sources/ui/borderpropertieswidget.ui
@@ -98,6 +98,14 @@
    </item>
   </layout>
  </widget>
+ <tabstops>
+  <tabstop>m_colums_count_sp</tabstop>
+  <tabstop>m_columns_width_sp</tabstop>
+  <tabstop>m_rows_count_sp</tabstop>
+  <tabstop>m_rows_height_sp</tabstop>
+  <tabstop>m_display_columns_cb</tabstop>
+  <tabstop>m_display_rows_cb</tabstop>
+ </tabstops>
  <resources/>
  <connections/>
 </ui>

--- a/sources/ui/conductorpropertieswidget.ui
+++ b/sources/ui/conductorpropertieswidget.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>662</width>
+    <width>666</width>
     <height>418</height>
    </rect>
   </property>
@@ -581,6 +581,41 @@
    <header>kcolorbutton.h</header>
   </customwidget>
  </customwidgets>
+ <tabstops>
+  <tabstop>tabWidget</tabstop>
+  <tabstop>tabWidget_2</tabstop>
+  <tabstop>m_multiwires_gb</tabstop>
+  <tabstop>m_one_text_per_folio_cb</tabstop>
+  <tabstop>m_text_size_sb</tabstop>
+  <tabstop>m_formula_le</tabstop>
+  <tabstop>m_text_le</tabstop>
+  <tabstop>m_show_text_cb</tabstop>
+  <tabstop>m_text_color_kpb</tabstop>
+  <tabstop>m_available_autonum_cb</tabstop>
+  <tabstop>m_edit_autonum_pb</tabstop>
+  <tabstop>m_function_le</tabstop>
+  <tabstop>m_tension_protocol_le</tabstop>
+  <tabstop>m_wire_color_le</tabstop>
+  <tabstop>m_wire_section_le</tabstop>
+  <tabstop>m_cable_le</tabstop>
+  <tabstop>m_bus_le</tabstop>
+  <tabstop>m_verti_cb</tabstop>
+  <tabstop>m_horiz_cb</tabstop>
+  <tabstop>m_singlewire_gb</tabstop>
+  <tabstop>m_phase_sb</tabstop>
+  <tabstop>m_update_preview_pb</tabstop>
+  <tabstop>m_neutral_cb</tabstop>
+  <tabstop>m_earth_cb</tabstop>
+  <tabstop>m_phase_cb</tabstop>
+  <tabstop>m_phase_slider</tabstop>
+  <tabstop>m_pen_cb</tabstop>
+  <tabstop>m_color_kpb</tabstop>
+  <tabstop>m_color_2_gb</tabstop>
+  <tabstop>m_dash_size_sb</tabstop>
+  <tabstop>m_color_2_kpb</tabstop>
+  <tabstop>m_cond_size_sb</tabstop>
+  <tabstop>m_line_style_cb</tabstop>
+ </tabstops>
  <resources>
   <include location="../../qelectrotech.qrc"/>
  </resources>

--- a/sources/ui/configpage/generalconfigurationpage.ui
+++ b/sources/ui/configpage/generalconfigurationpage.ui
@@ -17,7 +17,7 @@
    <item row="0" column="0">
     <widget class="QTabWidget" name="tabWidget">
      <property name="currentIndex">
-      <number>0</number>
+      <number>5</number>
      </property>
      <widget class="QWidget" name="tab_3">
       <attribute name="title">
@@ -811,19 +811,35 @@ Vous pouvez spécifier ici la valeur par défaut de ce champ pour les éléments
   </layout>
  </widget>
  <tabstops>
+  <tabstop>tabWidget</tabstop>
   <tabstop>m_use_system_color_cb</tabstop>
-  <tabstop>m_use_windows_mode_rb</tabstop>
-  <tabstop>m_use_tab_mode_rb</tabstop>
   <tabstop>m_use_gesture_trackpad</tabstop>
   <tabstop>m_zoom_out_beyond_folio</tabstop>
+  <tabstop>m_use_windows_mode_rb</tabstop>
+  <tabstop>m_use_tab_mode_rb</tabstop>
+  <tabstop>m_save_label_paste</tabstop>
+  <tabstop>m_use_folio_label</tabstop>
+  <tabstop>m_export_terminal</tabstop>
+  <tabstop>m_border_0</tabstop>
+  <tabstop>m_autosave_sb</tabstop>
   <tabstop>m_common_elmt_path_cb</tabstop>
   <tabstop>m_custom_elmt_path_cb</tabstop>
+  <tabstop>m_custom_tbt_path_cb</tabstop>
   <tabstop>m_highlight_integrated_elements</tabstop>
   <tabstop>m_default_elements_info</tabstop>
   <tabstop>m_lang_cb</tabstop>
   <tabstop>m_dyn_text_font_pb</tabstop>
   <tabstop>m_dyn_text_rotation_sb</tabstop>
   <tabstop>m_dyn_text_width_sb</tabstop>
+  <tabstop>m_indi_text_font_pb</tabstop>
+  <tabstop>m_indi_text_rotation_sb</tabstop>
+  <tabstop>m_font_pb</tabstop>
+  <tabstop>DiagramEditor_xGrid_sb</tabstop>
+  <tabstop>DiagramEditor_yGrid_sb</tabstop>
+  <tabstop>DiagramEditor_xKeyGrid_sb</tabstop>
+  <tabstop>DiagramEditor_yKeyGrid_sb</tabstop>
+  <tabstop>DiagramEditor_xKeyGridFine_sb</tabstop>
+  <tabstop>DiagramEditor_yKeyGridFine_sb</tabstop>
  </tabstops>
  <resources/>
  <connections/>

--- a/sources/ui/configsaveloaderwidget.ui
+++ b/sources/ui/configsaveloaderwidget.ui
@@ -29,7 +29,7 @@
       <string/>
      </property>
      <property name="icon">
-      <iconset>
+      <iconset resource="../../qelectrotech.qrc">
        <normaloff>:/ico/16x16/folder-open.png</normaloff>:/ico/16x16/folder-open.png</iconset>
      </property>
     </widget>
@@ -40,13 +40,21 @@
       <string/>
      </property>
      <property name="icon">
-      <iconset>
+      <iconset resource="../../qelectrotech.qrc">
        <normaloff>:/ico/16x16/document-save.png</normaloff>:/ico/16x16/document-save.png</iconset>
      </property>
     </widget>
    </item>
   </layout>
  </widget>
- <resources/>
+ <tabstops>
+  <tabstop>m_combo_box</tabstop>
+  <tabstop>m_load_pb</tabstop>
+  <tabstop>m_line_edit</tabstop>
+  <tabstop>m_save_pb</tabstop>
+ </tabstops>
+ <resources>
+  <include location="../../qelectrotech.qrc"/>
+ </resources>
  <connections/>
 </ui>

--- a/sources/ui/inditextpropertieswidget.ui
+++ b/sources/ui/inditextpropertieswidget.ui
@@ -163,6 +163,16 @@ Veuillez utiliser l'éditeur avancé pour cela.</string>
    </item>
   </layout>
  </widget>
+ <tabstops>
+  <tabstop>m_line_edit</tabstop>
+  <tabstop>m_font_pb</tabstop>
+  <tabstop>m_advanced_editor_pb</tabstop>
+  <tabstop>m_x_sb</tabstop>
+  <tabstop>m_y_sb</tabstop>
+  <tabstop>m_angle_sb</tabstop>
+  <tabstop>m_size_sb</tabstop>
+  <tabstop>m_break_html_pb</tabstop>
+ </tabstops>
  <resources/>
  <connections/>
 </ui>

--- a/sources/ui/shapegraphicsitempropertieswidget.ui
+++ b/sources/ui/shapegraphicsitempropertieswidget.ui
@@ -256,6 +256,15 @@
    <header>kcolorbutton.h</header>
   </customwidget>
  </customwidgets>
+ <tabstops>
+  <tabstop>m_style_cb</tabstop>
+  <tabstop>m_size_dsb</tabstop>
+  <tabstop>m_color_kpb</tabstop>
+  <tabstop>m_brush_style_cb</tabstop>
+  <tabstop>m_brush_color_kpb</tabstop>
+  <tabstop>m_lock_pos_cb</tabstop>
+  <tabstop>m_close_polygon</tabstop>
+ </tabstops>
  <resources/>
  <connections/>
 </ui>

--- a/sources/ui/xrefpropertieswidget.ui
+++ b/sources/ui/xrefpropertieswidget.ui
@@ -2,6 +2,14 @@
 <ui version="4.0">
  <class>XRefPropertiesWidget</class>
  <widget class="QWidget" name="XRefPropertiesWidget">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>376</width>
+    <height>531</height>
+   </rect>
+  </property>
   <property name="windowTitle">
    <string>Form</string>
   </property>
@@ -265,6 +273,20 @@
    </item>
   </layout>
  </widget>
+ <tabstops>
+  <tabstop>m_type_cb</tabstop>
+  <tabstop>m_snap_to_cb</tabstop>
+  <tabstop>m_offset_sb</tabstop>
+  <tabstop>m_xrefpos_cb</tabstop>
+  <tabstop>m_display_has_contacts_rb</tabstop>
+  <tabstop>m_display_has_cross_rb</tabstop>
+  <tabstop>m_master_le</tabstop>
+  <tabstop>m_slave_le</tabstop>
+  <tabstop>m_show_power_cb</tabstop>
+  <tabstop>m_power_prefix_le</tabstop>
+  <tabstop>m_delay_prefix_le</tabstop>
+  <tabstop>m_switch_prefix_le</tabstop>
+ </tabstops>
  <resources/>
  <connections/>
 </ui>


### PR DESCRIPTION
Fixed a typo that prevented existing PDF files from being displayed in SaveFileDialog for PDFs.

The way the file name for the PDF is generated has changed. If the project has already been saved, the PDF has the same file name (with .pdf of course); If not, the file name is generated from the project title (= same behavior as Save as - dialog for a .qet project file).