### PR TITLE
Add Williams EM symbols

### DIFF
--- a/elements/10_electric/20_manufacturers_articles/pinball/williams_em/common/pinball_em_williams_ground.elmt
+++ b/elements/10_electric/20_manufacturers_articles/pinball/williams_em/common/pinball_em_williams_ground.elmt
@@ -1,0 +1,16 @@
+<definition height="30" version="0.70" orientation="dyyy" width="20" hotspot_x="10" link_type="simple" type="element" hotspot_y="17">
+    <uuid uuid="{ff754778-ac11-493d-828a-5f763560b02e}"/>
+    <names>
+        <name lang="en">Ground</name>
+        <name lang="nl">Aarde</name>
+    </names>
+    <elementInformations/>
+    <informations></informations>
+    <description>
+        <line end1="none" length1="1.5" x2="0" style="line-style:normal;line-weight:normal;filling:none;color:black" y2="0" y1="-10" antialias="false" x1="0" end2="none" length2="1.5"/>
+        <line end1="none" length1="1.5" x2="7" style="line-style:normal;line-weight:hight;filling:none;color:black" y2="0" y1="0" antialias="false" x1="-7" end2="none" length2="1.5"/>
+        <line end1="none" length1="1.5" x2="-5" style="line-style:normal;line-weight:hight;filling:none;color:black" y2="4" y1="4" antialias="false" x1="5" end2="none" length2="1.5"/>
+        <line end1="none" length1="1.5" x2="3" style="line-style:normal;line-weight:hight;filling:none;color:black" y2="8" y1="8" antialias="false" x1="-3" end2="none" length2="1.5"/>
+        <terminal y="-10" orientation="n" x="0"/>
+    </description>
+</definition>

--- a/elements/10_electric/20_manufacturers_articles/pinball/williams_em/common/pinball_em_williams_not_connected_east.elmt
+++ b/elements/10_electric/20_manufacturers_articles/pinball/williams_em/common/pinball_em_williams_not_connected_east.elmt
@@ -1,0 +1,15 @@
+<definition height="20" version="0.70" orientation="dyyy" width="30" hotspot_x="11" link_type="simple" type="element" hotspot_y="10">
+    <uuid uuid="{4f47811e-036e-4ef0-a846-b656f51ca81e}"/>
+    <names>
+        <name lang="en">Not connected (east)</name>
+        <name lang="nl">Niet verbonden (oost)</name>
+    </names>
+    <elementInformations/>
+    <informations></informations>
+    <description>
+        <line end1="none" length1="1.5" x2="10" style="line-style:normal;line-weight:normal;filling:none;color:black" y2="0" y1="0" antialias="false" x1="0" end2="none" length2="1.5"/>
+        <line end1="none" length1="1.5" x2="5" style="line-style:normal;line-weight:normal;filling:none;color:black" y2="5" y1="-5" antialias="false" x1="-5" end2="none" length2="1.5"/>
+        <line end1="none" length1="1.5" x2="5" style="line-style:normal;line-weight:normal;filling:none;color:black" y2="-5" y1="5" antialias="false" x1="-5" end2="none" length2="1.5"/>
+        <terminal y="0" orientation="e" x="10"/>
+    </description>
+</definition>

--- a/elements/10_electric/20_manufacturers_articles/pinball/williams_em/common/pinball_em_williams_not_connected_north.elmt
+++ b/elements/10_electric/20_manufacturers_articles/pinball/williams_em/common/pinball_em_williams_not_connected_north.elmt
@@ -1,0 +1,15 @@
+<definition height="30" version="0.70" orientation="dyyy" width="20" hotspot_x="10" link_type="simple" type="element" hotspot_y="18">
+    <uuid uuid="{e446ec4b-827d-4df3-bed0-dd4adbd2b62a}"/>
+    <names>
+        <name lang="en">Not connected (north)</name>
+        <name lang="nl">Niet verbonden (noord)</name>
+    </names>
+    <elementInformations/>
+    <informations></informations>
+    <description>
+        <line end1="none" length1="1.5" x2="6" style="line-style:normal;line-weight:normal;filling:none;color:black" y2="6" y1="-6" antialias="false" x1="-6" end2="none" length2="1.5"/>
+        <line end1="none" length1="1.5" x2="-6" style="line-style:normal;line-weight:normal;filling:none;color:black" y2="6" y1="-6" antialias="false" x1="6" end2="none" length2="1.5"/>
+        <line end1="none" length1="1.5" x2="0" style="line-style:normal;line-weight:normal;filling:none;color:black" y2="-10" y1="0" antialias="false" x1="0" end2="none" length2="1.5"/>
+        <terminal y="-10" orientation="n" x="0"/>
+    </description>
+</definition>

--- a/elements/10_electric/20_manufacturers_articles/pinball/williams_em/common/pinball_em_williams_not_connected_south.elmt
+++ b/elements/10_electric/20_manufacturers_articles/pinball/williams_em/common/pinball_em_williams_not_connected_south.elmt
@@ -1,0 +1,15 @@
+<definition height="30" version="0.70" orientation="dyyy" width="20" hotspot_x="10" link_type="simple" type="element" hotspot_y="11">
+    <uuid uuid="{e16cfe95-6fbc-49a0-97ee-1c0991324964}"/>
+    <names>
+        <name lang="en">Not connected (south)</name>
+        <name lang="nl">Niet verbonden (zuid)</name>
+    </names>
+    <elementInformations/>
+    <informations></informations>
+    <description>
+        <line end1="none" length1="1.5" x2="0" style="line-style:normal;line-weight:normal;filling:none;color:black" y2="0" y1="10" antialias="false" x1="0" end2="none" length2="1.5"/>
+        <line end1="none" length1="1.5" x2="5" style="line-style:normal;line-weight:normal;filling:none;color:black" y2="-5" y1="5" antialias="false" x1="-5" end2="none" length2="1.5"/>
+        <line end1="none" length1="1.5" x2="-5" style="line-style:normal;line-weight:normal;filling:none;color:black" y2="-5" y1="5" antialias="false" x1="5" end2="none" length2="1.5"/>
+        <terminal y="10" orientation="s" x="0"/>
+    </description>
+</definition>

--- a/elements/10_electric/20_manufacturers_articles/pinball/williams_em/common/pinball_em_williams_not_connected_west.elmt
+++ b/elements/10_electric/20_manufacturers_articles/pinball/williams_em/common/pinball_em_williams_not_connected_west.elmt
@@ -1,0 +1,15 @@
+<definition height="20" version="0.70" orientation="dyyy" width="30" hotspot_x="18" link_type="simple" type="element" hotspot_y="10">
+    <uuid uuid="{b6b35ed3-cbaa-43b0-a5b2-6120925de98e}"/>
+    <names>
+        <name lang="en">Not connected (west)</name>
+        <name lang="nl">Niet verbonden (west)</name>
+    </names>
+    <elementInformations/>
+    <informations></informations>
+    <description>
+        <line end1="none" length1="1.5" x2="-10" style="line-style:normal;line-weight:normal;filling:none;color:black" y2="0" y1="0" antialias="false" x1="0" end2="none" length2="1.5"/>
+        <line end1="none" length1="1.5" x2="5" style="line-style:normal;line-weight:normal;filling:none;color:black" y2="5" y1="-5" antialias="false" x1="-5" end2="none" length2="1.5"/>
+        <line end1="none" length1="1.5" x2="5" style="line-style:normal;line-weight:normal;filling:none;color:black" y2="-5" y1="5" antialias="false" x1="-5" end2="none" length2="1.5"/>
+        <terminal y="0" orientation="w" x="-10"/>
+    </description>
+</definition>

--- a/elements/10_electric/20_manufacturers_articles/pinball/williams_em/common/qet_directory
+++ b/elements/10_electric/20_manufacturers_articles/pinball/williams_em/common/qet_directory
@@ -1,0 +1,6 @@
+<qet-directory>
+    <names>
+        <name lang="en">Common</name>
+        <name lang="nl">Algemeen</name>
+    </names>
+</qet-directory>

--- a/elements/10_electric/20_manufacturers_articles/pinball/williams_em/jacks/pinball_em_williams_jack_02.elmt
+++ b/elements/10_electric/20_manufacturers_articles/pinball/williams_em/jacks/pinball_em_williams_jack_02.elmt
@@ -1,0 +1,20 @@
+<definition height="50" version="0.70" orientation="dyyy" width="50" hotspot_x="24" link_type="simple" type="element" hotspot_y="15">
+    <uuid uuid="{48d90cab-e93d-4460-a1c8-4945e69144bf}"/>
+    <names>
+        <name lang="en">Jack with 2 positions</name>
+        <name lang="nl">Contact met 2 posities</name>
+    </names>
+    <elementInformations/>
+    <informations></informations>
+    <description>
+        <rect y="-10" height="40" width="20" rx="0" style="line-style:normal;line-weight:normal;filling:none;color:black" antialias="false" x="-10" ry="0"/>
+        <line end1="none" length1="1.5" x2="-10" style="line-style:normal;line-weight:normal;filling:none;color:black" y2="0" y1="0" antialias="false" x1="-20" end2="none" length2="1.5"/>
+        <line end1="none" length1="1.5" x2="-11" style="line-style:normal;line-weight:normal;filling:none;color:black" y2="20" y1="20" antialias="false" x1="-20" end2="none" length2="1.5"/>
+        <line end1="none" length1="1.5" x2="20" style="line-style:normal;line-weight:normal;filling:none;color:black" y2="20" y1="20" antialias="false" x1="10" end2="none" length2="1.5"/>
+        <line end1="none" length1="1.5" x2="10" style="line-style:normal;line-weight:normal;filling:none;color:black" y2="0" y1="0" antialias="false" x1="20" end2="none" length2="1.5"/>
+        <terminal y="0" orientation="e" x="20"/>
+        <terminal y="0" orientation="w" x="-20"/>
+        <terminal y="20" orientation="e" x="20"/>
+        <terminal y="20" orientation="w" x="-20"/>
+    </description>
+</definition>

--- a/elements/10_electric/20_manufacturers_articles/pinball/williams_em/jacks/pinball_em_williams_jack_03.elmt
+++ b/elements/10_electric/20_manufacturers_articles/pinball/williams_em/jacks/pinball_em_williams_jack_03.elmt
@@ -1,0 +1,24 @@
+<definition height="70" version="0.70" orientation="dyyy" width="50" hotspot_x="24" link_type="simple" type="element" hotspot_y="15">
+    <uuid uuid="{1e0d2098-80e3-4f87-a1a4-8979da3035e3}"/>
+    <names>
+        <name lang="en">Jack with 3 positions</name>
+        <name lang="nl">Contact met 3 posities</name>
+    </names>
+    <elementInformations/>
+    <informations></informations>
+    <description>
+        <rect y="-10" height="60" width="20" rx="0" style="line-style:normal;line-weight:normal;filling:none;color:black" antialias="false" x="-10" ry="0"/>
+        <line end1="none" length1="1.5" x2="-10" style="line-style:normal;line-weight:normal;filling:none;color:black" y2="0" y1="0" antialias="false" x1="-20" end2="none" length2="1.5"/>
+        <line end1="none" length1="1.5" x2="20" style="line-style:normal;line-weight:normal;filling:none;color:black" y2="0" y1="0" antialias="false" x1="10" end2="none" length2="1.5"/>
+        <line end1="none" length1="1.5" x2="10" style="line-style:normal;line-weight:normal;filling:none;color:black" y2="20" y1="20" antialias="false" x1="20" end2="none" length2="1.5"/>
+        <line end1="none" length1="1.5" x2="20" style="line-style:normal;line-weight:normal;filling:none;color:black" y2="40" y1="40" antialias="false" x1="10" end2="none" length2="1.5"/>
+        <line end1="none" length1="1.5" x2="-20" style="line-style:normal;line-weight:normal;filling:none;color:black" y2="40" y1="40" antialias="false" x1="-10" end2="none" length2="1.5"/>
+        <line end1="none" length1="1.5" x2="-10" style="line-style:normal;line-weight:normal;filling:none;color:black" y2="20" y1="20" antialias="false" x1="-20" end2="none" length2="1.5"/>
+        <terminal y="40" orientation="w" x="-20"/>
+        <terminal y="40" orientation="e" x="20"/>
+        <terminal y="0" orientation="w" x="-20"/>
+        <terminal y="20" orientation="w" x="-20"/>
+        <terminal y="20" orientation="e" x="20"/>
+        <terminal y="0" orientation="e" x="20"/>
+    </description>
+</definition>

--- a/elements/10_electric/20_manufacturers_articles/pinball/williams_em/jacks/pinball_em_williams_jack_04.elmt
+++ b/elements/10_electric/20_manufacturers_articles/pinball/williams_em/jacks/pinball_em_williams_jack_04.elmt
@@ -1,0 +1,28 @@
+<definition height="90" version="0.70" orientation="dyyy" width="50" hotspot_x="24" link_type="simple" type="element" hotspot_y="15">
+    <uuid uuid="{88b316e4-9fd7-4b89-af9e-3a70b840603b}"/>
+    <names>
+        <name lang="en">Jack with 4 positions</name>
+        <name lang="nl">Contact met 4 posities</name>
+    </names>
+    <elementInformations/>
+    <informations></informations>
+    <description>
+        <rect y="-10" height="80" width="20" rx="0" style="line-style:normal;line-weight:normal;filling:none;color:black" antialias="false" x="-10" ry="0"/>
+        <line end1="none" length1="1.5" x2="20" style="line-style:normal;line-weight:normal;filling:none;color:black" y2="0" y1="0" antialias="false" x1="10" end2="none" length2="1.5"/>
+        <line end1="none" length1="1.5" x2="20" style="line-style:normal;line-weight:normal;filling:none;color:black" y2="20" y1="20" antialias="false" x1="10" end2="none" length2="1.5"/>
+        <line end1="none" length1="1.5" x2="20" style="line-style:normal;line-weight:normal;filling:none;color:black" y2="40" y1="40" antialias="false" x1="10" end2="none" length2="1.5"/>
+        <line end1="none" length1="1.5" x2="20" style="line-style:normal;line-weight:normal;filling:none;color:black" y2="60" y1="60" antialias="false" x1="10" end2="none" length2="1.5"/>
+        <line end1="none" length1="1.5" x2="-20" style="line-style:normal;line-weight:normal;filling:none;color:black" y2="60" y1="60" antialias="false" x1="-10" end2="none" length2="1.5"/>
+        <line end1="none" length1="1.5" x2="-10" style="line-style:normal;line-weight:normal;filling:none;color:black" y2="40" y1="40" antialias="false" x1="-20" end2="none" length2="1.5"/>
+        <line end1="none" length1="1.5" x2="-20" style="line-style:normal;line-weight:normal;filling:none;color:black" y2="20" y1="20" antialias="false" x1="-10" end2="none" length2="1.5"/>
+        <line end1="none" length1="1.5" x2="-10" style="line-style:normal;line-weight:normal;filling:none;color:black" y2="0" y1="0" antialias="false" x1="-20" end2="none" length2="1.5"/>
+        <terminal y="20" orientation="w" x="-20"/>
+        <terminal y="0" orientation="w" x="-20"/>
+        <terminal y="60" orientation="w" x="-20"/>
+        <terminal y="20" orientation="e" x="20"/>
+        <terminal y="40" orientation="e" x="20"/>
+        <terminal y="60" orientation="e" x="20"/>
+        <terminal y="0" orientation="e" x="20"/>
+        <terminal y="40" orientation="w" x="-20"/>
+    </description>
+</definition>

--- a/elements/10_electric/20_manufacturers_articles/pinball/williams_em/jacks/pinball_em_williams_jack_05.elmt
+++ b/elements/10_electric/20_manufacturers_articles/pinball/williams_em/jacks/pinball_em_williams_jack_05.elmt
@@ -1,0 +1,32 @@
+<definition type="element" width="50" orientation="dyyy" hotspot_x="24" hotspot_y="15" version="0.70" link_type="simple" height="110">
+    <uuid uuid="{3398a8e0-2b95-4231-8820-ad19908d197a}"/>
+    <names>
+        <name lang="en">Jack with 5 positions</name>
+        <name lang="nl">Contact met 5 posities</name>
+    </names>
+    <elementInformations/>
+    <informations></informations>
+    <description>
+        <rect width="20" rx="0" x="-10" y="-10" ry="0" style="line-style:normal;line-weight:normal;filling:none;color:black" antialias="false" height="100"/>
+        <line length2="1.5" y2="0" end1="none" x1="-20" y1="0" length1="1.5" end2="none" style="line-style:normal;line-weight:normal;filling:none;color:black" antialias="false" x2="-10"/>
+        <line length2="1.5" y2="20" end1="none" x1="-20" y1="20" length1="1.5" end2="none" style="line-style:normal;line-weight:normal;filling:none;color:black" antialias="false" x2="-10"/>
+        <line length2="1.5" y2="40" end1="none" x1="-20" y1="40" length1="1.5" end2="none" style="line-style:normal;line-weight:normal;filling:none;color:black" antialias="false" x2="-10"/>
+        <line length2="1.5" y2="60" end1="none" x1="-20" y1="60" length1="1.5" end2="none" style="line-style:normal;line-weight:normal;filling:none;color:black" antialias="false" x2="-10"/>
+        <line length2="1.5" y2="80" end1="none" x1="-20" y1="80" length1="1.5" end2="none" style="line-style:normal;line-weight:normal;filling:none;color:black" antialias="false" x2="-10"/>
+        <line length2="1.5" y2="80" end1="none" x1="20" y1="80" length1="1.5" end2="none" style="line-style:normal;line-weight:normal;filling:none;color:black" antialias="false" x2="10"/>
+        <line length2="1.5" y2="60" end1="none" x1="10" y1="60" length1="1.5" end2="none" style="line-style:normal;line-weight:normal;filling:none;color:black" antialias="false" x2="20"/>
+        <line length2="1.5" y2="40" end1="none" x1="10" y1="40" length1="1.5" end2="none" style="line-style:normal;line-weight:normal;filling:none;color:black" antialias="false" x2="20"/>
+        <line length2="1.5" y2="20" end1="none" x1="10" y1="20" length1="1.5" end2="none" style="line-style:normal;line-weight:normal;filling:none;color:black" antialias="false" x2="20"/>
+        <line length2="1.5" y2="0" end1="none" x1="10" y1="0" length1="1.5" end2="none" style="line-style:normal;line-weight:normal;filling:none;color:black" antialias="false" x2="20"/>
+        <terminal x="-20" y="60" orientation="w"/>
+        <terminal x="-20" y="40" orientation="w"/>
+        <terminal x="-20" y="20" orientation="w"/>
+        <terminal x="20" y="20" orientation="e"/>
+        <terminal x="20" y="0" orientation="e"/>
+        <terminal x="20" y="40" orientation="e"/>
+        <terminal x="-20" y="80" orientation="w"/>
+        <terminal x="-20" y="0" orientation="w"/>
+        <terminal x="20" y="60" orientation="e"/>
+        <terminal x="20" y="80" orientation="e"/>
+    </description>
+</definition>

--- a/elements/10_electric/20_manufacturers_articles/pinball/williams_em/jacks/pinball_em_williams_jack_06.elmt
+++ b/elements/10_electric/20_manufacturers_articles/pinball/williams_em/jacks/pinball_em_williams_jack_06.elmt
@@ -1,0 +1,36 @@
+<definition height="130" version="0.70" orientation="dyyy" width="50" hotspot_x="24" link_type="simple" type="element" hotspot_y="15">
+    <uuid uuid="{8cdb64a3-1edc-4ac6-9e86-67c987e62457}"/>
+    <names>
+        <name lang="en">Jack with 6 positions</name>
+        <name lang="nl">Contact met 6 posities</name>
+    </names>
+    <elementInformations/>
+    <informations></informations>
+    <description>
+        <line end1="none" length1="1.5" x2="-10" style="line-style:normal;line-weight:normal;filling:none;color:black" y2="80" y1="80" antialias="false" x1="-20" end2="none" length2="1.5"/>
+        <line end1="none" length1="1.5" x2="-10" style="line-style:normal;line-weight:normal;filling:none;color:black" y2="60" y1="60" antialias="false" x1="-20" end2="none" length2="1.5"/>
+        <line end1="none" length1="1.5" x2="-10" style="line-style:normal;line-weight:normal;filling:none;color:black" y2="40" y1="40" antialias="false" x1="-20" end2="none" length2="1.5"/>
+        <line end1="none" length1="1.5" x2="-10" style="line-style:normal;line-weight:normal;filling:none;color:black" y2="20" y1="20" antialias="false" x1="-20" end2="none" length2="1.5"/>
+        <line end1="none" length1="1.5" x2="-10" style="line-style:normal;line-weight:normal;filling:none;color:black" y2="100" y1="100" antialias="false" x1="-20" end2="none" length2="1.5"/>
+        <rect y="-10" height="120" width="20" rx="0" style="line-style:normal;line-weight:normal;filling:none;color:black" antialias="false" x="-10" ry="0"/>
+        <line end1="none" length1="1.5" x2="-10" style="line-style:normal;line-weight:normal;filling:none;color:black" y2="0" y1="0" antialias="false" x1="-20" end2="none" length2="1.5"/>
+        <line end1="none" length1="1.5" x2="20" style="line-style:normal;line-weight:normal;filling:none;color:black" y2="60" y1="60" antialias="false" x1="10" end2="none" length2="1.5"/>
+        <line end1="none" length1="1.5" x2="20" style="line-style:normal;line-weight:normal;filling:none;color:black" y2="40" y1="40" antialias="false" x1="10" end2="none" length2="1.5"/>
+        <line end1="none" length1="1.5" x2="20" style="line-style:normal;line-weight:normal;filling:none;color:black" y2="20" y1="20" antialias="false" x1="10" end2="none" length2="1.5"/>
+        <line end1="none" length1="1.5" x2="20" style="line-style:normal;line-weight:normal;filling:none;color:black" y2="100" y1="100" antialias="false" x1="10" end2="none" length2="1.5"/>
+        <line end1="none" length1="1.5" x2="20" style="line-style:normal;line-weight:normal;filling:none;color:black" y2="80" y1="80" antialias="false" x1="10" end2="none" length2="1.5"/>
+        <line end1="none" length1="1.5" x2="20" style="line-style:normal;line-weight:normal;filling:none;color:black" y2="0" y1="0" antialias="false" x1="10" end2="none" length2="1.5"/>
+        <terminal y="0" orientation="e" x="20"/>
+        <terminal y="0" orientation="w" x="-20"/>
+        <terminal y="20" orientation="w" x="-20"/>
+        <terminal y="20" orientation="e" x="20"/>
+        <terminal y="40" orientation="w" x="-20"/>
+        <terminal y="40" orientation="e" x="20"/>
+        <terminal y="60" orientation="e" x="20"/>
+        <terminal y="60" orientation="w" x="-20"/>
+        <terminal y="100" orientation="w" x="-20"/>
+        <terminal y="100" orientation="e" x="20"/>
+        <terminal y="80" orientation="e" x="20"/>
+        <terminal y="80" orientation="w" x="-20"/>
+    </description>
+</definition>

--- a/elements/10_electric/20_manufacturers_articles/pinball/williams_em/jacks/pinball_em_williams_jack_07.elmt
+++ b/elements/10_electric/20_manufacturers_articles/pinball/williams_em/jacks/pinball_em_williams_jack_07.elmt
@@ -1,0 +1,40 @@
+<definition height="150" version="0.70" orientation="dyyy" width="50" hotspot_x="24" link_type="simple" type="element" hotspot_y="15">
+    <uuid uuid="{b95190d3-569c-4d29-9c08-eb63190954ef}"/>
+    <names>
+        <name lang="en">Jack with 7 positions</name>
+        <name lang="nl">Contact met 7 posities</name>
+    </names>
+    <elementInformations/>
+    <informations></informations>
+    <description>
+        <line end1="none" length1="1.5" x2="-10" style="line-style:normal;line-weight:normal;filling:none;color:black" y2="100" y1="100" antialias="false" x1="-20" end2="none" length2="1.5"/>
+        <rect y="-10" height="140" width="20" rx="0" style="line-style:normal;line-weight:normal;filling:none;color:black" antialias="false" x="-10" ry="0"/>
+        <line end1="none" length1="1.5" x2="-10" style="line-style:normal;line-weight:normal;filling:none;color:black" y2="0" y1="0" antialias="false" x1="-20" end2="none" length2="1.5"/>
+        <line end1="none" length1="1.5" x2="-10" style="line-style:normal;line-weight:normal;filling:none;color:black" y2="20" y1="20" antialias="false" x1="-20" end2="none" length2="1.5"/>
+        <line end1="none" length1="1.5" x2="-10" style="line-style:normal;line-weight:normal;filling:none;color:black" y2="60" y1="60" antialias="false" x1="-20" end2="none" length2="1.5"/>
+        <line end1="none" length1="1.5" x2="-10" style="line-style:normal;line-weight:normal;filling:none;color:black" y2="80" y1="80" antialias="false" x1="-20" end2="none" length2="1.5"/>
+        <line end1="none" length1="1.5" x2="-10" style="line-style:normal;line-weight:normal;filling:none;color:black" y2="40" y1="40" antialias="false" x1="-20" end2="none" length2="1.5"/>
+        <line end1="none" length1="1.5" x2="-10" style="line-style:normal;line-weight:normal;filling:none;color:black" y2="120" y1="120" antialias="false" x1="-20" end2="none" length2="1.5"/>
+        <line end1="none" length1="1.5" x2="20" style="line-style:normal;line-weight:normal;filling:none;color:black" y2="60" y1="60" antialias="false" x1="10" end2="none" length2="1.5"/>
+        <line end1="none" length1="1.5" x2="20" style="line-style:normal;line-weight:normal;filling:none;color:black" y2="0" y1="0" antialias="false" x1="10" end2="none" length2="1.5"/>
+        <line end1="none" length1="1.5" x2="20" style="line-style:normal;line-weight:normal;filling:none;color:black" y2="80" y1="80" antialias="false" x1="10" end2="none" length2="1.5"/>
+        <line end1="none" length1="1.5" x2="20" style="line-style:normal;line-weight:normal;filling:none;color:black" y2="40" y1="40" antialias="false" x1="10" end2="none" length2="1.5"/>
+        <line end1="none" length1="1.5" x2="20" style="line-style:normal;line-weight:normal;filling:none;color:black" y2="20" y1="20" antialias="false" x1="10" end2="none" length2="1.5"/>
+        <line end1="none" length1="1.5" x2="20" style="line-style:normal;line-weight:normal;filling:none;color:black" y2="100" y1="100" antialias="false" x1="10" end2="none" length2="1.5"/>
+        <line end1="none" length1="1.5" x2="20" style="line-style:normal;line-weight:normal;filling:none;color:black" y2="120" y1="120" antialias="false" x1="10" end2="none" length2="1.5"/>
+        <terminal y="100" orientation="w" x="-20"/>
+        <terminal y="100" orientation="e" x="20"/>
+        <terminal y="120" orientation="e" x="20"/>
+        <terminal y="120" orientation="w" x="-20"/>
+        <terminal y="20" orientation="e" x="20"/>
+        <terminal y="20" orientation="w" x="-20"/>
+        <terminal y="0" orientation="e" x="20"/>
+        <terminal y="0" orientation="w" x="-20"/>
+        <terminal y="40" orientation="e" x="20"/>
+        <terminal y="40" orientation="w" x="-20"/>
+        <terminal y="60" orientation="e" x="20"/>
+        <terminal y="60" orientation="w" x="-20"/>
+        <terminal y="80" orientation="e" x="20"/>
+        <terminal y="80" orientation="w" x="-20"/>
+    </description>
+</definition>

--- a/elements/10_electric/20_manufacturers_articles/pinball/williams_em/jacks/pinball_em_williams_jack_08.elmt
+++ b/elements/10_electric/20_manufacturers_articles/pinball/williams_em/jacks/pinball_em_williams_jack_08.elmt
@@ -1,0 +1,44 @@
+<definition height="170" version="0.70" orientation="dyyy" width="50" hotspot_x="24" link_type="simple" type="element" hotspot_y="15">
+    <uuid uuid="{aa0c2db1-cd6d-470e-a45f-1503fd898c7d}"/>
+    <names>
+        <name lang="en">Jack with 8 positions</name>
+        <name lang="nl">Contact met 8 posities</name>
+    </names>
+    <elementInformations/>
+    <informations></informations>
+    <description>
+        <rect y="-10" height="160" width="20" rx="0" style="line-style:normal;line-weight:normal;filling:none;color:black" antialias="false" x="-10" ry="0"/>
+        <line end1="none" length1="1.5" x2="-10" style="line-style:normal;line-weight:normal;filling:none;color:black" y2="80" y1="80" antialias="false" x1="-20" end2="none" length2="1.5"/>
+        <line end1="none" length1="1.5" x2="-10" style="line-style:normal;line-weight:normal;filling:none;color:black" y2="60" y1="60" antialias="false" x1="-20" end2="none" length2="1.5"/>
+        <line end1="none" length1="1.5" x2="-10" style="line-style:normal;line-weight:normal;filling:none;color:black" y2="20" y1="20" antialias="false" x1="-20" end2="none" length2="1.5"/>
+        <line end1="none" length1="1.5" x2="-10" style="line-style:normal;line-weight:normal;filling:none;color:black" y2="40" y1="40" antialias="false" x1="-20" end2="none" length2="1.5"/>
+        <line end1="none" length1="1.5" x2="-10" style="line-style:normal;line-weight:normal;filling:none;color:black" y2="0" y1="0" antialias="false" x1="-20" end2="none" length2="1.5"/>
+        <line end1="none" length1="1.5" x2="-10" style="line-style:normal;line-weight:normal;filling:none;color:black" y2="100" y1="100" antialias="false" x1="-20" end2="none" length2="1.5"/>
+        <line end1="none" length1="1.5" x2="-10" style="line-style:normal;line-weight:normal;filling:none;color:black" y2="120" y1="120" antialias="false" x1="-20" end2="none" length2="1.5"/>
+        <line end1="none" length1="1.5" x2="-10" style="line-style:normal;line-weight:normal;filling:none;color:black" y2="140" y1="140" antialias="false" x1="-20" end2="none" length2="1.5"/>
+        <line end1="none" length1="1.5" x2="20" style="line-style:normal;line-weight:normal;filling:none;color:black" y2="0" y1="0" antialias="false" x1="10" end2="none" length2="1.5"/>
+        <line end1="none" length1="1.5" x2="20" style="line-style:normal;line-weight:normal;filling:none;color:black" y2="140" y1="140" antialias="false" x1="10" end2="none" length2="1.5"/>
+        <line end1="none" length1="1.5" x2="20" style="line-style:normal;line-weight:normal;filling:none;color:black" y2="120" y1="120" antialias="false" x1="10" end2="none" length2="1.5"/>
+        <line end1="none" length1="1.5" x2="20" style="line-style:normal;line-weight:normal;filling:none;color:black" y2="20" y1="20" antialias="false" x1="10" end2="none" length2="1.5"/>
+        <line end1="none" length1="1.5" x2="20" style="line-style:normal;line-weight:normal;filling:none;color:black" y2="40" y1="40" antialias="false" x1="10" end2="none" length2="1.5"/>
+        <line end1="none" length1="1.5" x2="20" style="line-style:normal;line-weight:normal;filling:none;color:black" y2="80" y1="80" antialias="false" x1="10" end2="none" length2="1.5"/>
+        <line end1="none" length1="1.5" x2="20" style="line-style:normal;line-weight:normal;filling:none;color:black" y2="60" y1="60" antialias="false" x1="10" end2="none" length2="1.5"/>
+        <line end1="none" length1="1.5" x2="20" style="line-style:normal;line-weight:normal;filling:none;color:black" y2="100" y1="100" antialias="false" x1="10" end2="none" length2="1.5"/>
+        <terminal y="20" orientation="w" x="-20"/>
+        <terminal y="0" orientation="w" x="-20"/>
+        <terminal y="20" orientation="e" x="20"/>
+        <terminal y="0" orientation="e" x="20"/>
+        <terminal y="120" orientation="e" x="20"/>
+        <terminal y="60" orientation="e" x="20"/>
+        <terminal y="40" orientation="e" x="20"/>
+        <terminal y="80" orientation="e" x="20"/>
+        <terminal y="80" orientation="w" x="-20"/>
+        <terminal y="40" orientation="w" x="-20"/>
+        <terminal y="60" orientation="w" x="-20"/>
+        <terminal y="100" orientation="e" x="20"/>
+        <terminal y="100" orientation="w" x="-20"/>
+        <terminal y="140" orientation="e" x="20"/>
+        <terminal y="120" orientation="w" x="-20"/>
+        <terminal y="140" orientation="w" x="-20"/>
+    </description>
+</definition>

--- a/elements/10_electric/20_manufacturers_articles/pinball/williams_em/jacks/pinball_em_williams_jack_09.elmt
+++ b/elements/10_electric/20_manufacturers_articles/pinball/williams_em/jacks/pinball_em_williams_jack_09.elmt
@@ -1,0 +1,48 @@
+<definition height="190" version="0.70" orientation="dyyy" width="50" hotspot_x="24" link_type="simple" type="element" hotspot_y="15">
+    <uuid uuid="{d13c9554-6300-4f3a-bc7b-cadecf88a2a5}"/>
+    <names>
+        <name lang="en">Jack with 9 positions</name>
+        <name lang="nl">Contact met 9 posities</name>
+    </names>
+    <elementInformations/>
+    <informations></informations>
+    <description>
+        <line end1="none" length1="1.5" x2="-10" style="line-style:normal;line-weight:normal;filling:none;color:black" y2="100" y1="100" antialias="false" x1="-20" end2="none" length2="1.5"/>
+        <rect y="-10" height="180" width="20" rx="0" style="line-style:normal;line-weight:normal;filling:none;color:black" antialias="false" x="-10" ry="0"/>
+        <line end1="none" length1="1.5" x2="-10" style="line-style:normal;line-weight:normal;filling:none;color:black" y2="120" y1="120" antialias="false" x1="-20" end2="none" length2="1.5"/>
+        <line end1="none" length1="1.5" x2="-10" style="line-style:normal;line-weight:normal;filling:none;color:black" y2="60" y1="60" antialias="false" x1="-20" end2="none" length2="1.5"/>
+        <line end1="none" length1="1.5" x2="-10" style="line-style:normal;line-weight:normal;filling:none;color:black" y2="80" y1="80" antialias="false" x1="-20" end2="none" length2="1.5"/>
+        <line end1="none" length1="1.5" x2="-10" style="line-style:normal;line-weight:normal;filling:none;color:black" y2="0" y1="0" antialias="false" x1="-20" end2="none" length2="1.5"/>
+        <line end1="none" length1="1.5" x2="-10" style="line-style:normal;line-weight:normal;filling:none;color:black" y2="20" y1="20" antialias="false" x1="-20" end2="none" length2="1.5"/>
+        <line end1="none" length1="1.5" x2="-10" style="line-style:normal;line-weight:normal;filling:none;color:black" y2="160" y1="160" antialias="false" x1="-20" end2="none" length2="1.5"/>
+        <line end1="none" length1="1.5" x2="-10" style="line-style:normal;line-weight:normal;filling:none;color:black" y2="140" y1="140" antialias="false" x1="-20" end2="none" length2="1.5"/>
+        <line end1="none" length1="1.5" x2="-10" style="line-style:normal;line-weight:normal;filling:none;color:black" y2="40" y1="40" antialias="false" x1="-20" end2="none" length2="1.5"/>
+        <line end1="none" length1="1.5" x2="20" style="line-style:normal;line-weight:normal;filling:none;color:black" y2="140" y1="140" antialias="false" x1="10" end2="none" length2="1.5"/>
+        <line end1="none" length1="1.5" x2="20" style="line-style:normal;line-weight:normal;filling:none;color:black" y2="160" y1="160" antialias="false" x1="10" end2="none" length2="1.5"/>
+        <line end1="none" length1="1.5" x2="20" style="line-style:normal;line-weight:normal;filling:none;color:black" y2="20" y1="20" antialias="false" x1="10" end2="none" length2="1.5"/>
+        <line end1="none" length1="1.5" x2="20" style="line-style:normal;line-weight:normal;filling:none;color:black" y2="40" y1="40" antialias="false" x1="10" end2="none" length2="1.5"/>
+        <line end1="none" length1="1.5" x2="20" style="line-style:normal;line-weight:normal;filling:none;color:black" y2="100" y1="100" antialias="false" x1="10" end2="none" length2="1.5"/>
+        <line end1="none" length1="1.5" x2="20" style="line-style:normal;line-weight:normal;filling:none;color:black" y2="0" y1="0" antialias="false" x1="10" end2="none" length2="1.5"/>
+        <line end1="none" length1="1.5" x2="20" style="line-style:normal;line-weight:normal;filling:none;color:black" y2="120" y1="120" antialias="false" x1="10" end2="none" length2="1.5"/>
+        <line end1="none" length1="1.5" x2="20" style="line-style:normal;line-weight:normal;filling:none;color:black" y2="80" y1="80" antialias="false" x1="10" end2="none" length2="1.5"/>
+        <line end1="none" length1="1.5" x2="20" style="line-style:normal;line-weight:normal;filling:none;color:black" y2="60" y1="60" antialias="false" x1="10" end2="none" length2="1.5"/>
+        <terminal y="0" orientation="e" x="20"/>
+        <terminal y="0" orientation="w" x="-20"/>
+        <terminal y="100" orientation="e" x="20"/>
+        <terminal y="120" orientation="w" x="-20"/>
+        <terminal y="140" orientation="e" x="20"/>
+        <terminal y="60" orientation="w" x="-20"/>
+        <terminal y="80" orientation="e" x="20"/>
+        <terminal y="100" orientation="w" x="-20"/>
+        <terminal y="80" orientation="w" x="-20"/>
+        <terminal y="120" orientation="e" x="20"/>
+        <terminal y="60" orientation="e" x="20"/>
+        <terminal y="160" orientation="w" x="-20"/>
+        <terminal y="160" orientation="e" x="20"/>
+        <terminal y="140" orientation="w" x="-20"/>
+        <terminal y="40" orientation="e" x="20"/>
+        <terminal y="20" orientation="e" x="20"/>
+        <terminal y="40" orientation="w" x="-20"/>
+        <terminal y="20" orientation="w" x="-20"/>
+    </description>
+</definition>

--- a/elements/10_electric/20_manufacturers_articles/pinball/williams_em/jacks/pinball_em_williams_jack_10.elmt
+++ b/elements/10_electric/20_manufacturers_articles/pinball/williams_em/jacks/pinball_em_williams_jack_10.elmt
@@ -1,0 +1,52 @@
+<definition height="210" version="0.70" orientation="dyyy" width="50" hotspot_x="24" link_type="simple" type="element" hotspot_y="15">
+    <uuid uuid="{d8443641-f543-4e44-b838-615c066287b3}"/>
+    <names>
+        <name lang="en">Jack with 10 positions</name>
+        <name lang="nl">Contact met 10 posities</name>
+    </names>
+    <elementInformations/>
+    <informations></informations>
+    <description>
+        <rect y="-10" height="200" width="20" rx="0" style="line-style:normal;line-weight:normal;filling:none;color:black" antialias="false" x="-10" ry="0"/>
+        <line end1="none" length1="1.5" x2="-10" style="line-style:normal;line-weight:normal;filling:none;color:black" y2="120" y1="120" antialias="false" x1="-20" end2="none" length2="1.5"/>
+        <line end1="none" length1="1.5" x2="-10" style="line-style:normal;line-weight:normal;filling:none;color:black" y2="20" y1="20" antialias="false" x1="-20" end2="none" length2="1.5"/>
+        <line end1="none" length1="1.5" x2="-10" style="line-style:normal;line-weight:normal;filling:none;color:black" y2="0" y1="0" antialias="false" x1="-20" end2="none" length2="1.5"/>
+        <line end1="none" length1="1.5" x2="-10" style="line-style:normal;line-weight:normal;filling:none;color:black" y2="40" y1="40" antialias="false" x1="-20" end2="none" length2="1.5"/>
+        <line end1="none" length1="1.5" x2="-10" style="line-style:normal;line-weight:normal;filling:none;color:black" y2="60" y1="60" antialias="false" x1="-20" end2="none" length2="1.5"/>
+        <line end1="none" length1="1.5" x2="-10" style="line-style:normal;line-weight:normal;filling:none;color:black" y2="100" y1="100" antialias="false" x1="-20" end2="none" length2="1.5"/>
+        <line end1="none" length1="1.5" x2="-10" style="line-style:normal;line-weight:normal;filling:none;color:black" y2="140" y1="140" antialias="false" x1="-20" end2="none" length2="1.5"/>
+        <line end1="none" length1="1.5" x2="-10" style="line-style:normal;line-weight:normal;filling:none;color:black" y2="180" y1="180" antialias="false" x1="-20" end2="none" length2="1.5"/>
+        <line end1="none" length1="1.5" x2="-10" style="line-style:normal;line-weight:normal;filling:none;color:black" y2="160" y1="160" antialias="false" x1="-20" end2="none" length2="1.5"/>
+        <line end1="none" length1="1.5" x2="-10" style="line-style:normal;line-weight:normal;filling:none;color:black" y2="80" y1="80" antialias="false" x1="-20" end2="none" length2="1.5"/>
+        <line end1="none" length1="1.5" x2="20" style="line-style:normal;line-weight:normal;filling:none;color:black" y2="60" y1="60" antialias="false" x1="10" end2="none" length2="1.5"/>
+        <line end1="none" length1="1.5" x2="20" style="line-style:normal;line-weight:normal;filling:none;color:black" y2="180" y1="180" antialias="false" x1="10" end2="none" length2="1.5"/>
+        <line end1="none" length1="1.5" x2="20" style="line-style:normal;line-weight:normal;filling:none;color:black" y2="160" y1="160" antialias="false" x1="10" end2="none" length2="1.5"/>
+        <line end1="none" length1="1.5" x2="20" style="line-style:normal;line-weight:normal;filling:none;color:black" y2="140" y1="140" antialias="false" x1="10" end2="none" length2="1.5"/>
+        <line end1="none" length1="1.5" x2="20" style="line-style:normal;line-weight:normal;filling:none;color:black" y2="40" y1="40" antialias="false" x1="10" end2="none" length2="1.5"/>
+        <line end1="none" length1="1.5" x2="20" style="line-style:normal;line-weight:normal;filling:none;color:black" y2="100" y1="100" antialias="false" x1="10" end2="none" length2="1.5"/>
+        <line end1="none" length1="1.5" x2="20" style="line-style:normal;line-weight:normal;filling:none;color:black" y2="80" y1="80" antialias="false" x1="10" end2="none" length2="1.5"/>
+        <line end1="none" length1="1.5" x2="20" style="line-style:normal;line-weight:normal;filling:none;color:black" y2="120" y1="120" antialias="false" x1="10" end2="none" length2="1.5"/>
+        <line end1="none" length1="1.5" x2="20" style="line-style:normal;line-weight:normal;filling:none;color:black" y2="0" y1="0" antialias="false" x1="10" end2="none" length2="1.5"/>
+        <line end1="none" length1="1.5" x2="20" style="line-style:normal;line-weight:normal;filling:none;color:black" y2="20" y1="20" antialias="false" x1="10" end2="none" length2="1.5"/>
+        <terminal y="140" orientation="w" x="-20"/>
+        <terminal y="160" orientation="e" x="20"/>
+        <terminal y="140" orientation="e" x="20"/>
+        <terminal y="160" orientation="w" x="-20"/>
+        <terminal y="180" orientation="e" x="20"/>
+        <terminal y="180" orientation="w" x="-20"/>
+        <terminal y="20" orientation="w" x="-20"/>
+        <terminal y="40" orientation="e" x="20"/>
+        <terminal y="40" orientation="w" x="-20"/>
+        <terminal y="20" orientation="e" x="20"/>
+        <terminal y="0" orientation="w" x="-20"/>
+        <terminal y="0" orientation="e" x="20"/>
+        <terminal y="60" orientation="e" x="20"/>
+        <terminal y="60" orientation="w" x="-20"/>
+        <terminal y="80" orientation="w" x="-20"/>
+        <terminal y="80" orientation="e" x="20"/>
+        <terminal y="100" orientation="e" x="20"/>
+        <terminal y="100" orientation="w" x="-20"/>
+        <terminal y="120" orientation="w" x="-20"/>
+        <terminal y="120" orientation="e" x="20"/>
+    </description>
+</definition>

--- a/elements/10_electric/20_manufacturers_articles/pinball/williams_em/jacks/pinball_em_williams_jack_plug.elmt
+++ b/elements/10_electric/20_manufacturers_articles/pinball/williams_em/jacks/pinball_em_williams_jack_plug.elmt
@@ -1,0 +1,16 @@
+<definition height="20" version="0.70" orientation="dyyy" width="30" hotspot_x="14" link_type="simple" type="element" hotspot_y="10">
+    <uuid uuid="{648b691b-a9ce-44ae-96dd-c02039645205}"/>
+    <names>
+        <name lang="en">Plug</name>
+        <name lang="nl">Contactpin</name>
+    </names>
+    <elementInformations/>
+    <informations></informations>
+    <description>
+        <rect y="-5" height="10" width="4" rx="0" style="line-style:normal;line-weight:normal;filling:none;color:black" antialias="false" x="-2" ry="0"/>
+        <line end1="none" length1="1.5" x2="-2" style="line-style:normal;line-weight:normal;filling:none;color:black" y2="0" y1="0" antialias="false" x1="-10" end2="none" length2="1.5"/>
+        <line end1="none" length1="1.5" x2="10" style="line-style:normal;line-weight:normal;filling:none;color:black" y2="0" y1="0" antialias="false" x1="2" end2="none" length2="1.5"/>
+        <terminal y="0" orientation="e" x="10"/>
+        <terminal y="0" orientation="w" x="-10"/>
+    </description>
+</definition>

--- a/elements/10_electric/20_manufacturers_articles/pinball/williams_em/jacks/qet_directory
+++ b/elements/10_electric/20_manufacturers_articles/pinball/williams_em/jacks/qet_directory
@@ -1,0 +1,6 @@
+<qet-directory>
+    <names>
+        <name lang="en">Jacks</name>
+        <name lang="nl">Contacten</name>
+    </names>
+</qet-directory>

--- a/elements/10_electric/20_manufacturers_articles/pinball/williams_em/output/pinball_em_williams_coil.elmt
+++ b/elements/10_electric/20_manufacturers_articles/pinball/williams_em/output/pinball_em_williams_coil.elmt
@@ -1,0 +1,19 @@
+<definition height="20" version="0.70" orientation="dyyy" width="50" hotspot_x="24" link_type="simple" type="element" hotspot_y="10">
+    <uuid uuid="{2275166e-668f-4912-b838-1def0f65418e}"/>
+    <names>
+        <name lang="en">Coil</name>
+        <name lang="nl">Spoel</name>
+    </names>
+    <elementInformations/>
+    <informations></informations>
+    <description>
+        <arc y="-4" height="8" width="8" style="line-style:normal;line-weight:normal;filling:none;color:black" angle="180" antialias="true" start="0" x="-8"/>
+        <arc y="-4" height="8" width="8" style="line-style:normal;line-weight:normal;filling:none;color:black" angle="180" antialias="true" start="0" x="-16"/>
+        <arc y="-4" height="8" width="8" style="line-style:normal;line-weight:normal;filling:none;color:black" angle="180" antialias="true" start="0" x="0"/>
+        <arc y="-4" height="8" width="8" style="line-style:normal;line-weight:normal;filling:none;color:black" angle="180" antialias="true" start="0" x="8"/>
+        <line end1="none" length1="1.5" x2="-20" style="line-style:normal;line-weight:normal;filling:none;color:black" y2="0" y1="0" antialias="false" x1="-16" end2="none" length2="1.5"/>
+        <line end1="none" length1="1.5" x2="16" style="line-style:normal;line-weight:normal;filling:none;color:black" y2="0" y1="0" antialias="false" x1="20" end2="none" length2="1.5"/>
+        <terminal y="0" orientation="w" x="-20"/>
+        <terminal y="0" orientation="e" x="20"/>
+    </description>
+</definition>

--- a/elements/10_electric/20_manufacturers_articles/pinball/williams_em/output/pinball_em_williams_flipper_coil.elmt
+++ b/elements/10_electric/20_manufacturers_articles/pinball/williams_em/output/pinball_em_williams_flipper_coil.elmt
@@ -1,0 +1,22 @@
+<definition height="30" version="0.70" orientation="dyyy" width="50" hotspot_x="24" link_type="simple" type="element" hotspot_y="11">
+    <uuid uuid="{6d4161fc-3f61-48cc-8322-9d384c2f7550}"/>
+    <names>
+        <name lang="en">Flipper coil</name>
+        <name lang="nl">Flipperspoel</name>
+    </names>
+    <elementInformations/>
+    <informations></informations>
+    <description>
+        <arc y="-4" height="8" width="8" style="line-style:normal;line-weight:normal;filling:none;color:black" angle="180" antialias="true" start="0" x="0"/>
+        <arc y="-4" height="8" width="8" style="line-style:normal;line-weight:normal;filling:none;color:black" angle="180" antialias="true" start="0" x="8"/>
+        <arc y="-4" height="8" width="8" style="line-style:normal;line-weight:normal;filling:none;color:black" angle="180" antialias="true" start="0" x="-16"/>
+        <arc y="-4" height="8" width="8" style="line-style:normal;line-weight:normal;filling:none;color:black" angle="180" antialias="true" start="0" x="-8"/>
+        <line end1="none" length1="1.5" x2="-16" style="line-style:normal;line-weight:normal;filling:none;color:black" y2="0" y1="0" antialias="false" x1="-20" end2="none" length2="1.5"/>
+        <line end1="none" length1="1.5" x2="20" style="line-style:normal;line-weight:normal;filling:none;color:black" y2="0" y1="0" antialias="false" x1="16" end2="none" length2="1.5"/>
+        <line end1="none" length1="1.5" x2="0" style="line-style:normal;line-weight:normal;filling:none;color:black" y2="10" y1="0" antialias="false" x1="0" end2="none" length2="1.5"/>
+        <circle y="0" style="line-style:normal;line-weight:normal;filling:black;color:black" diameter="4" antialias="false" x="-2"/>
+        <terminal y="0" orientation="w" x="-20"/>
+        <terminal y="0" orientation="e" x="20"/>
+        <terminal y="10" orientation="s" x="0"/>
+    </description>
+</definition>

--- a/elements/10_electric/20_manufacturers_articles/pinball/williams_em/output/pinball_em_williams_lite.elmt
+++ b/elements/10_electric/20_manufacturers_articles/pinball/williams_em/output/pinball_em_williams_lite.elmt
@@ -1,0 +1,16 @@
+<definition height="30" version="0.70" orientation="dyyy" width="50" hotspot_x="24" link_type="simple" type="element" hotspot_y="15">
+    <uuid uuid="{06cf3371-5a2c-4887-aa73-667fa6dc718b}"/>
+    <names>
+        <name lang="en">Lite</name>
+        <name lang="nl">Lamp</name>
+    </names>
+    <elementInformations/>
+    <informations></informations>
+    <description>
+        <circle y="-10" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="20" antialias="false" x="-10"/>
+        <line end1="none" length1="1.5" x2="20" style="line-style:normal;line-weight:normal;filling:none;color:black" y2="0" y1="0" antialias="false" x1="10" end2="none" length2="1.5"/>
+        <line end1="none" length1="1.5" x2="-20" style="line-style:normal;line-weight:normal;filling:none;color:black" y2="0" y1="0" antialias="false" x1="-10" end2="none" length2="1.5"/>
+        <terminal y="0" orientation="e" x="20"/>
+        <terminal y="0" orientation="w" x="-20"/>
+    </description>
+</definition>

--- a/elements/10_electric/20_manufacturers_articles/pinball/williams_em/output/pinball_em_williams_motor.elmt
+++ b/elements/10_electric/20_manufacturers_articles/pinball/williams_em/output/pinball_em_williams_motor.elmt
@@ -1,0 +1,18 @@
+<definition height="30" version="0.70" orientation="dyyy" width="50" hotspot_x="24" link_type="simple" type="element" hotspot_y="15">
+    <uuid uuid="{1a497d79-1196-4b65-9d65-a8660693c5b8}"/>
+    <names>
+        <name lang="en">Motor</name>
+        <name lang="nl">Motor</name>
+    </names>
+    <elementInformations/>
+    <informations></informations>
+    <description>
+        <circle y="-10" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="20" antialias="false" x="-10"/>
+        <line end1="none" length1="1.5" x2="-16" style="line-style:normal;line-weight:normal;filling:none;color:black" y2="0" y1="0" antialias="false" x1="-20" end2="none" length2="1.5"/>
+        <line end1="none" length1="1.5" x2="16" style="line-style:normal;line-weight:normal;filling:none;color:black" y2="0" y1="0" antialias="false" x1="20" end2="none" length2="1.5"/>
+        <line end1="none" length1="1.5" x2="-10" style="line-style:normal;line-weight:normal;filling:none;color:black" y2="-10" y1="0" antialias="false" x1="-16" end2="none" length2="1.5"/>
+        <line end1="none" length1="1.5" x2="10" style="line-style:normal;line-weight:normal;filling:none;color:black" y2="10" y1="0" antialias="false" x1="16" end2="none" length2="1.5"/>
+        <terminal y="0" orientation="e" x="20"/>
+        <terminal y="0" orientation="w" x="-20"/>
+    </description>
+</definition>

--- a/elements/10_electric/20_manufacturers_articles/pinball/williams_em/output/qet_directory
+++ b/elements/10_electric/20_manufacturers_articles/pinball/williams_em/output/qet_directory
@@ -1,0 +1,6 @@
+<qet-directory>
+    <names>
+        <name lang="en">Output</name>
+        <name lang="nl">Uitvoer</name>
+    </names>
+</qet-directory>

--- a/elements/10_electric/20_manufacturers_articles/pinball/williams_em/power/pinball_em_williams_fuse.elmt
+++ b/elements/10_electric/20_manufacturers_articles/pinball/williams_em/power/pinball_em_williams_fuse.elmt
@@ -1,0 +1,21 @@
+<definition height="20" version="0.70" orientation="dyyy" width="50" hotspot_x="24" link_type="simple" type="element" hotspot_y="10">
+    <uuid uuid="{6cfb757b-80eb-472e-a72b-4d1e398ff0be}"/>
+    <names>
+        <name lang="en">Fuse</name>
+        <name lang="nl">Zekering</name>
+    </names>
+    <elementInformations/>
+    <informations></informations>
+    <description>
+        <arc y="-5" height="10" width="10" style="line-style:normal;line-weight:normal;filling:none;color:black" angle="180" antialias="true" start="0" x="0"/>
+        <arc y="-5" height="10" width="10" style="line-style:normal;line-weight:normal;filling:none;color:black" angle="180" antialias="true" start="180" x="-10"/>
+        <line end1="none" length1="1.5" x2="-12" style="line-style:normal;line-weight:normal;filling:none;color:black" y2="0" y1="0" antialias="false" x1="-10" end2="none" length2="1.5"/>
+        <line end1="none" length1="1.5" x2="12" style="line-style:normal;line-weight:normal;filling:none;color:black" y2="0" y1="0" antialias="false" x1="10" end2="none" length2="1.5"/>
+        <circle y="-2" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="4" antialias="false" x="-16"/>
+        <circle y="-2" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="4" antialias="false" x="12"/>
+        <line end1="none" length1="1.5" x2="-20" style="line-style:normal;line-weight:normal;filling:none;color:black" y2="0" y1="0" antialias="false" x1="-16" end2="none" length2="1.5"/>
+        <line end1="none" length1="1.5" x2="20" style="line-style:normal;line-weight:normal;filling:none;color:black" y2="0" y1="0" antialias="false" x1="16" end2="none" length2="1.5"/>
+        <terminal y="0" orientation="e" x="20"/>
+        <terminal y="0" orientation="w" x="-20"/>
+    </description>
+</definition>

--- a/elements/10_electric/20_manufacturers_articles/pinball/williams_em/power/pinball_em_williams_power_cord.elmt
+++ b/elements/10_electric/20_manufacturers_articles/pinball/williams_em/power/pinball_em_williams_power_cord.elmt
@@ -1,0 +1,21 @@
+<definition height="40" version="0.70" orientation="dyyy" width="50" hotspot_x="24" link_type="simple" type="element" hotspot_y="34">
+    <uuid uuid="{d67bb38e-704e-4df0-bcd5-6b5fc4f8b27f}"/>
+    <names>
+        <name lang="en">Power cord</name>
+        <name lang="nl">Stekker</name>
+    </names>
+    <elementInformations/>
+    <informations></informations>
+    <description>
+        <line end1="none" length1="1.5" x2="10" style="line-style:normal;line-weight:normal;filling:none;color:black" y2="-20" y1="-20" antialias="false" x1="-10" end2="none" length2="1.5"/>
+        <line end1="none" length1="1.5" x2="-20" style="line-style:normal;line-weight:normal;filling:none;color:black" y2="0" y1="0" antialias="false" x1="-5" end2="none" length2="1.5"/>
+        <line end1="none" length1="1.5" x2="5" style="line-style:normal;line-weight:normal;filling:none;color:black" y2="0" y1="0" antialias="false" x1="20" end2="none" length2="1.5"/>
+        <arc y="-30" height="20" width="20" style="line-style:normal;line-weight:normal;filling:none;color:black" angle="180" antialias="true" start="180" x="-10"/>
+        <line end1="none" length1="1.5" x2="-5" style="line-style:normal;line-weight:normal;filling:none;color:black" y2="-11" y1="0" antialias="false" x1="-5" end2="none" length2="1.5"/>
+        <line end1="none" length1="1.5" x2="5" style="line-style:normal;line-weight:normal;filling:none;color:black" y2="-11" y1="0" antialias="false" x1="5" end2="none" length2="1.5"/>
+        <line end1="none" length1="1.5" x2="-5" style="line-style:normal;line-weight:normal;filling:none;color:black" y2="-20" y1="-28" antialias="false" x1="-5" end2="none" length2="1.5"/>
+        <line end1="none" length1="1.5" x2="5" style="line-style:normal;line-weight:normal;filling:none;color:black" y2="-20" y1="-28" antialias="false" x1="5" end2="none" length2="1.5"/>
+        <terminal y="0" orientation="e" x="20"/>
+        <terminal y="0" orientation="w" x="-20"/>
+    </description>
+</definition>

--- a/elements/10_electric/20_manufacturers_articles/pinball/williams_em/power/pinball_em_williams_power_cord_ground.elmt
+++ b/elements/10_electric/20_manufacturers_articles/pinball/williams_em/power/pinball_em_williams_power_cord_ground.elmt
@@ -1,0 +1,24 @@
+<definition height="50" version="0.70" orientation="dyyy" width="50" hotspot_x="24" link_type="simple" type="element" hotspot_y="34">
+    <uuid uuid="{772a2b18-69f2-407b-8594-917ecc52a4d3}"/>
+    <names>
+        <name lang="en">Power cord with ground pin</name>
+        <name lang="nl">Stekker met aardedraad</name>
+    </names>
+    <elementInformations/>
+    <informations></informations>
+    <description>
+        <line end1="none" length1="1.5" x2="-5" style="line-style:normal;line-weight:normal;filling:none;color:black" y2="0" y1="0" antialias="false" x1="-20" end2="none" length2="1.5"/>
+        <line end1="none" length1="1.5" x2="20" style="line-style:normal;line-weight:normal;filling:none;color:black" y2="0" y1="0" antialias="false" x1="5" end2="none" length2="1.5"/>
+        <line end1="none" length1="1.5" x2="10" style="line-style:normal;line-weight:normal;filling:none;color:black" y2="-20" y1="-20" antialias="false" x1="-10" end2="none" length2="1.5"/>
+        <arc y="-30" height="20" width="20" style="line-style:normal;line-weight:normal;filling:none;color:black" angle="180" antialias="true" start="180" x="-10"/>
+        <line end1="none" length1="1.5" x2="-5" style="line-style:normal;line-weight:normal;filling:none;color:black" y2="-11" y1="0" antialias="false" x1="-5" end2="none" length2="1.5"/>
+        <line end1="none" length1="1.5" x2="5" style="line-style:normal;line-weight:normal;filling:none;color:black" y2="-11" y1="0" antialias="false" x1="5" end2="none" length2="1.5"/>
+        <line end1="none" length1="1.5" x2="5" style="line-style:normal;line-weight:normal;filling:none;color:black" y2="-27" y1="-20" antialias="false" x1="5" end2="none" length2="1.5"/>
+        <line end1="none" length1="1.5" x2="-5" style="line-style:normal;line-weight:normal;filling:none;color:black" y2="-27" y1="-20" antialias="false" x1="-5" end2="none" length2="1.5"/>
+        <line end1="none" length1="1.5" x2="0" style="line-style:normal;line-weight:normal;filling:none;color:black" y2="-25" y1="-20" antialias="false" x1="0" end2="none" length2="1.5"/>
+        <line end1="none" length1="1.5" x2="0" style="line-style:normal;line-weight:normal;filling:none;color:black" y2="10" y1="-10" antialias="false" x1="0" end2="none" length2="1.5"/>
+        <terminal y="10" orientation="s" x="0"/>
+        <terminal y="0" orientation="w" x="-20"/>
+        <terminal y="0" orientation="e" x="20"/>
+    </description>
+</definition>

--- a/elements/10_electric/20_manufacturers_articles/pinball/williams_em/power/pinball_em_williams_service_outlet.elmt
+++ b/elements/10_electric/20_manufacturers_articles/pinball/williams_em/power/pinball_em_williams_service_outlet.elmt
@@ -1,0 +1,18 @@
+<definition height="30" version="0.70" orientation="dyyy" width="50" hotspot_x="24" link_type="simple" type="element" hotspot_y="15">
+    <uuid uuid="{f75bd99b-67cd-4d09-bea0-677ba9528257}"/>
+    <names>
+        <name lang="en">Service outlet</name>
+        <name lang="nl">Servicestopcontact</name>
+    </names>
+    <elementInformations/>
+    <informations></informations>
+    <description>
+        <circle y="-10" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="20" antialias="false" x="-10"/>
+        <line end1="none" length1="1.5" x2="-20" style="line-style:normal;line-weight:normal;filling:none;color:black" y2="0" y1="0" antialias="false" x1="-10" end2="none" length2="1.5"/>
+        <line end1="none" length1="1.5" x2="20" style="line-style:normal;line-weight:normal;filling:none;color:black" y2="0" y1="0" antialias="false" x1="10" end2="none" length2="1.5"/>
+        <line end1="none" length1="1.5" x2="-4" style="line-style:normal;line-weight:normal;filling:none;color:black" y2="5" y1="-5" antialias="false" x1="-4" end2="none" length2="1.5"/>
+        <line end1="none" length1="1.5" x2="4" style="line-style:normal;line-weight:normal;filling:none;color:black" y2="5" y1="-5" antialias="false" x1="4" end2="none" length2="1.5"/>
+        <terminal y="0" orientation="w" x="-20"/>
+        <terminal y="0" orientation="e" x="20"/>
+    </description>
+</definition>

--- a/elements/10_electric/20_manufacturers_articles/pinball/williams_em/power/qet_directory
+++ b/elements/10_electric/20_manufacturers_articles/pinball/williams_em/power/qet_directory
@@ -1,0 +1,6 @@
+<qet-directory>
+    <names>
+        <name lang="en">Power</name>
+        <name lang="nl">Stroom</name>
+    </names>
+</qet-directory>

--- a/elements/10_electric/20_manufacturers_articles/pinball/williams_em/qet_directory
+++ b/elements/10_electric/20_manufacturers_articles/pinball/williams_em/qet_directory
@@ -1,0 +1,6 @@
+<qet-directory>
+    <names>
+        <name lang="en">Williams EM Schematics</name>
+        <name lang="nl">Williams EM Schema's</name>
+    </names>
+</qet-directory>

--- a/elements/10_electric/20_manufacturers_articles/pinball/williams_em/switches_common/mirrored/pinball_em_williams_switch_mb_bottom_m.elmt
+++ b/elements/10_electric/20_manufacturers_articles/pinball/williams_em/switches_common/mirrored/pinball_em_williams_switch_mb_bottom_m.elmt
@@ -1,0 +1,21 @@
+<definition hotspot_y="30" width="50" orientation="dyyy" height="40" version="0.70" hotspot_x="24" link_type="simple" type="element">
+    <uuid uuid="{52858864-b876-400b-b65e-7482add60868}"/>
+    <names>
+        <name lang="en">Switch (M.B.) - Bottom input - Mirrored</name>
+        <name lang="nl">Schakelaar (M.B.) - Input onder - Gespiegeld</name>
+    </names>
+    <elementInformations/>
+    <informations></informations>
+    <description>
+        <rect x="2" rx="0" antialias="false" y="-25" width="3" style="line-style:normal;line-weight:normal;filling:black;color:black" height="30" ry="0"/>
+        <line length2="1.5" x1="-20" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" length1="1.5" end1="none" end2="none" x2="-5" y2="-20" y1="-20"/>
+        <rect x="-5" rx="0" antialias="false" y="-7" width="3" style="line-style:normal;line-weight:normal;filling:black;color:black" height="12" ry="0"/>
+        <rect x="-5" rx="0" antialias="false" y="-25" width="3" style="line-style:normal;line-weight:normal;filling:black;color:black" height="12" ry="0"/>
+        <line length2="1.5" x1="5" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" length1="1.5" end1="none" end2="none" x2="20" y2="0" y1="0"/>
+        <line length2="1.5" x1="-20" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" length1="1.5" end1="none" end2="none" x2="-5" y2="0" y1="0"/>
+        <line length2="1.5" x1="10" antialias="false" style="line-style:normal;line-weight:hight;filling:none;color:black" length1="1.5" end1="none" end2="none" x2="-10" y2="5" y1="-5"/>
+        <terminal x="-20" y="-20" orientation="w"/>
+        <terminal x="20" y="0" orientation="e"/>
+        <terminal x="-20" y="0" orientation="w"/>
+    </description>
+</definition>

--- a/elements/10_electric/20_manufacturers_articles/pinball/williams_em/switches_common/mirrored/pinball_em_williams_switch_mb_bottom_mi.elmt
+++ b/elements/10_electric/20_manufacturers_articles/pinball/williams_em/switches_common/mirrored/pinball_em_williams_switch_mb_bottom_mi.elmt
@@ -1,0 +1,21 @@
+<definition height="40" orientation="dyyy" hotspot_y="30" link_type="simple" version="0.70" type="element" hotspot_x="24" width="50">
+    <uuid uuid="{5671de08-ab81-4f72-809b-7ac854e38016}"/>
+    <names>
+        <name lang="nl">Schakelaar (M.B.) - Input onder - Gespiegeld en omgekeerd</name>
+        <name lang="en">Switch (M.B.) - Bottom input - Mirrored and inverted</name>
+    </names>
+    <elementInformations/>
+    <informations></informations>
+    <description>
+        <rect height="30" rx="0" ry="0" x="2" y="-25" antialias="false" width="3" style="line-style:normal;line-weight:normal;filling:black;color:black"/>
+        <line x1="-20" end2="none" antialias="false" end1="none" y1="-20" length2="1.5" x2="-5" length1="1.5" y2="-20" style="line-style:normal;line-weight:normal;filling:none;color:black"/>
+        <rect height="12" rx="0" ry="0" x="-5" y="-7" antialias="false" width="3" style="line-style:normal;line-weight:normal;filling:black;color:black"/>
+        <rect height="12" rx="0" ry="0" x="-5" y="-25" antialias="false" width="3" style="line-style:normal;line-weight:normal;filling:black;color:black"/>
+        <line x1="5" end2="none" antialias="false" end1="none" y1="0" length2="1.5" x2="20" length1="1.5" y2="0" style="line-style:normal;line-weight:normal;filling:none;color:black"/>
+        <line x1="-20" end2="none" antialias="false" end1="none" y1="0" length2="1.5" x2="-5" length1="1.5" y2="0" style="line-style:normal;line-weight:normal;filling:none;color:black"/>
+        <line x1="10" end2="none" antialias="false" end1="none" y1="-25" length2="1.5" x2="-10" length1="1.5" y2="-15" style="line-style:normal;line-weight:hight;filling:none;color:black"/>
+        <terminal x="20" y="0" orientation="e"/>
+        <terminal x="-20" y="-20" orientation="w"/>
+        <terminal x="-20" y="0" orientation="w"/>
+    </description>
+</definition>

--- a/elements/10_electric/20_manufacturers_articles/pinball/williams_em/switches_common/mirrored/pinball_em_williams_switch_mb_center_m.elmt
+++ b/elements/10_electric/20_manufacturers_articles/pinball/williams_em/switches_common/mirrored/pinball_em_williams_switch_mb_center_m.elmt
@@ -1,0 +1,21 @@
+<definition height="40" orientation="dyyy" hotspot_y="20" link_type="simple" version="0.70" type="element" hotspot_x="24" width="50">
+    <uuid uuid="{762b188c-50f3-4900-b870-ea563c2cc7da}"/>
+    <names>
+        <name lang="nl">Schakelaar (M.B.) - Input midden - Gespiegeld</name>
+        <name lang="en">Switch (M.B.) - Center input - Mirrored</name>
+    </names>
+    <elementInformations/>
+    <informations></informations>
+    <description>
+        <rect height="30" rx="0" ry="0" x="2" y="-15" antialias="false" width="3" style="line-style:normal;line-weight:normal;filling:black;color:black"/>
+        <line x1="-20" end2="none" antialias="false" end1="none" y1="-10" length2="1.5" x2="-5" length1="1.5" y2="-10" style="line-style:normal;line-weight:normal;filling:none;color:black"/>
+        <rect height="12" rx="0" ry="0" x="-5" y="3" antialias="false" width="3" style="line-style:normal;line-weight:normal;filling:black;color:black"/>
+        <rect height="12" rx="0" ry="0" x="-5" y="-15" antialias="false" width="3" style="line-style:normal;line-weight:normal;filling:black;color:black"/>
+        <line x1="5" end2="none" antialias="false" end1="none" y1="0" length2="1.5" x2="20" length1="1.5" y2="0" style="line-style:normal;line-weight:normal;filling:none;color:black"/>
+        <line x1="-20" end2="none" antialias="false" end1="none" y1="10" length2="1.5" x2="-5" length1="1.5" y2="10" style="line-style:normal;line-weight:normal;filling:none;color:black"/>
+        <line x1="10" end2="none" antialias="false" end1="none" y1="5" length2="1.5" x2="-10" length1="1.5" y2="15" style="line-style:normal;line-weight:hight;filling:none;color:black"/>
+        <terminal x="-20" y="-10" orientation="w"/>
+        <terminal x="-20" y="10" orientation="w"/>
+        <terminal x="20" y="0" orientation="e"/>
+    </description>
+</definition>

--- a/elements/10_electric/20_manufacturers_articles/pinball/williams_em/switches_common/mirrored/pinball_em_williams_switch_mb_center_mi.elmt
+++ b/elements/10_electric/20_manufacturers_articles/pinball/williams_em/switches_common/mirrored/pinball_em_williams_switch_mb_center_mi.elmt
@@ -1,0 +1,21 @@
+<definition height="40" orientation="dyyy" hotspot_y="20" link_type="simple" version="0.70" type="element" hotspot_x="24" width="50">
+    <uuid uuid="{3509d560-3eb8-4527-b5b2-35d66bf3fc64}"/>
+    <names>
+        <name lang="nl">Schakelaar (M.B.) - Input midden - Gespiegeld en omgekeerd</name>
+        <name lang="en">Switch (M.B.) - Center input - Mirrored and inverted</name>
+    </names>
+    <elementInformations/>
+    <informations></informations>
+    <description>
+        <rect height="30" rx="0" ry="0" x="2" y="-15" antialias="false" width="3" style="line-style:normal;line-weight:normal;filling:black;color:black"/>
+        <line x1="-20" end2="none" antialias="false" end1="none" y1="-10" length2="1.5" x2="-5" length1="1.5" y2="-10" style="line-style:normal;line-weight:normal;filling:none;color:black"/>
+        <rect height="12" rx="0" ry="0" x="-5" y="3" antialias="false" width="3" style="line-style:normal;line-weight:normal;filling:black;color:black"/>
+        <rect height="12" rx="0" ry="0" x="-5" y="-15" antialias="false" width="3" style="line-style:normal;line-weight:normal;filling:black;color:black"/>
+        <line x1="5" end2="none" antialias="false" end1="none" y1="0" length2="1.5" x2="20" length1="1.5" y2="0" style="line-style:normal;line-weight:normal;filling:none;color:black"/>
+        <line x1="-20" end2="none" antialias="false" end1="none" y1="10" length2="1.5" x2="-5" length1="1.5" y2="10" style="line-style:normal;line-weight:normal;filling:none;color:black"/>
+        <line x1="10" end2="none" antialias="false" end1="none" y1="-15" length2="1.5" x2="-10" length1="1.5" y2="-5" style="line-style:normal;line-weight:hight;filling:none;color:black"/>
+        <terminal x="20" y="0" orientation="e"/>
+        <terminal x="-20" y="10" orientation="w"/>
+        <terminal x="-20" y="-10" orientation="w"/>
+    </description>
+</definition>

--- a/elements/10_electric/20_manufacturers_articles/pinball/williams_em/switches_common/mirrored/pinball_em_williams_switch_mb_top_m.elmt
+++ b/elements/10_electric/20_manufacturers_articles/pinball/williams_em/switches_common/mirrored/pinball_em_williams_switch_mb_top_m.elmt
@@ -1,0 +1,21 @@
+<definition height="40" orientation="dyyy" hotspot_y="10" link_type="simple" version="0.70" type="element" hotspot_x="24" width="50">
+    <uuid uuid="{b85f89b8-cbf2-4bda-ba31-8cc3570a4339}"/>
+    <names>
+        <name lang="nl">Schakelaar (M.B.) - Input boven - Gespiegeld</name>
+        <name lang="en">Switch (M.B.) - Top input - Mirrored</name>
+    </names>
+    <elementInformations/>
+    <informations></informations>
+    <description>
+        <rect height="30" rx="0" ry="0" x="2" y="-5" antialias="false" width="3" style="line-style:normal;line-weight:normal;filling:black;color:black"/>
+        <line x1="-20" end2="none" antialias="false" end1="none" y1="0" length2="1.5" x2="-5" length1="1.5" y2="0" style="line-style:normal;line-weight:normal;filling:none;color:black"/>
+        <rect height="12" rx="0" ry="0" x="-5" y="13" antialias="false" width="3" style="line-style:normal;line-weight:normal;filling:black;color:black"/>
+        <rect height="12" rx="0" ry="0" x="-5" y="-5" antialias="false" width="3" style="line-style:normal;line-weight:normal;filling:black;color:black"/>
+        <line x1="5" end2="none" antialias="false" end1="none" y1="0" length2="1.5" x2="20" length1="1.5" y2="0" style="line-style:normal;line-weight:normal;filling:none;color:black"/>
+        <line x1="-20" end2="none" antialias="false" end1="none" y1="20" length2="1.5" x2="-5" length1="1.5" y2="20" style="line-style:normal;line-weight:normal;filling:none;color:black"/>
+        <line x1="10" end2="none" antialias="false" end1="none" y1="15" length2="1.5" x2="-10" length1="1.5" y2="25" style="line-style:normal;line-weight:hight;filling:none;color:black"/>
+        <terminal x="20" y="0" orientation="e"/>
+        <terminal x="-20" y="20" orientation="w"/>
+        <terminal x="-20" y="0" orientation="w"/>
+    </description>
+</definition>

--- a/elements/10_electric/20_manufacturers_articles/pinball/williams_em/switches_common/mirrored/pinball_em_williams_switch_mb_top_mi.elmt
+++ b/elements/10_electric/20_manufacturers_articles/pinball/williams_em/switches_common/mirrored/pinball_em_williams_switch_mb_top_mi.elmt
@@ -1,0 +1,21 @@
+<definition height="40" orientation="dyyy" hotspot_y="10" link_type="simple" version="0.70" type="element" hotspot_x="24" width="50">
+    <uuid uuid="{6e72e029-0004-452d-9e0c-ed664e36f070}"/>
+    <names>
+        <name lang="nl">Schakelaar (M.B.) - Input boven - Gespiegeld en omgekeerd</name>
+        <name lang="en">Switch (M.B.) - Top input - Mirrored and inverted</name>
+    </names>
+    <elementInformations/>
+    <informations></informations>
+    <description>
+        <rect height="30" rx="0" ry="0" x="2" y="-5" antialias="false" width="3" style="line-style:normal;line-weight:normal;filling:black;color:black"/>
+        <line x1="-20" end2="none" antialias="false" end1="none" y1="0" length2="1.5" x2="-5" length1="1.5" y2="0" style="line-style:normal;line-weight:normal;filling:none;color:black"/>
+        <rect height="12" rx="0" ry="0" x="-5" y="13" antialias="false" width="3" style="line-style:normal;line-weight:normal;filling:black;color:black"/>
+        <rect height="12" rx="0" ry="0" x="-5" y="-5" antialias="false" width="3" style="line-style:normal;line-weight:normal;filling:black;color:black"/>
+        <line x1="5" end2="none" antialias="false" end1="none" y1="0" length2="1.5" x2="20" length1="1.5" y2="0" style="line-style:normal;line-weight:normal;filling:none;color:black"/>
+        <line x1="-20" end2="none" antialias="false" end1="none" y1="20" length2="1.5" x2="-5" length1="1.5" y2="20" style="line-style:normal;line-weight:normal;filling:none;color:black"/>
+        <line x1="10" end2="none" antialias="false" end1="none" y1="-5" length2="1.5" x2="-10" length1="1.5" y2="5" style="line-style:normal;line-weight:hight;filling:none;color:black"/>
+        <terminal x="-20" y="0" orientation="w"/>
+        <terminal x="20" y="0" orientation="e"/>
+        <terminal x="-20" y="20" orientation="w"/>
+    </description>
+</definition>

--- a/elements/10_electric/20_manufacturers_articles/pinball/williams_em/switches_common/mirrored/qet_directory
+++ b/elements/10_electric/20_manufacturers_articles/pinball/williams_em/switches_common/mirrored/qet_directory
@@ -1,0 +1,6 @@
+<qet-directory>
+    <names>
+        <name lang="en">Mirrored</name>
+        <name lang="nl">Gespiegeld</name>
+    </names>
+</qet-directory>

--- a/elements/10_electric/20_manufacturers_articles/pinball/williams_em/switches_common/pinball_em_williams_switch_mb_bottom.elmt
+++ b/elements/10_electric/20_manufacturers_articles/pinball/williams_em/switches_common/pinball_em_williams_switch_mb_bottom.elmt
@@ -1,0 +1,21 @@
+<definition hotspot_x="24" height="40" type="element" width="50" hotspot_y="30" version="0.70" link_type="simple" orientation="dyyy">
+    <uuid uuid="{6b2f7d0b-0bea-4db2-9da7-ed808130db45}"/>
+    <names>
+        <name lang="nl">Schakelaar (M.B.) - Input onder</name>
+        <name lang="en">Switch (M.B.) - Bottom input</name>
+    </names>
+    <elementInformations/>
+    <informations></informations>
+    <description>
+        <rect height="30" style="line-style:normal;line-weight:normal;filling:black;color:black" width="3" y="-25.25" ry="0" rx="0" x="-5" antialias="false"/>
+        <rect height="12" style="line-style:normal;line-weight:normal;filling:black;color:black" width="3" y="-7.25" ry="0" rx="0" x="2" antialias="false"/>
+        <rect height="12" style="line-style:normal;line-weight:normal;filling:black;color:black" width="3" y="-25.25" ry="0" rx="0" x="2" antialias="false"/>
+        <line style="line-style:normal;line-weight:normal;filling:none;color:black" x1="5" end1="none" length2="1.5" y2="-0.25" end2="none" y1="-0.25" x2="20" length1="1.5" antialias="false"/>
+        <line style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-20" end1="none" length2="1.5" y2="-0.25" end2="none" y1="-0.25" x2="-5" length1="1.5" antialias="false"/>
+        <line style="line-style:normal;line-weight:normal;filling:none;color:black" x1="5" end1="none" length2="1.5" y2="-20.25" end2="none" y1="-20.25" x2="20" length1="1.5" antialias="false"/>
+        <line style="line-style:normal;line-weight:hight;filling:none;color:black" x1="10" end1="none" length2="1.5" y2="4.75" end2="none" y1="-5.25" x2="-10" length1="1.5" antialias="false"/>
+        <terminal y="-0.25" x="20" orientation="e"/>
+        <terminal y="-20.25" x="20" orientation="e"/>
+        <terminal y="-0.25" x="-20" orientation="w"/>
+    </description>
+</definition>

--- a/elements/10_electric/20_manufacturers_articles/pinball/williams_em/switches_common/pinball_em_williams_switch_mb_bottom_i.elmt
+++ b/elements/10_electric/20_manufacturers_articles/pinball/williams_em/switches_common/pinball_em_williams_switch_mb_bottom_i.elmt
@@ -1,0 +1,21 @@
+<definition height="40" orientation="dyyy" hotspot_y="30" link_type="simple" version="0.70" type="element" hotspot_x="24" width="50">
+    <uuid uuid="{6321259d-91c7-4126-9bcf-c8ab9dedddf7}"/>
+    <names>
+        <name lang="nl">Schakelaar (M.B.) - Input onder - Omgekeerd</name>
+        <name lang="en">Switch (M.B.) - Bottom input - Inverted</name>
+    </names>
+    <elementInformations/>
+    <informations></informations>
+    <description>
+        <rect height="30" rx="0" ry="0" x="-5" y="-25" antialias="false" width="3" style="line-style:normal;line-weight:normal;filling:black;color:black"/>
+        <rect height="12" rx="0" ry="0" x="2" y="-7" antialias="false" width="3" style="line-style:normal;line-weight:normal;filling:black;color:black"/>
+        <rect height="12" rx="0" ry="0" x="2" y="-25" antialias="false" width="3" style="line-style:normal;line-weight:normal;filling:black;color:black"/>
+        <line x1="5" end2="none" antialias="false" end1="none" y1="0" length2="1.5" x2="20" length1="1.5" y2="0" style="line-style:normal;line-weight:normal;filling:none;color:black"/>
+        <line x1="-20" end2="none" antialias="false" end1="none" y1="0" length2="1.5" x2="-5" length1="1.5" y2="0" style="line-style:normal;line-weight:normal;filling:none;color:black"/>
+        <line x1="5" end2="none" antialias="false" end1="none" y1="-20" length2="1.5" x2="20" length1="1.5" y2="-20" style="line-style:normal;line-weight:normal;filling:none;color:black"/>
+        <line x1="10" end2="none" antialias="false" end1="none" y1="-24.75" length2="1.5" x2="-10" length1="1.5" y2="-14.75" style="line-style:normal;line-weight:hight;filling:none;color:black"/>
+        <terminal x="20" y="0" orientation="e"/>
+        <terminal x="20" y="-20" orientation="e"/>
+        <terminal x="-20" y="0" orientation="w"/>
+    </description>
+</definition>

--- a/elements/10_electric/20_manufacturers_articles/pinball/williams_em/switches_common/pinball_em_williams_switch_mb_center.elmt
+++ b/elements/10_electric/20_manufacturers_articles/pinball/williams_em/switches_common/pinball_em_williams_switch_mb_center.elmt
@@ -1,0 +1,21 @@
+<definition hotspot_x="24" height="40" type="element" width="50" hotspot_y="20" version="0.70" link_type="simple" orientation="dyyy">
+    <uuid uuid="{57993a2e-8feb-4920-97f7-5481bc1e63e3}"/>
+    <names>
+        <name lang="nl">Schakelaar (M.B.) - Input midden</name>
+        <name lang="en">Switch (M.B.) - Center input</name>
+    </names>
+    <elementInformations/>
+    <informations></informations>
+    <description>
+        <rect height="30" style="line-style:normal;line-weight:normal;filling:black;color:black" width="3" y="-15" ry="0" rx="0" x="-5" antialias="false"/>
+        <rect height="12" style="line-style:normal;line-weight:normal;filling:black;color:black" width="3" y="3" ry="0" rx="0" x="2" antialias="false"/>
+        <rect height="12" style="line-style:normal;line-weight:normal;filling:black;color:black" width="3" y="-15" ry="0" rx="0" x="2" antialias="false"/>
+        <line style="line-style:normal;line-weight:normal;filling:none;color:black" x1="5" end1="none" length2="1.5" y2="10" end2="none" y1="10" x2="20" length1="1.5" antialias="false"/>
+        <line style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-20" end1="none" length2="1.5" y2="0" end2="none" y1="0" x2="-5" length1="1.5" antialias="false"/>
+        <line style="line-style:normal;line-weight:normal;filling:none;color:black" x1="5" end1="none" length2="1.5" y2="-10" end2="none" y1="-10" x2="20" length1="1.5" antialias="false"/>
+        <line style="line-style:normal;line-weight:hight;filling:none;color:black" x1="10" end1="none" length2="1.5" y2="15" end2="none" y1="5" x2="-10" length1="1.5" antialias="false"/>
+        <terminal y="10" x="20" orientation="e"/>
+        <terminal y="-10" x="20" orientation="e"/>
+        <terminal y="0" x="-20" orientation="w"/>
+    </description>
+</definition>

--- a/elements/10_electric/20_manufacturers_articles/pinball/williams_em/switches_common/pinball_em_williams_switch_mb_center_i.elmt
+++ b/elements/10_electric/20_manufacturers_articles/pinball/williams_em/switches_common/pinball_em_williams_switch_mb_center_i.elmt
@@ -1,0 +1,21 @@
+<definition height="40" orientation="dyyy" hotspot_y="20" link_type="simple" version="0.70" type="element" hotspot_x="24" width="50">
+    <uuid uuid="{9a0c9775-c4ca-4a6b-809c-74ffb482fc6a}"/>
+    <names>
+        <name lang="nl">Schakelaar (M.B.) - Input midden - Omgekeerd</name>
+        <name lang="en">Switch (M.B.) - Center input - Inverted</name>
+    </names>
+    <elementInformations/>
+    <informations></informations>
+    <description>
+        <rect height="30" rx="0" ry="0" x="-5" y="-15" antialias="false" width="3" style="line-style:normal;line-weight:normal;filling:black;color:black"/>
+        <rect height="12" rx="0" ry="0" x="2" y="3" antialias="false" width="3" style="line-style:normal;line-weight:normal;filling:black;color:black"/>
+        <rect height="12" rx="0" ry="0" x="2" y="-15" antialias="false" width="3" style="line-style:normal;line-weight:normal;filling:black;color:black"/>
+        <line x1="5" end2="none" antialias="false" end1="none" y1="10" length2="1.5" x2="20" length1="1.5" y2="10" style="line-style:normal;line-weight:normal;filling:none;color:black"/>
+        <line x1="-20" end2="none" antialias="false" end1="none" y1="0" length2="1.5" x2="-5" length1="1.5" y2="0" style="line-style:normal;line-weight:normal;filling:none;color:black"/>
+        <line x1="5" end2="none" antialias="false" end1="none" y1="-10" length2="1.5" x2="20" length1="1.5" y2="-10" style="line-style:normal;line-weight:normal;filling:none;color:black"/>
+        <line x1="10" end2="none" antialias="false" end1="none" y1="-15" length2="1.5" x2="-10" length1="1.5" y2="-5" style="line-style:normal;line-weight:hight;filling:none;color:black"/>
+        <terminal x="20" y="-10" orientation="e"/>
+        <terminal x="20" y="10" orientation="e"/>
+        <terminal x="-20" y="0" orientation="w"/>
+    </description>
+</definition>

--- a/elements/10_electric/20_manufacturers_articles/pinball/williams_em/switches_common/pinball_em_williams_switch_mb_top.elmt
+++ b/elements/10_electric/20_manufacturers_articles/pinball/williams_em/switches_common/pinball_em_williams_switch_mb_top.elmt
@@ -1,0 +1,21 @@
+<definition hotspot_x="24" height="40" type="element" width="50" hotspot_y="10" version="0.70" link_type="simple" orientation="dyyy">
+    <uuid uuid="{01a0d1a8-0de0-4f5e-ac2b-2490c38301b0}"/>
+    <names>
+        <name lang="nl">Schakelaar (M.B.) - Input boven</name>
+        <name lang="en">Switch (M.B.) - Top input</name>
+    </names>
+    <elementInformations/>
+    <informations></informations>
+    <description>
+        <rect height="30" style="line-style:normal;line-weight:normal;filling:black;color:black" width="3" y="-5" ry="0" rx="0" x="-5" antialias="false"/>
+        <rect height="12" style="line-style:normal;line-weight:normal;filling:black;color:black" width="3" y="13" ry="0" rx="0" x="2" antialias="false"/>
+        <rect height="12" style="line-style:normal;line-weight:normal;filling:black;color:black" width="3" y="-5" ry="0" rx="0" x="2" antialias="false"/>
+        <line style="line-style:normal;line-weight:normal;filling:none;color:black" x1="5" end1="none" length2="1.5" y2="20" end2="none" y1="20" x2="20" length1="1.5" antialias="false"/>
+        <line style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-20" end1="none" length2="1.5" y2="0" end2="none" y1="0" x2="-5" length1="1.5" antialias="false"/>
+        <line style="line-style:normal;line-weight:normal;filling:none;color:black" x1="5" end1="none" length2="1.5" y2="0" end2="none" y1="0" x2="20" length1="1.5" antialias="false"/>
+        <line style="line-style:normal;line-weight:hight;filling:none;color:black" x1="10" end1="none" length2="1.5" y2="25" end2="none" y1="15" x2="-10" length1="1.5" antialias="false"/>
+        <terminal y="20" x="20" orientation="e"/>
+        <terminal y="0" x="20" orientation="e"/>
+        <terminal y="0" x="-20" orientation="w"/>
+    </description>
+</definition>

--- a/elements/10_electric/20_manufacturers_articles/pinball/williams_em/switches_common/pinball_em_williams_switch_mb_top_i.elmt
+++ b/elements/10_electric/20_manufacturers_articles/pinball/williams_em/switches_common/pinball_em_williams_switch_mb_top_i.elmt
@@ -1,0 +1,21 @@
+<definition height="40" orientation="dyyy" hotspot_y="10" link_type="simple" version="0.70" type="element" hotspot_x="24" width="50">
+    <uuid uuid="{130b56ae-6888-4b0d-bac8-5b49335e33ec}"/>
+    <names>
+        <name lang="nl">Schakelaar (M.B.) - Input boven - Omgekeerd</name>
+        <name lang="en">Switch (M.B) - Top input - Inverted</name>
+    </names>
+    <elementInformations/>
+    <informations></informations>
+    <description>
+        <rect height="30" rx="0" ry="0" x="-5" y="-5.25" antialias="false" width="3" style="line-style:normal;line-weight:normal;filling:black;color:black"/>
+        <rect height="12" rx="0" ry="0" x="2" y="12.75" antialias="false" width="3" style="line-style:normal;line-weight:normal;filling:black;color:black"/>
+        <rect height="12" rx="0" ry="0" x="2" y="-5.25" antialias="false" width="3" style="line-style:normal;line-weight:normal;filling:black;color:black"/>
+        <line x1="5" end2="none" antialias="false" end1="none" y1="19.75" length2="1.5" x2="20" length1="1.5" y2="19.75" style="line-style:normal;line-weight:normal;filling:none;color:black"/>
+        <line x1="-20" end2="none" antialias="false" end1="none" y1="-0.25" length2="1.5" x2="-5" length1="1.5" y2="-0.25" style="line-style:normal;line-weight:normal;filling:none;color:black"/>
+        <line x1="5" end2="none" antialias="false" end1="none" y1="-0.25" length2="1.5" x2="20" length1="1.5" y2="-0.25" style="line-style:normal;line-weight:normal;filling:none;color:black"/>
+        <line x1="10" end2="none" antialias="false" end1="none" y1="-5" length2="1.5" x2="-10" length1="1.5" y2="5" style="line-style:normal;line-weight:hight;filling:none;color:black"/>
+        <terminal x="20" y="-0.25" orientation="e"/>
+        <terminal x="-20" y="-0.25" orientation="w"/>
+        <terminal x="20" y="19.75" orientation="e"/>
+    </description>
+</definition>

--- a/elements/10_electric/20_manufacturers_articles/pinball/williams_em/switches_common/pinball_em_williams_switch_nc.elmt
+++ b/elements/10_electric/20_manufacturers_articles/pinball/williams_em/switches_common/pinball_em_williams_switch_nc.elmt
@@ -1,0 +1,18 @@
+<definition hotspot_x="24" height="20" type="element" width="50" hotspot_y="10" version="0.70" link_type="simple" orientation="dyyy">
+    <uuid uuid="{b4de77c7-a031-4ae2-b7f7-8ea5309631c7}"/>
+    <names>
+        <name lang="nl">Schakelaar (N.C.)</name>
+        <name lang="en">Switch (N.C.)</name>
+    </names>
+    <elementInformations/>
+    <informations></informations>
+    <description>
+        <rect height="10" style="line-style:normal;line-weight:normal;filling:black;color:black" width="3" y="-5" ry="0" rx="0" x="-5" antialias="false"/>
+        <rect height="10" style="line-style:normal;line-weight:normal;filling:black;color:black" width="3" y="-5" ry="0" rx="0" x="2" antialias="false"/>
+        <line style="line-style:normal;line-weight:normal;filling:none;color:black" x1="5" end1="none" length2="1.5" y2="0" end2="none" y1="0" x2="20" length1="1.5" antialias="false"/>
+        <line style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-5" end1="none" length2="1.5" y2="0" end2="none" y1="0" x2="-20" length1="1.5" antialias="false"/>
+        <line style="line-style:normal;line-weight:hight;filling:none;color:black" x1="10" end1="none" length2="1.5" y2="5" end2="none" y1="-5" x2="-10" length1="1.5" antialias="false"/>
+        <terminal y="0" x="-20" orientation="w"/>
+        <terminal y="0" x="20" orientation="e"/>
+    </description>
+</definition>

--- a/elements/10_electric/20_manufacturers_articles/pinball/williams_em/switches_common/pinball_em_williams_switch_no.elmt
+++ b/elements/10_electric/20_manufacturers_articles/pinball/williams_em/switches_common/pinball_em_williams_switch_no.elmt
@@ -1,0 +1,17 @@
+<definition hotspot_x="24" height="20" type="element" width="50" hotspot_y="10" version="0.70" link_type="simple" orientation="dyyy">
+    <uuid uuid="{5a15257d-de36-4aad-9b67-717ea5763a1c}"/>
+    <names>
+        <name lang="nl">Schakelaar (N.O.)</name>
+        <name lang="en">Switch (N.O.)</name>
+    </names>
+    <elementInformations/>
+    <informations></informations>
+    <description>
+        <rect height="10" style="line-style:normal;line-weight:normal;filling:black;color:black" width="3" y="-5" ry="0" rx="0" x="-5" antialias="false"/>
+        <rect height="10" style="line-style:normal;line-weight:normal;filling:black;color:black" width="3" y="-5" ry="0" rx="0" x="2" antialias="false"/>
+        <line style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-20" end1="none" length2="1.5" y2="0" end2="none" y1="0" x2="-5" length1="1.5" antialias="false"/>
+        <line style="line-style:normal;line-weight:normal;filling:none;color:black" x1="5" end1="none" length2="1.5" y2="0" end2="none" y1="0" x2="20" length1="1.5" antialias="false"/>
+        <terminal y="0" x="-20" orientation="w"/>
+        <terminal y="0" x="20" orientation="e"/>
+    </description>
+</definition>

--- a/elements/10_electric/20_manufacturers_articles/pinball/williams_em/switches_common/qet_directory
+++ b/elements/10_electric/20_manufacturers_articles/pinball/williams_em/switches_common/qet_directory
@@ -1,0 +1,6 @@
+<qet-directory>
+    <names>
+        <name lang="nl">Schakelaars - Algemeen</name>
+        <name lang="en">Switches - Common</name>
+    </names>
+</qet-directory>

--- a/elements/10_electric/20_manufacturers_articles/pinball/williams_em/switches_score_motor/mirrored/pinball_em_williams_switch_mb_sm_bottom_m.elmt
+++ b/elements/10_electric/20_manufacturers_articles/pinball/williams_em/switches_score_motor/mirrored/pinball_em_williams_switch_mb_sm_bottom_m.elmt
@@ -1,0 +1,25 @@
+<definition hotspot_y="35" width="50" orientation="dyyy" height="50" version="0.70" hotspot_x="24" link_type="simple" type="element">
+    <uuid uuid="{10830219-83b0-4488-8564-adfe27637f60}"/>
+    <names>
+        <name lang="en">Switch on Score Motor (M.B.) - Bottom input - Mirrored</name>
+        <name lang="nl">Schakelaar op Score Motor (M.B.) - Input onder - Gespiegeld</name>
+    </names>
+    <elementInformations/>
+    <informations></informations>
+    <description>
+        <rect x="2" rx="0" antialias="false" y="-25" width="3" style="line-style:normal;line-weight:normal;filling:black;color:black" height="30" ry="0"/>
+        <arc x="-10" start="0" antialias="true" y="-30" width="20" style="line-style:normal;line-weight:normal;filling:none;color:black" height="20" angle="180"/>
+        <line length2="1.5" x1="-10" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" length1="1.5" end1="none" end2="none" x2="-10" y2="0" y1="-20"/>
+        <line length2="1.5" x1="-20" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" length1="1.5" end1="none" end2="none" x2="-5" y2="-20" y1="-20"/>
+        <rect x="-5" rx="0" antialias="false" y="-7" width="3" style="line-style:normal;line-weight:normal;filling:black;color:black" height="12" ry="0"/>
+        <line length2="1.5" x1="10" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" length1="1.5" end1="none" end2="none" x2="10" y2="0" y1="-20"/>
+        <rect x="-5" rx="0" antialias="false" y="-25" width="3" style="line-style:normal;line-weight:normal;filling:black;color:black" height="12" ry="0"/>
+        <arc x="-10" start="180" antialias="true" y="-10" width="20" style="line-style:normal;line-weight:normal;filling:none;color:black" height="20" angle="180"/>
+        <line length2="1.5" x1="5" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" length1="1.5" end1="none" end2="none" x2="20" y2="0" y1="0"/>
+        <line length2="1.5" x1="-20" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" length1="1.5" end1="none" end2="none" x2="-5" y2="0" y1="0"/>
+        <line length2="1.5" x1="10" antialias="false" style="line-style:normal;line-weight:hight;filling:none;color:black" length1="1.5" end1="none" end2="none" x2="-10" y2="5" y1="-5"/>
+        <terminal x="-20" y="0" orientation="w"/>
+        <terminal x="-20" y="-20" orientation="w"/>
+        <terminal x="20" y="0" orientation="e"/>
+    </description>
+</definition>

--- a/elements/10_electric/20_manufacturers_articles/pinball/williams_em/switches_score_motor/mirrored/pinball_em_williams_switch_mb_sm_bottom_mi.elmt
+++ b/elements/10_electric/20_manufacturers_articles/pinball/williams_em/switches_score_motor/mirrored/pinball_em_williams_switch_mb_sm_bottom_mi.elmt
@@ -1,0 +1,25 @@
+<definition hotspot_y="35" width="50" orientation="dyyy" height="50" version="0.70" hotspot_x="24" link_type="simple" type="element">
+    <uuid uuid="{5854bbcc-54b3-41c1-b728-36ea16c235c7}"/>
+    <names>
+        <name lang="en">Switch on Score Motor (M.B.) - Bottom input - Mirrored and inverted</name>
+        <name lang="nl">Schakelaar op Score Motor (M.B.) - Input onder - Gespiegeld en omgekeerd</name>
+    </names>
+    <elementInformations/>
+    <informations></informations>
+    <description>
+        <rect x="2" rx="0" antialias="false" y="-25" width="3" style="line-style:normal;line-weight:normal;filling:black;color:black" height="30" ry="0"/>
+        <arc x="-10" start="0" antialias="true" y="-30" width="20" style="line-style:normal;line-weight:normal;filling:none;color:black" height="20" angle="180"/>
+        <line length2="1.5" x1="-20" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" length1="1.5" end1="none" end2="none" x2="-5" y2="-20" y1="-20"/>
+        <line length2="1.5" x1="-10" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" length1="1.5" end1="none" end2="none" x2="-10" y2="0" y1="-20"/>
+        <line length2="1.5" x1="10" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" length1="1.5" end1="none" end2="none" x2="10" y2="0" y1="-20"/>
+        <rect x="-5" rx="0" antialias="false" y="-7" width="3" style="line-style:normal;line-weight:normal;filling:black;color:black" height="12" ry="0"/>
+        <rect x="-5" rx="0" antialias="false" y="-25" width="3" style="line-style:normal;line-weight:normal;filling:black;color:black" height="12" ry="0"/>
+        <arc x="-10" start="180" antialias="true" y="-10" width="20" style="line-style:normal;line-weight:normal;filling:none;color:black" height="20" angle="180"/>
+        <line length2="1.5" x1="5" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" length1="1.5" end1="none" end2="none" x2="20" y2="0" y1="0"/>
+        <line length2="1.5" x1="-20" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" length1="1.5" end1="none" end2="none" x2="-5" y2="0" y1="0"/>
+        <line length2="1.5" x1="10" antialias="false" style="line-style:normal;line-weight:hight;filling:none;color:black" length1="1.5" end1="none" end2="none" x2="-10" y2="-15" y1="-25"/>
+        <terminal x="20" y="0" orientation="e"/>
+        <terminal x="-20" y="0" orientation="w"/>
+        <terminal x="-20" y="-20" orientation="w"/>
+    </description>
+</definition>

--- a/elements/10_electric/20_manufacturers_articles/pinball/williams_em/switches_score_motor/mirrored/pinball_em_williams_switch_mb_sm_center_m.elmt
+++ b/elements/10_electric/20_manufacturers_articles/pinball/williams_em/switches_score_motor/mirrored/pinball_em_williams_switch_mb_sm_center_m.elmt
@@ -1,0 +1,25 @@
+<definition hotspot_y="25" width="50" orientation="dyyy" height="50" version="0.70" hotspot_x="24" link_type="simple" type="element">
+    <uuid uuid="{b17bd886-7621-424a-b336-cdf9d15da91c}"/>
+    <names>
+        <name lang="en">Switch on Score Motor (M.B.) - Center input - Mirrored</name>
+        <name lang="nl">Schakelaar op Score Motor (M.B.) - Input midden - Gespiegeld</name>
+    </names>
+    <elementInformations/>
+    <informations></informations>
+    <description>
+        <arc x="-10" start="0" antialias="true" y="-20" width="20" style="line-style:normal;line-weight:normal;filling:none;color:black" height="20" angle="180"/>
+        <rect x="2" rx="0" antialias="false" y="-15.25" width="3" style="line-style:normal;line-weight:normal;filling:black;color:black" height="30" ry="0"/>
+        <line length2="1.5" x1="-10" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" length1="1.5" end1="none" end2="none" x2="-10" y2="10" y1="-10"/>
+        <line length2="1.5" x1="-20" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" length1="1.5" end1="none" end2="none" x2="-5" y2="-10.25" y1="-10.25"/>
+        <line length2="1.5" x1="10" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" length1="1.5" end1="none" end2="none" x2="10" y2="10" y1="-10"/>
+        <rect x="-5" rx="0" antialias="false" y="2.75" width="3" style="line-style:normal;line-weight:normal;filling:black;color:black" height="12" ry="0"/>
+        <arc x="-10" start="180" antialias="true" y="0" width="20" style="line-style:normal;line-weight:normal;filling:none;color:black" height="20" angle="180"/>
+        <rect x="-5" rx="0" antialias="false" y="-15.25" width="3" style="line-style:normal;line-weight:normal;filling:black;color:black" height="12" ry="0"/>
+        <line length2="1.5" x1="5" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" length1="1.5" end1="none" end2="none" x2="20" y2="-0.25" y1="-0.25"/>
+        <line length2="1.5" x1="-20" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" length1="1.5" end1="none" end2="none" x2="-5" y2="9.75" y1="9.75"/>
+        <line length2="1.5" x1="10" antialias="false" style="line-style:normal;line-weight:hight;filling:none;color:black" length1="1.5" end1="none" end2="none" x2="-10" y2="14.75" y1="4.75"/>
+        <terminal x="-20" y="9.75" orientation="w"/>
+        <terminal x="-20" y="-10.25" orientation="w"/>
+        <terminal x="20" y="-0.25" orientation="e"/>
+    </description>
+</definition>

--- a/elements/10_electric/20_manufacturers_articles/pinball/williams_em/switches_score_motor/mirrored/pinball_em_williams_switch_mb_sm_center_mi.elmt
+++ b/elements/10_electric/20_manufacturers_articles/pinball/williams_em/switches_score_motor/mirrored/pinball_em_williams_switch_mb_sm_center_mi.elmt
@@ -1,0 +1,25 @@
+<definition hotspot_y="25" width="50" orientation="dyyy" height="50" version="0.70" hotspot_x="24" link_type="simple" type="element">
+    <uuid uuid="{a5464c2a-4620-41a8-a18f-e34f0e0fa5ee}"/>
+    <names>
+        <name lang="en">Switch on Score Motor (M.B.) - Center input - Mirrored and inverted</name>
+        <name lang="nl">Schakelaar op Score Motor (M.B.) - Input midden - Gespiegeld en omgekeerd</name>
+    </names>
+    <elementInformations/>
+    <informations></informations>
+    <description>
+        <arc x="-10" start="0" antialias="true" y="-20" width="20" style="line-style:normal;line-weight:normal;filling:none;color:black" height="20" angle="180"/>
+        <rect x="2" rx="0" antialias="false" y="-15" width="3" style="line-style:normal;line-weight:normal;filling:black;color:black" height="30" ry="0"/>
+        <line length2="1.5" x1="-20" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" length1="1.5" end1="none" end2="none" x2="-5" y2="-10" y1="-10"/>
+        <line length2="1.5" x1="-10" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" length1="1.5" end1="none" end2="none" x2="-10" y2="10" y1="-10"/>
+        <rect x="-5" rx="0" antialias="false" y="3" width="3" style="line-style:normal;line-weight:normal;filling:black;color:black" height="12" ry="0"/>
+        <line length2="1.5" x1="10" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" length1="1.5" end1="none" end2="none" x2="10" y2="10" y1="-10"/>
+        <arc x="-10" start="180" antialias="true" y="0" width="20" style="line-style:normal;line-weight:normal;filling:none;color:black" height="20" angle="180"/>
+        <rect x="-5" rx="0" antialias="false" y="-15" width="3" style="line-style:normal;line-weight:normal;filling:black;color:black" height="12" ry="0"/>
+        <line length2="1.5" x1="5" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" length1="1.5" end1="none" end2="none" x2="20" y2="0" y1="0"/>
+        <line length2="1.5" x1="-20" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" length1="1.5" end1="none" end2="none" x2="-5" y2="10" y1="10"/>
+        <line length2="1.5" x1="10" antialias="false" style="line-style:normal;line-weight:hight;filling:none;color:black" length1="1.5" end1="none" end2="none" x2="-10" y2="-5" y1="-15"/>
+        <terminal x="-20" y="10" orientation="w"/>
+        <terminal x="-20" y="-10" orientation="w"/>
+        <terminal x="20" y="0" orientation="e"/>
+    </description>
+</definition>

--- a/elements/10_electric/20_manufacturers_articles/pinball/williams_em/switches_score_motor/mirrored/pinball_em_williams_switch_mb_sm_top_m.elmt
+++ b/elements/10_electric/20_manufacturers_articles/pinball/williams_em/switches_score_motor/mirrored/pinball_em_williams_switch_mb_sm_top_m.elmt
@@ -1,0 +1,25 @@
+<definition hotspot_y="15" width="50" orientation="dyyy" height="50" version="0.70" hotspot_x="24" link_type="simple" type="element">
+    <uuid uuid="{118827a9-bf0b-49d4-9c37-9679a3014ff2}"/>
+    <names>
+        <name lang="en">Switch on Score Motor (M.B.) - Top input - Mirrored</name>
+        <name lang="nl">Schakelaar op Score Motor (M.B.) - Input boven - Gespiegeld</name>
+    </names>
+    <elementInformations/>
+    <informations></informations>
+    <description>
+        <rect x="2" rx="0" antialias="false" y="-5" width="3" style="line-style:normal;line-weight:normal;filling:black;color:black" height="30" ry="0"/>
+        <arc x="-10" start="0" antialias="true" y="-10" width="20" style="line-style:normal;line-weight:normal;filling:none;color:black" height="20" angle="180"/>
+        <line length2="1.5" x1="-10" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" length1="1.5" end1="none" end2="none" x2="-10" y2="20" y1="0"/>
+        <line length2="1.5" x1="-20" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" length1="1.5" end1="none" end2="none" x2="-5" y2="0" y1="0"/>
+        <rect x="-5" rx="0" antialias="false" y="13" width="3" style="line-style:normal;line-weight:normal;filling:black;color:black" height="12" ry="0"/>
+        <line length2="1.5" x1="10" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" length1="1.5" end1="none" end2="none" x2="10" y2="20" y1="0"/>
+        <rect x="-5" rx="0" antialias="false" y="-5" width="3" style="line-style:normal;line-weight:normal;filling:black;color:black" height="12" ry="0"/>
+        <arc x="-10" start="180" antialias="true" y="10" width="20" style="line-style:normal;line-weight:normal;filling:none;color:black" height="20" angle="180"/>
+        <line length2="1.5" x1="5" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" length1="1.5" end1="none" end2="none" x2="20" y2="0" y1="0"/>
+        <line length2="1.5" x1="-20" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" length1="1.5" end1="none" end2="none" x2="-5" y2="20" y1="20"/>
+        <line length2="1.5" x1="10" antialias="false" style="line-style:normal;line-weight:hight;filling:none;color:black" length1="1.5" end1="none" end2="none" x2="-10" y2="25" y1="15"/>
+        <terminal x="-20" y="20" orientation="w"/>
+        <terminal x="20" y="0" orientation="e"/>
+        <terminal x="-20" y="0" orientation="w"/>
+    </description>
+</definition>

--- a/elements/10_electric/20_manufacturers_articles/pinball/williams_em/switches_score_motor/mirrored/pinball_em_williams_switch_mb_sm_top_mi.elmt
+++ b/elements/10_electric/20_manufacturers_articles/pinball/williams_em/switches_score_motor/mirrored/pinball_em_williams_switch_mb_sm_top_mi.elmt
@@ -1,0 +1,25 @@
+<definition hotspot_y="15" width="50" orientation="dyyy" height="50" version="0.70" hotspot_x="24" link_type="simple" type="element">
+    <uuid uuid="{d2347a8a-0c35-45a6-95e4-8a3a3100964f}"/>
+    <names>
+        <name lang="en">Switch on Score Motor (M.B.) - Top input - Mirrored and inverted</name>
+        <name lang="nl">Schakelaar op Score Motor (M.B.) - Input boven - Gespiegeld en omgekeerd</name>
+    </names>
+    <elementInformations/>
+    <informations></informations>
+    <description>
+        <arc x="-10" start="0" antialias="true" y="-10" width="20" style="line-style:normal;line-weight:normal;filling:none;color:black" height="20" angle="180"/>
+        <rect x="2" rx="0" antialias="false" y="-5" width="3" style="line-style:normal;line-weight:normal;filling:black;color:black" height="30" ry="0"/>
+        <line length2="1.5" x1="-20" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" length1="1.5" end1="none" end2="none" x2="-5" y2="0" y1="0"/>
+        <line length2="1.5" x1="-10" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" length1="1.5" end1="none" end2="none" x2="-10" y2="20" y1="0"/>
+        <line length2="1.5" x1="10" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" length1="1.5" end1="none" end2="none" x2="10" y2="20" y1="0"/>
+        <rect x="-5" rx="0" antialias="false" y="13" width="3" style="line-style:normal;line-weight:normal;filling:black;color:black" height="12" ry="0"/>
+        <arc x="-10" start="180" antialias="true" y="10" width="20" style="line-style:normal;line-weight:normal;filling:none;color:black" height="20" angle="180"/>
+        <rect x="-5" rx="0" antialias="false" y="-5" width="3" style="line-style:normal;line-weight:normal;filling:black;color:black" height="12" ry="0"/>
+        <line length2="1.5" x1="5" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" length1="1.5" end1="none" end2="none" x2="20" y2="0" y1="0"/>
+        <line length2="1.5" x1="-20" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" length1="1.5" end1="none" end2="none" x2="-5" y2="20" y1="20"/>
+        <line length2="1.5" x1="10" antialias="false" style="line-style:normal;line-weight:hight;filling:none;color:black" length1="1.5" end1="none" end2="none" x2="-10" y2="5" y1="-5"/>
+        <terminal x="-20" y="20" orientation="w"/>
+        <terminal x="20" y="0" orientation="e"/>
+        <terminal x="-20" y="0" orientation="w"/>
+    </description>
+</definition>

--- a/elements/10_electric/20_manufacturers_articles/pinball/williams_em/switches_score_motor/mirrored/qet_directory
+++ b/elements/10_electric/20_manufacturers_articles/pinball/williams_em/switches_score_motor/mirrored/qet_directory
@@ -1,0 +1,6 @@
+<qet-directory>
+    <names>
+        <name lang="en">Mirrored</name>
+        <name lang="nl">Gespiegeld</name>
+    </names>
+</qet-directory>

--- a/elements/10_electric/20_manufacturers_articles/pinball/williams_em/switches_score_motor/pinball_em_williams_switch_mb_sm_bottom.elmt
+++ b/elements/10_electric/20_manufacturers_articles/pinball/williams_em/switches_score_motor/pinball_em_williams_switch_mb_sm_bottom.elmt
@@ -1,0 +1,25 @@
+<definition type="element" hotspot_y="35" width="50" hotspot_x="24" version="0.70" link_type="simple" height="50" orientation="dyyy">
+    <uuid uuid="{925545b8-d804-4125-a17d-563abac148b4}"/>
+    <names>
+        <name lang="nl">Schakelaar op Score Motor (M.B.) - Input onder</name>
+        <name lang="en">Switch on Score Motor (M.B.) - Bottom input</name>
+    </names>
+    <elementInformations/>
+    <informations></informations>
+    <description>
+        <rect y="-25" rx="0" ry="0" width="3" antialias="false" style="line-style:normal;line-weight:normal;filling:black;color:black" x="-5" height="30"/>
+        <rect y="-7" rx="0" ry="0" width="3" antialias="false" style="line-style:normal;line-weight:normal;filling:black;color:black" x="2" height="12"/>
+        <rect y="-25" rx="0" ry="0" width="3" antialias="false" style="line-style:normal;line-weight:normal;filling:black;color:black" x="2" height="12"/>
+        <line x2="20" length2="1.5" y1="0" antialias="false" end1="none" length1="1.5" end2="none" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="5" y2="0"/>
+        <line x2="-5" length2="1.5" y1="0" antialias="false" end1="none" length1="1.5" end2="none" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-20" y2="0"/>
+        <line x2="20" length2="1.5" y1="-20" antialias="false" end1="none" length1="1.5" end2="none" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="5" y2="-20"/>
+        <line x2="-10" length2="1.5" y1="-5" antialias="false" end1="none" length1="1.5" end2="none" style="line-style:normal;line-weight:hight;filling:none;color:black" x1="10" y2="5"/>
+        <arc y="-30" start="0" width="20" antialias="true" style="line-style:normal;line-weight:normal;filling:none;color:black" x="-10" height="20" angle="180"/>
+        <line x2="-10" length2="1.5" y1="-20" antialias="false" end1="none" length1="1.5" end2="none" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-10" y2="0"/>
+        <line x2="10" length2="1.5" y1="-20" antialias="false" end1="none" length1="1.5" end2="none" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="10" y2="0"/>
+        <arc y="-10" start="180" width="20" antialias="true" style="line-style:normal;line-weight:normal;filling:none;color:black" x="-10" height="20" angle="180"/>
+        <terminal y="0" x="20" orientation="e"/>
+        <terminal y="0" x="-20" orientation="w"/>
+        <terminal y="-20" x="20" orientation="e"/>
+    </description>
+</definition>

--- a/elements/10_electric/20_manufacturers_articles/pinball/williams_em/switches_score_motor/pinball_em_williams_switch_mb_sm_bottom_i.elmt
+++ b/elements/10_electric/20_manufacturers_articles/pinball/williams_em/switches_score_motor/pinball_em_williams_switch_mb_sm_bottom_i.elmt
@@ -1,0 +1,25 @@
+<definition type="element" hotspot_y="35" width="50" hotspot_x="24" version="0.70" link_type="simple" height="50" orientation="dyyy">
+    <uuid uuid="{a366c41f-2629-4a8b-9dad-f06804bd84d6}"/>
+    <names>
+        <name lang="nl">Schakelaar op Score Motor (M.B.) - Input onder - Omgekeerd</name>
+        <name lang="en">Switch on Score Motor (M.B.) - Bottom input - Inverted</name>
+    </names>
+    <elementInformations/>
+    <informations></informations>
+    <description>
+        <rect y="-25" rx="0" ry="0" width="3" antialias="false" style="line-style:normal;line-weight:normal;filling:black;color:black" x="-5" height="30"/>
+        <rect y="-7" rx="0" ry="0" width="3" antialias="false" style="line-style:normal;line-weight:normal;filling:black;color:black" x="2" height="12"/>
+        <rect y="-25" rx="0" ry="0" width="3" antialias="false" style="line-style:normal;line-weight:normal;filling:black;color:black" x="2" height="12"/>
+        <line x2="20" length2="1.5" y1="0" antialias="false" end1="none" length1="1.5" end2="none" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="5" y2="0"/>
+        <line x2="-5" length2="1.5" y1="0" antialias="false" end1="none" length1="1.5" end2="none" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-20" y2="0"/>
+        <line x2="20" length2="1.5" y1="-20" antialias="false" end1="none" length1="1.5" end2="none" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="5" y2="-20"/>
+        <line x2="-10" length2="1.5" y1="-25" antialias="false" end1="none" length1="1.5" end2="none" style="line-style:normal;line-weight:hight;filling:none;color:black" x1="10" y2="-15"/>
+        <arc y="-30" start="0" width="20" antialias="true" style="line-style:normal;line-weight:normal;filling:none;color:black" x="-10" height="20" angle="180"/>
+        <line x2="-10" length2="1.5" y1="-20" antialias="false" end1="none" length1="1.5" end2="none" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-10" y2="0"/>
+        <line x2="10" length2="1.5" y1="-20" antialias="false" end1="none" length1="1.5" end2="none" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="10" y2="0"/>
+        <arc y="-10" start="180" width="20" antialias="true" style="line-style:normal;line-weight:normal;filling:none;color:black" x="-10" height="20" angle="180"/>
+        <terminal y="0" x="20" orientation="e"/>
+        <terminal y="0" x="-20" orientation="w"/>
+        <terminal y="-20" x="20" orientation="e"/>
+    </description>
+</definition>

--- a/elements/10_electric/20_manufacturers_articles/pinball/williams_em/switches_score_motor/pinball_em_williams_switch_mb_sm_center.elmt
+++ b/elements/10_electric/20_manufacturers_articles/pinball/williams_em/switches_score_motor/pinball_em_williams_switch_mb_sm_center.elmt
@@ -1,0 +1,25 @@
+<definition hotspot_y="25" width="50" orientation="dyyy" height="50" version="0.70" hotspot_x="24" link_type="simple" type="element">
+    <uuid uuid="{eda35b7a-2534-400d-b477-a07ff481a50d}"/>
+    <names>
+        <name lang="en">Switch on Score Motor (M.B.) - Center input</name>
+        <name lang="nl">Schakelaar op Score Motor (M.B.) - Input midden</name>
+    </names>
+    <elementInformations/>
+    <informations></informations>
+    <description>
+        <arc x="-10" start="0" antialias="true" y="-20" width="20" style="line-style:normal;line-weight:normal;filling:none;color:black" height="20" angle="180"/>
+        <rect x="-5" rx="0" antialias="false" y="-15" width="3" style="line-style:normal;line-weight:normal;filling:black;color:black" height="30" ry="0"/>
+        <line length2="1.5" x1="-10" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" length1="1.5" end1="none" end2="none" x2="-10" y2="10" y1="-10"/>
+        <rect x="2" rx="0" antialias="false" y="3" width="3" style="line-style:normal;line-weight:normal;filling:black;color:black" height="12" ry="0"/>
+        <line length2="1.5" x1="10" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" length1="1.5" end1="none" end2="none" x2="10" y2="10" y1="-10"/>
+        <rect x="2" rx="0" antialias="false" y="-15" width="3" style="line-style:normal;line-weight:normal;filling:black;color:black" height="12" ry="0"/>
+        <arc x="-10" start="180" antialias="true" y="0" width="20" style="line-style:normal;line-weight:normal;filling:none;color:black" height="20" angle="180"/>
+        <line length2="1.5" x1="5" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" length1="1.5" end1="none" end2="none" x2="20" y2="10" y1="10"/>
+        <line length2="1.5" x1="-20" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" length1="1.5" end1="none" end2="none" x2="-5" y2="0" y1="0"/>
+        <line length2="1.5" x1="5" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" length1="1.5" end1="none" end2="none" x2="20" y2="-10" y1="-10"/>
+        <line length2="1.5" x1="10" antialias="false" style="line-style:normal;line-weight:hight;filling:none;color:black" length1="1.5" end1="none" end2="none" x2="-10" y2="15" y1="5"/>
+        <terminal x="20" y="10" orientation="e"/>
+        <terminal x="20" y="-10" orientation="e"/>
+        <terminal x="-20" y="0" orientation="w"/>
+    </description>
+</definition>

--- a/elements/10_electric/20_manufacturers_articles/pinball/williams_em/switches_score_motor/pinball_em_williams_switch_mb_sm_center_i.elmt
+++ b/elements/10_electric/20_manufacturers_articles/pinball/williams_em/switches_score_motor/pinball_em_williams_switch_mb_sm_center_i.elmt
@@ -1,0 +1,25 @@
+<definition hotspot_y="25" width="50" orientation="dyyy" height="50" version="0.70" hotspot_x="24" link_type="simple" type="element">
+    <uuid uuid="{97121fe2-38e2-4c5e-b5ab-223bb4770b11}"/>
+    <names>
+        <name lang="en">Switch on Score Motor (M.B.) - Center input - Inverted</name>
+        <name lang="nl">Schakelaar op Score Motor (M.B.) - Input midden - Omgekeerd</name>
+    </names>
+    <elementInformations/>
+    <informations></informations>
+    <description>
+        <arc x="-10" start="0" antialias="true" y="-20" width="20" style="line-style:normal;line-weight:normal;filling:none;color:black" height="20" angle="180"/>
+        <rect x="-5" rx="0" antialias="false" y="-15" width="3" style="line-style:normal;line-weight:normal;filling:black;color:black" height="30" ry="0"/>
+        <line length2="1.5" x1="-10" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" length1="1.5" end1="none" end2="none" x2="-10" y2="10" y1="-10"/>
+        <rect x="2" rx="0" antialias="false" y="3" width="3" style="line-style:normal;line-weight:normal;filling:black;color:black" height="12" ry="0"/>
+        <line length2="1.5" x1="10" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" length1="1.5" end1="none" end2="none" x2="10" y2="10" y1="-10"/>
+        <rect x="2" rx="0" antialias="false" y="-15" width="3" style="line-style:normal;line-weight:normal;filling:black;color:black" height="12" ry="0"/>
+        <arc x="-10" start="180" antialias="true" y="0" width="20" style="line-style:normal;line-weight:normal;filling:none;color:black" height="20" angle="180"/>
+        <line length2="1.5" x1="5" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" length1="1.5" end1="none" end2="none" x2="20" y2="10" y1="10"/>
+        <line length2="1.5" x1="-20" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" length1="1.5" end1="none" end2="none" x2="-5" y2="0" y1="0"/>
+        <line length2="1.5" x1="5" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" length1="1.5" end1="none" end2="none" x2="20" y2="-10" y1="-10"/>
+        <line length2="1.5" x1="10" antialias="false" style="line-style:normal;line-weight:hight;filling:none;color:black" length1="1.5" end1="none" end2="none" x2="-10" y2="-5" y1="-15"/>
+        <terminal x="-20" y="0" orientation="w"/>
+        <terminal x="20" y="-10" orientation="e"/>
+        <terminal x="20" y="10" orientation="e"/>
+    </description>
+</definition>

--- a/elements/10_electric/20_manufacturers_articles/pinball/williams_em/switches_score_motor/pinball_em_williams_switch_mb_sm_top.elmt
+++ b/elements/10_electric/20_manufacturers_articles/pinball/williams_em/switches_score_motor/pinball_em_williams_switch_mb_sm_top.elmt
@@ -1,0 +1,25 @@
+<definition hotspot_y="15" width="50" orientation="dyyy" height="50" version="0.70" hotspot_x="24" link_type="simple" type="element">
+    <uuid uuid="{8da83d7e-0afb-4811-8903-633089863194}"/>
+    <names>
+        <name lang="en">Switch on Score Motor (M.B.) - Top input</name>
+        <name lang="nl">Schakelaar op Score Motor (M.B.) - Input boven</name>
+    </names>
+    <elementInformations/>
+    <informations></informations>
+    <description>
+        <arc x="-10" start="0" antialias="true" y="-10" width="20" style="line-style:normal;line-weight:normal;filling:none;color:black" height="20" angle="180"/>
+        <rect x="-5" rx="0" antialias="false" y="-5" width="3" style="line-style:normal;line-weight:normal;filling:black;color:black" height="30" ry="0"/>
+        <rect x="2" rx="0" antialias="false" y="13" width="3" style="line-style:normal;line-weight:normal;filling:black;color:black" height="12" ry="0"/>
+        <line length2="1.5" x1="-10" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" length1="1.5" end1="none" end2="none" x2="-10" y2="20" y1="0"/>
+        <rect x="2" rx="0" antialias="false" y="-5" width="3" style="line-style:normal;line-weight:normal;filling:black;color:black" height="12" ry="0"/>
+        <line length2="1.5" x1="10" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" length1="1.5" end1="none" end2="none" x2="10" y2="20" y1="0"/>
+        <arc x="-10" start="180" antialias="true" y="10" width="20" style="line-style:normal;line-weight:normal;filling:none;color:black" height="20" angle="180"/>
+        <line length2="1.5" x1="5" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" length1="1.5" end1="none" end2="none" x2="20" y2="20" y1="20"/>
+        <line length2="1.5" x1="-20" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" length1="1.5" end1="none" end2="none" x2="-5" y2="0" y1="0"/>
+        <line length2="1.5" x1="5" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" length1="1.5" end1="none" end2="none" x2="20" y2="0" y1="0"/>
+        <line length2="1.5" x1="10" antialias="false" style="line-style:normal;line-weight:hight;filling:none;color:black" length1="1.5" end1="none" end2="none" x2="-10" y2="25" y1="15"/>
+        <terminal x="20" y="20" orientation="e"/>
+        <terminal x="-20" y="0" orientation="w"/>
+        <terminal x="20" y="0" orientation="e"/>
+    </description>
+</definition>

--- a/elements/10_electric/20_manufacturers_articles/pinball/williams_em/switches_score_motor/pinball_em_williams_switch_mb_sm_top_i.elmt
+++ b/elements/10_electric/20_manufacturers_articles/pinball/williams_em/switches_score_motor/pinball_em_williams_switch_mb_sm_top_i.elmt
@@ -1,0 +1,25 @@
+<definition hotspot_y="15" width="50" orientation="dyyy" height="50" version="0.70" hotspot_x="24" link_type="simple" type="element">
+    <uuid uuid="{affc73ff-2963-4d34-911d-da56d8ba6452}"/>
+    <names>
+        <name lang="en">Switch on Score Motor (M.B.) - Top input - Inverted</name>
+        <name lang="nl">Schakelaar op Score Motor (M.B.) - Input boven - Omgekeerd</name>
+    </names>
+    <elementInformations/>
+    <informations></informations>
+    <description>
+        <rect x="-5" rx="0" antialias="false" y="-5" width="3" style="line-style:normal;line-weight:normal;filling:black;color:black" height="30" ry="0"/>
+        <arc x="-10" start="0" antialias="true" y="-10" width="20" style="line-style:normal;line-weight:normal;filling:none;color:black" height="20" angle="180"/>
+        <rect x="2" rx="0" antialias="false" y="13" width="3" style="line-style:normal;line-weight:normal;filling:black;color:black" height="12" ry="0"/>
+        <line length2="1.5" x1="-10" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" length1="1.5" end1="none" end2="none" x2="-10" y2="20" y1="0"/>
+        <rect x="2" rx="0" antialias="false" y="-5" width="3" style="line-style:normal;line-weight:normal;filling:black;color:black" height="12" ry="0"/>
+        <line length2="1.5" x1="10" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" length1="1.5" end1="none" end2="none" x2="10" y2="20" y1="0"/>
+        <line length2="1.5" x1="5" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" length1="1.5" end1="none" end2="none" x2="20" y2="20" y1="20"/>
+        <arc x="-10" start="180" antialias="true" y="10" width="20" style="line-style:normal;line-weight:normal;filling:none;color:black" height="20" angle="180"/>
+        <line length2="1.5" x1="-20" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" length1="1.5" end1="none" end2="none" x2="-5" y2="0" y1="0"/>
+        <line length2="1.5" x1="5" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" length1="1.5" end1="none" end2="none" x2="20" y2="0" y1="0"/>
+        <line length2="1.5" x1="10" antialias="false" style="line-style:normal;line-weight:hight;filling:none;color:black" length1="1.5" end1="none" end2="none" x2="-10" y2="5.25" y1="-4.75"/>
+        <terminal x="20" y="20" orientation="e"/>
+        <terminal x="-20" y="0" orientation="w"/>
+        <terminal x="20" y="0" orientation="e"/>
+    </description>
+</definition>

--- a/elements/10_electric/20_manufacturers_articles/pinball/williams_em/switches_score_motor/pinball_em_williams_switch_nc_sm.elmt
+++ b/elements/10_electric/20_manufacturers_articles/pinball/williams_em/switches_score_motor/pinball_em_williams_switch_nc_sm.elmt
@@ -1,0 +1,19 @@
+<definition hotspot_x="24" height="30" type="element" width="50" hotspot_y="15" version="0.70" link_type="simple" orientation="dyyy">
+    <uuid uuid="{b1b5df82-b447-41d7-bf0c-28d7301821af}"/>
+    <names>
+        <name lang="nl">Schakelaar op Score Motor (N.C.)</name>
+        <name lang="en">Switch on Score Motor (N.C.)</name>
+    </names>
+    <elementInformations/>
+    <informations></informations>
+    <description>
+        <rect height="10" style="line-style:normal;line-weight:normal;filling:black;color:black" width="3" y="-5" ry="0" rx="0" x="-5" antialias="false"/>
+        <rect height="10" style="line-style:normal;line-weight:normal;filling:black;color:black" width="3" y="-5" ry="0" rx="0" x="2" antialias="false"/>
+        <line style="line-style:normal;line-weight:normal;filling:none;color:black" x1="5" end1="none" length2="1.5" y2="0" end2="none" y1="0" x2="20" length1="1.5" antialias="false"/>
+        <line style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-5" end1="none" length2="1.5" y2="0" end2="none" y1="0" x2="-20" length1="1.5" antialias="false"/>
+        <line style="line-style:normal;line-weight:hight;filling:none;color:black" x1="10" end1="none" length2="1.5" y2="5" end2="none" y1="-5" x2="-10" length1="1.5" antialias="false"/>
+        <circle style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="20" y="-10" x="-10" antialias="false"/>
+        <terminal y="0" x="-20" orientation="w"/>
+        <terminal y="0" x="20" orientation="e"/>
+    </description>
+</definition>

--- a/elements/10_electric/20_manufacturers_articles/pinball/williams_em/switches_score_motor/pinball_em_williams_switch_no_sm.elmt
+++ b/elements/10_electric/20_manufacturers_articles/pinball/williams_em/switches_score_motor/pinball_em_williams_switch_no_sm.elmt
@@ -1,0 +1,18 @@
+<definition hotspot_x="24" height="30" type="element" width="50" hotspot_y="15" version="0.70" link_type="simple" orientation="dyyy">
+    <uuid uuid="{cf1b5449-9964-4d90-8114-a131a53ce467}"/>
+    <names>
+        <name lang="nl">Schakelaar op Score Motor (N.O.)</name>
+        <name lang="en">Switch on Score Motor (N.O.)</name>
+    </names>
+    <elementInformations/>
+    <informations></informations>
+    <description>
+        <rect height="10" style="line-style:normal;line-weight:normal;filling:black;color:black" width="3" y="-5" ry="0" rx="0" x="-5" antialias="false"/>
+        <rect height="10" style="line-style:normal;line-weight:normal;filling:black;color:black" width="3" y="-5" ry="0" rx="0" x="2" antialias="false"/>
+        <line style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-20" end1="none" length2="1.5" y2="0" end2="none" y1="0" x2="-5" length1="1.5" antialias="false"/>
+        <line style="line-style:normal;line-weight:normal;filling:none;color:black" x1="5" end1="none" length2="1.5" y2="0" end2="none" y1="0" x2="20" length1="1.5" antialias="false"/>
+        <circle style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="20" y="-10" x="-10" antialias="false"/>
+        <terminal y="0" x="20" orientation="e"/>
+        <terminal y="0" x="-20" orientation="w"/>
+    </description>
+</definition>

--- a/elements/10_electric/20_manufacturers_articles/pinball/williams_em/switches_score_motor/qet_directory
+++ b/elements/10_electric/20_manufacturers_articles/pinball/williams_em/switches_score_motor/qet_directory
@@ -1,0 +1,6 @@
+<qet-directory>
+    <names>
+        <name lang="nl">Schakelaars - Score Motor</name>
+        <name lang="en">Switches - Score Motor</name>
+    </names>
+</qet-directory>

--- a/elements/10_electric/20_manufacturers_articles/pinball/williams_em/units/qet_directory
+++ b/elements/10_electric/20_manufacturers_articles/pinball/williams_em/units/qet_directory
@@ -1,0 +1,6 @@
+<qet-directory>
+    <names>
+        <name lang="en">Units</name>
+        <name lang="nl">Units</name>
+    </names>
+</qet-directory>

--- a/elements/10_electric/20_manufacturers_articles/pinball/williams_em/units/wiper_between/pinball_em_williams_unit_wiper_between_04.elmt
+++ b/elements/10_electric/20_manufacturers_articles/pinball/williams_em/units/wiper_between/pinball_em_williams_unit_wiper_between_04.elmt
@@ -1,0 +1,39 @@
+<definition hotspot_y="15" width="70" orientation="dyyy" height="90" version="0.70" hotspot_x="34" link_type="simple" type="element">
+    <uuid uuid="{aac95ab4-e46a-401d-90c6-0564253d0711}"/>
+    <names>
+        <name lang="en">Wiper between 4 contact pairs</name>
+        <name lang="nl">Sleepcontact tussen 4 contactparen</name>
+    </names>
+    <elementInformations/>
+    <informations></informations>
+    <description>
+        <circle x="5" antialias="false" y="35" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="10"/>
+        <circle x="5" antialias="false" y="-5" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="10"/>
+        <circle x="5" antialias="false" y="55" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="10"/>
+        <circle x="5" antialias="false" y="15" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="10"/>
+        <rect x="-20" rx="0" antialias="false" y="-10" width="40" style="line-style:normal;line-weight:normal;filling:none;color:black" height="80" ry="0"/>
+        <circle x="-15" antialias="false" y="55" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="10"/>
+        <circle x="-15" antialias="false" y="35" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="10"/>
+        <circle x="-15" antialias="false" y="-5" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="10"/>
+        <circle x="-15" antialias="false" y="15" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="10"/>
+        <line length2="1.5" x1="-5" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" length1="1.5" end1="none" end2="none" x2="5" y2="0" y1="0"/>
+        <line length2="1.5" x1="15" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" length1="1.5" end1="none" end2="none" x2="30" y2="0" y1="0"/>
+        <line length2="1.5" x1="15" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" length1="1.5" end1="none" end2="none" x2="30" y2="20" y1="20"/>
+        <line length2="1.5" x1="15" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" length1="1.5" end1="none" end2="none" x2="30" y2="40" y1="40"/>
+        <line length2="1.5" x1="15" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" length1="1.5" end1="none" end2="none" x2="30" y2="60" y1="60"/>
+        <line length2="1.5" x1="-30" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" length1="1.5" end1="none" end2="none" x2="-16" y2="0" y1="0"/>
+        <line length2="1.5" x1="-30" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" length1="1.5" end1="none" end2="none" x2="-15" y2="20" y1="20"/>
+        <line length2="1.5" x1="-30" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" length1="1.5" end1="none" end2="none" x2="-16" y2="40" y1="40"/>
+        <line length2="1.5" x1="-30" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" length1="1.5" end1="none" end2="none" x2="-16" y2="60" y1="60"/>
+        <polygon x1="-5" y4="0" antialias="false" style="line-style:normal;line-weight:normal;filling:black;color:black" x2="-2" y2="-3" x3="-2" y1="0" x4="-5" y3="3"/>
+        <polygon x1="2" antialias="false" style="line-style:normal;line-weight:normal;filling:black;color:black" x2="5" y2="0" x3="2" y1="-3" y3="3"/>
+        <terminal x="30" y="0" orientation="e"/>
+        <terminal x="30" y="60" orientation="e"/>
+        <terminal x="-30" y="20" orientation="w"/>
+        <terminal x="30" y="20" orientation="e"/>
+        <terminal x="30" y="40" orientation="e"/>
+        <terminal x="-30" y="0" orientation="w"/>
+        <terminal x="-30" y="60" orientation="w"/>
+        <terminal x="-30" y="40" orientation="w"/>
+    </description>
+</definition>

--- a/elements/10_electric/20_manufacturers_articles/pinball/williams_em/units/wiper_between/pinball_em_williams_unit_wiper_between_10.elmt
+++ b/elements/10_electric/20_manufacturers_articles/pinball/williams_em/units/wiper_between/pinball_em_williams_unit_wiper_between_10.elmt
@@ -1,0 +1,75 @@
+<definition hotspot_y="15" width="70" orientation="dyyy" height="210" version="0.70" hotspot_x="34" link_type="simple" type="element">
+    <uuid uuid="{a7798588-80e2-4689-8a35-5a1b9459b69b}"/>
+    <names>
+        <name lang="en">Wiper between 10 contact pairs</name>
+        <name lang="nl">Sleepcontact tussen 10 contactparen</name>
+    </names>
+    <elementInformations/>
+    <informations></informations>
+    <description>
+        <circle x="5" antialias="false" y="155" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="10"/>
+        <circle x="5" antialias="false" y="35" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="10"/>
+        <circle x="5" antialias="false" y="95" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="10"/>
+        <circle x="5" antialias="false" y="115" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="10"/>
+        <circle x="5" antialias="false" y="175" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="10"/>
+        <circle x="5" antialias="false" y="-5" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="10"/>
+        <circle x="5" antialias="false" y="135" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="10"/>
+        <circle x="5" antialias="false" y="55" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="10"/>
+        <circle x="5" antialias="false" y="75" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="10"/>
+        <circle x="5" antialias="false" y="15" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="10"/>
+        <circle x="-15" antialias="false" y="115" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="10"/>
+        <circle x="-15" antialias="false" y="175" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="10"/>
+        <circle x="-15" antialias="false" y="95" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="10"/>
+        <rect x="-20" rx="0" antialias="false" y="-10" width="40" style="line-style:normal;line-weight:normal;filling:none;color:black" height="200" ry="0"/>
+        <circle x="-15" antialias="false" y="155" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="10"/>
+        <circle x="-15" antialias="false" y="135" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="10"/>
+        <circle x="-15" antialias="false" y="75" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="10"/>
+        <circle x="-15" antialias="false" y="55" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="10"/>
+        <line length2="1.5" x1="15" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" length1="1.5" end1="none" end2="none" x2="30" y2="140" y1="140"/>
+        <circle x="-15" antialias="false" y="35" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="10"/>
+        <line length2="1.5" x1="15" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" length1="1.5" end1="none" end2="none" x2="30" y2="80" y1="80"/>
+        <circle x="-15" antialias="false" y="-5" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="10"/>
+        <line length2="1.5" x1="15" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" length1="1.5" end1="none" end2="none" x2="30" y2="160" y1="160"/>
+        <line length2="1.5" x1="15" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" length1="1.5" end1="none" end2="none" x2="30" y2="100" y1="100"/>
+        <circle x="-15" antialias="false" y="15" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="10"/>
+        <line length2="1.5" x1="15" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" length1="1.5" end1="none" end2="none" x2="30" y2="180" y1="180"/>
+        <line length2="1.5" x1="15" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" length1="1.5" end1="none" end2="none" x2="30" y2="120" y1="120"/>
+        <line length2="1.5" x1="-5" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" length1="1.5" end1="none" end2="none" x2="5" y2="0" y1="0"/>
+        <line length2="1.5" x1="-30" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" length1="1.5" end1="none" end2="none" x2="-15" y2="80" y1="80"/>
+        <line length2="1.5" x1="-30" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" length1="1.5" end1="none" end2="none" x2="-15" y2="140" y1="140"/>
+        <line length2="1.5" x1="-30" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" length1="1.5" end1="none" end2="none" x2="-16" y2="160" y1="160"/>
+        <line length2="1.5" x1="-30" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" length1="1.5" end1="none" end2="none" x2="-16" y2="100" y1="100"/>
+        <line length2="1.5" x1="15" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" length1="1.5" end1="none" end2="none" x2="30" y2="0" y1="0"/>
+        <line length2="1.5" x1="-30" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" length1="1.5" end1="none" end2="none" x2="-16" y2="120" y1="120"/>
+        <line length2="1.5" x1="-30" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" length1="1.5" end1="none" end2="none" x2="-16" y2="180" y1="180"/>
+        <line length2="1.5" x1="15" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" length1="1.5" end1="none" end2="none" x2="30" y2="20" y1="20"/>
+        <line length2="1.5" x1="15" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" length1="1.5" end1="none" end2="none" x2="30" y2="40" y1="40"/>
+        <line length2="1.5" x1="15" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" length1="1.5" end1="none" end2="none" x2="30" y2="60" y1="60"/>
+        <line length2="1.5" x1="-30" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" length1="1.5" end1="none" end2="none" x2="-16" y2="0" y1="0"/>
+        <line length2="1.5" x1="-30" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" length1="1.5" end1="none" end2="none" x2="-15" y2="20" y1="20"/>
+        <line length2="1.5" x1="-30" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" length1="1.5" end1="none" end2="none" x2="-16" y2="40" y1="40"/>
+        <line length2="1.5" x1="-30" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" length1="1.5" end1="none" end2="none" x2="-16" y2="60" y1="60"/>
+        <polygon x1="-5" y4="0" antialias="false" style="line-style:normal;line-weight:normal;filling:black;color:black" x2="-2" y2="-3" x3="-2" y1="0" x4="-5" y3="3"/>
+        <polygon x1="2" antialias="false" style="line-style:normal;line-weight:normal;filling:black;color:black" x2="5" y2="0" x3="2" y1="-3" y3="3"/>
+        <terminal x="30" y="120" orientation="e"/>
+        <terminal x="-30" y="80" orientation="w"/>
+        <terminal x="-30" y="120" orientation="w"/>
+        <terminal x="-30" y="100" orientation="w"/>
+        <terminal x="30" y="80" orientation="e"/>
+        <terminal x="30" y="100" orientation="e"/>
+        <terminal x="-30" y="0" orientation="w"/>
+        <terminal x="30" y="0" orientation="e"/>
+        <terminal x="-30" y="20" orientation="w"/>
+        <terminal x="-30" y="60" orientation="w"/>
+        <terminal x="-30" y="40" orientation="w"/>
+        <terminal x="30" y="20" orientation="e"/>
+        <terminal x="30" y="60" orientation="e"/>
+        <terminal x="30" y="40" orientation="e"/>
+        <terminal x="-30" y="160" orientation="w"/>
+        <terminal x="-30" y="180" orientation="w"/>
+        <terminal x="30" y="140" orientation="e"/>
+        <terminal x="30" y="180" orientation="e"/>
+        <terminal x="30" y="160" orientation="e"/>
+        <terminal x="-30" y="140" orientation="w"/>
+    </description>
+</definition>

--- a/elements/10_electric/20_manufacturers_articles/pinball/williams_em/units/wiper_between/pinball_em_williams_wiper_3_between_3.elmt
+++ b/elements/10_electric/20_manufacturers_articles/pinball/williams_em/units/wiper_between/pinball_em_williams_wiper_3_between_3.elmt
@@ -1,0 +1,39 @@
+<definition hotspot_y="15" width="70" orientation="dyyy" height="130" version="0.70" hotspot_x="34" link_type="simple" type="element">
+    <uuid uuid="{e2c18efc-1f4f-45cb-a814-09c1b5554535}"/>
+    <names>
+        <name lang="en">3 wipers between 3 contact pairs</name>
+        <name lang="nl">3 sleepcontacten tussen 3 contactparen</name>
+    </names>
+    <elementInformations/>
+    <informations></informations>
+    <description>
+        <line length2="1.5" x1="-5" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" length1="1.5" end1="none" end2="none" x2="5" y2="40" y1="40"/>
+        <line length2="1.5" x1="-5" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" length1="1.5" end1="none" end2="none" x2="5" y2="20" y1="20"/>
+        <circle x="5" antialias="false" y="75" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="10"/>
+        <polygon x1="-5" y4="20" antialias="false" style="line-style:normal;line-weight:normal;filling:black;color:black" x2="-2" y2="17" x3="-2" y1="20" x4="-5" y3="23"/>
+        <polygon x1="-5" y4="40" antialias="false" style="line-style:normal;line-weight:normal;filling:black;color:black" x2="-2" y2="37" x3="-2" y1="40" x4="-5" y3="43"/>
+        <polygon x1="2" antialias="false" style="line-style:normal;line-weight:normal;filling:black;color:black" x2="5" y2="40" x3="2" y1="37" y3="43"/>
+        <polygon x1="2" antialias="false" style="line-style:normal;line-weight:normal;filling:black;color:black" x2="5" y2="20" x3="2" y1="17" y3="23"/>
+        <circle x="5" antialias="false" y="95" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="10"/>
+        <circle x="5" antialias="false" y="55" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="10"/>
+        <rect x="-20" rx="0" antialias="false" y="-10" width="40" style="line-style:normal;line-weight:normal;filling:none;color:black" height="120" ry="0"/>
+        <circle x="-15" antialias="false" y="95" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="10"/>
+        <circle x="-15" antialias="false" y="75" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="10"/>
+        <circle x="-15" antialias="false" y="55" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="10"/>
+        <line length2="1.5" x1="-5" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" length1="1.5" end1="none" end2="none" x2="5" y2="0" y1="0"/>
+        <line length2="1.5" x1="15" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" length1="1.5" end1="none" end2="none" x2="30" y2="60" y1="60"/>
+        <line length2="1.5" x1="15" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" length1="1.5" end1="none" end2="none" x2="30" y2="80" y1="80"/>
+        <line length2="1.5" x1="15" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" length1="1.5" end1="none" end2="none" x2="30" y2="100" y1="100"/>
+        <line length2="1.5" x1="-30" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" length1="1.5" end1="none" end2="none" x2="-15" y2="60" y1="60"/>
+        <line length2="1.5" x1="-30" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" length1="1.5" end1="none" end2="none" x2="-16" y2="80" y1="80"/>
+        <line length2="1.5" x1="-30" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" length1="1.5" end1="none" end2="none" x2="-16" y2="100" y1="100"/>
+        <polygon x1="-5" y4="0" antialias="false" style="line-style:normal;line-weight:normal;filling:black;color:black" x2="-2" y2="-3" x3="-2" y1="0" x4="-5" y3="3"/>
+        <polygon x1="2" antialias="false" style="line-style:normal;line-weight:normal;filling:black;color:black" x2="5" y2="0" x3="2" y1="-3" y3="3"/>
+        <terminal x="30" y="100" orientation="e"/>
+        <terminal x="-30" y="80" orientation="w"/>
+        <terminal x="-30" y="60" orientation="w"/>
+        <terminal x="30" y="60" orientation="e"/>
+        <terminal x="30" y="80" orientation="e"/>
+        <terminal x="-30" y="100" orientation="w"/>
+    </description>
+</definition>

--- a/elements/10_electric/20_manufacturers_articles/pinball/williams_em/units/wiper_between/qet_directory
+++ b/elements/10_electric/20_manufacturers_articles/pinball/williams_em/units/wiper_between/qet_directory
@@ -1,0 +1,6 @@
+<qet-directory>
+    <names>
+        <name lang="en">Wiper between</name>
+        <name lang="nl">Sleepcontact tussen</name>
+    </names>
+</qet-directory>

--- a/elements/10_electric/20_manufacturers_articles/pinball/williams_em/units/wiper_to/pinball_em_williams_unit_wiper_to_02.elmt
+++ b/elements/10_electric/20_manufacturers_articles/pinball/williams_em/units/wiper_to/pinball_em_williams_unit_wiper_to_02.elmt
@@ -1,0 +1,21 @@
+<definition hotspot_y="15" width="70" orientation="dyyy" height="50" version="0.70" hotspot_x="34" link_type="simple" type="element">
+    <uuid uuid="{292efe3b-b14f-4bf4-b666-7edcff8c76e6}"/>
+    <names>
+        <name lang="en">Wiper to 2 contacts</name>
+        <name lang="nl">Sleepcontact naar 2 polen</name>
+    </names>
+    <elementInformations/>
+    <informations></informations>
+    <description>
+        <circle x="-15" antialias="false" y="15" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="10"/>
+        <rect x="-20" rx="0" antialias="false" y="-10" width="40" style="line-style:normal;line-weight:normal;filling:none;color:black" height="40" ry="0"/>
+        <circle x="-15" antialias="false" y="-5" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="10"/>
+        <line length2="1.5" x1="-30" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" length1="1.5" end1="none" end2="none" x2="-15" y2="0" y1="0"/>
+        <line length2="1.5" x1="-30" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" length1="1.5" end1="none" end2="none" x2="-15" y2="20" y1="20"/>
+        <line length2="1.5" x1="-5" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" length1="1.5" end1="none" end2="none" x2="30" y2="0" y1="0"/>
+        <polygon x1="-2" y4="-3" antialias="false" style="line-style:normal;line-weight:normal;filling:black;color:black" x2="-2" y2="3" x3="-5" y1="-3" x4="-2" y3="0"/>
+        <terminal x="30" y="0" orientation="e"/>
+        <terminal x="-30" y="20" orientation="w"/>
+        <terminal x="-30" y="0" orientation="w"/>
+    </description>
+</definition>

--- a/elements/10_electric/20_manufacturers_articles/pinball/williams_em/units/wiper_to/pinball_em_williams_unit_wiper_to_03.elmt
+++ b/elements/10_electric/20_manufacturers_articles/pinball/williams_em/units/wiper_to/pinball_em_williams_unit_wiper_to_03.elmt
@@ -1,0 +1,24 @@
+<definition hotspot_y="15" width="70" orientation="dyyy" height="70" version="0.70" hotspot_x="34" link_type="simple" type="element">
+    <uuid uuid="{b1ae72b5-69cf-4f1a-b618-8f5d4e0b55c6}"/>
+    <names>
+        <name lang="en">Wiper to 3 contacts</name>
+        <name lang="nl">Sleepcontact naar 3 polen</name>
+    </names>
+    <elementInformations/>
+    <informations></informations>
+    <description>
+        <circle x="-15" antialias="false" y="15" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="10"/>
+        <circle x="-15" antialias="false" y="35" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="10"/>
+        <rect x="-20" rx="0" antialias="false" y="-10" width="40" style="line-style:normal;line-weight:normal;filling:none;color:black" height="60" ry="0"/>
+        <line length2="1.5" x1="-30" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" length1="1.5" end1="none" end2="none" x2="-15" y2="40" y1="40"/>
+        <circle x="-15" antialias="false" y="-5" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="10"/>
+        <line length2="1.5" x1="-30" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" length1="1.5" end1="none" end2="none" x2="-15" y2="0" y1="0"/>
+        <line length2="1.5" x1="-30" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" length1="1.5" end1="none" end2="none" x2="-15" y2="20" y1="20"/>
+        <line length2="1.5" x1="-5" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" length1="1.5" end1="none" end2="none" x2="30" y2="0" y1="0"/>
+        <polygon x1="-2" y4="-3" antialias="false" style="line-style:normal;line-weight:normal;filling:black;color:black" x2="-2" y2="3" x3="-5" y1="-3" x4="-2" y3="0"/>
+        <terminal x="30" y="0" orientation="e"/>
+        <terminal x="-30" y="20" orientation="w"/>
+        <terminal x="-30" y="0" orientation="w"/>
+        <terminal x="-30" y="40" orientation="w"/>
+    </description>
+</definition>

--- a/elements/10_electric/20_manufacturers_articles/pinball/williams_em/units/wiper_to/pinball_em_williams_unit_wiper_to_04.elmt
+++ b/elements/10_electric/20_manufacturers_articles/pinball/williams_em/units/wiper_to/pinball_em_williams_unit_wiper_to_04.elmt
@@ -1,0 +1,27 @@
+<definition hotspot_y="15" width="70" orientation="dyyy" height="90" version="0.70" hotspot_x="34" link_type="simple" type="element">
+    <uuid uuid="{c8f0c752-3215-409d-96f5-0dee5f6f89c5}"/>
+    <names>
+        <name lang="en">Wiper to 4 contacts</name>
+        <name lang="nl">Sleepcontact naar 4 polen</name>
+    </names>
+    <elementInformations/>
+    <informations></informations>
+    <description>
+        <circle x="-15" antialias="false" y="55" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="10"/>
+        <circle x="-15" antialias="false" y="15" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="10"/>
+        <circle x="-15" antialias="false" y="35" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="10"/>
+        <line length2="1.5" x1="-30" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" length1="1.5" end1="none" end2="none" x2="-15" y2="60" y1="60"/>
+        <rect x="-20" rx="0" antialias="false" y="-10" width="40" style="line-style:normal;line-weight:normal;filling:none;color:black" height="80" ry="0"/>
+        <line length2="1.5" x1="-30" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" length1="1.5" end1="none" end2="none" x2="-15" y2="40" y1="40"/>
+        <circle x="-15" antialias="false" y="-5" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="10"/>
+        <line length2="1.5" x1="-30" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" length1="1.5" end1="none" end2="none" x2="-15" y2="0" y1="0"/>
+        <line length2="1.5" x1="-30" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" length1="1.5" end1="none" end2="none" x2="-15" y2="20" y1="20"/>
+        <line length2="1.5" x1="-5" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" length1="1.5" end1="none" end2="none" x2="30" y2="0" y1="0"/>
+        <polygon x1="-2" y4="-3" antialias="false" style="line-style:normal;line-weight:normal;filling:black;color:black" x2="-2" y2="3" x3="-5" y1="-3" x4="-2" y3="0"/>
+        <terminal x="-30" y="60" orientation="w"/>
+        <terminal x="-30" y="20" orientation="w"/>
+        <terminal x="30" y="0" orientation="e"/>
+        <terminal x="-30" y="40" orientation="w"/>
+        <terminal x="-30" y="0" orientation="w"/>
+    </description>
+</definition>

--- a/elements/10_electric/20_manufacturers_articles/pinball/williams_em/units/wiper_to/pinball_em_williams_unit_wiper_to_05.elmt
+++ b/elements/10_electric/20_manufacturers_articles/pinball/williams_em/units/wiper_to/pinball_em_williams_unit_wiper_to_05.elmt
@@ -1,0 +1,30 @@
+<definition hotspot_y="15" width="70" orientation="dyyy" height="110" version="0.70" hotspot_x="34" link_type="simple" type="element">
+    <uuid uuid="{4f2df3dd-0521-4ed2-879c-e2ad597ab05a}"/>
+    <names>
+        <name lang="en">Wiper to 5 contacts</name>
+        <name lang="nl">Sleepcontact naar 5 polen</name>
+    </names>
+    <elementInformations/>
+    <informations></informations>
+    <description>
+        <circle x="-15" antialias="false" y="75" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="10"/>
+        <circle x="-15" antialias="false" y="55" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="10"/>
+        <line length2="1.5" x1="-30" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" length1="1.5" end1="none" end2="none" x2="-15" y2="80" y1="80"/>
+        <circle x="-15" antialias="false" y="15" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="10"/>
+        <circle x="-15" antialias="false" y="35" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="10"/>
+        <line length2="1.5" x1="-30" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" length1="1.5" end1="none" end2="none" x2="-15" y2="60" y1="60"/>
+        <rect x="-20" rx="0" antialias="false" y="-10" width="40" style="line-style:normal;line-weight:normal;filling:none;color:black" height="100" ry="0"/>
+        <line length2="1.5" x1="-30" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" length1="1.5" end1="none" end2="none" x2="-15" y2="40" y1="40"/>
+        <circle x="-15" antialias="false" y="-5" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="10"/>
+        <line length2="1.5" x1="-30" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" length1="1.5" end1="none" end2="none" x2="-15" y2="0" y1="0"/>
+        <line length2="1.5" x1="-30" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" length1="1.5" end1="none" end2="none" x2="-15" y2="20" y1="20"/>
+        <line length2="1.5" x1="-5" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" length1="1.5" end1="none" end2="none" x2="30" y2="0" y1="0"/>
+        <polygon x1="-2" y4="-3" antialias="false" style="line-style:normal;line-weight:normal;filling:black;color:black" x2="-2" y2="3" x3="-5" y1="-3" x4="-2" y3="0"/>
+        <terminal x="-30" y="40" orientation="w"/>
+        <terminal x="-30" y="0" orientation="w"/>
+        <terminal x="-30" y="20" orientation="w"/>
+        <terminal x="30" y="0" orientation="e"/>
+        <terminal x="-30" y="60" orientation="w"/>
+        <terminal x="-30" y="80" orientation="w"/>
+    </description>
+</definition>

--- a/elements/10_electric/20_manufacturers_articles/pinball/williams_em/units/wiper_to/pinball_em_williams_unit_wiper_to_06.elmt
+++ b/elements/10_electric/20_manufacturers_articles/pinball/williams_em/units/wiper_to/pinball_em_williams_unit_wiper_to_06.elmt
@@ -1,0 +1,33 @@
+<definition hotspot_y="15" width="70" orientation="dyyy" height="130" version="0.70" hotspot_x="34" link_type="simple" type="element">
+    <uuid uuid="{eb3e79b4-1f02-4044-a625-4bdd2440e827}"/>
+    <names>
+        <name lang="en">Wiper to 6 contacts</name>
+        <name lang="nl">Sleepcontact naar 6 polen</name>
+    </names>
+    <elementInformations/>
+    <informations></informations>
+    <description>
+        <circle x="-15" antialias="false" y="75" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="10"/>
+        <circle x="-15" antialias="false" y="95" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="10"/>
+        <circle x="-15" antialias="false" y="55" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="10"/>
+        <line length2="1.5" x1="-30" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" length1="1.5" end1="none" end2="none" x2="-15" y2="100" y1="100"/>
+        <line length2="1.5" x1="-30" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" length1="1.5" end1="none" end2="none" x2="-15" y2="80" y1="80"/>
+        <circle x="-15" antialias="false" y="15" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="10"/>
+        <circle x="-15" antialias="false" y="35" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="10"/>
+        <line length2="1.5" x1="-30" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" length1="1.5" end1="none" end2="none" x2="-15" y2="60" y1="60"/>
+        <rect x="-20" rx="0" antialias="false" y="-10" width="40" style="line-style:normal;line-weight:normal;filling:none;color:black" height="120" ry="0"/>
+        <line length2="1.5" x1="-30" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" length1="1.5" end1="none" end2="none" x2="-15" y2="40" y1="40"/>
+        <circle x="-15" antialias="false" y="-5" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="10"/>
+        <line length2="1.5" x1="-30" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" length1="1.5" end1="none" end2="none" x2="-15" y2="0" y1="0"/>
+        <line length2="1.5" x1="-30" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" length1="1.5" end1="none" end2="none" x2="-15" y2="20" y1="20"/>
+        <line length2="1.5" x1="-5" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" length1="1.5" end1="none" end2="none" x2="30" y2="0" y1="0"/>
+        <polygon x1="-2" y4="-3" antialias="false" style="line-style:normal;line-weight:normal;filling:black;color:black" x2="-2" y2="3" x3="-5" y1="-3" x4="-2" y3="0"/>
+        <terminal x="-30" y="100" orientation="w"/>
+        <terminal x="-30" y="40" orientation="w"/>
+        <terminal x="-30" y="0" orientation="w"/>
+        <terminal x="-30" y="20" orientation="w"/>
+        <terminal x="30" y="0" orientation="e"/>
+        <terminal x="-30" y="80" orientation="w"/>
+        <terminal x="-30" y="60" orientation="w"/>
+    </description>
+</definition>

--- a/elements/10_electric/20_manufacturers_articles/pinball/williams_em/units/wiper_to/pinball_em_williams_unit_wiper_to_10.elmt
+++ b/elements/10_electric/20_manufacturers_articles/pinball/williams_em/units/wiper_to/pinball_em_williams_unit_wiper_to_10.elmt
@@ -1,0 +1,45 @@
+<definition hotspot_y="15" width="70" orientation="dyyy" height="210" version="0.70" hotspot_x="34" link_type="simple" type="element">
+    <uuid uuid="{f152f6a0-17e9-4590-879e-9c6a360d2903}"/>
+    <names>
+        <name lang="en">Wiper to 10 contacts</name>
+        <name lang="nl">Sleepcontact naar 10 polen</name>
+    </names>
+    <elementInformations/>
+    <informations></informations>
+    <description>
+        <circle x="-15" antialias="false" y="155" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="10"/>
+        <circle x="-15" antialias="false" y="75" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="10"/>
+        <circle x="-15" antialias="false" y="175" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="10"/>
+        <circle x="-15" antialias="false" y="95" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="10"/>
+        <circle x="-15" antialias="false" y="135" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="10"/>
+        <circle x="-15" antialias="false" y="55" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="10"/>
+        <line length2="1.5" x1="-30" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" length1="1.5" end1="none" end2="none" x2="-15" y2="100" y1="100"/>
+        <line length2="1.5" x1="-30" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" length1="1.5" end1="none" end2="none" x2="-15" y2="180" y1="180"/>
+        <line length2="1.5" x1="-30" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" length1="1.5" end1="none" end2="none" x2="-15" y2="160" y1="160"/>
+        <line length2="1.5" x1="-30" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" length1="1.5" end1="none" end2="none" x2="-15" y2="80" y1="80"/>
+        <circle x="-15" antialias="false" y="115" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="10"/>
+        <circle x="-15" antialias="false" y="15" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="10"/>
+        <line length2="1.5" x1="-30" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" length1="1.5" end1="none" end2="none" x2="-15" y2="140" y1="140"/>
+        <circle x="-15" antialias="false" y="35" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="10"/>
+        <line length2="1.5" x1="-30" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" length1="1.5" end1="none" end2="none" x2="-15" y2="120" y1="120"/>
+        <line length2="1.5" x1="-30" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" length1="1.5" end1="none" end2="none" x2="-15" y2="60" y1="60"/>
+        <rect x="-20" rx="0" antialias="false" y="-10" width="40" style="line-style:normal;line-weight:normal;filling:none;color:black" height="200" ry="0"/>
+        <line length2="1.5" x1="-30" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" length1="1.5" end1="none" end2="none" x2="-15" y2="40" y1="40"/>
+        <circle x="-15" antialias="false" y="-5" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="10"/>
+        <line length2="1.5" x1="-30" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" length1="1.5" end1="none" end2="none" x2="-15" y2="0" y1="0"/>
+        <line length2="1.5" x1="-30" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" length1="1.5" end1="none" end2="none" x2="-15" y2="20" y1="20"/>
+        <line length2="1.5" x1="-5" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" length1="1.5" end1="none" end2="none" x2="30" y2="0" y1="0"/>
+        <polygon x1="-2" y4="-3" antialias="false" style="line-style:normal;line-weight:normal;filling:black;color:black" x2="-2" y2="3" x3="-5" y1="-3" x4="-2" y3="0"/>
+        <terminal x="-30" y="40" orientation="w"/>
+        <terminal x="-30" y="20" orientation="w"/>
+        <terminal x="30" y="0" orientation="e"/>
+        <terminal x="-30" y="0" orientation="w"/>
+        <terminal x="-30" y="60" orientation="w"/>
+        <terminal x="-30" y="80" orientation="w"/>
+        <terminal x="-30" y="100" orientation="w"/>
+        <terminal x="-30" y="120" orientation="w"/>
+        <terminal x="-30" y="140" orientation="w"/>
+        <terminal x="-30" y="160" orientation="w"/>
+        <terminal x="-30" y="180" orientation="w"/>
+    </description>
+</definition>

--- a/elements/10_electric/20_manufacturers_articles/pinball/williams_em/units/wiper_to/pinball_em_williams_unit_wiper_to_11.elmt
+++ b/elements/10_electric/20_manufacturers_articles/pinball/williams_em/units/wiper_to/pinball_em_williams_unit_wiper_to_11.elmt
@@ -1,0 +1,48 @@
+<definition hotspot_y="15" width="70" orientation="dyyy" height="230" version="0.70" hotspot_x="34" link_type="simple" type="element">
+    <uuid uuid="{36c95bf0-254c-4d0a-81af-866db548ae97}"/>
+    <names>
+        <name lang="en">Wiper to 11 contacts</name>
+        <name lang="nl">Sleepcontact naar 11 polen</name>
+    </names>
+    <elementInformations/>
+    <informations></informations>
+    <description>
+        <circle x="-15" antialias="false" y="195" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="10"/>
+        <circle x="-15" antialias="false" y="155" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="10"/>
+        <circle x="-15" antialias="false" y="75" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="10"/>
+        <line length2="1.5" x1="-30" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" length1="1.5" end1="none" end2="none" x2="-15" y2="200" y1="200"/>
+        <circle x="-15" antialias="false" y="175" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="10"/>
+        <circle x="-15" antialias="false" y="95" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="10"/>
+        <circle x="-15" antialias="false" y="135" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="10"/>
+        <circle x="-15" antialias="false" y="55" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="10"/>
+        <line length2="1.5" x1="-30" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" length1="1.5" end1="none" end2="none" x2="-15" y2="100" y1="100"/>
+        <line length2="1.5" x1="-30" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" length1="1.5" end1="none" end2="none" x2="-15" y2="180" y1="180"/>
+        <line length2="1.5" x1="-30" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" length1="1.5" end1="none" end2="none" x2="-15" y2="160" y1="160"/>
+        <line length2="1.5" x1="-30" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" length1="1.5" end1="none" end2="none" x2="-15" y2="80" y1="80"/>
+        <circle x="-15" antialias="false" y="115" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="10"/>
+        <circle x="-15" antialias="false" y="15" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="10"/>
+        <line length2="1.5" x1="-30" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" length1="1.5" end1="none" end2="none" x2="-15" y2="140" y1="140"/>
+        <circle x="-15" antialias="false" y="35" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="10"/>
+        <line length2="1.5" x1="-30" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" length1="1.5" end1="none" end2="none" x2="-15" y2="120" y1="120"/>
+        <line length2="1.5" x1="-30" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" length1="1.5" end1="none" end2="none" x2="-15" y2="60" y1="60"/>
+        <rect x="-20" rx="0" antialias="false" y="-10" width="40" style="line-style:normal;line-weight:normal;filling:none;color:black" height="220" ry="0"/>
+        <line length2="1.5" x1="-30" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" length1="1.5" end1="none" end2="none" x2="-15" y2="40" y1="40"/>
+        <circle x="-15" antialias="false" y="-5" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="10"/>
+        <line length2="1.5" x1="-30" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" length1="1.5" end1="none" end2="none" x2="-15" y2="0" y1="0"/>
+        <line length2="1.5" x1="-30" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" length1="1.5" end1="none" end2="none" x2="-15" y2="20" y1="20"/>
+        <line length2="1.5" x1="-5" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" length1="1.5" end1="none" end2="none" x2="30" y2="0" y1="0"/>
+        <polygon x1="-2" y4="-3" antialias="false" style="line-style:normal;line-weight:normal;filling:black;color:black" x2="-2" y2="3" x3="-5" y1="-3" x4="-2" y3="0"/>
+        <terminal x="-30" y="140" orientation="w"/>
+        <terminal x="-30" y="160" orientation="w"/>
+        <terminal x="30" y="0" orientation="e"/>
+        <terminal x="-30" y="60" orientation="w"/>
+        <terminal x="-30" y="80" orientation="w"/>
+        <terminal x="-30" y="0" orientation="w"/>
+        <terminal x="-30" y="40" orientation="w"/>
+        <terminal x="-30" y="120" orientation="w"/>
+        <terminal x="-30" y="100" orientation="w"/>
+        <terminal x="-30" y="20" orientation="w"/>
+        <terminal x="-30" y="180" orientation="w"/>
+        <terminal x="-30" y="200" orientation="w"/>
+    </description>
+</definition>

--- a/elements/10_electric/20_manufacturers_articles/pinball/williams_em/units/wiper_to/qet_directory
+++ b/elements/10_electric/20_manufacturers_articles/pinball/williams_em/units/wiper_to/qet_directory
@@ -1,0 +1,6 @@
+<qet-directory>
+    <names>
+        <name lang="en">Wiper to</name>
+        <name lang="nl">Sleepcontact naar</name>
+    </names>
+</qet-directory>

--- a/examples/pinball_williams_em.qet
+++ b/examples/pinball_williams_em.qet
@@ -1,0 +1,3048 @@
+<project title="" folioSheetQuantity="0" version="0.70">
+    <properties>
+        <property show="1" name="savedtime">23:00</property>
+        <property show="1" name="savedfilename">example</property>
+        <property show="1" name="saveddate">3-2-2021</property>
+        <property show="1" name="savedfilepath">C:/Users/Thomas/Application Data/qet/elements/pinball_em_williams_schematic/example.qet</property>
+    </properties>
+    <newdiagrams>
+        <border rows="8" rowsize="80" displayrows="true" cols="17" colsize="60" displaycols="true"/>
+        <inset plant="" title="" date="null" indexrev="" folio="%id/%total" auto_page_num="" locmach="" filename="" author="" version="" displayAt="bottom"/>
+        <conductors horizrotatetext="0" vertical-alignment="AlignRight" type="multi" displaytext="1" onetextperfolio="0" numsize="7" dash-size="1" num="_" condsize="1" vertirotatetext="270" color2="#000000" tension-protocol="" horizontal-alignment="AlignBottom" formula="" function="" bicolor="false"/>
+        <report label="%f-%l%c"/>
+        <xrefs>
+            <xref delayprefix="" switchprefix="" type="protection" master_label="%f-%l%c" snapto="label" displayhas="cross" slave_label="(%f-%l%c)" showpowerctc="false" offset="0" powerprefix=""/>
+            <xref delayprefix="" switchprefix="" type="commutator" master_label="%f-%l%c" snapto="label" displayhas="cross" slave_label="(%f-%l%c)" showpowerctc="false" offset="0" powerprefix=""/>
+            <xref delayprefix="" switchprefix="" type="coil" master_label="%f-%l%c" snapto="label" displayhas="cross" slave_label="(%f-%l%c)" showpowerctc="false" offset="0" powerprefix=""/>
+        </xrefs>
+        <conductors_autonums current_autonum="" freeze_new_conductors="false"/>
+        <folio_autonums/>
+        <element_autonums freeze_new_elements="false" current_autonum=""/>
+    </newdiagrams>
+    <diagram date="20210203" plant="" locmach="" displayAt="bottom" rows="8" folio="%id/%total" displaycols="true" version="0.70+a375424c0d79751d3" freezeNewConductor="false" rowsize="80" cols="17" filename="example.qet" auto_page_num="Maak een automatische bladnummering" author="Thomas Gravekamp" height="660" title="Example page for Williams EM Schematic Symbols" indexrev="" freezeNewElement="false" order="1" displayrows="true" colsize="60">
+        <defaultconductor horizrotatetext="0" vertical-alignment="AlignRight" type="multi" displaytext="1" onetextperfolio="0" numsize="7" dash-size="2" num="_" condsize="1" vertirotatetext="270" color2="#000000" tension-protocol="" horizontal-alignment="AlignBottom" formula="" function="" bicolor="false"/>
+        <elements>
+            <element freezeLabel="false" type="embed://import/pinball_em_williams_schematic/jacks/pinball_em_williams_jack_03.elmt" x="570" y="380" orientation="0" z="10" uuid="{ff6d715c-80dc-431d-9094-6c48bab6ad0c}" prefix="">
+                <terminals>
+                    <terminal number="_" nameHidden="0" x="-16" y="0" orientation="3" name="_" id="0"/>
+                    <terminal number="_" nameHidden="0" x="16" y="0" orientation="1" name="_" id="1"/>
+                    <terminal number="_" nameHidden="0" x="-16" y="20" orientation="3" name="_" id="2"/>
+                    <terminal number="_" nameHidden="0" x="16" y="20" orientation="1" name="_" id="3"/>
+                    <terminal number="_" nameHidden="0" x="-16" y="40" orientation="3" name="_" id="4"/>
+                    <terminal number="_" nameHidden="0" x="16" y="40" orientation="1" name="_" id="5"/>
+                </terminals>
+                <inputs/>
+                <elementInformations>
+                    <elementInformation show="1" name="formula"></elementInformation>
+                </elementInformations>
+                <dynamic_texts>
+                    <dynamic_elmt_text x="-40" y="-40" Halignment="AlignLeft" uuid="{9e7ff872-f172-48b8-bbc0-1e34041f7eac}" frame="false" text_from="UserText" rotation="0" font="Sans Serif,9,-1,5,0,0,0,0,0,0,normal" Valignment="AlignTop" text_width="80">
+                        <text>3 positions</text>
+                    </dynamic_elmt_text>
+                </dynamic_texts>
+                <texts_groups/>
+            </element>
+            <element freezeLabel="false" type="embed://import/pinball_em_williams_schematic/switches_score_motor/mirrored/pinball_em_williams_switch_mb_sm_center_mi.elmt" x="920" y="210" orientation="0" z="10" uuid="{cc14269c-bb16-4885-8655-fcb1e811fcc5}" prefix="">
+                <terminals>
+                    <terminal number="_" nameHidden="0" x="-16" y="-10" orientation="3" name="_" id="6"/>
+                    <terminal number="_" nameHidden="0" x="16" y="0" orientation="1" name="_" id="7"/>
+                    <terminal number="_" nameHidden="0" x="-16" y="10" orientation="3" name="_" id="8"/>
+                </terminals>
+                <inputs/>
+                <elementInformations>
+                    <elementInformation show="1" name="formula"></elementInformation>
+                </elementInformations>
+                <dynamic_texts/>
+                <texts_groups/>
+            </element>
+            <element freezeLabel="false" type="embed://import/pinball_em_williams_schematic/units/wiper_to/pinball_em_williams_unit_wiper_to_06.elmt" x="780" y="490" orientation="0" z="10" uuid="{9d1d6b58-c0eb-4c53-9a88-f6dfc0f46990}" prefix="">
+                <terminals>
+                    <terminal number="_" nameHidden="0" x="-26" y="0" orientation="3" name="_" id="9"/>
+                    <terminal number="_" nameHidden="0" x="26" y="0" orientation="1" name="_" id="10"/>
+                    <terminal number="_" nameHidden="0" x="-26" y="20" orientation="3" name="_" id="11"/>
+                    <terminal number="_" nameHidden="0" x="-26" y="40" orientation="3" name="_" id="12"/>
+                    <terminal number="_" nameHidden="0" x="-26" y="60" orientation="3" name="_" id="13"/>
+                    <terminal number="_" nameHidden="0" x="-26" y="80" orientation="3" name="_" id="14"/>
+                    <terminal number="_" nameHidden="0" x="-26" y="100" orientation="3" name="_" id="15"/>
+                </terminals>
+                <inputs/>
+                <elementInformations>
+                    <elementInformation show="1" name="formula"></elementInformation>
+                </elementInformations>
+                <dynamic_texts>
+                    <dynamic_elmt_text x="-40" y="110" Halignment="AlignLeft" uuid="{9551b3c8-0ff2-4764-8262-f858b2b7822d}" frame="false" text_from="UserText" rotation="0" font="Sans Serif,9,-1,5,0,0,0,0,0,0,normal" Valignment="AlignTop" text_width="80">
+                        <text>Wiper to 6 contacts</text>
+                    </dynamic_elmt_text>
+                </dynamic_texts>
+                <texts_groups/>
+            </element>
+            <element freezeLabel="false" type="embed://import/pinball_em_williams_schematic/units/wiper_between/pinball_em_williams_unit_wiper_between_04.elmt" x="500" y="530" orientation="0" z="10" uuid="{9c598148-9654-470a-b3e1-15762e818fd2}" prefix="">
+                <terminals>
+                    <terminal number="_" nameHidden="0" x="-26" y="0" orientation="3" name="_" id="16"/>
+                    <terminal number="_" nameHidden="0" x="26" y="0" orientation="1" name="_" id="17"/>
+                    <terminal number="_" nameHidden="0" x="-26" y="20" orientation="3" name="_" id="18"/>
+                    <terminal number="_" nameHidden="0" x="26" y="20" orientation="1" name="_" id="19"/>
+                    <terminal number="_" nameHidden="0" x="-26" y="40" orientation="3" name="_" id="20"/>
+                    <terminal number="_" nameHidden="0" x="26" y="40" orientation="1" name="_" id="21"/>
+                    <terminal number="_" nameHidden="0" x="-26" y="60" orientation="3" name="_" id="22"/>
+                    <terminal number="_" nameHidden="0" x="26" y="60" orientation="1" name="_" id="23"/>
+                </terminals>
+                <inputs/>
+                <elementInformations>
+                    <elementInformation show="1" name="formula"></elementInformation>
+                </elementInformations>
+                <dynamic_texts>
+                    <dynamic_elmt_text x="-40" y="70" Halignment="AlignLeft" uuid="{ba10e81a-f5ea-4446-93a1-986a9eff53d8}" frame="false" text_from="UserText" rotation="0" font="Sans Serif,9,-1,5,0,0,0,0,0,0,normal" Valignment="AlignTop" text_width="80">
+                        <text>Wiper between 4 contacts</text>
+                    </dynamic_elmt_text>
+                </dynamic_texts>
+                <texts_groups/>
+            </element>
+            <element freezeLabel="false" type="embed://import/pinball_em_williams_schematic/units/wiper_to/pinball_em_williams_unit_wiper_to_11.elmt" x="990" y="390" orientation="0" z="10" uuid="{a2baeea4-a41d-49d1-a693-fee13bbbdcbd}" prefix="">
+                <terminals>
+                    <terminal number="_" nameHidden="0" x="-26" y="0" orientation="3" name="_" id="24"/>
+                    <terminal number="_" nameHidden="0" x="26" y="0" orientation="1" name="_" id="25"/>
+                    <terminal number="_" nameHidden="0" x="-26" y="20" orientation="3" name="_" id="26"/>
+                    <terminal number="_" nameHidden="0" x="-26" y="40" orientation="3" name="_" id="27"/>
+                    <terminal number="_" nameHidden="0" x="-26" y="60" orientation="3" name="_" id="28"/>
+                    <terminal number="_" nameHidden="0" x="-26" y="80" orientation="3" name="_" id="29"/>
+                    <terminal number="_" nameHidden="0" x="-26" y="100" orientation="3" name="_" id="30"/>
+                    <terminal number="_" nameHidden="0" x="-26" y="120" orientation="3" name="_" id="31"/>
+                    <terminal number="_" nameHidden="0" x="-26" y="140" orientation="3" name="_" id="32"/>
+                    <terminal number="_" nameHidden="0" x="-26" y="160" orientation="3" name="_" id="33"/>
+                    <terminal number="_" nameHidden="0" x="-26" y="180" orientation="3" name="_" id="34"/>
+                    <terminal number="_" nameHidden="0" x="-26" y="200" orientation="3" name="_" id="35"/>
+                </terminals>
+                <inputs/>
+                <elementInformations>
+                    <elementInformation show="1" name="formula"></elementInformation>
+                </elementInformations>
+                <dynamic_texts>
+                    <dynamic_elmt_text x="-40" y="210" Halignment="AlignLeft" uuid="{eab1d13d-38df-4836-a9e3-e288665b959b}" frame="false" text_from="UserText" rotation="0" font="Sans Serif,9,-1,5,0,0,0,0,0,0,normal" Valignment="AlignTop" text_width="80">
+                        <text>Wiper to 11 contacts</text>
+                    </dynamic_elmt_text>
+                </dynamic_texts>
+                <texts_groups/>
+            </element>
+            <element freezeLabel="false" type="embed://import/pinball_em_williams_schematic/switches_common/pinball_em_williams_switch_no.elmt" x="500" y="100" orientation="0" z="10" uuid="{bc5fdd7f-679b-4fca-9b82-287943eb47c1}" prefix="">
+                <terminals>
+                    <terminal number="_" nameHidden="0" x="-16" y="0" orientation="3" name="_" id="36"/>
+                    <terminal number="_" nameHidden="0" x="16" y="0" orientation="1" name="_" id="37"/>
+                </terminals>
+                <inputs/>
+                <elementInformations>
+                    <elementInformation show="1" name="formula"></elementInformation>
+                </elementInformations>
+                <dynamic_texts>
+                    <dynamic_elmt_text x="-50" y="-30" Halignment="AlignLeft" uuid="{51d72482-d3de-4f8c-be27-6dd4193f9791}" frame="false" text_from="UserText" rotation="0" font="Sans Serif,9,-1,5,0,0,0,0,0,0,normal" Valignment="AlignTop" text_width="100">
+                        <text>Switch (N.O.)</text>
+                    </dynamic_elmt_text>
+                </dynamic_texts>
+                <texts_groups/>
+            </element>
+            <element freezeLabel="false" type="embed://import/pinball_em_williams_schematic/switches_common/mirrored/pinball_em_williams_switch_mb_bottom_mi.elmt" x="620" y="270" orientation="0" z="10" uuid="{920ed7da-a1a4-4eb2-917c-220011d490e6}" prefix="">
+                <terminals>
+                    <terminal number="_" nameHidden="0" x="-16" y="-20" orientation="3" name="_" id="38"/>
+                    <terminal number="_" nameHidden="0" x="-16" y="0" orientation="3" name="_" id="39"/>
+                    <terminal number="_" nameHidden="0" x="16" y="0" orientation="1" name="_" id="40"/>
+                </terminals>
+                <inputs/>
+                <elementInformations>
+                    <elementInformation show="1" name="formula"></elementInformation>
+                </elementInformations>
+                <dynamic_texts/>
+                <texts_groups/>
+            </element>
+            <element freezeLabel="false" type="embed://import/pinball_em_williams_schematic/switches_score_motor/mirrored/pinball_em_williams_switch_mb_sm_bottom_mi.elmt" x="920" y="270" orientation="0" z="10" uuid="{7b4f4da4-178c-404d-8e00-090d4160a797}" prefix="">
+                <terminals>
+                    <terminal number="_" nameHidden="0" x="-16" y="-20" orientation="3" name="_" id="41"/>
+                    <terminal number="_" nameHidden="0" x="-16" y="0" orientation="3" name="_" id="42"/>
+                    <terminal number="_" nameHidden="0" x="16" y="0" orientation="1" name="_" id="43"/>
+                </terminals>
+                <inputs/>
+                <elementInformations>
+                    <elementInformation show="1" name="formula"></elementInformation>
+                </elementInformations>
+                <dynamic_texts/>
+                <texts_groups/>
+            </element>
+            <element freezeLabel="false" type="embed://import/pinball_em_williams_schematic/jacks/pinball_em_williams_jack_04.elmt" x="500" y="380" orientation="0" z="10" uuid="{cab72bb6-e9fc-4a69-a537-7919e97fe139}" prefix="">
+                <terminals>
+                    <terminal number="_" nameHidden="0" x="-16" y="0" orientation="3" name="_" id="44"/>
+                    <terminal number="_" nameHidden="0" x="16" y="0" orientation="1" name="_" id="45"/>
+                    <terminal number="_" nameHidden="0" x="-16" y="20" orientation="3" name="_" id="46"/>
+                    <terminal number="_" nameHidden="0" x="16" y="20" orientation="1" name="_" id="47"/>
+                    <terminal number="_" nameHidden="0" x="-16" y="40" orientation="3" name="_" id="48"/>
+                    <terminal number="_" nameHidden="0" x="16" y="40" orientation="1" name="_" id="49"/>
+                    <terminal number="_" nameHidden="0" x="-16" y="60" orientation="3" name="_" id="50"/>
+                    <terminal number="_" nameHidden="0" x="16" y="60" orientation="1" name="_" id="51"/>
+                </terminals>
+                <inputs/>
+                <elementInformations>
+                    <elementInformation show="1" name="formula"></elementInformation>
+                </elementInformations>
+                <dynamic_texts>
+                    <dynamic_elmt_text x="-40" y="-40" Halignment="AlignLeft" uuid="{f3092f44-fc9c-46cf-8f7d-9c4ed6dd5911}" frame="false" text_from="UserText" rotation="0" font="Sans Serif,9,-1,5,0,0,0,0,0,0,normal" Valignment="AlignTop" text_width="80">
+                        <text>4 positions</text>
+                    </dynamic_elmt_text>
+                </dynamic_texts>
+                <texts_groups/>
+            </element>
+            <element freezeLabel="false" type="embed://import/pinball_em_williams_schematic/jacks/pinball_em_williams_jack_plug.elmt" x="700" y="380" orientation="0" z="10" uuid="{a5937eee-971f-4fb3-8ca7-8b7383060516}" prefix="">
+                <terminals>
+                    <terminal number="_" nameHidden="0" x="-6" y="0" orientation="3" name="_" id="52"/>
+                    <terminal number="_" nameHidden="0" x="6" y="0" orientation="1" name="_" id="53"/>
+                </terminals>
+                <inputs/>
+                <elementInformations>
+                    <elementInformation show="1" name="formula"></elementInformation>
+                </elementInformations>
+                <dynamic_texts>
+                    <dynamic_elmt_text x="-40" y="-40" Halignment="AlignLeft" uuid="{cf00fa37-a42a-4d26-8d1e-1e5b4ae83e27}" frame="false" text_from="UserText" rotation="0" font="Sans Serif,9,-1,5,0,0,0,0,0,0,normal" Valignment="AlignTop" text_width="80">
+                        <text>Plug</text>
+                    </dynamic_elmt_text>
+                </dynamic_texts>
+                <texts_groups/>
+            </element>
+            <element freezeLabel="false" type="embed://import/pinball_em_williams_schematic/switches_score_motor/pinball_em_williams_switch_mb_sm_center_i.elmt" x="860" y="210" orientation="0" z="10" uuid="{11390982-7bd7-4fb7-8675-cc01856a8499}" prefix="">
+                <terminals>
+                    <terminal number="_" nameHidden="0" x="16" y="-10" orientation="1" name="_" id="54"/>
+                    <terminal number="_" nameHidden="0" x="-16" y="0" orientation="3" name="_" id="55"/>
+                    <terminal number="_" nameHidden="0" x="16" y="10" orientation="1" name="_" id="56"/>
+                </terminals>
+                <inputs/>
+                <elementInformations>
+                    <elementInformation show="1" name="formula"></elementInformation>
+                </elementInformations>
+                <dynamic_texts/>
+                <texts_groups/>
+            </element>
+            <element freezeLabel="false" type="embed://import/pinball_em_williams_schematic/switches_common/mirrored/pinball_em_williams_switch_mb_bottom_m.elmt" x="680" y="270" orientation="0" z="10" uuid="{289c7db5-a6f2-48a8-8972-572a42fd6252}" prefix="">
+                <terminals>
+                    <terminal number="_" nameHidden="0" x="-16" y="-20" orientation="3" name="_" id="57"/>
+                    <terminal number="_" nameHidden="0" x="-16" y="0" orientation="3" name="_" id="58"/>
+                    <terminal number="_" nameHidden="0" x="16" y="0" orientation="1" name="_" id="59"/>
+                </terminals>
+                <inputs/>
+                <elementInformations>
+                    <elementInformation show="1" name="formula"></elementInformation>
+                </elementInformations>
+                <dynamic_texts/>
+                <texts_groups/>
+            </element>
+            <element freezeLabel="false" type="embed://import/pinball_em_williams_schematic/switches_score_motor/pinball_em_williams_switch_mb_sm_top_i.elmt" x="800" y="150" orientation="0" z="10" uuid="{dbf3f425-55fe-4a0e-81fd-1f072bb4b91d}" prefix="">
+                <terminals>
+                    <terminal number="_" nameHidden="0" x="-16" y="0" orientation="3" name="_" id="60"/>
+                    <terminal number="_" nameHidden="0" x="16" y="0" orientation="1" name="_" id="61"/>
+                    <terminal number="_" nameHidden="0" x="16" y="20" orientation="1" name="_" id="62"/>
+                </terminals>
+                <inputs/>
+                <elementInformations>
+                    <elementInformation show="1" name="formula"></elementInformation>
+                </elementInformations>
+                <dynamic_texts>
+                    <dynamic_elmt_text x="-50" y="-30" Halignment="AlignLeft" uuid="{fdab27f5-d4a1-4e47-8a03-8fe33cc15967}" frame="false" text_from="UserText" rotation="0" font="Sans Serif,9,-1,5,0,0,0,0,0,0,normal" Valignment="AlignTop" text_width="101">
+                        <text>Switch (M.B.)</text>
+                    </dynamic_elmt_text>
+                </dynamic_texts>
+                <texts_groups/>
+            </element>
+            <element freezeLabel="false" type="embed://import/pinball_em_williams_schematic/switches_common/mirrored/pinball_em_williams_switch_mb_top_m.elmt" x="680" y="150" orientation="0" z="10" uuid="{78ae78d0-4d85-4ae4-a1a6-3f38e3cce6b6}" prefix="">
+                <terminals>
+                    <terminal number="_" nameHidden="0" x="-16" y="0" orientation="3" name="_" id="63"/>
+                    <terminal number="_" nameHidden="0" x="16" y="0" orientation="1" name="_" id="64"/>
+                    <terminal number="_" nameHidden="0" x="-16" y="20" orientation="3" name="_" id="65"/>
+                </terminals>
+                <inputs/>
+                <elementInformations>
+                    <elementInformation show="1" name="formula"></elementInformation>
+                </elementInformations>
+                <dynamic_texts/>
+                <texts_groups/>
+            </element>
+            <element freezeLabel="false" type="embed://import/pinball_em_williams_schematic/switches_common/mirrored/pinball_em_williams_switch_mb_center_m.elmt" x="680" y="210" orientation="0" z="10" uuid="{e591b524-d7c9-4031-b7d0-9804e0a7c6d4}" prefix="">
+                <terminals>
+                    <terminal number="_" nameHidden="0" x="-16" y="-10" orientation="3" name="_" id="66"/>
+                    <terminal number="_" nameHidden="0" x="16" y="0" orientation="1" name="_" id="67"/>
+                    <terminal number="_" nameHidden="0" x="-16" y="10" orientation="3" name="_" id="68"/>
+                </terminals>
+                <inputs/>
+                <elementInformations>
+                    <elementInformation show="1" name="formula"></elementInformation>
+                </elementInformations>
+                <dynamic_texts/>
+                <texts_groups/>
+            </element>
+            <element freezeLabel="false" type="embed://import/pinball_em_williams_schematic/switches_common/mirrored/pinball_em_williams_switch_mb_center_mi.elmt" x="620" y="210" orientation="0" z="10" uuid="{0d17cd3c-0c0b-457a-94f2-66008ad88d80}" prefix="">
+                <terminals>
+                    <terminal number="_" nameHidden="0" x="-16" y="-10" orientation="3" name="_" id="69"/>
+                    <terminal number="_" nameHidden="0" x="16" y="0" orientation="1" name="_" id="70"/>
+                    <terminal number="_" nameHidden="0" x="-16" y="10" orientation="3" name="_" id="71"/>
+                </terminals>
+                <inputs/>
+                <elementInformations>
+                    <elementInformation show="1" name="formula"></elementInformation>
+                </elementInformations>
+                <dynamic_texts/>
+                <texts_groups/>
+            </element>
+            <element freezeLabel="false" type="embed://import/pinball_em_williams_schematic/jacks/pinball_em_williams_jack_10.elmt" x="80" y="380" orientation="0" z="10" uuid="{1de7a164-5343-4105-bab9-52e472efa024}" prefix="">
+                <terminals>
+                    <terminal number="_" nameHidden="0" x="-16" y="0" orientation="3" name="_" id="72"/>
+                    <terminal number="_" nameHidden="0" x="16" y="0" orientation="1" name="_" id="73"/>
+                    <terminal number="_" nameHidden="0" x="-16" y="20" orientation="3" name="_" id="74"/>
+                    <terminal number="_" nameHidden="0" x="16" y="20" orientation="1" name="_" id="75"/>
+                    <terminal number="_" nameHidden="0" x="-16" y="40" orientation="3" name="_" id="76"/>
+                    <terminal number="_" nameHidden="0" x="16" y="40" orientation="1" name="_" id="77"/>
+                    <terminal number="_" nameHidden="0" x="-16" y="60" orientation="3" name="_" id="78"/>
+                    <terminal number="_" nameHidden="0" x="16" y="60" orientation="1" name="_" id="79"/>
+                    <terminal number="_" nameHidden="0" x="-16" y="80" orientation="3" name="_" id="80"/>
+                    <terminal number="_" nameHidden="0" x="16" y="80" orientation="1" name="_" id="81"/>
+                    <terminal number="_" nameHidden="0" x="-16" y="100" orientation="3" name="_" id="82"/>
+                    <terminal number="_" nameHidden="0" x="16" y="100" orientation="1" name="_" id="83"/>
+                    <terminal number="_" nameHidden="0" x="-16" y="120" orientation="3" name="_" id="84"/>
+                    <terminal number="_" nameHidden="0" x="16" y="120" orientation="1" name="_" id="85"/>
+                    <terminal number="_" nameHidden="0" x="-16" y="140" orientation="3" name="_" id="86"/>
+                    <terminal number="_" nameHidden="0" x="16" y="140" orientation="1" name="_" id="87"/>
+                    <terminal number="_" nameHidden="0" x="-16" y="160" orientation="3" name="_" id="88"/>
+                    <terminal number="_" nameHidden="0" x="16" y="160" orientation="1" name="_" id="89"/>
+                    <terminal number="_" nameHidden="0" x="-16" y="180" orientation="3" name="_" id="90"/>
+                    <terminal number="_" nameHidden="0" x="16" y="180" orientation="1" name="_" id="91"/>
+                </terminals>
+                <inputs/>
+                <elementInformations>
+                    <elementInformation show="1" name="formula"></elementInformation>
+                </elementInformations>
+                <dynamic_texts>
+                    <dynamic_elmt_text x="-40" y="-40" Halignment="AlignLeft" uuid="{fe2c5769-88d4-43f8-b117-d743b48045fe}" frame="false" text_from="UserText" rotation="0" font="Sans Serif,9,-1,5,0,0,0,0,0,0,normal" Valignment="AlignTop" text_width="80">
+                        <text>10 positions</text>
+                    </dynamic_elmt_text>
+                </dynamic_texts>
+                <texts_groups/>
+            </element>
+            <element freezeLabel="false" type="embed://import/pinball_em_williams_schematic/switches_score_motor/mirrored/pinball_em_williams_switch_mb_sm_center_m.elmt" x="980" y="210" orientation="0" z="10" uuid="{d7b552b9-901d-4264-88d0-371be072f02e}" prefix="">
+                <terminals>
+                    <terminal number="_" nameHidden="0" x="-16" y="-10.25" orientation="3" name="_" id="92"/>
+                    <terminal number="_" nameHidden="0" x="16" y="-0.25" orientation="1" name="_" id="93"/>
+                    <terminal number="_" nameHidden="0" x="-16" y="9.75" orientation="3" name="_" id="94"/>
+                </terminals>
+                <inputs/>
+                <elementInformations>
+                    <elementInformation show="1" name="formula"></elementInformation>
+                </elementInformations>
+                <dynamic_texts/>
+                <texts_groups/>
+            </element>
+            <element freezeLabel="false" type="embed://import/pinball_em_williams_schematic/switches_common/pinball_em_williams_switch_nc.elmt" x="620" y="100" orientation="0" z="10" uuid="{c02f3ff8-c0d5-45d7-844f-df2abed92a2e}" prefix="">
+                <terminals>
+                    <terminal number="_" nameHidden="0" x="-16" y="0" orientation="3" name="_" id="95"/>
+                    <terminal number="_" nameHidden="0" x="16" y="0" orientation="1" name="_" id="96"/>
+                </terminals>
+                <inputs/>
+                <elementInformations>
+                    <elementInformation show="1" name="formula"></elementInformation>
+                </elementInformations>
+                <dynamic_texts>
+                    <dynamic_elmt_text x="-50" y="-30" Halignment="AlignLeft" uuid="{9f495296-7bb3-433a-b558-7f80aab2df72}" frame="false" text_from="UserText" rotation="0" font="Sans Serif,9,-1,5,0,0,0,0,0,0,normal" Valignment="AlignTop" text_width="100">
+                        <text>Switch (N.C.)</text>
+                    </dynamic_elmt_text>
+                </dynamic_texts>
+                <texts_groups/>
+            </element>
+            <element freezeLabel="false" type="embed://import/pinball_em_williams_schematic/jacks/pinball_em_williams_jack_06.elmt" x="360" y="380" orientation="0" z="10" uuid="{a40bc88d-c731-4e9a-b12a-55e62fd8c965}" prefix="">
+                <terminals>
+                    <terminal number="_" nameHidden="0" x="-16" y="0" orientation="3" name="_" id="97"/>
+                    <terminal number="_" nameHidden="0" x="16" y="0" orientation="1" name="_" id="98"/>
+                    <terminal number="_" nameHidden="0" x="-16" y="20" orientation="3" name="_" id="99"/>
+                    <terminal number="_" nameHidden="0" x="16" y="20" orientation="1" name="_" id="100"/>
+                    <terminal number="_" nameHidden="0" x="-16" y="40" orientation="3" name="_" id="101"/>
+                    <terminal number="_" nameHidden="0" x="16" y="40" orientation="1" name="_" id="102"/>
+                    <terminal number="_" nameHidden="0" x="-16" y="60" orientation="3" name="_" id="103"/>
+                    <terminal number="_" nameHidden="0" x="16" y="60" orientation="1" name="_" id="104"/>
+                    <terminal number="_" nameHidden="0" x="-16" y="80" orientation="3" name="_" id="105"/>
+                    <terminal number="_" nameHidden="0" x="16" y="80" orientation="1" name="_" id="106"/>
+                    <terminal number="_" nameHidden="0" x="-16" y="100" orientation="3" name="_" id="107"/>
+                    <terminal number="_" nameHidden="0" x="16" y="100" orientation="1" name="_" id="108"/>
+                </terminals>
+                <inputs/>
+                <elementInformations>
+                    <elementInformation show="1" name="formula"></elementInformation>
+                </elementInformations>
+                <dynamic_texts>
+                    <dynamic_elmt_text x="-40" y="-40" Halignment="AlignLeft" uuid="{50607046-87e6-4636-b20e-208bec3e4e16}" frame="false" text_from="UserText" rotation="0" font="Sans Serif,9,-1,5,0,0,0,0,0,0,normal" Valignment="AlignTop" text_width="80">
+                        <text>6 positions</text>
+                    </dynamic_elmt_text>
+                </dynamic_texts>
+                <texts_groups/>
+            </element>
+            <element freezeLabel="false" type="embed://import/pinball_em_williams_schematic/jacks/pinball_em_williams_jack_08.elmt" x="220" y="380" orientation="0" z="10" uuid="{b7c8e18a-a318-419a-a295-dff5f7b4a3d1}" prefix="">
+                <terminals>
+                    <terminal number="_" nameHidden="0" x="-16" y="0" orientation="3" name="_" id="109"/>
+                    <terminal number="_" nameHidden="0" x="16" y="0" orientation="1" name="_" id="110"/>
+                    <terminal number="_" nameHidden="0" x="-16" y="20" orientation="3" name="_" id="111"/>
+                    <terminal number="_" nameHidden="0" x="16" y="20" orientation="1" name="_" id="112"/>
+                    <terminal number="_" nameHidden="0" x="-16" y="40" orientation="3" name="_" id="113"/>
+                    <terminal number="_" nameHidden="0" x="16" y="40" orientation="1" name="_" id="114"/>
+                    <terminal number="_" nameHidden="0" x="-16" y="60" orientation="3" name="_" id="115"/>
+                    <terminal number="_" nameHidden="0" x="16" y="60" orientation="1" name="_" id="116"/>
+                    <terminal number="_" nameHidden="0" x="-16" y="80" orientation="3" name="_" id="117"/>
+                    <terminal number="_" nameHidden="0" x="16" y="80" orientation="1" name="_" id="118"/>
+                    <terminal number="_" nameHidden="0" x="-16" y="100" orientation="3" name="_" id="119"/>
+                    <terminal number="_" nameHidden="0" x="16" y="100" orientation="1" name="_" id="120"/>
+                    <terminal number="_" nameHidden="0" x="-16" y="120" orientation="3" name="_" id="121"/>
+                    <terminal number="_" nameHidden="0" x="16" y="120" orientation="1" name="_" id="122"/>
+                    <terminal number="_" nameHidden="0" x="-16" y="140" orientation="3" name="_" id="123"/>
+                    <terminal number="_" nameHidden="0" x="16" y="140" orientation="1" name="_" id="124"/>
+                </terminals>
+                <inputs/>
+                <elementInformations>
+                    <elementInformation show="1" name="formula"></elementInformation>
+                </elementInformations>
+                <dynamic_texts>
+                    <dynamic_elmt_text x="-40" y="-40" Halignment="AlignLeft" uuid="{668dd9cc-9647-4079-87d3-6093616e1eb6}" frame="false" text_from="UserText" rotation="0" font="Sans Serif,9,-1,5,0,0,0,0,0,0,normal" Valignment="AlignTop" text_width="80">
+                        <text>8 positions</text>
+                    </dynamic_elmt_text>
+                </dynamic_texts>
+                <texts_groups/>
+            </element>
+            <element freezeLabel="false" type="embed://import/pinball_em_williams_schematic/switches_score_motor/pinball_em_williams_switch_mb_sm_bottom_i.elmt" x="860" y="270" orientation="0" z="10" uuid="{f0a2133e-c369-4f26-aec5-f3b45b659893}" prefix="">
+                <terminals>
+                    <terminal number="_" nameHidden="0" x="16" y="-20" orientation="1" name="_" id="125"/>
+                    <terminal number="_" nameHidden="0" x="-16" y="0" orientation="3" name="_" id="126"/>
+                    <terminal number="_" nameHidden="0" x="16" y="0" orientation="1" name="_" id="127"/>
+                </terminals>
+                <inputs/>
+                <elementInformations>
+                    <elementInformation show="1" name="formula"></elementInformation>
+                </elementInformations>
+                <dynamic_texts/>
+                <texts_groups/>
+            </element>
+            <element freezeLabel="false" type="embed://import/pinball_em_williams_schematic/switches_score_motor/mirrored/pinball_em_williams_switch_mb_sm_top_mi.elmt" x="920" y="150" orientation="0" z="10" uuid="{ee630610-4d5d-4b5f-ade3-5808e45ae5e3}" prefix="">
+                <terminals>
+                    <terminal number="_" nameHidden="0" x="-16" y="0" orientation="3" name="_" id="128"/>
+                    <terminal number="_" nameHidden="0" x="16" y="0" orientation="1" name="_" id="129"/>
+                    <terminal number="_" nameHidden="0" x="-16" y="20" orientation="3" name="_" id="130"/>
+                </terminals>
+                <inputs/>
+                <elementInformations>
+                    <elementInformation show="1" name="formula"></elementInformation>
+                </elementInformations>
+                <dynamic_texts/>
+                <texts_groups/>
+            </element>
+            <element freezeLabel="false" type="embed://import/pinball_em_williams_schematic/switches_common/mirrored/pinball_em_williams_switch_mb_top_mi.elmt" x="620" y="150" orientation="0" z="10" uuid="{844a76c7-6fb9-4f93-a9f8-c6594d2e1a5e}" prefix="">
+                <terminals>
+                    <terminal number="_" nameHidden="0" x="-16" y="0" orientation="3" name="_" id="131"/>
+                    <terminal number="_" nameHidden="0" x="16" y="0" orientation="1" name="_" id="132"/>
+                    <terminal number="_" nameHidden="0" x="-16" y="20" orientation="3" name="_" id="133"/>
+                </terminals>
+                <inputs/>
+                <elementInformations>
+                    <elementInformation show="1" name="formula"></elementInformation>
+                </elementInformations>
+                <dynamic_texts/>
+                <texts_groups/>
+            </element>
+            <element freezeLabel="false" type="embed://import/pinball_em_williams_schematic/common/pinball_em_williams_not_connected_east.elmt" x="230" y="110" orientation="0" z="10" uuid="{72c50e18-54af-4597-84a3-c6d8c747b5dc}" prefix="">
+                <terminals>
+                    <terminal number="_" nameHidden="0" x="6" y="0" orientation="1" name="_" id="134"/>
+                </terminals>
+                <inputs/>
+                <elementInformations>
+                    <elementInformation show="1" name="formula"></elementInformation>
+                </elementInformations>
+                <dynamic_texts>
+                    <dynamic_elmt_text x="-40" y="-40" Halignment="AlignLeft" uuid="{52cfbc87-99b7-47bb-9f5a-ca00172c7011}" frame="false" text_from="UserText" rotation="0" font="Sans Serif,9,-1,5,0,0,0,0,0,0,normal" Valignment="AlignTop" text_width="80">
+                        <text>N.C. (East)</text>
+                    </dynamic_elmt_text>
+                </dynamic_texts>
+                <texts_groups/>
+            </element>
+            <element freezeLabel="false" type="embed://import/pinball_em_williams_schematic/common/pinball_em_williams_not_connected_north.elmt" x="150" y="110" orientation="0" z="10" uuid="{3ed46ad5-b2f1-4850-965d-1289891177e1}" prefix="">
+                <terminals>
+                    <terminal number="_" nameHidden="0" x="0" y="-6" orientation="0" name="_" id="135"/>
+                </terminals>
+                <inputs/>
+                <elementInformations>
+                    <elementInformation show="1" name="formula"></elementInformation>
+                </elementInformations>
+                <dynamic_texts>
+                    <dynamic_elmt_text x="-40" y="-40" Halignment="AlignLeft" uuid="{5917ba74-6d3d-4330-a942-2a89d4f02a73}" frame="false" text_from="UserText" rotation="0" font="Sans Serif,9,-1,5,0,0,0,0,0,0,normal" Valignment="AlignTop" text_width="80">
+                        <text>N.C. (North)</text>
+                    </dynamic_elmt_text>
+                </dynamic_texts>
+                <texts_groups/>
+            </element>
+            <element freezeLabel="false" type="embed://import/pinball_em_williams_schematic/common/pinball_em_williams_not_connected_south.elmt" x="310" y="110" orientation="0" z="10" uuid="{64231394-54f9-46ed-b85e-bb3c510e9d73}" prefix="">
+                <terminals>
+                    <terminal number="_" nameHidden="0" x="0" y="6" orientation="2" name="_" id="136"/>
+                </terminals>
+                <inputs/>
+                <elementInformations>
+                    <elementInformation show="1" name="formula"></elementInformation>
+                </elementInformations>
+                <dynamic_texts>
+                    <dynamic_elmt_text x="-40" y="-40" Halignment="AlignLeft" uuid="{4daf8185-1f9d-47cc-8ce5-07c1805ece8f}" frame="false" text_from="UserText" rotation="0" font="Sans Serif,9,-1,5,0,0,0,0,0,0,normal" Valignment="AlignTop" text_width="80">
+                        <text>N.C. (South)</text>
+                    </dynamic_elmt_text>
+                </dynamic_texts>
+                <texts_groups/>
+            </element>
+            <element freezeLabel="false" type="embed://import/pinball_em_williams_schematic/common/pinball_em_williams_not_connected_west.elmt" x="390" y="110" orientation="0" z="10" uuid="{1e5785cf-3e03-4206-89ce-e317b000b2bd}" prefix="">
+                <terminals>
+                    <terminal number="_" nameHidden="0" x="-6" y="0" orientation="3" name="_" id="137"/>
+                </terminals>
+                <inputs/>
+                <elementInformations>
+                    <elementInformation show="1" name="formula"></elementInformation>
+                </elementInformations>
+                <dynamic_texts>
+                    <dynamic_elmt_text x="-40" y="-40" Halignment="AlignLeft" uuid="{c09804e5-1eb8-4427-86e8-5f52e9d373b7}" frame="false" text_from="UserText" rotation="0" font="Sans Serif,9,-1,5,0,0,0,0,0,0,normal" Valignment="AlignTop" text_width="80">
+                        <text>N.C. (West)</text>
+                    </dynamic_elmt_text>
+                </dynamic_texts>
+                <texts_groups/>
+            </element>
+            <element freezeLabel="false" type="embed://import/pinball_em_williams_schematic/jacks/pinball_em_williams_jack_05.elmt" x="430" y="380" orientation="0" z="10" uuid="{ed4e961e-2cdc-4a00-99de-58639273fe1b}" prefix="">
+                <terminals>
+                    <terminal number="_" nameHidden="0" x="-16" y="0" orientation="3" name="_" id="138"/>
+                    <terminal number="_" nameHidden="0" x="16" y="0" orientation="1" name="_" id="139"/>
+                    <terminal number="_" nameHidden="0" x="-16" y="20" orientation="3" name="_" id="140"/>
+                    <terminal number="_" nameHidden="0" x="16" y="20" orientation="1" name="_" id="141"/>
+                    <terminal number="_" nameHidden="0" x="-16" y="40" orientation="3" name="_" id="142"/>
+                    <terminal number="_" nameHidden="0" x="16" y="40" orientation="1" name="_" id="143"/>
+                    <terminal number="_" nameHidden="0" x="-16" y="60" orientation="3" name="_" id="144"/>
+                    <terminal number="_" nameHidden="0" x="16" y="60" orientation="1" name="_" id="145"/>
+                    <terminal number="_" nameHidden="0" x="-16" y="80" orientation="3" name="_" id="146"/>
+                    <terminal number="_" nameHidden="0" x="16" y="80" orientation="1" name="_" id="147"/>
+                </terminals>
+                <inputs/>
+                <elementInformations>
+                    <elementInformation show="1" name="formula"></elementInformation>
+                </elementInformations>
+                <dynamic_texts>
+                    <dynamic_elmt_text x="-40" y="-40" Halignment="AlignLeft" uuid="{9d651027-ec1c-4919-b2c0-fb88790e502f}" frame="false" text_from="UserText" rotation="0" font="Sans Serif,9,-1,5,0,0,0,0,0,0,normal" Valignment="AlignTop" text_width="80">
+                        <text>5 positions</text>
+                    </dynamic_elmt_text>
+                </dynamic_texts>
+                <texts_groups/>
+            </element>
+            <element freezeLabel="false" type="embed://import/pinball_em_williams_schematic/switches_score_motor/pinball_em_williams_switch_mb_sm_bottom.elmt" x="800" y="270" orientation="0" z="10" uuid="{4840e2aa-ac17-48b7-9929-a2ea1b2eec1a}" prefix="">
+                <terminals>
+                    <terminal number="_" nameHidden="0" x="16" y="-20" orientation="1" name="_" id="148"/>
+                    <terminal number="_" nameHidden="0" x="-16" y="0" orientation="3" name="_" id="149"/>
+                    <terminal number="_" nameHidden="0" x="16" y="0" orientation="1" name="_" id="150"/>
+                </terminals>
+                <inputs/>
+                <elementInformations>
+                    <elementInformation show="1" name="formula"></elementInformation>
+                </elementInformations>
+                <dynamic_texts/>
+                <texts_groups/>
+            </element>
+            <element freezeLabel="false" type="embed://import/pinball_em_williams_schematic/jacks/pinball_em_williams_jack_02.elmt" x="640" y="380" orientation="0" z="10" uuid="{0aff4111-34f3-405f-a6c8-e96b85337d6f}" prefix="">
+                <terminals>
+                    <terminal number="_" nameHidden="0" x="-16" y="0" orientation="3" name="_" id="151"/>
+                    <terminal number="_" nameHidden="0" x="16" y="0" orientation="1" name="_" id="152"/>
+                    <terminal number="_" nameHidden="0" x="-16" y="20" orientation="3" name="_" id="153"/>
+                    <terminal number="_" nameHidden="0" x="16" y="20" orientation="1" name="_" id="154"/>
+                </terminals>
+                <inputs/>
+                <elementInformations>
+                    <elementInformation show="1" name="formula"></elementInformation>
+                </elementInformations>
+                <dynamic_texts>
+                    <dynamic_elmt_text x="-40" y="-40" Halignment="AlignLeft" uuid="{80cda6ed-4257-411d-8bb2-e7382b8fb6f3}" frame="false" text_from="UserText" rotation="0" font="Sans Serif,9,-1,5,0,0,0,0,0,0,normal" Valignment="AlignTop" text_width="80">
+                        <text>2 positions</text>
+                    </dynamic_elmt_text>
+                </dynamic_texts>
+                <texts_groups/>
+            </element>
+            <element freezeLabel="false" type="embed://import/pinball_em_williams_schematic/switches_score_motor/pinball_em_williams_switch_mb_sm_center.elmt" x="800" y="210" orientation="0" z="10" uuid="{1ff676de-bbdc-465b-a9d3-028a6b1825ad}" prefix="">
+                <terminals>
+                    <terminal number="_" nameHidden="0" x="16" y="-10" orientation="1" name="_" id="155"/>
+                    <terminal number="_" nameHidden="0" x="-16" y="0" orientation="3" name="_" id="156"/>
+                    <terminal number="_" nameHidden="0" x="16" y="10" orientation="1" name="_" id="157"/>
+                </terminals>
+                <inputs/>
+                <elementInformations>
+                    <elementInformation show="1" name="formula"></elementInformation>
+                </elementInformations>
+                <dynamic_texts/>
+                <texts_groups/>
+            </element>
+            <element freezeLabel="false" type="embed://import/pinball_em_williams_schematic/output/pinball_em_williams_coil.elmt" x="80" y="220" orientation="0" z="10" uuid="{36fae336-ff7a-4ce1-ade2-75583ba9bab1}" prefix="">
+                <terminals>
+                    <terminal number="_" nameHidden="0" x="-16" y="0" orientation="3" name="_" id="158"/>
+                    <terminal number="_" nameHidden="0" x="16" y="0" orientation="1" name="_" id="159"/>
+                </terminals>
+                <inputs/>
+                <elementInformations>
+                    <elementInformation show="1" name="formula"></elementInformation>
+                </elementInformations>
+                <dynamic_texts>
+                    <dynamic_elmt_text x="-30" y="-30" Halignment="AlignLeft" uuid="{9e63c5ea-3f0f-4d8d-bbd6-0d4cc4d66626}" frame="false" text_from="UserText" rotation="0" font="Sans Serif,9,-1,5,0,0,0,0,0,0,normal" Valignment="AlignTop" text_width="60">
+                        <text>Coil</text>
+                    </dynamic_elmt_text>
+                </dynamic_texts>
+                <texts_groups/>
+            </element>
+            <element freezeLabel="false" type="embed://import/pinball_em_williams_schematic/jacks/pinball_em_williams_jack_09.elmt" x="150" y="380" orientation="0" z="10" uuid="{3da4432c-bd3a-4db8-bbe6-988660b4e8a5}" prefix="">
+                <terminals>
+                    <terminal number="_" nameHidden="0" x="-16" y="0" orientation="3" name="_" id="160"/>
+                    <terminal number="_" nameHidden="0" x="16" y="0" orientation="1" name="_" id="161"/>
+                    <terminal number="_" nameHidden="0" x="-16" y="20" orientation="3" name="_" id="162"/>
+                    <terminal number="_" nameHidden="0" x="16" y="20" orientation="1" name="_" id="163"/>
+                    <terminal number="_" nameHidden="0" x="-16" y="40" orientation="3" name="_" id="164"/>
+                    <terminal number="_" nameHidden="0" x="16" y="40" orientation="1" name="_" id="165"/>
+                    <terminal number="_" nameHidden="0" x="-16" y="60" orientation="3" name="_" id="166"/>
+                    <terminal number="_" nameHidden="0" x="16" y="60" orientation="1" name="_" id="167"/>
+                    <terminal number="_" nameHidden="0" x="-16" y="80" orientation="3" name="_" id="168"/>
+                    <terminal number="_" nameHidden="0" x="16" y="80" orientation="1" name="_" id="169"/>
+                    <terminal number="_" nameHidden="0" x="-16" y="100" orientation="3" name="_" id="170"/>
+                    <terminal number="_" nameHidden="0" x="16" y="100" orientation="1" name="_" id="171"/>
+                    <terminal number="_" nameHidden="0" x="-16" y="120" orientation="3" name="_" id="172"/>
+                    <terminal number="_" nameHidden="0" x="16" y="120" orientation="1" name="_" id="173"/>
+                    <terminal number="_" nameHidden="0" x="-16" y="140" orientation="3" name="_" id="174"/>
+                    <terminal number="_" nameHidden="0" x="16" y="140" orientation="1" name="_" id="175"/>
+                    <terminal number="_" nameHidden="0" x="-16" y="160" orientation="3" name="_" id="176"/>
+                    <terminal number="_" nameHidden="0" x="16" y="160" orientation="1" name="_" id="177"/>
+                </terminals>
+                <inputs/>
+                <elementInformations>
+                    <elementInformation show="1" name="formula"></elementInformation>
+                </elementInformations>
+                <dynamic_texts>
+                    <dynamic_elmt_text x="-40" y="-40" Halignment="AlignLeft" uuid="{8cc9420a-6361-4c9a-aecb-e4c728303655}" frame="false" text_from="UserText" rotation="0" font="Sans Serif,9,-1,5,0,0,0,0,0,0,normal" Valignment="AlignTop" text_width="80">
+                        <text>9 positions</text>
+                    </dynamic_elmt_text>
+                </dynamic_texts>
+                <texts_groups/>
+            </element>
+            <element freezeLabel="false" type="embed://import/pinball_em_williams_schematic/switches_score_motor/mirrored/pinball_em_williams_switch_mb_sm_top_m.elmt" x="980" y="150" orientation="0" z="10" uuid="{05d12868-6fed-4190-a34c-8dc3e0127290}" prefix="">
+                <terminals>
+                    <terminal number="_" nameHidden="0" x="-16" y="0" orientation="3" name="_" id="178"/>
+                    <terminal number="_" nameHidden="0" x="16" y="0" orientation="1" name="_" id="179"/>
+                    <terminal number="_" nameHidden="0" x="-16" y="20" orientation="3" name="_" id="180"/>
+                </terminals>
+                <inputs/>
+                <elementInformations>
+                    <elementInformation show="1" name="formula"></elementInformation>
+                </elementInformations>
+                <dynamic_texts/>
+                <texts_groups/>
+            </element>
+            <element freezeLabel="false" type="embed://import/pinball_em_williams_schematic/common/pinball_em_williams_ground.elmt" x="80" y="110" orientation="0" z="10" uuid="{11ebff8a-e385-4081-a790-b94930854c6a}" prefix="">
+                <terminals>
+                    <terminal number="_" nameHidden="0" x="0" y="-6" orientation="0" name="_" id="181"/>
+                </terminals>
+                <inputs/>
+                <elementInformations>
+                    <elementInformation show="1" name="formula"></elementInformation>
+                </elementInformations>
+                <dynamic_texts>
+                    <dynamic_elmt_text x="-30" y="-40" Halignment="AlignLeft" uuid="{6d1f6d96-24fe-4362-a87b-961682656804}" frame="false" text_from="UserText" rotation="0" font="Sans Serif,9,-1,5,0,0,0,0,0,0,normal" Valignment="AlignTop" text_width="60">
+                        <text>Ground</text>
+                    </dynamic_elmt_text>
+                </dynamic_texts>
+                <texts_groups/>
+            </element>
+            <element freezeLabel="false" type="embed://import/pinball_em_williams_schematic/switches_score_motor/mirrored/pinball_em_williams_switch_mb_sm_bottom_m.elmt" x="980" y="270" orientation="0" z="10" uuid="{17347118-a4e8-46af-bbf1-efeffba76761}" prefix="">
+                <terminals>
+                    <terminal number="_" nameHidden="0" x="-16" y="-20" orientation="3" name="_" id="182"/>
+                    <terminal number="_" nameHidden="0" x="-16" y="0" orientation="3" name="_" id="183"/>
+                    <terminal number="_" nameHidden="0" x="16" y="0" orientation="1" name="_" id="184"/>
+                </terminals>
+                <inputs/>
+                <elementInformations>
+                    <elementInformation show="1" name="formula"></elementInformation>
+                </elementInformations>
+                <dynamic_texts/>
+                <texts_groups/>
+            </element>
+            <element freezeLabel="false" type="embed://import/pinball_em_williams_schematic/units/wiper_to/pinball_em_williams_unit_wiper_to_10.elmt" x="920" y="410" orientation="0" z="10" uuid="{08bd2d22-9ebd-4d99-ae3b-8044ff5fd90a}" prefix="">
+                <terminals>
+                    <terminal number="_" nameHidden="0" x="-26" y="0" orientation="3" name="_" id="185"/>
+                    <terminal number="_" nameHidden="0" x="26" y="0" orientation="1" name="_" id="186"/>
+                    <terminal number="_" nameHidden="0" x="-26" y="20" orientation="3" name="_" id="187"/>
+                    <terminal number="_" nameHidden="0" x="-26" y="40" orientation="3" name="_" id="188"/>
+                    <terminal number="_" nameHidden="0" x="-26" y="60" orientation="3" name="_" id="189"/>
+                    <terminal number="_" nameHidden="0" x="-26" y="80" orientation="3" name="_" id="190"/>
+                    <terminal number="_" nameHidden="0" x="-26" y="100" orientation="3" name="_" id="191"/>
+                    <terminal number="_" nameHidden="0" x="-26" y="120" orientation="3" name="_" id="192"/>
+                    <terminal number="_" nameHidden="0" x="-26" y="140" orientation="3" name="_" id="193"/>
+                    <terminal number="_" nameHidden="0" x="-26" y="160" orientation="3" name="_" id="194"/>
+                    <terminal number="_" nameHidden="0" x="-26" y="180" orientation="3" name="_" id="195"/>
+                </terminals>
+                <inputs/>
+                <elementInformations>
+                    <elementInformation show="1" name="formula"></elementInformation>
+                </elementInformations>
+                <dynamic_texts>
+                    <dynamic_elmt_text x="-40" y="190" Halignment="AlignLeft" uuid="{95eeb426-d224-4343-b247-9d726ac94bd7}" frame="false" text_from="UserText" rotation="0" font="Sans Serif,9,-1,5,0,0,0,0,0,0,normal" Valignment="AlignTop" text_width="80">
+                        <text>Wiper to 10 contacts</text>
+                    </dynamic_elmt_text>
+                </dynamic_texts>
+                <texts_groups/>
+            </element>
+            <element freezeLabel="false" type="embed://import/pinball_em_williams_schematic/units/wiper_to/pinball_em_williams_unit_wiper_to_03.elmt" x="430" y="550" orientation="0" z="10" uuid="{ce5b55b1-df5d-475e-ab10-cc9cc51e5412}" prefix="">
+                <terminals>
+                    <terminal number="_" nameHidden="0" x="-26" y="0" orientation="3" name="_" id="196"/>
+                    <terminal number="_" nameHidden="0" x="26" y="0" orientation="1" name="_" id="197"/>
+                    <terminal number="_" nameHidden="0" x="-26" y="20" orientation="3" name="_" id="198"/>
+                    <terminal number="_" nameHidden="0" x="-26" y="40" orientation="3" name="_" id="199"/>
+                </terminals>
+                <inputs/>
+                <elementInformations>
+                    <elementInformation show="1" name="formula"></elementInformation>
+                </elementInformations>
+                <dynamic_texts>
+                    <dynamic_elmt_text x="-40" y="50" Halignment="AlignLeft" uuid="{4d826472-f6bb-4343-b9e7-10af2bc61fa2}" frame="false" text_from="UserText" rotation="0" font="Sans Serif,9,-1,5,0,0,0,0,0,0,normal" Valignment="AlignTop" text_width="80">
+                        <text>Wiper to 3 contacts</text>
+                    </dynamic_elmt_text>
+                </dynamic_texts>
+                <texts_groups/>
+            </element>
+            <element freezeLabel="false" type="embed://import/pinball_em_williams_schematic/units/wiper_to/pinball_em_williams_unit_wiper_to_02.elmt" x="360" y="570" orientation="0" z="10" uuid="{d10264d5-e89a-44c0-a9e0-4520cccab7e3}" prefix="">
+                <terminals>
+                    <terminal number="_" nameHidden="0" x="-26" y="0" orientation="3" name="_" id="200"/>
+                    <terminal number="_" nameHidden="0" x="26" y="0" orientation="1" name="_" id="201"/>
+                    <terminal number="_" nameHidden="0" x="-26" y="20" orientation="3" name="_" id="202"/>
+                </terminals>
+                <inputs/>
+                <elementInformations>
+                    <elementInformation show="1" name="formula"></elementInformation>
+                </elementInformations>
+                <dynamic_texts>
+                    <dynamic_elmt_text x="-40" y="30" Halignment="AlignLeft" uuid="{893426ff-6fcf-4460-a79d-6206a32e8198}" frame="false" text_from="UserText" rotation="0" font="Sans Serif,9,-1,5,0,0,0,0,0,0,normal" Valignment="AlignTop" text_width="80">
+                        <text>Wiper to 2 contacts</text>
+                    </dynamic_elmt_text>
+                </dynamic_texts>
+                <texts_groups/>
+            </element>
+            <element freezeLabel="false" type="embed://import/pinball_em_williams_schematic/units/wiper_to/pinball_em_williams_unit_wiper_to_05.elmt" x="640" y="510" orientation="0" z="10" uuid="{0eaac927-9afc-4c54-90c4-3afb6d8c6428}" prefix="">
+                <terminals>
+                    <terminal number="_" nameHidden="0" x="-26" y="0" orientation="3" name="_" id="203"/>
+                    <terminal number="_" nameHidden="0" x="26" y="0" orientation="1" name="_" id="204"/>
+                    <terminal number="_" nameHidden="0" x="-26" y="20" orientation="3" name="_" id="205"/>
+                    <terminal number="_" nameHidden="0" x="-26" y="40" orientation="3" name="_" id="206"/>
+                    <terminal number="_" nameHidden="0" x="-26" y="60" orientation="3" name="_" id="207"/>
+                    <terminal number="_" nameHidden="0" x="-26" y="80" orientation="3" name="_" id="208"/>
+                </terminals>
+                <inputs/>
+                <elementInformations>
+                    <elementInformation show="1" name="formula"></elementInformation>
+                </elementInformations>
+                <dynamic_texts>
+                    <dynamic_elmt_text x="-40" y="90" Halignment="AlignLeft" uuid="{26b79206-aefb-4ba5-bc75-d96bd79f7b00}" frame="false" text_from="UserText" rotation="0" font="Sans Serif,9,-1,5,0,0,0,0,0,0,normal" Valignment="AlignTop" text_width="80">
+                        <text>Wiper to 5 contacts</text>
+                    </dynamic_elmt_text>
+                </dynamic_texts>
+                <texts_groups/>
+            </element>
+            <element freezeLabel="false" type="embed://import/pinball_em_williams_schematic/units/wiper_between/pinball_em_williams_wiper_3_between_3.elmt" x="710" y="490" orientation="0" z="10" uuid="{7bdf893c-73e7-4e96-9635-06097693ea2c}" prefix="">
+                <terminals>
+                    <terminal number="_" nameHidden="0" x="-26" y="60" orientation="3" name="_" id="209"/>
+                    <terminal number="_" nameHidden="0" x="26" y="60" orientation="1" name="_" id="210"/>
+                    <terminal number="_" nameHidden="0" x="-26" y="80" orientation="3" name="_" id="211"/>
+                    <terminal number="_" nameHidden="0" x="26" y="80" orientation="1" name="_" id="212"/>
+                    <terminal number="_" nameHidden="0" x="-26" y="100" orientation="3" name="_" id="213"/>
+                    <terminal number="_" nameHidden="0" x="26" y="100" orientation="1" name="_" id="214"/>
+                </terminals>
+                <inputs/>
+                <elementInformations>
+                    <elementInformation show="1" name="formula"></elementInformation>
+                </elementInformations>
+                <dynamic_texts>
+                    <dynamic_elmt_text x="-40" y="110" Halignment="AlignLeft" uuid="{aac030b3-4160-4433-9136-58e59989be81}" frame="false" text_from="UserText" rotation="0" font="Sans Serif,9,-1,5,0,0,0,0,0,0,normal" Valignment="AlignTop" text_width="80">
+                        <text>3 wipers between 3 contacts</text>
+                    </dynamic_elmt_text>
+                </dynamic_texts>
+                <texts_groups/>
+            </element>
+            <element freezeLabel="false" type="embed://import/pinball_em_williams_schematic/units/wiper_between/pinball_em_williams_unit_wiper_between_10.elmt" x="850" y="410" orientation="0" z="10" uuid="{f9daa7e4-04ba-4de4-be6f-2484b826ca4a}" prefix="">
+                <terminals>
+                    <terminal number="_" nameHidden="0" x="-26" y="0" orientation="3" name="_" id="215"/>
+                    <terminal number="_" nameHidden="0" x="26" y="0" orientation="1" name="_" id="216"/>
+                    <terminal number="_" nameHidden="0" x="-26" y="20" orientation="3" name="_" id="217"/>
+                    <terminal number="_" nameHidden="0" x="26" y="20" orientation="1" name="_" id="218"/>
+                    <terminal number="_" nameHidden="0" x="-26" y="40" orientation="3" name="_" id="219"/>
+                    <terminal number="_" nameHidden="0" x="26" y="40" orientation="1" name="_" id="220"/>
+                    <terminal number="_" nameHidden="0" x="-26" y="60" orientation="3" name="_" id="221"/>
+                    <terminal number="_" nameHidden="0" x="26" y="60" orientation="1" name="_" id="222"/>
+                    <terminal number="_" nameHidden="0" x="-26" y="80" orientation="3" name="_" id="223"/>
+                    <terminal number="_" nameHidden="0" x="26" y="80" orientation="1" name="_" id="224"/>
+                    <terminal number="_" nameHidden="0" x="-26" y="100" orientation="3" name="_" id="225"/>
+                    <terminal number="_" nameHidden="0" x="26" y="100" orientation="1" name="_" id="226"/>
+                    <terminal number="_" nameHidden="0" x="-26" y="120" orientation="3" name="_" id="227"/>
+                    <terminal number="_" nameHidden="0" x="26" y="120" orientation="1" name="_" id="228"/>
+                    <terminal number="_" nameHidden="0" x="-26" y="140" orientation="3" name="_" id="229"/>
+                    <terminal number="_" nameHidden="0" x="26" y="140" orientation="1" name="_" id="230"/>
+                    <terminal number="_" nameHidden="0" x="-26" y="160" orientation="3" name="_" id="231"/>
+                    <terminal number="_" nameHidden="0" x="26" y="160" orientation="1" name="_" id="232"/>
+                    <terminal number="_" nameHidden="0" x="-26" y="180" orientation="3" name="_" id="233"/>
+                    <terminal number="_" nameHidden="0" x="26" y="180" orientation="1" name="_" id="234"/>
+                </terminals>
+                <inputs/>
+                <elementInformations>
+                    <elementInformation show="1" name="formula"></elementInformation>
+                </elementInformations>
+                <dynamic_texts>
+                    <dynamic_elmt_text x="-40" y="190" Halignment="AlignLeft" uuid="{1c63e15e-a2d0-4f3c-8618-e72b53a80f47}" frame="false" text_from="UserText" rotation="0" font="Sans Serif,9,-1,5,0,0,0,0,0,0,normal" Valignment="AlignTop" text_width="80">
+                        <text>Wiper between 10 contacts</text>
+                    </dynamic_elmt_text>
+                </dynamic_texts>
+                <texts_groups/>
+            </element>
+            <element freezeLabel="false" type="embed://import/pinball_em_williams_schematic/units/wiper_to/pinball_em_williams_unit_wiper_to_04.elmt" x="570" y="530" orientation="0" z="10" uuid="{90261f50-ddd7-4931-b9fb-866655aaecee}" prefix="">
+                <terminals>
+                    <terminal number="_" nameHidden="0" x="-26" y="0" orientation="3" name="_" id="235"/>
+                    <terminal number="_" nameHidden="0" x="26" y="0" orientation="1" name="_" id="236"/>
+                    <terminal number="_" nameHidden="0" x="-26" y="20" orientation="3" name="_" id="237"/>
+                    <terminal number="_" nameHidden="0" x="-26" y="40" orientation="3" name="_" id="238"/>
+                    <terminal number="_" nameHidden="0" x="-26" y="60" orientation="3" name="_" id="239"/>
+                </terminals>
+                <inputs/>
+                <elementInformations>
+                    <elementInformation show="1" name="formula"></elementInformation>
+                </elementInformations>
+                <dynamic_texts>
+                    <dynamic_elmt_text x="-40" y="70" Halignment="AlignLeft" uuid="{053b3529-b4fe-4117-bc41-5bb7a50fe127}" frame="false" text_from="UserText" rotation="0" font="Sans Serif,9,-1,5,0,0,0,0,0,0,normal" Valignment="AlignTop" text_width="80">
+                        <text>Wiper to 4 contacts</text>
+                    </dynamic_elmt_text>
+                </dynamic_texts>
+                <texts_groups/>
+            </element>
+            <element freezeLabel="false" type="embed://import/pinball_em_williams_schematic/switches_score_motor/pinball_em_williams_switch_nc_sm.elmt" x="920" y="100" orientation="0" z="10" uuid="{4d0a214c-6a35-4028-8872-121f3b93c656}" prefix="">
+                <terminals>
+                    <terminal number="_" nameHidden="0" x="-16" y="0" orientation="3" name="_" id="240"/>
+                    <terminal number="_" nameHidden="0" x="16" y="0" orientation="1" name="_" id="241"/>
+                </terminals>
+                <inputs/>
+                <elementInformations>
+                    <elementInformation show="1" name="formula"></elementInformation>
+                </elementInformations>
+                <dynamic_texts>
+                    <dynamic_elmt_text x="-50" y="-30" Halignment="AlignLeft" uuid="{7703df35-7e14-490c-8059-f3be61e5c77f}" frame="false" text_from="UserText" rotation="0" font="Sans Serif,9,-1,5,0,0,0,0,0,0,normal" Valignment="AlignTop" text_width="100">
+                        <text>Switch (N.C.)</text>
+                    </dynamic_elmt_text>
+                </dynamic_texts>
+                <texts_groups/>
+            </element>
+            <element freezeLabel="false" type="embed://import/pinball_em_williams_schematic/output/pinball_em_williams_flipper_coil.elmt" x="140" y="220" orientation="0" z="10" uuid="{1402a7b8-7401-4ef2-8ffa-4adcc67238e3}" prefix="">
+                <terminals>
+                    <terminal number="_" nameHidden="0" x="-16" y="0" orientation="3" name="_" id="242"/>
+                    <terminal number="_" nameHidden="0" x="16" y="0" orientation="1" name="_" id="243"/>
+                    <terminal number="_" nameHidden="0" x="0" y="6" orientation="2" name="_" id="244"/>
+                </terminals>
+                <inputs/>
+                <elementInformations>
+                    <elementInformation show="1" name="formula"></elementInformation>
+                </elementInformations>
+                <dynamic_texts>
+                    <dynamic_elmt_text x="-30" y="-30" Halignment="AlignLeft" uuid="{13591024-6713-47ad-a89c-f0524d451267}" frame="false" text_from="UserText" rotation="0" font="Sans Serif,9,-1,5,0,0,0,0,0,0,normal" Valignment="AlignTop" text_width="60">
+                        <text>Flipper</text>
+                    </dynamic_elmt_text>
+                </dynamic_texts>
+                <texts_groups/>
+            </element>
+            <element freezeLabel="false" type="embed://import/pinball_em_williams_schematic/output/pinball_em_williams_lite.elmt" x="80" y="270" orientation="0" z="10" uuid="{871ad132-fc93-4a6d-a73f-c2cab66f2c42}" prefix="">
+                <terminals>
+                    <terminal number="_" nameHidden="0" x="-16" y="0" orientation="3" name="_" id="245"/>
+                    <terminal number="_" nameHidden="0" x="16" y="0" orientation="1" name="_" id="246"/>
+                </terminals>
+                <inputs/>
+                <elementInformations>
+                    <elementInformation show="1" name="formula"></elementInformation>
+                </elementInformations>
+                <dynamic_texts>
+                    <dynamic_elmt_text x="-30" y="-30" Halignment="AlignLeft" uuid="{1827f02d-2886-4f51-a673-a000ee33c03c}" frame="false" text_from="UserText" rotation="0" font="Sans Serif,9,-1,5,0,0,0,0,0,0,normal" Valignment="AlignTop" text_width="60">
+                        <text>Lite</text>
+                    </dynamic_elmt_text>
+                </dynamic_texts>
+                <texts_groups/>
+            </element>
+            <element freezeLabel="false" type="embed://import/pinball_em_williams_schematic/switches_common/pinball_em_williams_switch_mb_bottom.elmt" x="500" y="270" orientation="0" z="10" uuid="{f22b4723-fd0f-4667-8b43-c11fa07c7e5b}" prefix="">
+                <terminals>
+                    <terminal number="_" nameHidden="0" x="16" y="-20.25" orientation="1" name="_" id="247"/>
+                    <terminal number="_" nameHidden="0" x="-16" y="-0.25" orientation="3" name="_" id="248"/>
+                    <terminal number="_" nameHidden="0" x="16" y="-0.25" orientation="1" name="_" id="249"/>
+                </terminals>
+                <inputs/>
+                <elementInformations>
+                    <elementInformation show="1" name="formula"></elementInformation>
+                </elementInformations>
+                <dynamic_texts/>
+                <texts_groups/>
+            </element>
+            <element freezeLabel="false" type="embed://import/pinball_em_williams_schematic/switches_common/pinball_em_williams_switch_mb_top.elmt" x="500" y="150" orientation="0" z="10" uuid="{d7df1c60-d69f-4930-a6ba-6d4c766e7f0f}" prefix="">
+                <terminals>
+                    <terminal number="_" nameHidden="0" x="-16" y="0" orientation="3" name="_" id="250"/>
+                    <terminal number="_" nameHidden="0" x="16" y="0" orientation="1" name="_" id="251"/>
+                    <terminal number="_" nameHidden="0" x="16" y="20" orientation="1" name="_" id="252"/>
+                </terminals>
+                <inputs/>
+                <elementInformations>
+                    <elementInformation show="1" name="formula"></elementInformation>
+                </elementInformations>
+                <dynamic_texts>
+                    <dynamic_elmt_text x="-50" y="-30" Halignment="AlignLeft" uuid="{2269943e-5143-4708-9672-b792848bc455}" frame="false" text_from="UserText" rotation="0" font="Sans Serif,9,-1,5,0,0,0,0,0,0,normal" Valignment="AlignTop" text_width="100">
+                        <text>Switch (M.B.)</text>
+                    </dynamic_elmt_text>
+                </dynamic_texts>
+                <texts_groups/>
+            </element>
+            <element freezeLabel="false" type="embed://import/pinball_em_williams_schematic/switches_common/pinball_em_williams_switch_mb_bottom_i.elmt" x="560" y="270" orientation="0" z="10" uuid="{36826f47-eb6b-4e1b-b442-104a5e8e8c1c}" prefix="">
+                <terminals>
+                    <terminal number="_" nameHidden="0" x="16" y="-20" orientation="1" name="_" id="253"/>
+                    <terminal number="_" nameHidden="0" x="-16" y="0" orientation="3" name="_" id="254"/>
+                    <terminal number="_" nameHidden="0" x="16" y="0" orientation="1" name="_" id="255"/>
+                </terminals>
+                <inputs/>
+                <elementInformations>
+                    <elementInformation show="1" name="formula"></elementInformation>
+                </elementInformations>
+                <dynamic_texts/>
+                <texts_groups/>
+            </element>
+            <element freezeLabel="false" type="embed://import/pinball_em_williams_schematic/switches_common/pinball_em_williams_switch_mb_center_i.elmt" x="560" y="210" orientation="0" z="10" uuid="{eb0b458e-e1d5-4b0e-8efd-6726f6f497a1}" prefix="">
+                <terminals>
+                    <terminal number="_" nameHidden="0" x="16" y="-10" orientation="1" name="_" id="256"/>
+                    <terminal number="_" nameHidden="0" x="-16" y="0" orientation="3" name="_" id="257"/>
+                    <terminal number="_" nameHidden="0" x="16" y="10" orientation="1" name="_" id="258"/>
+                </terminals>
+                <inputs/>
+                <elementInformations>
+                    <elementInformation show="1" name="formula"></elementInformation>
+                </elementInformations>
+                <dynamic_texts/>
+                <texts_groups/>
+            </element>
+            <element freezeLabel="false" type="embed://import/pinball_em_williams_schematic/power/pinball_em_williams_power_cord_ground.elmt" x="380" y="260" orientation="0" z="10" uuid="{55e22e49-64cd-4561-bd86-0521523797e4}" prefix="">
+                <terminals>
+                    <terminal number="_" nameHidden="0" x="-16" y="0" orientation="3" name="_" id="259"/>
+                    <terminal number="_" nameHidden="0" x="16" y="0" orientation="1" name="_" id="260"/>
+                    <terminal number="_" nameHidden="0" x="0" y="6" orientation="2" name="_" id="261"/>
+                </terminals>
+                <inputs/>
+                <elementInformations>
+                    <elementInformation show="1" name="formula"></elementInformation>
+                </elementInformations>
+                <dynamic_texts>
+                    <dynamic_elmt_text x="-30" y="-60" Halignment="AlignLeft" uuid="{f38a6dbe-6b51-4932-9ec5-d6e86d5550bf}" frame="false" text_from="UserText" rotation="0" font="Sans Serif,9,-1,5,0,0,0,0,0,0,normal" Valignment="AlignTop" text_width="60">
+                        <text>Cord</text>
+                    </dynamic_elmt_text>
+                </dynamic_texts>
+                <texts_groups/>
+            </element>
+            <element freezeLabel="false" type="embed://import/pinball_em_williams_schematic/switches_score_motor/pinball_em_williams_switch_mb_sm_top.elmt" x="860" y="150" orientation="0" z="10" uuid="{2054661a-74fd-4087-9571-8fadf5009fd7}" prefix="">
+                <terminals>
+                    <terminal number="_" nameHidden="0" x="-16" y="0" orientation="3" name="_" id="262"/>
+                    <terminal number="_" nameHidden="0" x="16" y="0" orientation="1" name="_" id="263"/>
+                    <terminal number="_" nameHidden="0" x="16" y="20" orientation="1" name="_" id="264"/>
+                </terminals>
+                <inputs/>
+                <elementInformations>
+                    <elementInformation show="1" name="formula"></elementInformation>
+                </elementInformations>
+                <dynamic_texts/>
+                <texts_groups/>
+            </element>
+            <element freezeLabel="false" type="embed://import/pinball_em_williams_schematic/switches_score_motor/pinball_em_williams_switch_no_sm.elmt" x="800" y="100" orientation="0" z="10" uuid="{a8a89fe9-c1e7-4d30-ac42-dcc775779a42}" prefix="">
+                <terminals>
+                    <terminal number="_" nameHidden="0" x="-16" y="0" orientation="3" name="_" id="265"/>
+                    <terminal number="_" nameHidden="0" x="16" y="0" orientation="1" name="_" id="266"/>
+                </terminals>
+                <inputs/>
+                <elementInformations>
+                    <elementInformation show="1" name="formula"></elementInformation>
+                </elementInformations>
+                <dynamic_texts>
+                    <dynamic_elmt_text x="-50" y="-30" Halignment="AlignLeft" uuid="{a0aebb91-86f5-4c39-9c41-4bc1c4661306}" frame="false" text_from="UserText" rotation="0" font="Sans Serif,9,-1,5,0,0,0,0,0,0,normal" Valignment="AlignTop" text_width="100">
+                        <text>Switch (N.O.)</text>
+                    </dynamic_elmt_text>
+                </dynamic_texts>
+                <texts_groups/>
+            </element>
+            <element freezeLabel="false" type="embed://import/pinball_em_williams_schematic/jacks/pinball_em_williams_jack_07.elmt" x="290" y="380" orientation="0" z="10" uuid="{a6b91ccd-ee41-4a82-95fd-e4d4fc8b48aa}" prefix="">
+                <terminals>
+                    <terminal number="_" nameHidden="0" x="-16" y="0" orientation="3" name="_" id="267"/>
+                    <terminal number="_" nameHidden="0" x="16" y="0" orientation="1" name="_" id="268"/>
+                    <terminal number="_" nameHidden="0" x="-16" y="20" orientation="3" name="_" id="269"/>
+                    <terminal number="_" nameHidden="0" x="16" y="20" orientation="1" name="_" id="270"/>
+                    <terminal number="_" nameHidden="0" x="-16" y="40" orientation="3" name="_" id="271"/>
+                    <terminal number="_" nameHidden="0" x="16" y="40" orientation="1" name="_" id="272"/>
+                    <terminal number="_" nameHidden="0" x="-16" y="60" orientation="3" name="_" id="273"/>
+                    <terminal number="_" nameHidden="0" x="16" y="60" orientation="1" name="_" id="274"/>
+                    <terminal number="_" nameHidden="0" x="-16" y="80" orientation="3" name="_" id="275"/>
+                    <terminal number="_" nameHidden="0" x="16" y="80" orientation="1" name="_" id="276"/>
+                    <terminal number="_" nameHidden="0" x="-16" y="100" orientation="3" name="_" id="277"/>
+                    <terminal number="_" nameHidden="0" x="16" y="100" orientation="1" name="_" id="278"/>
+                    <terminal number="_" nameHidden="0" x="-16" y="120" orientation="3" name="_" id="279"/>
+                    <terminal number="_" nameHidden="0" x="16" y="120" orientation="1" name="_" id="280"/>
+                </terminals>
+                <inputs/>
+                <elementInformations>
+                    <elementInformation show="1" name="formula"></elementInformation>
+                </elementInformations>
+                <dynamic_texts>
+                    <dynamic_elmt_text x="-40" y="-40" Halignment="AlignLeft" uuid="{1b95bc97-d10b-48f6-8b95-ecd83d1a1bc6}" frame="false" text_from="UserText" rotation="0" font="Sans Serif,9,-1,5,0,0,0,0,0,0,normal" Valignment="AlignTop" text_width="80">
+                        <text>7 positions</text>
+                    </dynamic_elmt_text>
+                </dynamic_texts>
+                <texts_groups/>
+            </element>
+            <element freezeLabel="false" type="embed://import/pinball_em_williams_schematic/power/pinball_em_williams_service_outlet.elmt" x="240" y="270" orientation="0" z="10" uuid="{21851f54-ca7b-4df6-863f-6589c70754fe}" prefix="">
+                <terminals>
+                    <terminal number="_" nameHidden="0" x="-16" y="0" orientation="3" name="_" id="281"/>
+                    <terminal number="_" nameHidden="0" x="16" y="0" orientation="1" name="_" id="282"/>
+                </terminals>
+                <inputs/>
+                <elementInformations>
+                    <elementInformation show="1" name="formula"></elementInformation>
+                </elementInformations>
+                <dynamic_texts>
+                    <dynamic_elmt_text x="-30" y="-30" Halignment="AlignLeft" uuid="{54242518-ad2b-4f76-88cc-b262f01f5dd1}" frame="false" text_from="UserText" rotation="0" font="Sans Serif,9,-1,5,0,0,0,0,0,0,normal" Valignment="AlignTop" text_width="60">
+                        <text>Socket</text>
+                    </dynamic_elmt_text>
+                </dynamic_texts>
+                <texts_groups/>
+            </element>
+            <element freezeLabel="false" type="embed://import/pinball_em_williams_schematic/switches_common/pinball_em_williams_switch_mb_top_i.elmt" x="560" y="150" orientation="0" z="10" uuid="{7e19d757-ed85-4a53-bb53-8eeed8c1c771}" prefix="">
+                <terminals>
+                    <terminal number="_" nameHidden="0" x="-16" y="-0.25" orientation="3" name="_" id="283"/>
+                    <terminal number="_" nameHidden="0" x="16" y="-0.25" orientation="1" name="_" id="284"/>
+                    <terminal number="_" nameHidden="0" x="16" y="19.75" orientation="1" name="_" id="285"/>
+                </terminals>
+                <inputs/>
+                <elementInformations>
+                    <elementInformation show="1" name="formula"></elementInformation>
+                </elementInformations>
+                <dynamic_texts/>
+                <texts_groups/>
+            </element>
+            <element freezeLabel="false" type="embed://import/pinball_em_williams_schematic/power/pinball_em_williams_fuse.elmt" x="240" y="220" orientation="0" z="10" uuid="{1f2b03f0-6f54-4a25-b2ba-2958c0e3eb16}" prefix="">
+                <terminals>
+                    <terminal number="_" nameHidden="0" x="-16" y="0" orientation="3" name="_" id="286"/>
+                    <terminal number="_" nameHidden="0" x="16" y="0" orientation="1" name="_" id="287"/>
+                </terminals>
+                <inputs/>
+                <elementInformations>
+                    <elementInformation show="1" name="formula"></elementInformation>
+                </elementInformations>
+                <dynamic_texts>
+                    <dynamic_elmt_text x="-30" y="-30" Halignment="AlignLeft" uuid="{fb319450-ca78-4e68-abc2-5e40edf12dae}" frame="false" text_from="UserText" rotation="0" font="Sans Serif,9,-1,5,0,0,0,0,0,0,normal" Valignment="AlignTop" text_width="60">
+                        <text>Fuse</text>
+                    </dynamic_elmt_text>
+                </dynamic_texts>
+                <texts_groups/>
+            </element>
+            <element freezeLabel="false" type="embed://import/pinball_em_williams_schematic/switches_common/pinball_em_williams_switch_mb_center.elmt" x="500" y="210" orientation="0" z="10" uuid="{d7684360-fc66-49e1-88f1-aa27aa4518a6}" prefix="">
+                <terminals>
+                    <terminal number="_" nameHidden="0" x="16" y="-10" orientation="1" name="_" id="288"/>
+                    <terminal number="_" nameHidden="0" x="-16" y="0" orientation="3" name="_" id="289"/>
+                    <terminal number="_" nameHidden="0" x="16" y="10" orientation="1" name="_" id="290"/>
+                </terminals>
+                <inputs/>
+                <elementInformations>
+                    <elementInformation show="1" name="formula"></elementInformation>
+                </elementInformations>
+                <dynamic_texts/>
+                <texts_groups/>
+            </element>
+            <element freezeLabel="false" type="embed://import/pinball_em_williams_schematic/power/pinball_em_williams_power_cord.elmt" x="310" y="260" orientation="0" z="10" uuid="{e678afe7-b278-4da3-b468-a6fa3ff478c8}" prefix="">
+                <terminals>
+                    <terminal number="_" nameHidden="0" x="-16" y="0" orientation="3" name="_" id="291"/>
+                    <terminal number="_" nameHidden="0" x="16" y="0" orientation="1" name="_" id="292"/>
+                </terminals>
+                <inputs/>
+                <elementInformations>
+                    <elementInformation show="1" name="formula"></elementInformation>
+                </elementInformations>
+                <dynamic_texts>
+                    <dynamic_elmt_text x="-30" y="-60" Halignment="AlignLeft" uuid="{d4a0e29f-686d-402e-b500-8c182fae9068}" frame="false" text_from="UserText" rotation="0" font="Sans Serif,9,-1,5,0,0,0,0,0,0,normal" Valignment="AlignTop" text_width="60">
+                        <text>Cord</text>
+                    </dynamic_elmt_text>
+                </dynamic_texts>
+                <texts_groups/>
+            </element>
+            <element freezeLabel="false" type="embed://import/pinball_em_williams_schematic/output/pinball_em_williams_motor.elmt" x="140" y="270" orientation="0" z="10" uuid="{b64bfed2-86c9-4ac9-931a-075a6fee22d5}" prefix="">
+                <terminals>
+                    <terminal number="_" nameHidden="0" x="-16" y="0" orientation="3" name="_" id="293"/>
+                    <terminal number="_" nameHidden="0" x="16" y="0" orientation="1" name="_" id="294"/>
+                </terminals>
+                <inputs/>
+                <elementInformations>
+                    <elementInformation show="1" name="formula"></elementInformation>
+                </elementInformations>
+                <dynamic_texts>
+                    <dynamic_elmt_text x="-30" y="-30" Halignment="AlignLeft" uuid="{03cb2792-e06d-403b-97cd-73fdbc61c2d5}" frame="false" text_from="UserText" rotation="0" font="Sans Serif,9,-1,5,0,0,0,0,0,0,normal" Valignment="AlignTop" text_width="60">
+                        <text>Motor</text>
+                    </dynamic_elmt_text>
+                </dynamic_texts>
+                <texts_groups/>
+            </element>
+        </elements>
+        <inputs>
+            <input x="750" y="40" rotation="0" text="&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;>&#xa;&lt;html>&lt;head>&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; />&lt;style type=&quot;text/css&quot;>&#xa;p, li { white-space: pre-wrap; }&#xa;&lt;/style>&lt;/head>&lt;body style=&quot; font-family:'Sans Serif'; font-size:9pt; font-weight:0; font-style:normal;&quot;>&#xa;&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;>&lt;span style=&quot; font-size:12pt; font-weight:600;&quot;>Switches - Score Motor&lt;/span>&lt;/p>&lt;/body>&lt;/html>" font="Sans Serif,9,-1,5,0,0,0,0,0,0,normal"/>
+            <input x="450" y="40" rotation="0" text="&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;>&#xa;&lt;html>&lt;head>&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; />&lt;style type=&quot;text/css&quot;>&#xa;p, li { white-space: pre-wrap; }&#xa;&lt;/style>&lt;/head>&lt;body style=&quot; font-family:'Sans Serif'; font-size:9pt; font-weight:0; font-style:normal;&quot;>&#xa;&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;>&lt;span style=&quot; font-size:12pt; font-weight:600;&quot;>Switches - Common&lt;/span>&lt;/p>&lt;/body>&lt;/html>" font="Sans Serif,9,-1,5,0,0,0,0,0,0,normal"/>
+            <input x="750" y="310" rotation="0" text="&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;>&#xa;&lt;html>&lt;head>&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; />&lt;style type=&quot;text/css&quot;>&#xa;p, li { white-space: pre-wrap; }&#xa;&lt;/style>&lt;/head>&lt;body style=&quot; font-family:'Sans Serif'; font-size:9pt; font-weight:0; font-style:normal;&quot;>&#xa;&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;>&lt;span style=&quot; font-size:12pt; font-weight:600;&quot;>Units - Wiper contacts&lt;/span>&lt;/p>&lt;/body>&lt;/html>" font="Sans Serif,9,-1,5,0,0,0,0,0,0,normal"/>
+            <input x="40" y="160" rotation="0" text="&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;>&#xa;&lt;html>&lt;head>&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; />&lt;style type=&quot;text/css&quot;>&#xa;p, li { white-space: pre-wrap; }&#xa;&lt;/style>&lt;/head>&lt;body style=&quot; font-family:'Sans Serif'; font-size:9pt; font-weight:0; font-style:normal;&quot;>&#xa;&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;>&lt;span style=&quot; font-size:12pt; font-weight:600;&quot;>Outputs&lt;/span>&lt;/p>&lt;/body>&lt;/html>" font="Sans Serif,9,-1,5,0,0,0,0,0,0,normal"/>
+            <input x="200" y="160" rotation="0" text="&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;>&#xa;&lt;html>&lt;head>&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; />&lt;style type=&quot;text/css&quot;>&#xa;p, li { white-space: pre-wrap; }&#xa;&lt;/style>&lt;/head>&lt;body style=&quot; font-family:'Sans Serif'; font-size:9pt; font-weight:0; font-style:normal;&quot;>&#xa;&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;>&lt;span style=&quot; font-size:12pt; font-weight:600;&quot;>Power&lt;/span>&lt;/p>&lt;/body>&lt;/html>" font="Sans Serif,9,-1,5,0,0,0,0,0,0,normal"/>
+            <input x="40" y="40" rotation="0" text="&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;>&#xa;&lt;html>&lt;head>&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; />&lt;style type=&quot;text/css&quot;>&#xa;p, li { white-space: pre-wrap; }&#xa;&lt;/style>&lt;/head>&lt;body style=&quot; font-family:'Sans Serif'; font-size:9pt; font-weight:0; font-style:normal;&quot;>&#xa;&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;>&lt;span style=&quot; font-size:12pt; font-weight:600;&quot;>Common symbols&lt;/span>&lt;/p>&lt;/body>&lt;/html>" font="Sans Serif,9,-1,5,0,0,0,0,0,0,normal"/>
+            <input x="40" y="310" rotation="0" text="&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;>&#xa;&lt;html>&lt;head>&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; />&lt;style type=&quot;text/css&quot;>&#xa;p, li { white-space: pre-wrap; }&#xa;&lt;/style>&lt;/head>&lt;body style=&quot; font-family:'Sans Serif'; font-size:9pt; font-weight:0; font-style:normal;&quot;>&#xa;&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;>&lt;span style=&quot; font-size:12pt; font-weight:600;&quot;>Contacts&lt;/span>&lt;/p>&lt;/body>&lt;/html>" font="Sans Serif,9,-1,5,0,0,0,0,0,0,normal"/>
+        </inputs>
+        <shapes>
+            <shape y2="290" is_movable="1" type="Line" x1="730" y1="40" z="0" closed="0" x2="730">
+                <pen widthF="1" color="#000000" style="SolidLine"/>
+                <brush color="#000000" style="NoBrush"/>
+            </shape>
+            <shape y2="160" is_movable="1" type="Line" x1="200" y1="160" z="0" closed="0" x2="430">
+                <pen widthF="1" color="#000000" style="SolidLine"/>
+                <brush color="#000000" style="NoBrush"/>
+            </shape>
+            <shape y2="290" is_movable="1" type="Line" x1="180" y1="160" z="0" closed="0" x2="180">
+                <pen widthF="1" color="#000000" style="SolidLine"/>
+                <brush color="#000000" style="NoBrush"/>
+            </shape>
+            <shape y2="290" is_movable="1" type="Line" x1="200" y1="160" z="0" closed="0" x2="200">
+                <pen widthF="1" color="#000000" style="SolidLine"/>
+                <brush color="#000000" style="NoBrush"/>
+            </shape>
+            <shape y2="290" is_movable="1" type="Line" x1="430" y1="290" z="0" closed="0" x2="200">
+                <pen widthF="1" color="#000000" style="SolidLine"/>
+                <brush color="#000000" style="NoBrush"/>
+            </shape>
+            <shape y2="190" is_movable="1" type="Line" x1="200" y1="190" z="0" closed="0" x2="430">
+                <pen widthF="1" color="#000000" style="SolidLine"/>
+                <brush color="#000000" style="NoBrush"/>
+            </shape>
+            <shape y2="590" is_movable="1" type="Line" x1="40" y1="590" z="0" closed="0" x2="120">
+                <pen widthF="1" color="#000000" style="SolidLine"/>
+                <brush color="#000000" style="NoBrush"/>
+            </shape>
+            <shape y2="340" is_movable="1" type="Line" x1="40" y1="340" z="0" closed="0" x2="730">
+                <pen widthF="1" color="#000000" style="SolidLine"/>
+                <brush color="#000000" style="NoBrush"/>
+            </shape>
+            <shape y2="310" is_movable="1" type="Line" x1="40" y1="310" z="0" closed="0" x2="730">
+                <pen widthF="1" color="#000000" style="SolidLine"/>
+                <brush color="#000000" style="NoBrush"/>
+            </shape>
+            <shape y2="310" is_movable="1" type="Line" x1="730" y1="410" z="0" closed="0" x2="730">
+                <pen widthF="1" color="#000000" style="SolidLine"/>
+                <brush color="#000000" style="NoBrush"/>
+            </shape>
+            <shape y2="340" is_movable="1" type="Line" x1="750" y1="340" z="0" closed="0" x2="1030">
+                <pen widthF="1" color="#000000" style="SolidLine"/>
+                <brush color="#000000" style="NoBrush"/>
+            </shape>
+            <shape y2="40" is_movable="1" type="Line" x1="450" y1="40" z="0" closed="0" x2="730">
+                <pen widthF="1" color="#000000" style="SolidLine"/>
+                <brush color="#000000" style="NoBrush"/>
+            </shape>
+            <shape y2="70" is_movable="1" type="Line" x1="750" y1="70" z="0" closed="0" x2="1030">
+                <pen widthF="1" color="#000000" style="SolidLine"/>
+                <brush color="#000000" style="NoBrush"/>
+            </shape>
+            <shape y2="160" is_movable="1" type="Line" x1="40" y1="160" z="0" closed="0" x2="180">
+                <pen widthF="1" color="#000000" style="SolidLine"/>
+                <brush color="#000000" style="NoBrush"/>
+            </shape>
+            <shape y2="430" is_movable="1" type="Line" x1="750" y1="310" z="0" closed="0" x2="750">
+                <pen widthF="1" color="#000000" style="SolidLine"/>
+                <brush color="#000000" style="NoBrush"/>
+            </shape>
+            <shape y2="310" is_movable="1" type="Line" x1="750" y1="310" z="0" closed="0" x2="1030">
+                <pen widthF="1" color="#000000" style="SolidLine"/>
+                <brush color="#000000" style="NoBrush"/>
+            </shape>
+            <shape y2="650" is_movable="1" type="Line" x1="1030" y1="650" z="0" closed="0" x2="310">
+                <pen widthF="1" color="#000000" style="SolidLine"/>
+                <brush color="#000000" style="NoBrush"/>
+            </shape>
+            <shape y2="430" is_movable="1" type="Line" x1="310" y1="560" z="0" closed="0" x2="750">
+                <pen widthF="1" color="#000000" style="SolidLine"/>
+                <brush color="#000000" style="NoBrush"/>
+            </shape>
+            <shape y2="560" is_movable="1" type="Line" x1="310" y1="650" z="0" closed="0" x2="310">
+                <pen widthF="1" color="#000000" style="SolidLine"/>
+                <brush color="#000000" style="NoBrush"/>
+            </shape>
+            <shape y2="290" is_movable="1" type="Line" x1="430" y1="160" z="0" closed="0" x2="430">
+                <pen widthF="1" color="#000000" style="SolidLine"/>
+                <brush color="#000000" style="NoBrush"/>
+            </shape>
+            <shape y2="290" is_movable="1" type="Line" x1="40" y1="160" z="0" closed="0" x2="40">
+                <pen widthF="1" color="#000000" style="SolidLine"/>
+                <brush color="#000000" style="NoBrush"/>
+            </shape>
+            <shape y2="190" is_movable="1" type="Line" x1="40" y1="190" z="0" closed="0" x2="180">
+                <pen widthF="1" color="#000000" style="SolidLine"/>
+                <brush color="#000000" style="NoBrush"/>
+            </shape>
+            <shape y2="410" is_movable="1" type="Line" x1="120" y1="590" z="0" closed="0" x2="730">
+                <pen widthF="1" color="#000000" style="SolidLine"/>
+                <brush color="#000000" style="NoBrush"/>
+            </shape>
+            <shape y2="40" is_movable="1" type="Line" x1="1030" y1="290" z="0" closed="0" x2="1030">
+                <pen widthF="1" color="#000000" style="SolidLine"/>
+                <brush color="#000000" style="NoBrush"/>
+            </shape>
+            <shape y2="290" is_movable="1" type="Line" x1="730" y1="290" z="0" closed="0" x2="450">
+                <pen widthF="1" color="#000000" style="SolidLine"/>
+                <brush color="#000000" style="NoBrush"/>
+            </shape>
+            <shape y2="70" is_movable="1" type="Line" x1="450" y1="70" z="0" closed="0" x2="730">
+                <pen widthF="1" color="#000000" style="SolidLine"/>
+                <brush color="#000000" style="NoBrush"/>
+            </shape>
+            <shape y2="40" is_movable="1" type="Line" x1="1030" y1="40" z="0" closed="0" x2="750">
+                <pen widthF="1" color="#000000" style="SolidLine"/>
+                <brush color="#000000" style="NoBrush"/>
+            </shape>
+            <shape y2="290" is_movable="1" type="Line" x1="40" y1="290" z="0" closed="0" x2="180">
+                <pen widthF="1" color="#000000" style="SolidLine"/>
+                <brush color="#000000" style="NoBrush"/>
+            </shape>
+            <shape y2="650" is_movable="1" type="Line" x1="1030" y1="310" z="0" closed="0" x2="1030">
+                <pen widthF="1" color="#000000" style="SolidLine"/>
+                <brush color="#000000" style="NoBrush"/>
+            </shape>
+            <shape y2="290" is_movable="1" type="Line" x1="750" y1="290" z="0" closed="0" x2="1030">
+                <pen widthF="1" color="#000000" style="SolidLine"/>
+                <brush color="#000000" style="NoBrush"/>
+            </shape>
+            <shape y2="40" is_movable="1" type="Line" x1="450" y1="290" z="0" closed="0" x2="450">
+                <pen widthF="1" color="#000000" style="SolidLine"/>
+                <brush color="#000000" style="NoBrush"/>
+            </shape>
+            <shape y2="290" is_movable="1" type="Line" x1="750" y1="40" z="0" closed="0" x2="750">
+                <pen widthF="1" color="#000000" style="SolidLine"/>
+                <brush color="#000000" style="NoBrush"/>
+            </shape>
+            <shape y2="590" is_movable="1" type="Line" x1="40" y1="310" z="0" closed="0" x2="40">
+                <pen widthF="1" color="#000000" style="SolidLine"/>
+                <brush color="#000000" style="NoBrush"/>
+            </shape>
+            <shape y2="140" is_movable="1" type="Line" x1="430" y1="40" z="0" closed="0" x2="430">
+                <pen widthF="1" color="#000000" style="SolidLine"/>
+                <brush color="#000000" style="NoBrush"/>
+            </shape>
+            <shape y2="140" is_movable="1" type="Line" x1="430" y1="140" z="0" closed="0" x2="40">
+                <pen widthF="1" color="#000000" style="SolidLine"/>
+                <brush color="#000000" style="NoBrush"/>
+            </shape>
+            <shape y2="40" is_movable="1" type="Line" x1="40" y1="140" z="0" closed="0" x2="40">
+                <pen widthF="1" color="#000000" style="SolidLine"/>
+                <brush color="#000000" style="NoBrush"/>
+            </shape>
+            <shape y2="40" is_movable="1" type="Line" x1="40" y1="40" z="0" closed="0" x2="430">
+                <pen widthF="1" color="#000000" style="SolidLine"/>
+                <brush color="#000000" style="NoBrush"/>
+            </shape>
+            <shape y2="70" is_movable="1" type="Line" x1="40" y1="70" z="0" closed="0" x2="430">
+                <pen widthF="1" color="#000000" style="SolidLine"/>
+                <brush color="#000000" style="NoBrush"/>
+            </shape>
+        </shapes>
+    </diagram>
+    <collection>
+        <category name="import">
+            <names>
+                <name lang="sl">Uvoženi elementi</name>
+                <name lang="pl">Elementy importowane</name>
+                <name lang="it">Elementi importati</name>
+                <name lang="ca">Elements importats</name>
+                <name lang="ro">Elemente importate</name>
+                <name lang="en">Imported elements</name>
+                <name lang="el">Εισηγμένα στοιχεία</name>
+                <name lang="ru">Импортированные элементы</name>
+                <name lang="tr">İthal öğeler</name>
+                <name lang="pt">elementos importados</name>
+                <name lang="hr">Uvezeni elementi</name>
+                <name lang="de">Importierte elemente</name>
+                <name lang="cs">Zavedené prvky</name>
+                <name lang="es">Elementos importados</name>
+                <name lang="nl">Elementen geïmporteerd</name>
+                <name lang="da">Importerede elementer</name>
+                <name lang="fr">Éléments importés</name>
+            </names>
+            <category name="pinball_em_williams_schematic">
+                <names>
+                    <name lang="en">Williams EM Schematics</name>
+                    <name lang="nl">Williams EM Schema's</name>
+                </names>
+                <category name="common">
+                    <names>
+                        <name lang="en">Common</name>
+                        <name lang="nl">Algemeen</name>
+                    </names>
+                    <element name="pinball_em_williams_ground.elmt">
+                        <definition width="20" type="element" orientation="dyyy" hotspot_x="10" hotspot_y="17" version="0.70" link_type="simple" height="30">
+                            <uuid uuid="{ff754778-ac11-493d-828a-5f763560b02e}"/>
+                            <names>
+                                <name lang="en">Ground</name>
+                                <name lang="nl">Aarde</name>
+                            </names>
+                            <elementInformations/>
+                            <informations/>
+                            <description>
+                                <line length2="1.5" end1="none" y2="0" y1="-10" x1="0" length1="1.5" end2="none" style="line-style:normal;line-weight:normal;filling:none;color:black" antialias="false" x2="0"/>
+                                <line length2="1.5" end1="none" y2="0" y1="0" x1="-7" length1="1.5" end2="none" style="line-style:normal;line-weight:hight;filling:none;color:black" antialias="false" x2="7"/>
+                                <line length2="1.5" end1="none" y2="4" y1="4" x1="5" length1="1.5" end2="none" style="line-style:normal;line-weight:hight;filling:none;color:black" antialias="false" x2="-5"/>
+                                <line length2="1.5" end1="none" y2="8" y1="8" x1="-3" length1="1.5" end2="none" style="line-style:normal;line-weight:hight;filling:none;color:black" antialias="false" x2="3"/>
+                                <terminal y="-10" orientation="n" x="0"/>
+                            </description>
+                        </definition>
+                    </element>
+                    <element name="pinball_em_williams_not_connected_east.elmt">
+                        <definition width="30" type="element" orientation="dyyy" hotspot_x="11" hotspot_y="10" version="0.70" link_type="simple" height="20">
+                            <uuid uuid="{4f47811e-036e-4ef0-a846-b656f51ca81e}"/>
+                            <names>
+                                <name lang="en">Not connected (east)</name>
+                                <name lang="nl">Niet verbonden (oost)</name>
+                            </names>
+                            <elementInformations/>
+                            <informations/>
+                            <description>
+                                <line length2="1.5" end1="none" y2="0" y1="0" x1="0" length1="1.5" end2="none" style="line-style:normal;line-weight:normal;filling:none;color:black" antialias="false" x2="10"/>
+                                <line length2="1.5" end1="none" y2="5" y1="-5" x1="-5" length1="1.5" end2="none" style="line-style:normal;line-weight:normal;filling:none;color:black" antialias="false" x2="5"/>
+                                <line length2="1.5" end1="none" y2="-5" y1="5" x1="-5" length1="1.5" end2="none" style="line-style:normal;line-weight:normal;filling:none;color:black" antialias="false" x2="5"/>
+                                <terminal y="0" orientation="e" x="10"/>
+                            </description>
+                        </definition>
+                    </element>
+                    <element name="pinball_em_williams_not_connected_north.elmt">
+                        <definition width="20" type="element" orientation="dyyy" hotspot_x="10" hotspot_y="18" version="0.70" link_type="simple" height="30">
+                            <uuid uuid="{e446ec4b-827d-4df3-bed0-dd4adbd2b62a}"/>
+                            <names>
+                                <name lang="en">Not connected (north)</name>
+                                <name lang="nl">Niet verbonden (noord)</name>
+                            </names>
+                            <elementInformations/>
+                            <informations/>
+                            <description>
+                                <line length2="1.5" end1="none" y2="6" y1="-6" x1="-6" length1="1.5" end2="none" style="line-style:normal;line-weight:normal;filling:none;color:black" antialias="false" x2="6"/>
+                                <line length2="1.5" end1="none" y2="6" y1="-6" x1="6" length1="1.5" end2="none" style="line-style:normal;line-weight:normal;filling:none;color:black" antialias="false" x2="-6"/>
+                                <line length2="1.5" end1="none" y2="-10" y1="0" x1="0" length1="1.5" end2="none" style="line-style:normal;line-weight:normal;filling:none;color:black" antialias="false" x2="0"/>
+                                <terminal y="-10" orientation="n" x="0"/>
+                            </description>
+                        </definition>
+                    </element>
+                    <element name="pinball_em_williams_not_connected_south.elmt">
+                        <definition width="20" type="element" orientation="dyyy" hotspot_x="10" hotspot_y="11" version="0.70" link_type="simple" height="30">
+                            <uuid uuid="{e16cfe95-6fbc-49a0-97ee-1c0991324964}"/>
+                            <names>
+                                <name lang="en">Not connected (south)</name>
+                                <name lang="nl">Niet verbonden (zuid)</name>
+                            </names>
+                            <elementInformations/>
+                            <informations/>
+                            <description>
+                                <line length2="1.5" end1="none" y2="0" y1="10" x1="0" length1="1.5" end2="none" style="line-style:normal;line-weight:normal;filling:none;color:black" antialias="false" x2="0"/>
+                                <line length2="1.5" end1="none" y2="-5" y1="5" x1="-5" length1="1.5" end2="none" style="line-style:normal;line-weight:normal;filling:none;color:black" antialias="false" x2="5"/>
+                                <line length2="1.5" end1="none" y2="-5" y1="5" x1="5" length1="1.5" end2="none" style="line-style:normal;line-weight:normal;filling:none;color:black" antialias="false" x2="-5"/>
+                                <terminal y="10" orientation="s" x="0"/>
+                            </description>
+                        </definition>
+                    </element>
+                    <element name="pinball_em_williams_not_connected_west.elmt">
+                        <definition width="30" type="element" orientation="dyyy" hotspot_x="18" hotspot_y="10" version="0.70" link_type="simple" height="20">
+                            <uuid uuid="{b6b35ed3-cbaa-43b0-a5b2-6120925de98e}"/>
+                            <names>
+                                <name lang="en">Not connected (west)</name>
+                                <name lang="nl">Niet verbonden (west)</name>
+                            </names>
+                            <elementInformations/>
+                            <informations/>
+                            <description>
+                                <line length2="1.5" end1="none" y2="0" y1="0" x1="0" length1="1.5" end2="none" style="line-style:normal;line-weight:normal;filling:none;color:black" antialias="false" x2="-10"/>
+                                <line length2="1.5" end1="none" y2="5" y1="-5" x1="-5" length1="1.5" end2="none" style="line-style:normal;line-weight:normal;filling:none;color:black" antialias="false" x2="5"/>
+                                <line length2="1.5" end1="none" y2="-5" y1="5" x1="-5" length1="1.5" end2="none" style="line-style:normal;line-weight:normal;filling:none;color:black" antialias="false" x2="5"/>
+                                <terminal y="0" orientation="w" x="-10"/>
+                            </description>
+                        </definition>
+                    </element>
+                </category>
+                <category name="jacks">
+                    <names>
+                        <name lang="en">Jacks</name>
+                        <name lang="nl">Contacten</name>
+                    </names>
+                    <element name="pinball_em_williams_jack_02.elmt">
+                        <definition width="50" type="element" orientation="dyyy" hotspot_x="24" hotspot_y="15" version="0.70" link_type="simple" height="50">
+                            <uuid uuid="{48d90cab-e93d-4460-a1c8-4945e69144bf}"/>
+                            <names>
+                                <name lang="en">Jack with 2 positions</name>
+                                <name lang="nl">Contact met 2 posities</name>
+                            </names>
+                            <elementInformations/>
+                            <informations/>
+                            <description>
+                                <rect width="20" rx="0" y="-10" x="-10" ry="0" style="line-style:normal;line-weight:normal;filling:none;color:black" antialias="false" height="40"/>
+                                <line length2="1.5" end1="none" y2="0" y1="0" x1="-20" length1="1.5" end2="none" style="line-style:normal;line-weight:normal;filling:none;color:black" antialias="false" x2="-10"/>
+                                <line length2="1.5" end1="none" y2="20" y1="20" x1="-20" length1="1.5" end2="none" style="line-style:normal;line-weight:normal;filling:none;color:black" antialias="false" x2="-11"/>
+                                <line length2="1.5" end1="none" y2="20" y1="20" x1="10" length1="1.5" end2="none" style="line-style:normal;line-weight:normal;filling:none;color:black" antialias="false" x2="20"/>
+                                <line length2="1.5" end1="none" y2="0" y1="0" x1="20" length1="1.5" end2="none" style="line-style:normal;line-weight:normal;filling:none;color:black" antialias="false" x2="10"/>
+                                <terminal y="0" orientation="e" x="20"/>
+                                <terminal y="0" orientation="w" x="-20"/>
+                                <terminal y="20" orientation="e" x="20"/>
+                                <terminal y="20" orientation="w" x="-20"/>
+                            </description>
+                        </definition>
+                    </element>
+                    <element name="pinball_em_williams_jack_03.elmt">
+                        <definition width="50" type="element" orientation="dyyy" hotspot_x="24" hotspot_y="15" version="0.70" link_type="simple" height="70">
+                            <uuid uuid="{1e0d2098-80e3-4f87-a1a4-8979da3035e3}"/>
+                            <names>
+                                <name lang="en">Jack with 3 positions</name>
+                                <name lang="nl">Contact met 3 posities</name>
+                            </names>
+                            <elementInformations/>
+                            <informations/>
+                            <description>
+                                <rect width="20" rx="0" y="-10" x="-10" ry="0" style="line-style:normal;line-weight:normal;filling:none;color:black" antialias="false" height="60"/>
+                                <line length2="1.5" end1="none" y2="0" y1="0" x1="-20" length1="1.5" end2="none" style="line-style:normal;line-weight:normal;filling:none;color:black" antialias="false" x2="-10"/>
+                                <line length2="1.5" end1="none" y2="0" y1="0" x1="10" length1="1.5" end2="none" style="line-style:normal;line-weight:normal;filling:none;color:black" antialias="false" x2="20"/>
+                                <line length2="1.5" end1="none" y2="20" y1="20" x1="20" length1="1.5" end2="none" style="line-style:normal;line-weight:normal;filling:none;color:black" antialias="false" x2="10"/>
+                                <line length2="1.5" end1="none" y2="40" y1="40" x1="10" length1="1.5" end2="none" style="line-style:normal;line-weight:normal;filling:none;color:black" antialias="false" x2="20"/>
+                                <line length2="1.5" end1="none" y2="40" y1="40" x1="-10" length1="1.5" end2="none" style="line-style:normal;line-weight:normal;filling:none;color:black" antialias="false" x2="-20"/>
+                                <line length2="1.5" end1="none" y2="20" y1="20" x1="-20" length1="1.5" end2="none" style="line-style:normal;line-weight:normal;filling:none;color:black" antialias="false" x2="-10"/>
+                                <terminal y="40" orientation="w" x="-20"/>
+                                <terminal y="40" orientation="e" x="20"/>
+                                <terminal y="0" orientation="w" x="-20"/>
+                                <terminal y="20" orientation="w" x="-20"/>
+                                <terminal y="20" orientation="e" x="20"/>
+                                <terminal y="0" orientation="e" x="20"/>
+                            </description>
+                        </definition>
+                    </element>
+                    <element name="pinball_em_williams_jack_04.elmt">
+                        <definition width="50" type="element" orientation="dyyy" hotspot_x="24" hotspot_y="15" version="0.70" link_type="simple" height="90">
+                            <uuid uuid="{88b316e4-9fd7-4b89-af9e-3a70b840603b}"/>
+                            <names>
+                                <name lang="en">Jack with 4 positions</name>
+                                <name lang="nl">Contact met 4 posities</name>
+                            </names>
+                            <elementInformations/>
+                            <informations/>
+                            <description>
+                                <rect width="20" rx="0" y="-10" x="-10" ry="0" style="line-style:normal;line-weight:normal;filling:none;color:black" antialias="false" height="80"/>
+                                <line length2="1.5" end1="none" y2="0" y1="0" x1="10" length1="1.5" end2="none" style="line-style:normal;line-weight:normal;filling:none;color:black" antialias="false" x2="20"/>
+                                <line length2="1.5" end1="none" y2="20" y1="20" x1="10" length1="1.5" end2="none" style="line-style:normal;line-weight:normal;filling:none;color:black" antialias="false" x2="20"/>
+                                <line length2="1.5" end1="none" y2="40" y1="40" x1="10" length1="1.5" end2="none" style="line-style:normal;line-weight:normal;filling:none;color:black" antialias="false" x2="20"/>
+                                <line length2="1.5" end1="none" y2="60" y1="60" x1="10" length1="1.5" end2="none" style="line-style:normal;line-weight:normal;filling:none;color:black" antialias="false" x2="20"/>
+                                <line length2="1.5" end1="none" y2="60" y1="60" x1="-10" length1="1.5" end2="none" style="line-style:normal;line-weight:normal;filling:none;color:black" antialias="false" x2="-20"/>
+                                <line length2="1.5" end1="none" y2="40" y1="40" x1="-20" length1="1.5" end2="none" style="line-style:normal;line-weight:normal;filling:none;color:black" antialias="false" x2="-10"/>
+                                <line length2="1.5" end1="none" y2="20" y1="20" x1="-10" length1="1.5" end2="none" style="line-style:normal;line-weight:normal;filling:none;color:black" antialias="false" x2="-20"/>
+                                <line length2="1.5" end1="none" y2="0" y1="0" x1="-20" length1="1.5" end2="none" style="line-style:normal;line-weight:normal;filling:none;color:black" antialias="false" x2="-10"/>
+                                <terminal y="20" orientation="w" x="-20"/>
+                                <terminal y="0" orientation="w" x="-20"/>
+                                <terminal y="60" orientation="w" x="-20"/>
+                                <terminal y="20" orientation="e" x="20"/>
+                                <terminal y="40" orientation="e" x="20"/>
+                                <terminal y="60" orientation="e" x="20"/>
+                                <terminal y="0" orientation="e" x="20"/>
+                                <terminal y="40" orientation="w" x="-20"/>
+                            </description>
+                        </definition>
+                    </element>
+                    <element name="pinball_em_williams_jack_06.elmt">
+                        <definition width="50" type="element" orientation="dyyy" hotspot_x="24" hotspot_y="15" version="0.70" link_type="simple" height="130">
+                            <uuid uuid="{8cdb64a3-1edc-4ac6-9e86-67c987e62457}"/>
+                            <names>
+                                <name lang="en">Jack with 6 positions</name>
+                                <name lang="nl">Contact met 6 posities</name>
+                            </names>
+                            <elementInformations/>
+                            <informations/>
+                            <description>
+                                <line length2="1.5" end1="none" y2="80" y1="80" x1="-20" length1="1.5" end2="none" style="line-style:normal;line-weight:normal;filling:none;color:black" antialias="false" x2="-10"/>
+                                <line length2="1.5" end1="none" y2="60" y1="60" x1="-20" length1="1.5" end2="none" style="line-style:normal;line-weight:normal;filling:none;color:black" antialias="false" x2="-10"/>
+                                <line length2="1.5" end1="none" y2="40" y1="40" x1="-20" length1="1.5" end2="none" style="line-style:normal;line-weight:normal;filling:none;color:black" antialias="false" x2="-10"/>
+                                <line length2="1.5" end1="none" y2="20" y1="20" x1="-20" length1="1.5" end2="none" style="line-style:normal;line-weight:normal;filling:none;color:black" antialias="false" x2="-10"/>
+                                <line length2="1.5" end1="none" y2="100" y1="100" x1="-20" length1="1.5" end2="none" style="line-style:normal;line-weight:normal;filling:none;color:black" antialias="false" x2="-10"/>
+                                <rect width="20" rx="0" y="-10" x="-10" ry="0" style="line-style:normal;line-weight:normal;filling:none;color:black" antialias="false" height="120"/>
+                                <line length2="1.5" end1="none" y2="0" y1="0" x1="-20" length1="1.5" end2="none" style="line-style:normal;line-weight:normal;filling:none;color:black" antialias="false" x2="-10"/>
+                                <line length2="1.5" end1="none" y2="60" y1="60" x1="10" length1="1.5" end2="none" style="line-style:normal;line-weight:normal;filling:none;color:black" antialias="false" x2="20"/>
+                                <line length2="1.5" end1="none" y2="40" y1="40" x1="10" length1="1.5" end2="none" style="line-style:normal;line-weight:normal;filling:none;color:black" antialias="false" x2="20"/>
+                                <line length2="1.5" end1="none" y2="20" y1="20" x1="10" length1="1.5" end2="none" style="line-style:normal;line-weight:normal;filling:none;color:black" antialias="false" x2="20"/>
+                                <line length2="1.5" end1="none" y2="100" y1="100" x1="10" length1="1.5" end2="none" style="line-style:normal;line-weight:normal;filling:none;color:black" antialias="false" x2="20"/>
+                                <line length2="1.5" end1="none" y2="80" y1="80" x1="10" length1="1.5" end2="none" style="line-style:normal;line-weight:normal;filling:none;color:black" antialias="false" x2="20"/>
+                                <line length2="1.5" end1="none" y2="0" y1="0" x1="10" length1="1.5" end2="none" style="line-style:normal;line-weight:normal;filling:none;color:black" antialias="false" x2="20"/>
+                                <terminal y="0" orientation="e" x="20"/>
+                                <terminal y="0" orientation="w" x="-20"/>
+                                <terminal y="20" orientation="w" x="-20"/>
+                                <terminal y="20" orientation="e" x="20"/>
+                                <terminal y="40" orientation="w" x="-20"/>
+                                <terminal y="40" orientation="e" x="20"/>
+                                <terminal y="60" orientation="e" x="20"/>
+                                <terminal y="60" orientation="w" x="-20"/>
+                                <terminal y="100" orientation="w" x="-20"/>
+                                <terminal y="100" orientation="e" x="20"/>
+                                <terminal y="80" orientation="e" x="20"/>
+                                <terminal y="80" orientation="w" x="-20"/>
+                            </description>
+                        </definition>
+                    </element>
+                    <element name="pinball_em_williams_jack_05.elmt">
+                        <definition type="element" width="50" orientation="dyyy" hotspot_x="24" hotspot_y="15" version="0.70" link_type="simple" height="110">
+                            <uuid uuid="{3398a8e0-2b95-4231-8820-ad19908d197a}"/>
+                            <names>
+                                <name lang="en">Jack with 5 positions</name>
+                                <name lang="nl">Contact met 5 posities</name>
+                            </names>
+                            <elementInformations/>
+                            <informations/>
+                            <description>
+                                <rect width="20" rx="0" x="-10" y="-10" ry="0" style="line-style:normal;line-weight:normal;filling:none;color:black" antialias="false" height="100"/>
+                                <line length2="1.5" y2="0" end1="none" x1="-20" y1="0" length1="1.5" end2="none" style="line-style:normal;line-weight:normal;filling:none;color:black" antialias="false" x2="-10"/>
+                                <line length2="1.5" y2="20" end1="none" x1="-20" y1="20" length1="1.5" end2="none" style="line-style:normal;line-weight:normal;filling:none;color:black" antialias="false" x2="-10"/>
+                                <line length2="1.5" y2="40" end1="none" x1="-20" y1="40" length1="1.5" end2="none" style="line-style:normal;line-weight:normal;filling:none;color:black" antialias="false" x2="-10"/>
+                                <line length2="1.5" y2="60" end1="none" x1="-20" y1="60" length1="1.5" end2="none" style="line-style:normal;line-weight:normal;filling:none;color:black" antialias="false" x2="-10"/>
+                                <line length2="1.5" y2="80" end1="none" x1="-20" y1="80" length1="1.5" end2="none" style="line-style:normal;line-weight:normal;filling:none;color:black" antialias="false" x2="-10"/>
+                                <line length2="1.5" y2="80" end1="none" x1="20" y1="80" length1="1.5" end2="none" style="line-style:normal;line-weight:normal;filling:none;color:black" antialias="false" x2="10"/>
+                                <line length2="1.5" y2="60" end1="none" x1="10" y1="60" length1="1.5" end2="none" style="line-style:normal;line-weight:normal;filling:none;color:black" antialias="false" x2="20"/>
+                                <line length2="1.5" y2="40" end1="none" x1="10" y1="40" length1="1.5" end2="none" style="line-style:normal;line-weight:normal;filling:none;color:black" antialias="false" x2="20"/>
+                                <line length2="1.5" y2="20" end1="none" x1="10" y1="20" length1="1.5" end2="none" style="line-style:normal;line-weight:normal;filling:none;color:black" antialias="false" x2="20"/>
+                                <line length2="1.5" y2="0" end1="none" x1="10" y1="0" length1="1.5" end2="none" style="line-style:normal;line-weight:normal;filling:none;color:black" antialias="false" x2="20"/>
+                                <terminal x="-20" y="60" orientation="w"/>
+                                <terminal x="-20" y="40" orientation="w"/>
+                                <terminal x="-20" y="20" orientation="w"/>
+                                <terminal x="20" y="20" orientation="e"/>
+                                <terminal x="20" y="0" orientation="e"/>
+                                <terminal x="20" y="40" orientation="e"/>
+                                <terminal x="-20" y="80" orientation="w"/>
+                                <terminal x="-20" y="0" orientation="w"/>
+                                <terminal x="20" y="60" orientation="e"/>
+                                <terminal x="20" y="80" orientation="e"/>
+                            </description>
+                        </definition>
+                    </element>
+                    <element name="pinball_em_williams_jack_07.elmt">
+                        <definition width="50" type="element" orientation="dyyy" hotspot_x="24" hotspot_y="15" version="0.70" link_type="simple" height="150">
+                            <uuid uuid="{b95190d3-569c-4d29-9c08-eb63190954ef}"/>
+                            <names>
+                                <name lang="en">Jack with 7 positions</name>
+                                <name lang="nl">Contact met 7 posities</name>
+                            </names>
+                            <elementInformations/>
+                            <informations/>
+                            <description>
+                                <line length2="1.5" end1="none" y2="100" y1="100" x1="-20" length1="1.5" end2="none" style="line-style:normal;line-weight:normal;filling:none;color:black" antialias="false" x2="-10"/>
+                                <rect width="20" rx="0" y="-10" x="-10" ry="0" style="line-style:normal;line-weight:normal;filling:none;color:black" antialias="false" height="140"/>
+                                <line length2="1.5" end1="none" y2="0" y1="0" x1="-20" length1="1.5" end2="none" style="line-style:normal;line-weight:normal;filling:none;color:black" antialias="false" x2="-10"/>
+                                <line length2="1.5" end1="none" y2="20" y1="20" x1="-20" length1="1.5" end2="none" style="line-style:normal;line-weight:normal;filling:none;color:black" antialias="false" x2="-10"/>
+                                <line length2="1.5" end1="none" y2="60" y1="60" x1="-20" length1="1.5" end2="none" style="line-style:normal;line-weight:normal;filling:none;color:black" antialias="false" x2="-10"/>
+                                <line length2="1.5" end1="none" y2="80" y1="80" x1="-20" length1="1.5" end2="none" style="line-style:normal;line-weight:normal;filling:none;color:black" antialias="false" x2="-10"/>
+                                <line length2="1.5" end1="none" y2="40" y1="40" x1="-20" length1="1.5" end2="none" style="line-style:normal;line-weight:normal;filling:none;color:black" antialias="false" x2="-10"/>
+                                <line length2="1.5" end1="none" y2="120" y1="120" x1="-20" length1="1.5" end2="none" style="line-style:normal;line-weight:normal;filling:none;color:black" antialias="false" x2="-10"/>
+                                <line length2="1.5" end1="none" y2="60" y1="60" x1="10" length1="1.5" end2="none" style="line-style:normal;line-weight:normal;filling:none;color:black" antialias="false" x2="20"/>
+                                <line length2="1.5" end1="none" y2="0" y1="0" x1="10" length1="1.5" end2="none" style="line-style:normal;line-weight:normal;filling:none;color:black" antialias="false" x2="20"/>
+                                <line length2="1.5" end1="none" y2="80" y1="80" x1="10" length1="1.5" end2="none" style="line-style:normal;line-weight:normal;filling:none;color:black" antialias="false" x2="20"/>
+                                <line length2="1.5" end1="none" y2="40" y1="40" x1="10" length1="1.5" end2="none" style="line-style:normal;line-weight:normal;filling:none;color:black" antialias="false" x2="20"/>
+                                <line length2="1.5" end1="none" y2="20" y1="20" x1="10" length1="1.5" end2="none" style="line-style:normal;line-weight:normal;filling:none;color:black" antialias="false" x2="20"/>
+                                <line length2="1.5" end1="none" y2="100" y1="100" x1="10" length1="1.5" end2="none" style="line-style:normal;line-weight:normal;filling:none;color:black" antialias="false" x2="20"/>
+                                <line length2="1.5" end1="none" y2="120" y1="120" x1="10" length1="1.5" end2="none" style="line-style:normal;line-weight:normal;filling:none;color:black" antialias="false" x2="20"/>
+                                <terminal y="100" orientation="w" x="-20"/>
+                                <terminal y="100" orientation="e" x="20"/>
+                                <terminal y="120" orientation="e" x="20"/>
+                                <terminal y="120" orientation="w" x="-20"/>
+                                <terminal y="20" orientation="e" x="20"/>
+                                <terminal y="20" orientation="w" x="-20"/>
+                                <terminal y="0" orientation="e" x="20"/>
+                                <terminal y="0" orientation="w" x="-20"/>
+                                <terminal y="40" orientation="e" x="20"/>
+                                <terminal y="40" orientation="w" x="-20"/>
+                                <terminal y="60" orientation="e" x="20"/>
+                                <terminal y="60" orientation="w" x="-20"/>
+                                <terminal y="80" orientation="e" x="20"/>
+                                <terminal y="80" orientation="w" x="-20"/>
+                            </description>
+                        </definition>
+                    </element>
+                    <element name="pinball_em_williams_jack_08.elmt">
+                        <definition width="50" type="element" orientation="dyyy" hotspot_x="24" hotspot_y="15" version="0.70" link_type="simple" height="170">
+                            <uuid uuid="{aa0c2db1-cd6d-470e-a45f-1503fd898c7d}"/>
+                            <names>
+                                <name lang="en">Jack with 8 positions</name>
+                                <name lang="nl">Contact met 8 posities</name>
+                            </names>
+                            <elementInformations/>
+                            <informations/>
+                            <description>
+                                <rect width="20" rx="0" y="-10" x="-10" ry="0" style="line-style:normal;line-weight:normal;filling:none;color:black" antialias="false" height="160"/>
+                                <line length2="1.5" end1="none" y2="80" y1="80" x1="-20" length1="1.5" end2="none" style="line-style:normal;line-weight:normal;filling:none;color:black" antialias="false" x2="-10"/>
+                                <line length2="1.5" end1="none" y2="60" y1="60" x1="-20" length1="1.5" end2="none" style="line-style:normal;line-weight:normal;filling:none;color:black" antialias="false" x2="-10"/>
+                                <line length2="1.5" end1="none" y2="20" y1="20" x1="-20" length1="1.5" end2="none" style="line-style:normal;line-weight:normal;filling:none;color:black" antialias="false" x2="-10"/>
+                                <line length2="1.5" end1="none" y2="40" y1="40" x1="-20" length1="1.5" end2="none" style="line-style:normal;line-weight:normal;filling:none;color:black" antialias="false" x2="-10"/>
+                                <line length2="1.5" end1="none" y2="0" y1="0" x1="-20" length1="1.5" end2="none" style="line-style:normal;line-weight:normal;filling:none;color:black" antialias="false" x2="-10"/>
+                                <line length2="1.5" end1="none" y2="100" y1="100" x1="-20" length1="1.5" end2="none" style="line-style:normal;line-weight:normal;filling:none;color:black" antialias="false" x2="-10"/>
+                                <line length2="1.5" end1="none" y2="120" y1="120" x1="-20" length1="1.5" end2="none" style="line-style:normal;line-weight:normal;filling:none;color:black" antialias="false" x2="-10"/>
+                                <line length2="1.5" end1="none" y2="140" y1="140" x1="-20" length1="1.5" end2="none" style="line-style:normal;line-weight:normal;filling:none;color:black" antialias="false" x2="-10"/>
+                                <line length2="1.5" end1="none" y2="0" y1="0" x1="10" length1="1.5" end2="none" style="line-style:normal;line-weight:normal;filling:none;color:black" antialias="false" x2="20"/>
+                                <line length2="1.5" end1="none" y2="140" y1="140" x1="10" length1="1.5" end2="none" style="line-style:normal;line-weight:normal;filling:none;color:black" antialias="false" x2="20"/>
+                                <line length2="1.5" end1="none" y2="120" y1="120" x1="10" length1="1.5" end2="none" style="line-style:normal;line-weight:normal;filling:none;color:black" antialias="false" x2="20"/>
+                                <line length2="1.5" end1="none" y2="20" y1="20" x1="10" length1="1.5" end2="none" style="line-style:normal;line-weight:normal;filling:none;color:black" antialias="false" x2="20"/>
+                                <line length2="1.5" end1="none" y2="40" y1="40" x1="10" length1="1.5" end2="none" style="line-style:normal;line-weight:normal;filling:none;color:black" antialias="false" x2="20"/>
+                                <line length2="1.5" end1="none" y2="80" y1="80" x1="10" length1="1.5" end2="none" style="line-style:normal;line-weight:normal;filling:none;color:black" antialias="false" x2="20"/>
+                                <line length2="1.5" end1="none" y2="60" y1="60" x1="10" length1="1.5" end2="none" style="line-style:normal;line-weight:normal;filling:none;color:black" antialias="false" x2="20"/>
+                                <line length2="1.5" end1="none" y2="100" y1="100" x1="10" length1="1.5" end2="none" style="line-style:normal;line-weight:normal;filling:none;color:black" antialias="false" x2="20"/>
+                                <terminal y="20" orientation="w" x="-20"/>
+                                <terminal y="0" orientation="w" x="-20"/>
+                                <terminal y="20" orientation="e" x="20"/>
+                                <terminal y="0" orientation="e" x="20"/>
+                                <terminal y="120" orientation="e" x="20"/>
+                                <terminal y="60" orientation="e" x="20"/>
+                                <terminal y="40" orientation="e" x="20"/>
+                                <terminal y="80" orientation="e" x="20"/>
+                                <terminal y="80" orientation="w" x="-20"/>
+                                <terminal y="40" orientation="w" x="-20"/>
+                                <terminal y="60" orientation="w" x="-20"/>
+                                <terminal y="100" orientation="e" x="20"/>
+                                <terminal y="100" orientation="w" x="-20"/>
+                                <terminal y="140" orientation="e" x="20"/>
+                                <terminal y="120" orientation="w" x="-20"/>
+                                <terminal y="140" orientation="w" x="-20"/>
+                            </description>
+                        </definition>
+                    </element>
+                    <element name="pinball_em_williams_jack_09.elmt">
+                        <definition width="50" type="element" orientation="dyyy" hotspot_x="24" hotspot_y="15" version="0.70" link_type="simple" height="190">
+                            <uuid uuid="{d13c9554-6300-4f3a-bc7b-cadecf88a2a5}"/>
+                            <names>
+                                <name lang="en">Jack with 9 positions</name>
+                                <name lang="nl">Contact met 9 posities</name>
+                            </names>
+                            <elementInformations/>
+                            <informations/>
+                            <description>
+                                <line length2="1.5" end1="none" y2="100" y1="100" x1="-20" length1="1.5" end2="none" style="line-style:normal;line-weight:normal;filling:none;color:black" antialias="false" x2="-10"/>
+                                <rect width="20" rx="0" y="-10" x="-10" ry="0" style="line-style:normal;line-weight:normal;filling:none;color:black" antialias="false" height="180"/>
+                                <line length2="1.5" end1="none" y2="120" y1="120" x1="-20" length1="1.5" end2="none" style="line-style:normal;line-weight:normal;filling:none;color:black" antialias="false" x2="-10"/>
+                                <line length2="1.5" end1="none" y2="60" y1="60" x1="-20" length1="1.5" end2="none" style="line-style:normal;line-weight:normal;filling:none;color:black" antialias="false" x2="-10"/>
+                                <line length2="1.5" end1="none" y2="80" y1="80" x1="-20" length1="1.5" end2="none" style="line-style:normal;line-weight:normal;filling:none;color:black" antialias="false" x2="-10"/>
+                                <line length2="1.5" end1="none" y2="0" y1="0" x1="-20" length1="1.5" end2="none" style="line-style:normal;line-weight:normal;filling:none;color:black" antialias="false" x2="-10"/>
+                                <line length2="1.5" end1="none" y2="20" y1="20" x1="-20" length1="1.5" end2="none" style="line-style:normal;line-weight:normal;filling:none;color:black" antialias="false" x2="-10"/>
+                                <line length2="1.5" end1="none" y2="160" y1="160" x1="-20" length1="1.5" end2="none" style="line-style:normal;line-weight:normal;filling:none;color:black" antialias="false" x2="-10"/>
+                                <line length2="1.5" end1="none" y2="140" y1="140" x1="-20" length1="1.5" end2="none" style="line-style:normal;line-weight:normal;filling:none;color:black" antialias="false" x2="-10"/>
+                                <line length2="1.5" end1="none" y2="40" y1="40" x1="-20" length1="1.5" end2="none" style="line-style:normal;line-weight:normal;filling:none;color:black" antialias="false" x2="-10"/>
+                                <line length2="1.5" end1="none" y2="140" y1="140" x1="10" length1="1.5" end2="none" style="line-style:normal;line-weight:normal;filling:none;color:black" antialias="false" x2="20"/>
+                                <line length2="1.5" end1="none" y2="160" y1="160" x1="10" length1="1.5" end2="none" style="line-style:normal;line-weight:normal;filling:none;color:black" antialias="false" x2="20"/>
+                                <line length2="1.5" end1="none" y2="20" y1="20" x1="10" length1="1.5" end2="none" style="line-style:normal;line-weight:normal;filling:none;color:black" antialias="false" x2="20"/>
+                                <line length2="1.5" end1="none" y2="40" y1="40" x1="10" length1="1.5" end2="none" style="line-style:normal;line-weight:normal;filling:none;color:black" antialias="false" x2="20"/>
+                                <line length2="1.5" end1="none" y2="100" y1="100" x1="10" length1="1.5" end2="none" style="line-style:normal;line-weight:normal;filling:none;color:black" antialias="false" x2="20"/>
+                                <line length2="1.5" end1="none" y2="0" y1="0" x1="10" length1="1.5" end2="none" style="line-style:normal;line-weight:normal;filling:none;color:black" antialias="false" x2="20"/>
+                                <line length2="1.5" end1="none" y2="120" y1="120" x1="10" length1="1.5" end2="none" style="line-style:normal;line-weight:normal;filling:none;color:black" antialias="false" x2="20"/>
+                                <line length2="1.5" end1="none" y2="80" y1="80" x1="10" length1="1.5" end2="none" style="line-style:normal;line-weight:normal;filling:none;color:black" antialias="false" x2="20"/>
+                                <line length2="1.5" end1="none" y2="60" y1="60" x1="10" length1="1.5" end2="none" style="line-style:normal;line-weight:normal;filling:none;color:black" antialias="false" x2="20"/>
+                                <terminal y="0" orientation="e" x="20"/>
+                                <terminal y="0" orientation="w" x="-20"/>
+                                <terminal y="100" orientation="e" x="20"/>
+                                <terminal y="120" orientation="w" x="-20"/>
+                                <terminal y="140" orientation="e" x="20"/>
+                                <terminal y="60" orientation="w" x="-20"/>
+                                <terminal y="80" orientation="e" x="20"/>
+                                <terminal y="100" orientation="w" x="-20"/>
+                                <terminal y="80" orientation="w" x="-20"/>
+                                <terminal y="120" orientation="e" x="20"/>
+                                <terminal y="60" orientation="e" x="20"/>
+                                <terminal y="160" orientation="w" x="-20"/>
+                                <terminal y="160" orientation="e" x="20"/>
+                                <terminal y="140" orientation="w" x="-20"/>
+                                <terminal y="40" orientation="e" x="20"/>
+                                <terminal y="20" orientation="e" x="20"/>
+                                <terminal y="40" orientation="w" x="-20"/>
+                                <terminal y="20" orientation="w" x="-20"/>
+                            </description>
+                        </definition>
+                    </element>
+                    <element name="pinball_em_williams_jack_10.elmt">
+                        <definition width="50" type="element" orientation="dyyy" hotspot_x="24" hotspot_y="15" version="0.70" link_type="simple" height="210">
+                            <uuid uuid="{d8443641-f543-4e44-b838-615c066287b3}"/>
+                            <names>
+                                <name lang="en">Jack with 10 positions</name>
+                                <name lang="nl">Contact met 10 posities</name>
+                            </names>
+                            <elementInformations/>
+                            <informations/>
+                            <description>
+                                <rect width="20" rx="0" y="-10" x="-10" ry="0" style="line-style:normal;line-weight:normal;filling:none;color:black" antialias="false" height="200"/>
+                                <line length2="1.5" end1="none" y2="120" y1="120" x1="-20" length1="1.5" end2="none" style="line-style:normal;line-weight:normal;filling:none;color:black" antialias="false" x2="-10"/>
+                                <line length2="1.5" end1="none" y2="20" y1="20" x1="-20" length1="1.5" end2="none" style="line-style:normal;line-weight:normal;filling:none;color:black" antialias="false" x2="-10"/>
+                                <line length2="1.5" end1="none" y2="0" y1="0" x1="-20" length1="1.5" end2="none" style="line-style:normal;line-weight:normal;filling:none;color:black" antialias="false" x2="-10"/>
+                                <line length2="1.5" end1="none" y2="40" y1="40" x1="-20" length1="1.5" end2="none" style="line-style:normal;line-weight:normal;filling:none;color:black" antialias="false" x2="-10"/>
+                                <line length2="1.5" end1="none" y2="60" y1="60" x1="-20" length1="1.5" end2="none" style="line-style:normal;line-weight:normal;filling:none;color:black" antialias="false" x2="-10"/>
+                                <line length2="1.5" end1="none" y2="100" y1="100" x1="-20" length1="1.5" end2="none" style="line-style:normal;line-weight:normal;filling:none;color:black" antialias="false" x2="-10"/>
+                                <line length2="1.5" end1="none" y2="140" y1="140" x1="-20" length1="1.5" end2="none" style="line-style:normal;line-weight:normal;filling:none;color:black" antialias="false" x2="-10"/>
+                                <line length2="1.5" end1="none" y2="180" y1="180" x1="-20" length1="1.5" end2="none" style="line-style:normal;line-weight:normal;filling:none;color:black" antialias="false" x2="-10"/>
+                                <line length2="1.5" end1="none" y2="160" y1="160" x1="-20" length1="1.5" end2="none" style="line-style:normal;line-weight:normal;filling:none;color:black" antialias="false" x2="-10"/>
+                                <line length2="1.5" end1="none" y2="80" y1="80" x1="-20" length1="1.5" end2="none" style="line-style:normal;line-weight:normal;filling:none;color:black" antialias="false" x2="-10"/>
+                                <line length2="1.5" end1="none" y2="60" y1="60" x1="10" length1="1.5" end2="none" style="line-style:normal;line-weight:normal;filling:none;color:black" antialias="false" x2="20"/>
+                                <line length2="1.5" end1="none" y2="180" y1="180" x1="10" length1="1.5" end2="none" style="line-style:normal;line-weight:normal;filling:none;color:black" antialias="false" x2="20"/>
+                                <line length2="1.5" end1="none" y2="160" y1="160" x1="10" length1="1.5" end2="none" style="line-style:normal;line-weight:normal;filling:none;color:black" antialias="false" x2="20"/>
+                                <line length2="1.5" end1="none" y2="140" y1="140" x1="10" length1="1.5" end2="none" style="line-style:normal;line-weight:normal;filling:none;color:black" antialias="false" x2="20"/>
+                                <line length2="1.5" end1="none" y2="40" y1="40" x1="10" length1="1.5" end2="none" style="line-style:normal;line-weight:normal;filling:none;color:black" antialias="false" x2="20"/>
+                                <line length2="1.5" end1="none" y2="100" y1="100" x1="10" length1="1.5" end2="none" style="line-style:normal;line-weight:normal;filling:none;color:black" antialias="false" x2="20"/>
+                                <line length2="1.5" end1="none" y2="80" y1="80" x1="10" length1="1.5" end2="none" style="line-style:normal;line-weight:normal;filling:none;color:black" antialias="false" x2="20"/>
+                                <line length2="1.5" end1="none" y2="120" y1="120" x1="10" length1="1.5" end2="none" style="line-style:normal;line-weight:normal;filling:none;color:black" antialias="false" x2="20"/>
+                                <line length2="1.5" end1="none" y2="0" y1="0" x1="10" length1="1.5" end2="none" style="line-style:normal;line-weight:normal;filling:none;color:black" antialias="false" x2="20"/>
+                                <line length2="1.5" end1="none" y2="20" y1="20" x1="10" length1="1.5" end2="none" style="line-style:normal;line-weight:normal;filling:none;color:black" antialias="false" x2="20"/>
+                                <terminal y="140" orientation="w" x="-20"/>
+                                <terminal y="160" orientation="e" x="20"/>
+                                <terminal y="140" orientation="e" x="20"/>
+                                <terminal y="160" orientation="w" x="-20"/>
+                                <terminal y="180" orientation="e" x="20"/>
+                                <terminal y="180" orientation="w" x="-20"/>
+                                <terminal y="20" orientation="w" x="-20"/>
+                                <terminal y="40" orientation="e" x="20"/>
+                                <terminal y="40" orientation="w" x="-20"/>
+                                <terminal y="20" orientation="e" x="20"/>
+                                <terminal y="0" orientation="w" x="-20"/>
+                                <terminal y="0" orientation="e" x="20"/>
+                                <terminal y="60" orientation="e" x="20"/>
+                                <terminal y="60" orientation="w" x="-20"/>
+                                <terminal y="80" orientation="w" x="-20"/>
+                                <terminal y="80" orientation="e" x="20"/>
+                                <terminal y="100" orientation="e" x="20"/>
+                                <terminal y="100" orientation="w" x="-20"/>
+                                <terminal y="120" orientation="w" x="-20"/>
+                                <terminal y="120" orientation="e" x="20"/>
+                            </description>
+                        </definition>
+                    </element>
+                    <element name="pinball_em_williams_jack_plug.elmt">
+                        <definition width="30" type="element" orientation="dyyy" hotspot_x="14" hotspot_y="10" version="0.70" link_type="simple" height="20">
+                            <uuid uuid="{648b691b-a9ce-44ae-96dd-c02039645205}"/>
+                            <names>
+                                <name lang="en">Plug</name>
+                                <name lang="nl">Contactpin</name>
+                            </names>
+                            <elementInformations/>
+                            <informations/>
+                            <description>
+                                <rect width="4" rx="0" y="-5" x="-2" ry="0" style="line-style:normal;line-weight:normal;filling:none;color:black" antialias="false" height="10"/>
+                                <line length2="1.5" end1="none" y2="0" y1="0" x1="-10" length1="1.5" end2="none" style="line-style:normal;line-weight:normal;filling:none;color:black" antialias="false" x2="-2"/>
+                                <line length2="1.5" end1="none" y2="0" y1="0" x1="2" length1="1.5" end2="none" style="line-style:normal;line-weight:normal;filling:none;color:black" antialias="false" x2="10"/>
+                                <terminal y="0" orientation="e" x="10"/>
+                                <terminal y="0" orientation="w" x="-10"/>
+                            </description>
+                        </definition>
+                    </element>
+                </category>
+                <category name="output">
+                    <names>
+                        <name lang="en">Output</name>
+                        <name lang="nl">Uitvoer</name>
+                    </names>
+                    <element name="pinball_em_williams_coil.elmt">
+                        <definition width="50" type="element" orientation="dyyy" hotspot_x="24" hotspot_y="10" version="0.70" link_type="simple" height="20">
+                            <uuid uuid="{2275166e-668f-4912-b838-1def0f65418e}"/>
+                            <names>
+                                <name lang="en">Coil</name>
+                                <name lang="nl">Spoel</name>
+                            </names>
+                            <elementInformations/>
+                            <informations/>
+                            <description>
+                                <arc width="8" y="-4" x="-8" start="0" style="line-style:normal;line-weight:normal;filling:none;color:black" antialias="true" height="8" angle="180"/>
+                                <arc width="8" y="-4" x="-16" start="0" style="line-style:normal;line-weight:normal;filling:none;color:black" antialias="true" height="8" angle="180"/>
+                                <arc width="8" y="-4" x="0" start="0" style="line-style:normal;line-weight:normal;filling:none;color:black" antialias="true" height="8" angle="180"/>
+                                <arc width="8" y="-4" x="8" start="0" style="line-style:normal;line-weight:normal;filling:none;color:black" antialias="true" height="8" angle="180"/>
+                                <line length2="1.5" end1="none" y2="0" y1="0" x1="-16" length1="1.5" end2="none" style="line-style:normal;line-weight:normal;filling:none;color:black" antialias="false" x2="-20"/>
+                                <line length2="1.5" end1="none" y2="0" y1="0" x1="20" length1="1.5" end2="none" style="line-style:normal;line-weight:normal;filling:none;color:black" antialias="false" x2="16"/>
+                                <terminal y="0" orientation="w" x="-20"/>
+                                <terminal y="0" orientation="e" x="20"/>
+                            </description>
+                        </definition>
+                    </element>
+                    <element name="pinball_em_williams_flipper_coil.elmt">
+                        <definition width="50" type="element" orientation="dyyy" hotspot_x="24" hotspot_y="11" version="0.70" link_type="simple" height="30">
+                            <uuid uuid="{6d4161fc-3f61-48cc-8322-9d384c2f7550}"/>
+                            <names>
+                                <name lang="en">Flipper coil</name>
+                                <name lang="nl">Flipperspoel</name>
+                            </names>
+                            <elementInformations/>
+                            <informations/>
+                            <description>
+                                <arc width="8" y="-4" x="0" start="0" style="line-style:normal;line-weight:normal;filling:none;color:black" antialias="true" height="8" angle="180"/>
+                                <arc width="8" y="-4" x="8" start="0" style="line-style:normal;line-weight:normal;filling:none;color:black" antialias="true" height="8" angle="180"/>
+                                <arc width="8" y="-4" x="-16" start="0" style="line-style:normal;line-weight:normal;filling:none;color:black" antialias="true" height="8" angle="180"/>
+                                <arc width="8" y="-4" x="-8" start="0" style="line-style:normal;line-weight:normal;filling:none;color:black" antialias="true" height="8" angle="180"/>
+                                <line length2="1.5" end1="none" y2="0" y1="0" x1="-20" length1="1.5" end2="none" style="line-style:normal;line-weight:normal;filling:none;color:black" antialias="false" x2="-16"/>
+                                <line length2="1.5" end1="none" y2="0" y1="0" x1="16" length1="1.5" end2="none" style="line-style:normal;line-weight:normal;filling:none;color:black" antialias="false" x2="20"/>
+                                <line length2="1.5" end1="none" y2="10" y1="0" x1="0" length1="1.5" end2="none" style="line-style:normal;line-weight:normal;filling:none;color:black" antialias="false" x2="0"/>
+                                <circle y="0" x="-2" diameter="4" style="line-style:normal;line-weight:normal;filling:black;color:black" antialias="false"/>
+                                <terminal y="0" orientation="w" x="-20"/>
+                                <terminal y="0" orientation="e" x="20"/>
+                                <terminal y="10" orientation="s" x="0"/>
+                            </description>
+                        </definition>
+                    </element>
+                    <element name="pinball_em_williams_lite.elmt">
+                        <definition width="50" type="element" orientation="dyyy" hotspot_x="24" hotspot_y="15" version="0.70" link_type="simple" height="30">
+                            <uuid uuid="{06cf3371-5a2c-4887-aa73-667fa6dc718b}"/>
+                            <names>
+                                <name lang="en">Lite</name>
+                                <name lang="nl">Lamp</name>
+                            </names>
+                            <elementInformations/>
+                            <informations/>
+                            <description>
+                                <circle y="-10" x="-10" diameter="20" style="line-style:normal;line-weight:normal;filling:none;color:black" antialias="false"/>
+                                <line length2="1.5" end1="none" y2="0" y1="0" x1="10" length1="1.5" end2="none" style="line-style:normal;line-weight:normal;filling:none;color:black" antialias="false" x2="20"/>
+                                <line length2="1.5" end1="none" y2="0" y1="0" x1="-10" length1="1.5" end2="none" style="line-style:normal;line-weight:normal;filling:none;color:black" antialias="false" x2="-20"/>
+                                <terminal y="0" orientation="e" x="20"/>
+                                <terminal y="0" orientation="w" x="-20"/>
+                            </description>
+                        </definition>
+                    </element>
+                    <element name="pinball_em_williams_motor.elmt">
+                        <definition width="50" type="element" orientation="dyyy" hotspot_x="24" hotspot_y="15" version="0.70" link_type="simple" height="30">
+                            <uuid uuid="{1a497d79-1196-4b65-9d65-a8660693c5b8}"/>
+                            <names>
+                                <name lang="en">Motor</name>
+                                <name lang="nl">Motor</name>
+                            </names>
+                            <elementInformations/>
+                            <informations/>
+                            <description>
+                                <circle y="-10" x="-10" diameter="20" style="line-style:normal;line-weight:normal;filling:none;color:black" antialias="false"/>
+                                <line length2="1.5" end1="none" y2="0" y1="0" x1="-20" length1="1.5" end2="none" style="line-style:normal;line-weight:normal;filling:none;color:black" antialias="false" x2="-16"/>
+                                <line length2="1.5" end1="none" y2="0" y1="0" x1="20" length1="1.5" end2="none" style="line-style:normal;line-weight:normal;filling:none;color:black" antialias="false" x2="16"/>
+                                <line length2="1.5" end1="none" y2="-10" y1="0" x1="-16" length1="1.5" end2="none" style="line-style:normal;line-weight:normal;filling:none;color:black" antialias="false" x2="-10"/>
+                                <line length2="1.5" end1="none" y2="10" y1="0" x1="16" length1="1.5" end2="none" style="line-style:normal;line-weight:normal;filling:none;color:black" antialias="false" x2="10"/>
+                                <terminal y="0" orientation="e" x="20"/>
+                                <terminal y="0" orientation="w" x="-20"/>
+                            </description>
+                        </definition>
+                    </element>
+                </category>
+                <category name="power">
+                    <names>
+                        <name lang="en">Power</name>
+                        <name lang="nl">Stroom</name>
+                    </names>
+                    <element name="pinball_em_williams_fuse.elmt">
+                        <definition width="50" type="element" orientation="dyyy" hotspot_x="24" hotspot_y="10" version="0.70" link_type="simple" height="20">
+                            <uuid uuid="{6cfb757b-80eb-472e-a72b-4d1e398ff0be}"/>
+                            <names>
+                                <name lang="en">Fuse</name>
+                                <name lang="nl">Zekering</name>
+                            </names>
+                            <elementInformations/>
+                            <informations/>
+                            <description>
+                                <arc width="10" y="-5" x="0" start="0" style="line-style:normal;line-weight:normal;filling:none;color:black" antialias="true" height="10" angle="180"/>
+                                <arc width="10" y="-5" x="-10" start="180" style="line-style:normal;line-weight:normal;filling:none;color:black" antialias="true" height="10" angle="180"/>
+                                <line length2="1.5" end1="none" y2="0" y1="0" x1="-10" length1="1.5" end2="none" style="line-style:normal;line-weight:normal;filling:none;color:black" antialias="false" x2="-12"/>
+                                <line length2="1.5" end1="none" y2="0" y1="0" x1="10" length1="1.5" end2="none" style="line-style:normal;line-weight:normal;filling:none;color:black" antialias="false" x2="12"/>
+                                <circle y="-2" x="-16" diameter="4" style="line-style:normal;line-weight:normal;filling:none;color:black" antialias="false"/>
+                                <circle y="-2" x="12" diameter="4" style="line-style:normal;line-weight:normal;filling:none;color:black" antialias="false"/>
+                                <line length2="1.5" end1="none" y2="0" y1="0" x1="-16" length1="1.5" end2="none" style="line-style:normal;line-weight:normal;filling:none;color:black" antialias="false" x2="-20"/>
+                                <line length2="1.5" end1="none" y2="0" y1="0" x1="16" length1="1.5" end2="none" style="line-style:normal;line-weight:normal;filling:none;color:black" antialias="false" x2="20"/>
+                                <terminal y="0" orientation="e" x="20"/>
+                                <terminal y="0" orientation="w" x="-20"/>
+                            </description>
+                        </definition>
+                    </element>
+                    <element name="pinball_em_williams_power_cord.elmt">
+                        <definition width="50" type="element" orientation="dyyy" hotspot_x="24" hotspot_y="34" version="0.70" link_type="simple" height="40">
+                            <uuid uuid="{d67bb38e-704e-4df0-bcd5-6b5fc4f8b27f}"/>
+                            <names>
+                                <name lang="en">Power cord</name>
+                                <name lang="nl">Stekker</name>
+                            </names>
+                            <elementInformations/>
+                            <informations/>
+                            <description>
+                                <line length2="1.5" end1="none" y2="-20" y1="-20" x1="-10" length1="1.5" end2="none" style="line-style:normal;line-weight:normal;filling:none;color:black" antialias="false" x2="10"/>
+                                <line length2="1.5" end1="none" y2="0" y1="0" x1="-5" length1="1.5" end2="none" style="line-style:normal;line-weight:normal;filling:none;color:black" antialias="false" x2="-20"/>
+                                <line length2="1.5" end1="none" y2="0" y1="0" x1="20" length1="1.5" end2="none" style="line-style:normal;line-weight:normal;filling:none;color:black" antialias="false" x2="5"/>
+                                <arc width="20" y="-30" x="-10" start="180" style="line-style:normal;line-weight:normal;filling:none;color:black" antialias="true" height="20" angle="180"/>
+                                <line length2="1.5" end1="none" y2="-11" y1="0" x1="-5" length1="1.5" end2="none" style="line-style:normal;line-weight:normal;filling:none;color:black" antialias="false" x2="-5"/>
+                                <line length2="1.5" end1="none" y2="-11" y1="0" x1="5" length1="1.5" end2="none" style="line-style:normal;line-weight:normal;filling:none;color:black" antialias="false" x2="5"/>
+                                <line length2="1.5" end1="none" y2="-20" y1="-28" x1="-5" length1="1.5" end2="none" style="line-style:normal;line-weight:normal;filling:none;color:black" antialias="false" x2="-5"/>
+                                <line length2="1.5" end1="none" y2="-20" y1="-28" x1="5" length1="1.5" end2="none" style="line-style:normal;line-weight:normal;filling:none;color:black" antialias="false" x2="5"/>
+                                <terminal y="0" orientation="e" x="20"/>
+                                <terminal y="0" orientation="w" x="-20"/>
+                            </description>
+                        </definition>
+                    </element>
+                    <element name="pinball_em_williams_power_cord_ground.elmt">
+                        <definition width="50" type="element" orientation="dyyy" hotspot_x="24" hotspot_y="34" version="0.70" link_type="simple" height="50">
+                            <uuid uuid="{772a2b18-69f2-407b-8594-917ecc52a4d3}"/>
+                            <names>
+                                <name lang="en">Power cord with ground pin</name>
+                                <name lang="nl">Stekker met aardedraad</name>
+                            </names>
+                            <elementInformations/>
+                            <informations/>
+                            <description>
+                                <line length2="1.5" end1="none" y2="0" y1="0" x1="-20" length1="1.5" end2="none" style="line-style:normal;line-weight:normal;filling:none;color:black" antialias="false" x2="-5"/>
+                                <line length2="1.5" end1="none" y2="0" y1="0" x1="5" length1="1.5" end2="none" style="line-style:normal;line-weight:normal;filling:none;color:black" antialias="false" x2="20"/>
+                                <line length2="1.5" end1="none" y2="-20" y1="-20" x1="-10" length1="1.5" end2="none" style="line-style:normal;line-weight:normal;filling:none;color:black" antialias="false" x2="10"/>
+                                <arc width="20" y="-30" x="-10" start="180" style="line-style:normal;line-weight:normal;filling:none;color:black" antialias="true" height="20" angle="180"/>
+                                <line length2="1.5" end1="none" y2="-11" y1="0" x1="-5" length1="1.5" end2="none" style="line-style:normal;line-weight:normal;filling:none;color:black" antialias="false" x2="-5"/>
+                                <line length2="1.5" end1="none" y2="-11" y1="0" x1="5" length1="1.5" end2="none" style="line-style:normal;line-weight:normal;filling:none;color:black" antialias="false" x2="5"/>
+                                <line length2="1.5" end1="none" y2="-27" y1="-20" x1="5" length1="1.5" end2="none" style="line-style:normal;line-weight:normal;filling:none;color:black" antialias="false" x2="5"/>
+                                <line length2="1.5" end1="none" y2="-27" y1="-20" x1="-5" length1="1.5" end2="none" style="line-style:normal;line-weight:normal;filling:none;color:black" antialias="false" x2="-5"/>
+                                <line length2="1.5" end1="none" y2="-25" y1="-20" x1="0" length1="1.5" end2="none" style="line-style:normal;line-weight:normal;filling:none;color:black" antialias="false" x2="0"/>
+                                <line length2="1.5" end1="none" y2="10" y1="-10" x1="0" length1="1.5" end2="none" style="line-style:normal;line-weight:normal;filling:none;color:black" antialias="false" x2="0"/>
+                                <terminal y="10" orientation="s" x="0"/>
+                                <terminal y="0" orientation="w" x="-20"/>
+                                <terminal y="0" orientation="e" x="20"/>
+                            </description>
+                        </definition>
+                    </element>
+                    <element name="pinball_em_williams_service_outlet.elmt">
+                        <definition width="50" type="element" orientation="dyyy" hotspot_x="24" hotspot_y="15" version="0.70" link_type="simple" height="30">
+                            <uuid uuid="{f75bd99b-67cd-4d09-bea0-677ba9528257}"/>
+                            <names>
+                                <name lang="en">Service outlet</name>
+                                <name lang="nl">Servicestopcontact</name>
+                            </names>
+                            <elementInformations/>
+                            <informations/>
+                            <description>
+                                <circle y="-10" x="-10" diameter="20" style="line-style:normal;line-weight:normal;filling:none;color:black" antialias="false"/>
+                                <line length2="1.5" end1="none" y2="0" y1="0" x1="-10" length1="1.5" end2="none" style="line-style:normal;line-weight:normal;filling:none;color:black" antialias="false" x2="-20"/>
+                                <line length2="1.5" end1="none" y2="0" y1="0" x1="10" length1="1.5" end2="none" style="line-style:normal;line-weight:normal;filling:none;color:black" antialias="false" x2="20"/>
+                                <line length2="1.5" end1="none" y2="5" y1="-5" x1="-4" length1="1.5" end2="none" style="line-style:normal;line-weight:normal;filling:none;color:black" antialias="false" x2="-4"/>
+                                <line length2="1.5" end1="none" y2="5" y1="-5" x1="4" length1="1.5" end2="none" style="line-style:normal;line-weight:normal;filling:none;color:black" antialias="false" x2="4"/>
+                                <terminal y="0" orientation="w" x="-20"/>
+                                <terminal y="0" orientation="e" x="20"/>
+                            </description>
+                        </definition>
+                    </element>
+                </category>
+                <category name="switches_common">
+                    <names>
+                        <name lang="en">Switches - Common</name>
+                        <name lang="nl">Schakelaars - Algemeen</name>
+                    </names>
+                    <element name="pinball_em_williams_switch_mb_bottom.elmt">
+                        <definition type="element" width="50" orientation="dyyy" hotspot_x="24" hotspot_y="30" version="0.70" link_type="simple" height="40">
+                            <uuid uuid="{6b2f7d0b-0bea-4db2-9da7-ed808130db45}"/>
+                            <names>
+                                <name lang="nl">Schakelaar (M.B.) - Input onder</name>
+                                <name lang="en">Switch (M.B.) - Bottom input</name>
+                            </names>
+                            <elementInformations/>
+                            <informations/>
+                            <description>
+                                <rect width="3" rx="0" y="-25.25" x="-5" ry="0" style="line-style:normal;line-weight:normal;filling:black;color:black" antialias="false" height="30"/>
+                                <rect width="3" rx="0" y="-7.25" x="2" ry="0" style="line-style:normal;line-weight:normal;filling:black;color:black" antialias="false" height="12"/>
+                                <rect width="3" rx="0" y="-25.25" x="2" ry="0" style="line-style:normal;line-weight:normal;filling:black;color:black" antialias="false" height="12"/>
+                                <line length2="1.5" end1="none" y2="-0.25" x1="5" y1="-0.25" length1="1.5" end2="none" style="line-style:normal;line-weight:normal;filling:none;color:black" antialias="false" x2="20"/>
+                                <line length2="1.5" end1="none" y2="-0.25" x1="-20" y1="-0.25" length1="1.5" end2="none" style="line-style:normal;line-weight:normal;filling:none;color:black" antialias="false" x2="-5"/>
+                                <line length2="1.5" end1="none" y2="-20.25" x1="5" y1="-20.25" length1="1.5" end2="none" style="line-style:normal;line-weight:normal;filling:none;color:black" antialias="false" x2="20"/>
+                                <line length2="1.5" end1="none" y2="4.75" x1="10" y1="-5.25" length1="1.5" end2="none" style="line-style:normal;line-weight:hight;filling:none;color:black" antialias="false" x2="-10"/>
+                                <terminal y="-0.25" x="20" orientation="e"/>
+                                <terminal y="-20.25" x="20" orientation="e"/>
+                                <terminal y="-0.25" x="-20" orientation="w"/>
+                            </description>
+                        </definition>
+                    </element>
+                    <element name="pinball_em_williams_switch_mb_bottom_i.elmt">
+                        <definition type="element" width="50" orientation="dyyy" hotspot_x="24" hotspot_y="30" link_type="simple" version="0.70" height="40">
+                            <uuid uuid="{6321259d-91c7-4126-9bcf-c8ab9dedddf7}"/>
+                            <names>
+                                <name lang="nl">Schakelaar (M.B.) - Input onder - Omgekeerd</name>
+                                <name lang="en">Switch (M.B.) - Bottom input - Inverted</name>
+                            </names>
+                            <elementInformations/>
+                            <informations/>
+                            <description>
+                                <rect rx="0" width="3" x="-5" y="-25" ry="0" antialias="false" style="line-style:normal;line-weight:normal;filling:black;color:black" height="30"/>
+                                <rect rx="0" width="3" x="2" y="-7" ry="0" antialias="false" style="line-style:normal;line-weight:normal;filling:black;color:black" height="12"/>
+                                <rect rx="0" width="3" x="2" y="-25" ry="0" antialias="false" style="line-style:normal;line-weight:normal;filling:black;color:black" height="12"/>
+                                <line length2="1.5" end1="none" y2="0" x1="5" y1="0" length1="1.5" end2="none" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" x2="20"/>
+                                <line length2="1.5" end1="none" y2="0" x1="-20" y1="0" length1="1.5" end2="none" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" x2="-5"/>
+                                <line length2="1.5" end1="none" y2="-20" x1="5" y1="-20" length1="1.5" end2="none" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" x2="20"/>
+                                <line length2="1.5" end1="none" y2="-14.75" x1="10" y1="-24.75" length1="1.5" end2="none" antialias="false" style="line-style:normal;line-weight:hight;filling:none;color:black" x2="-10"/>
+                                <terminal x="20" y="0" orientation="e"/>
+                                <terminal x="20" y="-20" orientation="e"/>
+                                <terminal x="-20" y="0" orientation="w"/>
+                            </description>
+                        </definition>
+                    </element>
+                    <element name="pinball_em_williams_switch_mb_center.elmt">
+                        <definition type="element" width="50" orientation="dyyy" hotspot_x="24" hotspot_y="20" version="0.70" link_type="simple" height="40">
+                            <uuid uuid="{57993a2e-8feb-4920-97f7-5481bc1e63e3}"/>
+                            <names>
+                                <name lang="nl">Schakelaar (M.B.) - Input midden</name>
+                                <name lang="en">Switch (M.B.) - Center input</name>
+                            </names>
+                            <elementInformations/>
+                            <informations/>
+                            <description>
+                                <rect width="3" rx="0" y="-15" x="-5" ry="0" style="line-style:normal;line-weight:normal;filling:black;color:black" antialias="false" height="30"/>
+                                <rect width="3" rx="0" y="3" x="2" ry="0" style="line-style:normal;line-weight:normal;filling:black;color:black" antialias="false" height="12"/>
+                                <rect width="3" rx="0" y="-15" x="2" ry="0" style="line-style:normal;line-weight:normal;filling:black;color:black" antialias="false" height="12"/>
+                                <line length2="1.5" end1="none" y2="10" x1="5" y1="10" length1="1.5" end2="none" style="line-style:normal;line-weight:normal;filling:none;color:black" antialias="false" x2="20"/>
+                                <line length2="1.5" end1="none" y2="0" x1="-20" y1="0" length1="1.5" end2="none" style="line-style:normal;line-weight:normal;filling:none;color:black" antialias="false" x2="-5"/>
+                                <line length2="1.5" end1="none" y2="-10" x1="5" y1="-10" length1="1.5" end2="none" style="line-style:normal;line-weight:normal;filling:none;color:black" antialias="false" x2="20"/>
+                                <line length2="1.5" end1="none" y2="15" x1="10" y1="5" length1="1.5" end2="none" style="line-style:normal;line-weight:hight;filling:none;color:black" antialias="false" x2="-10"/>
+                                <terminal y="10" x="20" orientation="e"/>
+                                <terminal y="-10" x="20" orientation="e"/>
+                                <terminal y="0" x="-20" orientation="w"/>
+                            </description>
+                        </definition>
+                    </element>
+                    <element name="pinball_em_williams_switch_mb_center_i.elmt">
+                        <definition type="element" width="50" orientation="dyyy" hotspot_x="24" hotspot_y="20" link_type="simple" version="0.70" height="40">
+                            <uuid uuid="{9a0c9775-c4ca-4a6b-809c-74ffb482fc6a}"/>
+                            <names>
+                                <name lang="nl">Schakelaar (M.B.) - Input midden - Omgekeerd</name>
+                                <name lang="en">Switch (M.B.) - Center input - Inverted</name>
+                            </names>
+                            <elementInformations/>
+                            <informations/>
+                            <description>
+                                <rect rx="0" width="3" x="-5" y="-15" ry="0" antialias="false" style="line-style:normal;line-weight:normal;filling:black;color:black" height="30"/>
+                                <rect rx="0" width="3" x="2" y="3" ry="0" antialias="false" style="line-style:normal;line-weight:normal;filling:black;color:black" height="12"/>
+                                <rect rx="0" width="3" x="2" y="-15" ry="0" antialias="false" style="line-style:normal;line-weight:normal;filling:black;color:black" height="12"/>
+                                <line length2="1.5" end1="none" y2="10" x1="5" y1="10" length1="1.5" end2="none" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" x2="20"/>
+                                <line length2="1.5" end1="none" y2="0" x1="-20" y1="0" length1="1.5" end2="none" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" x2="-5"/>
+                                <line length2="1.5" end1="none" y2="-10" x1="5" y1="-10" length1="1.5" end2="none" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" x2="20"/>
+                                <line length2="1.5" end1="none" y2="-5" x1="10" y1="-15" length1="1.5" end2="none" antialias="false" style="line-style:normal;line-weight:hight;filling:none;color:black" x2="-10"/>
+                                <terminal x="20" y="-10" orientation="e"/>
+                                <terminal x="20" y="10" orientation="e"/>
+                                <terminal x="-20" y="0" orientation="w"/>
+                            </description>
+                        </definition>
+                    </element>
+                    <element name="pinball_em_williams_switch_mb_top.elmt">
+                        <definition type="element" width="50" orientation="dyyy" hotspot_x="24" hotspot_y="10" version="0.70" link_type="simple" height="40">
+                            <uuid uuid="{01a0d1a8-0de0-4f5e-ac2b-2490c38301b0}"/>
+                            <names>
+                                <name lang="nl">Schakelaar (M.B.) - Input boven</name>
+                                <name lang="en">Switch (M.B.) - Top input</name>
+                            </names>
+                            <elementInformations/>
+                            <informations/>
+                            <description>
+                                <rect width="3" rx="0" y="-5" x="-5" ry="0" style="line-style:normal;line-weight:normal;filling:black;color:black" antialias="false" height="30"/>
+                                <rect width="3" rx="0" y="13" x="2" ry="0" style="line-style:normal;line-weight:normal;filling:black;color:black" antialias="false" height="12"/>
+                                <rect width="3" rx="0" y="-5" x="2" ry="0" style="line-style:normal;line-weight:normal;filling:black;color:black" antialias="false" height="12"/>
+                                <line length2="1.5" end1="none" y2="20" x1="5" y1="20" length1="1.5" end2="none" style="line-style:normal;line-weight:normal;filling:none;color:black" antialias="false" x2="20"/>
+                                <line length2="1.5" end1="none" y2="0" x1="-20" y1="0" length1="1.5" end2="none" style="line-style:normal;line-weight:normal;filling:none;color:black" antialias="false" x2="-5"/>
+                                <line length2="1.5" end1="none" y2="0" x1="5" y1="0" length1="1.5" end2="none" style="line-style:normal;line-weight:normal;filling:none;color:black" antialias="false" x2="20"/>
+                                <line length2="1.5" end1="none" y2="25" x1="10" y1="15" length1="1.5" end2="none" style="line-style:normal;line-weight:hight;filling:none;color:black" antialias="false" x2="-10"/>
+                                <terminal y="20" x="20" orientation="e"/>
+                                <terminal y="0" x="20" orientation="e"/>
+                                <terminal y="0" x="-20" orientation="w"/>
+                            </description>
+                        </definition>
+                    </element>
+                    <element name="pinball_em_williams_switch_mb_top_i.elmt">
+                        <definition type="element" width="50" orientation="dyyy" hotspot_x="24" hotspot_y="10" link_type="simple" version="0.70" height="40">
+                            <uuid uuid="{130b56ae-6888-4b0d-bac8-5b49335e33ec}"/>
+                            <names>
+                                <name lang="nl">Schakelaar (M.B.) - Input boven - Omgekeerd</name>
+                                <name lang="en">Switch (M.B) - Top input - Inverted</name>
+                            </names>
+                            <elementInformations/>
+                            <informations/>
+                            <description>
+                                <rect rx="0" width="3" x="-5" y="-5.25" ry="0" antialias="false" style="line-style:normal;line-weight:normal;filling:black;color:black" height="30"/>
+                                <rect rx="0" width="3" x="2" y="12.75" ry="0" antialias="false" style="line-style:normal;line-weight:normal;filling:black;color:black" height="12"/>
+                                <rect rx="0" width="3" x="2" y="-5.25" ry="0" antialias="false" style="line-style:normal;line-weight:normal;filling:black;color:black" height="12"/>
+                                <line length2="1.5" end1="none" y2="19.75" x1="5" y1="19.75" length1="1.5" end2="none" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" x2="20"/>
+                                <line length2="1.5" end1="none" y2="-0.25" x1="-20" y1="-0.25" length1="1.5" end2="none" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" x2="-5"/>
+                                <line length2="1.5" end1="none" y2="-0.25" x1="5" y1="-0.25" length1="1.5" end2="none" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" x2="20"/>
+                                <line length2="1.5" end1="none" y2="5" x1="10" y1="-5" length1="1.5" end2="none" antialias="false" style="line-style:normal;line-weight:hight;filling:none;color:black" x2="-10"/>
+                                <terminal x="20" y="-0.25" orientation="e"/>
+                                <terminal x="-20" y="-0.25" orientation="w"/>
+                                <terminal x="20" y="19.75" orientation="e"/>
+                            </description>
+                        </definition>
+                    </element>
+                    <element name="pinball_em_williams_switch_nc.elmt">
+                        <definition type="element" width="50" orientation="dyyy" hotspot_x="24" hotspot_y="10" version="0.70" link_type="simple" height="20">
+                            <uuid uuid="{b4de77c7-a031-4ae2-b7f7-8ea5309631c7}"/>
+                            <names>
+                                <name lang="nl">Schakelaar (N.C.)</name>
+                                <name lang="en">Switch (N.C.)</name>
+                            </names>
+                            <elementInformations/>
+                            <informations/>
+                            <description>
+                                <rect width="3" rx="0" y="-5" x="-5" ry="0" style="line-style:normal;line-weight:normal;filling:black;color:black" antialias="false" height="10"/>
+                                <rect width="3" rx="0" y="-5" x="2" ry="0" style="line-style:normal;line-weight:normal;filling:black;color:black" antialias="false" height="10"/>
+                                <line length2="1.5" end1="none" y2="0" x1="5" y1="0" length1="1.5" end2="none" style="line-style:normal;line-weight:normal;filling:none;color:black" antialias="false" x2="20"/>
+                                <line length2="1.5" end1="none" y2="0" x1="-5" y1="0" length1="1.5" end2="none" style="line-style:normal;line-weight:normal;filling:none;color:black" antialias="false" x2="-20"/>
+                                <line length2="1.5" end1="none" y2="5" x1="10" y1="-5" length1="1.5" end2="none" style="line-style:normal;line-weight:hight;filling:none;color:black" antialias="false" x2="-10"/>
+                                <terminal y="0" x="-20" orientation="w"/>
+                                <terminal y="0" x="20" orientation="e"/>
+                            </description>
+                        </definition>
+                    </element>
+                    <element name="pinball_em_williams_switch_no.elmt">
+                        <definition type="element" width="50" orientation="dyyy" hotspot_x="24" hotspot_y="10" version="0.70" link_type="simple" height="20">
+                            <uuid uuid="{5a15257d-de36-4aad-9b67-717ea5763a1c}"/>
+                            <names>
+                                <name lang="nl">Schakelaar (N.O.)</name>
+                                <name lang="en">Switch (N.O.)</name>
+                            </names>
+                            <elementInformations/>
+                            <informations/>
+                            <description>
+                                <rect width="3" rx="0" y="-5" x="-5" ry="0" style="line-style:normal;line-weight:normal;filling:black;color:black" antialias="false" height="10"/>
+                                <rect width="3" rx="0" y="-5" x="2" ry="0" style="line-style:normal;line-weight:normal;filling:black;color:black" antialias="false" height="10"/>
+                                <line length2="1.5" end1="none" y2="0" x1="-20" y1="0" length1="1.5" end2="none" style="line-style:normal;line-weight:normal;filling:none;color:black" antialias="false" x2="-5"/>
+                                <line length2="1.5" end1="none" y2="0" x1="5" y1="0" length1="1.5" end2="none" style="line-style:normal;line-weight:normal;filling:none;color:black" antialias="false" x2="20"/>
+                                <terminal y="0" x="-20" orientation="w"/>
+                                <terminal y="0" x="20" orientation="e"/>
+                            </description>
+                        </definition>
+                    </element>
+                    <category name="mirrored">
+                        <names>
+                            <name lang="en">Mirrored</name>
+                            <name lang="nl">Gespiegeld</name>
+                        </names>
+                        <element name="pinball_em_williams_switch_mb_bottom_m.elmt">
+                            <definition width="50" type="element" orientation="dyyy" hotspot_x="24" hotspot_y="30" version="0.70" link_type="simple" height="40">
+                                <uuid uuid="{52858864-b876-400b-b65e-7482add60868}"/>
+                                <names>
+                                    <name lang="en">Switch (M.B.) - Bottom input - Mirrored</name>
+                                    <name lang="nl">Schakelaar (M.B.) - Input onder - Gespiegeld</name>
+                                </names>
+                                <elementInformations/>
+                                <informations/>
+                                <description>
+                                    <rect rx="0" width="3" x="2" y="-25" ry="0" antialias="false" style="line-style:normal;line-weight:normal;filling:black;color:black" height="30"/>
+                                    <line length2="1.5" end1="none" y2="-20" x1="-20" y1="-20" length1="1.5" end2="none" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" x2="-5"/>
+                                    <rect rx="0" width="3" x="-5" y="-7" ry="0" antialias="false" style="line-style:normal;line-weight:normal;filling:black;color:black" height="12"/>
+                                    <rect rx="0" width="3" x="-5" y="-25" ry="0" antialias="false" style="line-style:normal;line-weight:normal;filling:black;color:black" height="12"/>
+                                    <line length2="1.5" end1="none" y2="0" x1="5" y1="0" length1="1.5" end2="none" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" x2="20"/>
+                                    <line length2="1.5" end1="none" y2="0" x1="-20" y1="0" length1="1.5" end2="none" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" x2="-5"/>
+                                    <line length2="1.5" end1="none" y2="5" x1="10" y1="-5" length1="1.5" end2="none" antialias="false" style="line-style:normal;line-weight:hight;filling:none;color:black" x2="-10"/>
+                                    <terminal x="-20" y="-20" orientation="w"/>
+                                    <terminal x="20" y="0" orientation="e"/>
+                                    <terminal x="-20" y="0" orientation="w"/>
+                                </description>
+                            </definition>
+                        </element>
+                        <element name="pinball_em_williams_switch_mb_bottom_mi.elmt">
+                            <definition type="element" width="50" orientation="dyyy" hotspot_x="24" hotspot_y="30" link_type="simple" version="0.70" height="40">
+                                <uuid uuid="{5671de08-ab81-4f72-809b-7ac854e38016}"/>
+                                <names>
+                                    <name lang="nl">Schakelaar (M.B.) - Input onder - Gespiegeld en omgekeerd</name>
+                                    <name lang="en">Switch (M.B.) - Bottom input - Mirrored and inverted</name>
+                                </names>
+                                <elementInformations/>
+                                <informations/>
+                                <description>
+                                    <rect rx="0" width="3" x="2" y="-25" ry="0" antialias="false" style="line-style:normal;line-weight:normal;filling:black;color:black" height="30"/>
+                                    <line length2="1.5" end1="none" y2="-20" x1="-20" y1="-20" length1="1.5" end2="none" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" x2="-5"/>
+                                    <rect rx="0" width="3" x="-5" y="-7" ry="0" antialias="false" style="line-style:normal;line-weight:normal;filling:black;color:black" height="12"/>
+                                    <rect rx="0" width="3" x="-5" y="-25" ry="0" antialias="false" style="line-style:normal;line-weight:normal;filling:black;color:black" height="12"/>
+                                    <line length2="1.5" end1="none" y2="0" x1="5" y1="0" length1="1.5" end2="none" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" x2="20"/>
+                                    <line length2="1.5" end1="none" y2="0" x1="-20" y1="0" length1="1.5" end2="none" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" x2="-5"/>
+                                    <line length2="1.5" end1="none" y2="-15" x1="10" y1="-25" length1="1.5" end2="none" antialias="false" style="line-style:normal;line-weight:hight;filling:none;color:black" x2="-10"/>
+                                    <terminal x="20" y="0" orientation="e"/>
+                                    <terminal x="-20" y="-20" orientation="w"/>
+                                    <terminal x="-20" y="0" orientation="w"/>
+                                </description>
+                            </definition>
+                        </element>
+                        <element name="pinball_em_williams_switch_mb_center_m.elmt">
+                            <definition type="element" width="50" orientation="dyyy" hotspot_x="24" hotspot_y="20" link_type="simple" version="0.70" height="40">
+                                <uuid uuid="{762b188c-50f3-4900-b870-ea563c2cc7da}"/>
+                                <names>
+                                    <name lang="nl">Schakelaar (M.B.) - Input midden - Gespiegeld</name>
+                                    <name lang="en">Switch (M.B.) - Center input - Mirrored</name>
+                                </names>
+                                <elementInformations/>
+                                <informations/>
+                                <description>
+                                    <rect rx="0" width="3" x="2" y="-15" ry="0" antialias="false" style="line-style:normal;line-weight:normal;filling:black;color:black" height="30"/>
+                                    <line length2="1.5" end1="none" y2="-10" x1="-20" y1="-10" length1="1.5" end2="none" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" x2="-5"/>
+                                    <rect rx="0" width="3" x="-5" y="3" ry="0" antialias="false" style="line-style:normal;line-weight:normal;filling:black;color:black" height="12"/>
+                                    <rect rx="0" width="3" x="-5" y="-15" ry="0" antialias="false" style="line-style:normal;line-weight:normal;filling:black;color:black" height="12"/>
+                                    <line length2="1.5" end1="none" y2="0" x1="5" y1="0" length1="1.5" end2="none" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" x2="20"/>
+                                    <line length2="1.5" end1="none" y2="10" x1="-20" y1="10" length1="1.5" end2="none" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" x2="-5"/>
+                                    <line length2="1.5" end1="none" y2="15" x1="10" y1="5" length1="1.5" end2="none" antialias="false" style="line-style:normal;line-weight:hight;filling:none;color:black" x2="-10"/>
+                                    <terminal x="-20" y="-10" orientation="w"/>
+                                    <terminal x="-20" y="10" orientation="w"/>
+                                    <terminal x="20" y="0" orientation="e"/>
+                                </description>
+                            </definition>
+                        </element>
+                        <element name="pinball_em_williams_switch_mb_center_mi.elmt">
+                            <definition type="element" width="50" orientation="dyyy" hotspot_x="24" hotspot_y="20" link_type="simple" version="0.70" height="40">
+                                <uuid uuid="{3509d560-3eb8-4527-b5b2-35d66bf3fc64}"/>
+                                <names>
+                                    <name lang="nl">Schakelaar (M.B.) - Input midden - Gespiegeld en omgekeerd</name>
+                                    <name lang="en">Switch (M.B.) - Center input - Mirrored and inverted</name>
+                                </names>
+                                <elementInformations/>
+                                <informations/>
+                                <description>
+                                    <rect rx="0" width="3" x="2" y="-15" ry="0" antialias="false" style="line-style:normal;line-weight:normal;filling:black;color:black" height="30"/>
+                                    <line length2="1.5" end1="none" y2="-10" x1="-20" y1="-10" length1="1.5" end2="none" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" x2="-5"/>
+                                    <rect rx="0" width="3" x="-5" y="3" ry="0" antialias="false" style="line-style:normal;line-weight:normal;filling:black;color:black" height="12"/>
+                                    <rect rx="0" width="3" x="-5" y="-15" ry="0" antialias="false" style="line-style:normal;line-weight:normal;filling:black;color:black" height="12"/>
+                                    <line length2="1.5" end1="none" y2="0" x1="5" y1="0" length1="1.5" end2="none" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" x2="20"/>
+                                    <line length2="1.5" end1="none" y2="10" x1="-20" y1="10" length1="1.5" end2="none" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" x2="-5"/>
+                                    <line length2="1.5" end1="none" y2="-5" x1="10" y1="-15" length1="1.5" end2="none" antialias="false" style="line-style:normal;line-weight:hight;filling:none;color:black" x2="-10"/>
+                                    <terminal x="20" y="0" orientation="e"/>
+                                    <terminal x="-20" y="10" orientation="w"/>
+                                    <terminal x="-20" y="-10" orientation="w"/>
+                                </description>
+                            </definition>
+                        </element>
+                        <element name="pinball_em_williams_switch_mb_top_m.elmt">
+                            <definition type="element" width="50" orientation="dyyy" hotspot_x="24" hotspot_y="10" link_type="simple" version="0.70" height="40">
+                                <uuid uuid="{b85f89b8-cbf2-4bda-ba31-8cc3570a4339}"/>
+                                <names>
+                                    <name lang="nl">Schakelaar (M.B.) - Input boven - Gespiegeld</name>
+                                    <name lang="en">Switch (M.B.) - Top input - Mirrored</name>
+                                </names>
+                                <elementInformations/>
+                                <informations/>
+                                <description>
+                                    <rect rx="0" width="3" x="2" y="-5" ry="0" antialias="false" style="line-style:normal;line-weight:normal;filling:black;color:black" height="30"/>
+                                    <line length2="1.5" end1="none" y2="0" x1="-20" y1="0" length1="1.5" end2="none" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" x2="-5"/>
+                                    <rect rx="0" width="3" x="-5" y="13" ry="0" antialias="false" style="line-style:normal;line-weight:normal;filling:black;color:black" height="12"/>
+                                    <rect rx="0" width="3" x="-5" y="-5" ry="0" antialias="false" style="line-style:normal;line-weight:normal;filling:black;color:black" height="12"/>
+                                    <line length2="1.5" end1="none" y2="0" x1="5" y1="0" length1="1.5" end2="none" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" x2="20"/>
+                                    <line length2="1.5" end1="none" y2="20" x1="-20" y1="20" length1="1.5" end2="none" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" x2="-5"/>
+                                    <line length2="1.5" end1="none" y2="25" x1="10" y1="15" length1="1.5" end2="none" antialias="false" style="line-style:normal;line-weight:hight;filling:none;color:black" x2="-10"/>
+                                    <terminal x="20" y="0" orientation="e"/>
+                                    <terminal x="-20" y="20" orientation="w"/>
+                                    <terminal x="-20" y="0" orientation="w"/>
+                                </description>
+                            </definition>
+                        </element>
+                        <element name="pinball_em_williams_switch_mb_top_mi.elmt">
+                            <definition type="element" width="50" orientation="dyyy" hotspot_x="24" hotspot_y="10" link_type="simple" version="0.70" height="40">
+                                <uuid uuid="{6e72e029-0004-452d-9e0c-ed664e36f070}"/>
+                                <names>
+                                    <name lang="nl">Schakelaar (M.B.) - Input boven - Gespiegeld en omgekeerd</name>
+                                    <name lang="en">Switch (M.B.) - Top input - Mirrored and inverted</name>
+                                </names>
+                                <elementInformations/>
+                                <informations/>
+                                <description>
+                                    <rect rx="0" width="3" x="2" y="-5" ry="0" antialias="false" style="line-style:normal;line-weight:normal;filling:black;color:black" height="30"/>
+                                    <line length2="1.5" end1="none" y2="0" x1="-20" y1="0" length1="1.5" end2="none" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" x2="-5"/>
+                                    <rect rx="0" width="3" x="-5" y="13" ry="0" antialias="false" style="line-style:normal;line-weight:normal;filling:black;color:black" height="12"/>
+                                    <rect rx="0" width="3" x="-5" y="-5" ry="0" antialias="false" style="line-style:normal;line-weight:normal;filling:black;color:black" height="12"/>
+                                    <line length2="1.5" end1="none" y2="0" x1="5" y1="0" length1="1.5" end2="none" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" x2="20"/>
+                                    <line length2="1.5" end1="none" y2="20" x1="-20" y1="20" length1="1.5" end2="none" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" x2="-5"/>
+                                    <line length2="1.5" end1="none" y2="5" x1="10" y1="-5" length1="1.5" end2="none" antialias="false" style="line-style:normal;line-weight:hight;filling:none;color:black" x2="-10"/>
+                                    <terminal x="-20" y="0" orientation="w"/>
+                                    <terminal x="20" y="0" orientation="e"/>
+                                    <terminal x="-20" y="20" orientation="w"/>
+                                </description>
+                            </definition>
+                        </element>
+                    </category>
+                </category>
+                <category name="switches_score_motor">
+                    <names>
+                        <name lang="en">Switches - Score Motor</name>
+                        <name lang="nl">Schakelaars - Score Motor</name>
+                    </names>
+                    <element name="pinball_em_williams_switch_no_sm.elmt">
+                        <definition type="element" width="50" orientation="dyyy" hotspot_x="24" hotspot_y="15" version="0.70" link_type="simple" height="30">
+                            <uuid uuid="{cf1b5449-9964-4d90-8114-a131a53ce467}"/>
+                            <names>
+                                <name lang="nl">Schakelaar op Score Motor (N.O.)</name>
+                                <name lang="en">Switch on Score Motor (N.O.)</name>
+                            </names>
+                            <elementInformations/>
+                            <informations/>
+                            <description>
+                                <rect width="3" rx="0" y="-5" x="-5" ry="0" style="line-style:normal;line-weight:normal;filling:black;color:black" antialias="false" height="10"/>
+                                <rect width="3" rx="0" y="-5" x="2" ry="0" style="line-style:normal;line-weight:normal;filling:black;color:black" antialias="false" height="10"/>
+                                <line length2="1.5" end1="none" y2="0" x1="-20" y1="0" length1="1.5" end2="none" style="line-style:normal;line-weight:normal;filling:none;color:black" antialias="false" x2="-5"/>
+                                <line length2="1.5" end1="none" y2="0" x1="5" y1="0" length1="1.5" end2="none" style="line-style:normal;line-weight:normal;filling:none;color:black" antialias="false" x2="20"/>
+                                <circle y="-10" x="-10" diameter="20" style="line-style:normal;line-weight:normal;filling:none;color:black" antialias="false"/>
+                                <terminal y="0" x="20" orientation="e"/>
+                                <terminal y="0" x="-20" orientation="w"/>
+                            </description>
+                        </definition>
+                    </element>
+                    <element name="pinball_em_williams_switch_nc_sm.elmt">
+                        <definition type="element" width="50" orientation="dyyy" hotspot_x="24" hotspot_y="15" version="0.70" link_type="simple" height="30">
+                            <uuid uuid="{b1b5df82-b447-41d7-bf0c-28d7301821af}"/>
+                            <names>
+                                <name lang="nl">Schakelaar op Score Motor (N.C.)</name>
+                                <name lang="en">Switch on Score Motor (N.C.)</name>
+                            </names>
+                            <elementInformations/>
+                            <informations/>
+                            <description>
+                                <rect width="3" rx="0" y="-5" x="-5" ry="0" style="line-style:normal;line-weight:normal;filling:black;color:black" antialias="false" height="10"/>
+                                <rect width="3" rx="0" y="-5" x="2" ry="0" style="line-style:normal;line-weight:normal;filling:black;color:black" antialias="false" height="10"/>
+                                <line length2="1.5" end1="none" y2="0" x1="5" y1="0" length1="1.5" end2="none" style="line-style:normal;line-weight:normal;filling:none;color:black" antialias="false" x2="20"/>
+                                <line length2="1.5" end1="none" y2="0" x1="-5" y1="0" length1="1.5" end2="none" style="line-style:normal;line-weight:normal;filling:none;color:black" antialias="false" x2="-20"/>
+                                <line length2="1.5" end1="none" y2="5" x1="10" y1="-5" length1="1.5" end2="none" style="line-style:normal;line-weight:hight;filling:none;color:black" antialias="false" x2="-10"/>
+                                <circle y="-10" x="-10" diameter="20" style="line-style:normal;line-weight:normal;filling:none;color:black" antialias="false"/>
+                                <terminal y="0" x="-20" orientation="w"/>
+                                <terminal y="0" x="20" orientation="e"/>
+                            </description>
+                        </definition>
+                    </element>
+                    <element name="pinball_em_williams_switch_mb_sm_bottom.elmt">
+                        <definition type="element" width="50" orientation="dyyy" hotspot_x="24" hotspot_y="35" version="0.70" link_type="simple" height="50">
+                            <uuid uuid="{925545b8-d804-4125-a17d-563abac148b4}"/>
+                            <names>
+                                <name lang="nl">Schakelaar op Score Motor (M.B.) - Input onder</name>
+                                <name lang="en">Switch on Score Motor (M.B.) - Bottom input</name>
+                            </names>
+                            <elementInformations/>
+                            <informations/>
+                            <description>
+                                <rect rx="0" width="3" y="-25" x="-5" ry="0" antialias="false" style="line-style:normal;line-weight:normal;filling:black;color:black" height="30"/>
+                                <rect rx="0" width="3" y="-7" x="2" ry="0" antialias="false" style="line-style:normal;line-weight:normal;filling:black;color:black" height="12"/>
+                                <rect rx="0" width="3" y="-25" x="2" ry="0" antialias="false" style="line-style:normal;line-weight:normal;filling:black;color:black" height="12"/>
+                                <line length2="1.5" end1="none" y2="0" y1="0" x1="5" length1="1.5" end2="none" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" x2="20"/>
+                                <line length2="1.5" end1="none" y2="0" y1="0" x1="-20" length1="1.5" end2="none" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" x2="-5"/>
+                                <line length2="1.5" end1="none" y2="-20" y1="-20" x1="5" length1="1.5" end2="none" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" x2="20"/>
+                                <line length2="1.5" end1="none" y2="5" y1="-5" x1="10" length1="1.5" end2="none" antialias="false" style="line-style:normal;line-weight:hight;filling:none;color:black" x2="-10"/>
+                                <arc width="20" y="-30" x="-10" start="0" antialias="true" style="line-style:normal;line-weight:normal;filling:none;color:black" height="20" angle="180"/>
+                                <line length2="1.5" end1="none" y2="0" y1="-20" x1="-10" length1="1.5" end2="none" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" x2="-10"/>
+                                <line length2="1.5" end1="none" y2="0" y1="-20" x1="10" length1="1.5" end2="none" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" x2="10"/>
+                                <arc width="20" y="-10" x="-10" start="180" antialias="true" style="line-style:normal;line-weight:normal;filling:none;color:black" height="20" angle="180"/>
+                                <terminal y="0" x="20" orientation="e"/>
+                                <terminal y="0" x="-20" orientation="w"/>
+                                <terminal y="-20" x="20" orientation="e"/>
+                            </description>
+                        </definition>
+                    </element>
+                    <element name="pinball_em_williams_switch_mb_sm_bottom_i.elmt">
+                        <definition type="element" width="50" orientation="dyyy" hotspot_x="24" hotspot_y="35" version="0.70" link_type="simple" height="50">
+                            <uuid uuid="{a366c41f-2629-4a8b-9dad-f06804bd84d6}"/>
+                            <names>
+                                <name lang="nl">Schakelaar op Score Motor (M.B.) - Input onder - Omgekeerd</name>
+                                <name lang="en">Switch on Score Motor (M.B.) - Bottom input - Inverted</name>
+                            </names>
+                            <elementInformations/>
+                            <informations/>
+                            <description>
+                                <rect rx="0" width="3" y="-25" x="-5" ry="0" antialias="false" style="line-style:normal;line-weight:normal;filling:black;color:black" height="30"/>
+                                <rect rx="0" width="3" y="-7" x="2" ry="0" antialias="false" style="line-style:normal;line-weight:normal;filling:black;color:black" height="12"/>
+                                <rect rx="0" width="3" y="-25" x="2" ry="0" antialias="false" style="line-style:normal;line-weight:normal;filling:black;color:black" height="12"/>
+                                <line length2="1.5" end1="none" y2="0" y1="0" x1="5" length1="1.5" end2="none" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" x2="20"/>
+                                <line length2="1.5" end1="none" y2="0" y1="0" x1="-20" length1="1.5" end2="none" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" x2="-5"/>
+                                <line length2="1.5" end1="none" y2="-20" y1="-20" x1="5" length1="1.5" end2="none" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" x2="20"/>
+                                <line length2="1.5" end1="none" y2="-15" y1="-25" x1="10" length1="1.5" end2="none" antialias="false" style="line-style:normal;line-weight:hight;filling:none;color:black" x2="-10"/>
+                                <arc width="20" y="-30" x="-10" start="0" antialias="true" style="line-style:normal;line-weight:normal;filling:none;color:black" height="20" angle="180"/>
+                                <line length2="1.5" end1="none" y2="0" y1="-20" x1="-10" length1="1.5" end2="none" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" x2="-10"/>
+                                <line length2="1.5" end1="none" y2="0" y1="-20" x1="10" length1="1.5" end2="none" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" x2="10"/>
+                                <arc width="20" y="-10" x="-10" start="180" antialias="true" style="line-style:normal;line-weight:normal;filling:none;color:black" height="20" angle="180"/>
+                                <terminal y="0" x="20" orientation="e"/>
+                                <terminal y="0" x="-20" orientation="w"/>
+                                <terminal y="-20" x="20" orientation="e"/>
+                            </description>
+                        </definition>
+                    </element>
+                    <element name="pinball_em_williams_switch_mb_sm_center.elmt">
+                        <definition width="50" type="element" orientation="dyyy" hotspot_x="24" hotspot_y="25" version="0.70" link_type="simple" height="50">
+                            <uuid uuid="{eda35b7a-2534-400d-b477-a07ff481a50d}"/>
+                            <names>
+                                <name lang="en">Switch on Score Motor (M.B.) - Center input</name>
+                                <name lang="nl">Schakelaar op Score Motor (M.B.) - Input midden</name>
+                            </names>
+                            <elementInformations/>
+                            <informations/>
+                            <description>
+                                <arc width="20" x="-10" y="-20" start="0" antialias="true" style="line-style:normal;line-weight:normal;filling:none;color:black" height="20" angle="180"/>
+                                <rect rx="0" width="3" x="-5" y="-15" ry="0" antialias="false" style="line-style:normal;line-weight:normal;filling:black;color:black" height="30"/>
+                                <line length2="1.5" end1="none" y2="10" x1="-10" y1="-10" length1="1.5" end2="none" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" x2="-10"/>
+                                <rect rx="0" width="3" x="2" y="3" ry="0" antialias="false" style="line-style:normal;line-weight:normal;filling:black;color:black" height="12"/>
+                                <line length2="1.5" end1="none" y2="10" x1="10" y1="-10" length1="1.5" end2="none" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" x2="10"/>
+                                <rect rx="0" width="3" x="2" y="-15" ry="0" antialias="false" style="line-style:normal;line-weight:normal;filling:black;color:black" height="12"/>
+                                <arc width="20" x="-10" y="0" start="180" antialias="true" style="line-style:normal;line-weight:normal;filling:none;color:black" height="20" angle="180"/>
+                                <line length2="1.5" end1="none" y2="10" x1="5" y1="10" length1="1.5" end2="none" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" x2="20"/>
+                                <line length2="1.5" end1="none" y2="0" x1="-20" y1="0" length1="1.5" end2="none" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" x2="-5"/>
+                                <line length2="1.5" end1="none" y2="-10" x1="5" y1="-10" length1="1.5" end2="none" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" x2="20"/>
+                                <line length2="1.5" end1="none" y2="15" x1="10" y1="5" length1="1.5" end2="none" antialias="false" style="line-style:normal;line-weight:hight;filling:none;color:black" x2="-10"/>
+                                <terminal x="20" y="10" orientation="e"/>
+                                <terminal x="20" y="-10" orientation="e"/>
+                                <terminal x="-20" y="0" orientation="w"/>
+                            </description>
+                        </definition>
+                    </element>
+                    <element name="pinball_em_williams_switch_mb_sm_center_i.elmt">
+                        <definition width="50" type="element" orientation="dyyy" hotspot_x="24" hotspot_y="25" version="0.70" link_type="simple" height="50">
+                            <uuid uuid="{97121fe2-38e2-4c5e-b5ab-223bb4770b11}"/>
+                            <names>
+                                <name lang="en">Switch on Score Motor (M.B.) - Center input - Inverted</name>
+                                <name lang="nl">Schakelaar op Score Motor (M.B.) - Input midden - Omgekeerd</name>
+                            </names>
+                            <elementInformations/>
+                            <informations/>
+                            <description>
+                                <arc width="20" x="-10" y="-20" start="0" antialias="true" style="line-style:normal;line-weight:normal;filling:none;color:black" height="20" angle="180"/>
+                                <rect rx="0" width="3" x="-5" y="-15" ry="0" antialias="false" style="line-style:normal;line-weight:normal;filling:black;color:black" height="30"/>
+                                <line length2="1.5" end1="none" y2="10" x1="-10" y1="-10" length1="1.5" end2="none" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" x2="-10"/>
+                                <rect rx="0" width="3" x="2" y="3" ry="0" antialias="false" style="line-style:normal;line-weight:normal;filling:black;color:black" height="12"/>
+                                <line length2="1.5" end1="none" y2="10" x1="10" y1="-10" length1="1.5" end2="none" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" x2="10"/>
+                                <rect rx="0" width="3" x="2" y="-15" ry="0" antialias="false" style="line-style:normal;line-weight:normal;filling:black;color:black" height="12"/>
+                                <arc width="20" x="-10" y="0" start="180" antialias="true" style="line-style:normal;line-weight:normal;filling:none;color:black" height="20" angle="180"/>
+                                <line length2="1.5" end1="none" y2="10" x1="5" y1="10" length1="1.5" end2="none" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" x2="20"/>
+                                <line length2="1.5" end1="none" y2="0" x1="-20" y1="0" length1="1.5" end2="none" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" x2="-5"/>
+                                <line length2="1.5" end1="none" y2="-10" x1="5" y1="-10" length1="1.5" end2="none" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" x2="20"/>
+                                <line length2="1.5" end1="none" y2="-5" x1="10" y1="-15" length1="1.5" end2="none" antialias="false" style="line-style:normal;line-weight:hight;filling:none;color:black" x2="-10"/>
+                                <terminal x="-20" y="0" orientation="w"/>
+                                <terminal x="20" y="-10" orientation="e"/>
+                                <terminal x="20" y="10" orientation="e"/>
+                            </description>
+                        </definition>
+                    </element>
+                    <element name="pinball_em_williams_switch_mb_sm_top.elmt">
+                        <definition width="50" type="element" orientation="dyyy" hotspot_x="24" hotspot_y="15" version="0.70" link_type="simple" height="50">
+                            <uuid uuid="{8da83d7e-0afb-4811-8903-633089863194}"/>
+                            <names>
+                                <name lang="en">Switch on Score Motor (M.B.) - Top input</name>
+                                <name lang="nl">Schakelaar op Score Motor (M.B.) - Input boven</name>
+                            </names>
+                            <elementInformations/>
+                            <informations/>
+                            <description>
+                                <arc width="20" x="-10" y="-10" start="0" antialias="true" style="line-style:normal;line-weight:normal;filling:none;color:black" height="20" angle="180"/>
+                                <rect rx="0" width="3" x="-5" y="-5" ry="0" antialias="false" style="line-style:normal;line-weight:normal;filling:black;color:black" height="30"/>
+                                <rect rx="0" width="3" x="2" y="13" ry="0" antialias="false" style="line-style:normal;line-weight:normal;filling:black;color:black" height="12"/>
+                                <line length2="1.5" end1="none" y2="20" x1="-10" y1="0" length1="1.5" end2="none" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" x2="-10"/>
+                                <rect rx="0" width="3" x="2" y="-5" ry="0" antialias="false" style="line-style:normal;line-weight:normal;filling:black;color:black" height="12"/>
+                                <line length2="1.5" end1="none" y2="20" x1="10" y1="0" length1="1.5" end2="none" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" x2="10"/>
+                                <arc width="20" x="-10" y="10" start="180" antialias="true" style="line-style:normal;line-weight:normal;filling:none;color:black" height="20" angle="180"/>
+                                <line length2="1.5" end1="none" y2="20" x1="5" y1="20" length1="1.5" end2="none" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" x2="20"/>
+                                <line length2="1.5" end1="none" y2="0" x1="-20" y1="0" length1="1.5" end2="none" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" x2="-5"/>
+                                <line length2="1.5" end1="none" y2="0" x1="5" y1="0" length1="1.5" end2="none" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" x2="20"/>
+                                <line length2="1.5" end1="none" y2="25" x1="10" y1="15" length1="1.5" end2="none" antialias="false" style="line-style:normal;line-weight:hight;filling:none;color:black" x2="-10"/>
+                                <terminal x="20" y="20" orientation="e"/>
+                                <terminal x="-20" y="0" orientation="w"/>
+                                <terminal x="20" y="0" orientation="e"/>
+                            </description>
+                        </definition>
+                    </element>
+                    <element name="pinball_em_williams_switch_mb_sm_top_i.elmt">
+                        <definition width="50" type="element" orientation="dyyy" hotspot_x="24" hotspot_y="15" version="0.70" link_type="simple" height="50">
+                            <uuid uuid="{affc73ff-2963-4d34-911d-da56d8ba6452}"/>
+                            <names>
+                                <name lang="en">Switch on Score Motor (M.B.) - Top input - Inverted</name>
+                                <name lang="nl">Schakelaar op Score Motor (M.B.) - Input boven - Omgekeerd</name>
+                            </names>
+                            <elementInformations/>
+                            <informations/>
+                            <description>
+                                <rect rx="0" width="3" x="-5" y="-5" ry="0" antialias="false" style="line-style:normal;line-weight:normal;filling:black;color:black" height="30"/>
+                                <arc width="20" x="-10" y="-10" start="0" antialias="true" style="line-style:normal;line-weight:normal;filling:none;color:black" height="20" angle="180"/>
+                                <rect rx="0" width="3" x="2" y="13" ry="0" antialias="false" style="line-style:normal;line-weight:normal;filling:black;color:black" height="12"/>
+                                <line length2="1.5" end1="none" y2="20" x1="-10" y1="0" length1="1.5" end2="none" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" x2="-10"/>
+                                <rect rx="0" width="3" x="2" y="-5" ry="0" antialias="false" style="line-style:normal;line-weight:normal;filling:black;color:black" height="12"/>
+                                <line length2="1.5" end1="none" y2="20" x1="10" y1="0" length1="1.5" end2="none" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" x2="10"/>
+                                <line length2="1.5" end1="none" y2="20" x1="5" y1="20" length1="1.5" end2="none" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" x2="20"/>
+                                <arc width="20" x="-10" y="10" start="180" antialias="true" style="line-style:normal;line-weight:normal;filling:none;color:black" height="20" angle="180"/>
+                                <line length2="1.5" end1="none" y2="0" x1="-20" y1="0" length1="1.5" end2="none" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" x2="-5"/>
+                                <line length2="1.5" end1="none" y2="0" x1="5" y1="0" length1="1.5" end2="none" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" x2="20"/>
+                                <line length2="1.5" end1="none" y2="5.25" x1="10" y1="-4.75" length1="1.5" end2="none" antialias="false" style="line-style:normal;line-weight:hight;filling:none;color:black" x2="-10"/>
+                                <terminal x="20" y="20" orientation="e"/>
+                                <terminal x="-20" y="0" orientation="w"/>
+                                <terminal x="20" y="0" orientation="e"/>
+                            </description>
+                        </definition>
+                    </element>
+                    <category name="mirrored">
+                        <names>
+                            <name lang="en">Mirrored</name>
+                            <name lang="nl">Gespiegeld</name>
+                        </names>
+                        <element name="pinball_em_williams_switch_mb_sm_bottom_m.elmt">
+                            <definition width="50" type="element" orientation="dyyy" hotspot_x="24" hotspot_y="35" version="0.70" link_type="simple" height="50">
+                                <uuid uuid="{10830219-83b0-4488-8564-adfe27637f60}"/>
+                                <names>
+                                    <name lang="en">Switch on Score Motor (M.B.) - Bottom input - Mirrored</name>
+                                    <name lang="nl">Schakelaar op Score Motor (M.B.) - Input onder - Gespiegeld</name>
+                                </names>
+                                <elementInformations/>
+                                <informations/>
+                                <description>
+                                    <rect rx="0" width="3" x="2" y="-25" ry="0" antialias="false" style="line-style:normal;line-weight:normal;filling:black;color:black" height="30"/>
+                                    <arc width="20" x="-10" y="-30" start="0" antialias="true" style="line-style:normal;line-weight:normal;filling:none;color:black" height="20" angle="180"/>
+                                    <line length2="1.5" end1="none" y2="0" x1="-10" y1="-20" length1="1.5" end2="none" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" x2="-10"/>
+                                    <line length2="1.5" end1="none" y2="-20" x1="-20" y1="-20" length1="1.5" end2="none" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" x2="-5"/>
+                                    <rect rx="0" width="3" x="-5" y="-7" ry="0" antialias="false" style="line-style:normal;line-weight:normal;filling:black;color:black" height="12"/>
+                                    <line length2="1.5" end1="none" y2="0" x1="10" y1="-20" length1="1.5" end2="none" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" x2="10"/>
+                                    <rect rx="0" width="3" x="-5" y="-25" ry="0" antialias="false" style="line-style:normal;line-weight:normal;filling:black;color:black" height="12"/>
+                                    <arc width="20" x="-10" y="-10" start="180" antialias="true" style="line-style:normal;line-weight:normal;filling:none;color:black" height="20" angle="180"/>
+                                    <line length2="1.5" end1="none" y2="0" x1="5" y1="0" length1="1.5" end2="none" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" x2="20"/>
+                                    <line length2="1.5" end1="none" y2="0" x1="-20" y1="0" length1="1.5" end2="none" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" x2="-5"/>
+                                    <line length2="1.5" end1="none" y2="5" x1="10" y1="-5" length1="1.5" end2="none" antialias="false" style="line-style:normal;line-weight:hight;filling:none;color:black" x2="-10"/>
+                                    <terminal x="-20" y="0" orientation="w"/>
+                                    <terminal x="-20" y="-20" orientation="w"/>
+                                    <terminal x="20" y="0" orientation="e"/>
+                                </description>
+                            </definition>
+                        </element>
+                        <element name="pinball_em_williams_switch_mb_sm_bottom_mi.elmt">
+                            <definition width="50" type="element" orientation="dyyy" hotspot_x="24" hotspot_y="35" version="0.70" link_type="simple" height="50">
+                                <uuid uuid="{5854bbcc-54b3-41c1-b728-36ea16c235c7}"/>
+                                <names>
+                                    <name lang="en">Switch on Score Motor (M.B.) - Bottom input - Mirrored and inverted</name>
+                                    <name lang="nl">Schakelaar op Score Motor (M.B.) - Input onder - Gespiegeld en omgekeerd</name>
+                                </names>
+                                <elementInformations/>
+                                <informations/>
+                                <description>
+                                    <rect rx="0" width="3" x="2" y="-25" ry="0" antialias="false" style="line-style:normal;line-weight:normal;filling:black;color:black" height="30"/>
+                                    <arc width="20" x="-10" y="-30" start="0" antialias="true" style="line-style:normal;line-weight:normal;filling:none;color:black" height="20" angle="180"/>
+                                    <line length2="1.5" end1="none" y2="-20" x1="-20" y1="-20" length1="1.5" end2="none" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" x2="-5"/>
+                                    <line length2="1.5" end1="none" y2="0" x1="-10" y1="-20" length1="1.5" end2="none" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" x2="-10"/>
+                                    <line length2="1.5" end1="none" y2="0" x1="10" y1="-20" length1="1.5" end2="none" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" x2="10"/>
+                                    <rect rx="0" width="3" x="-5" y="-7" ry="0" antialias="false" style="line-style:normal;line-weight:normal;filling:black;color:black" height="12"/>
+                                    <rect rx="0" width="3" x="-5" y="-25" ry="0" antialias="false" style="line-style:normal;line-weight:normal;filling:black;color:black" height="12"/>
+                                    <arc width="20" x="-10" y="-10" start="180" antialias="true" style="line-style:normal;line-weight:normal;filling:none;color:black" height="20" angle="180"/>
+                                    <line length2="1.5" end1="none" y2="0" x1="5" y1="0" length1="1.5" end2="none" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" x2="20"/>
+                                    <line length2="1.5" end1="none" y2="0" x1="-20" y1="0" length1="1.5" end2="none" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" x2="-5"/>
+                                    <line length2="1.5" end1="none" y2="-15" x1="10" y1="-25" length1="1.5" end2="none" antialias="false" style="line-style:normal;line-weight:hight;filling:none;color:black" x2="-10"/>
+                                    <terminal x="20" y="0" orientation="e"/>
+                                    <terminal x="-20" y="0" orientation="w"/>
+                                    <terminal x="-20" y="-20" orientation="w"/>
+                                </description>
+                            </definition>
+                        </element>
+                        <element name="pinball_em_williams_switch_mb_sm_center_m.elmt">
+                            <definition width="50" type="element" orientation="dyyy" hotspot_x="24" hotspot_y="25" version="0.70" link_type="simple" height="50">
+                                <uuid uuid="{b17bd886-7621-424a-b336-cdf9d15da91c}"/>
+                                <names>
+                                    <name lang="en">Switch on Score Motor (M.B.) - Center input - Mirrored</name>
+                                    <name lang="nl">Schakelaar op Score Motor (M.B.) - Input midden - Gespiegeld</name>
+                                </names>
+                                <elementInformations/>
+                                <informations/>
+                                <description>
+                                    <arc width="20" x="-10" y="-20" start="0" antialias="true" style="line-style:normal;line-weight:normal;filling:none;color:black" height="20" angle="180"/>
+                                    <rect rx="0" width="3" x="2" y="-15.25" ry="0" antialias="false" style="line-style:normal;line-weight:normal;filling:black;color:black" height="30"/>
+                                    <line length2="1.5" end1="none" y2="10" x1="-10" y1="-10" length1="1.5" end2="none" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" x2="-10"/>
+                                    <line length2="1.5" end1="none" y2="-10.25" x1="-20" y1="-10.25" length1="1.5" end2="none" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" x2="-5"/>
+                                    <line length2="1.5" end1="none" y2="10" x1="10" y1="-10" length1="1.5" end2="none" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" x2="10"/>
+                                    <rect rx="0" width="3" x="-5" y="2.75" ry="0" antialias="false" style="line-style:normal;line-weight:normal;filling:black;color:black" height="12"/>
+                                    <arc width="20" x="-10" y="0" start="180" antialias="true" style="line-style:normal;line-weight:normal;filling:none;color:black" height="20" angle="180"/>
+                                    <rect rx="0" width="3" x="-5" y="-15.25" ry="0" antialias="false" style="line-style:normal;line-weight:normal;filling:black;color:black" height="12"/>
+                                    <line length2="1.5" end1="none" y2="-0.25" x1="5" y1="-0.25" length1="1.5" end2="none" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" x2="20"/>
+                                    <line length2="1.5" end1="none" y2="9.75" x1="-20" y1="9.75" length1="1.5" end2="none" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" x2="-5"/>
+                                    <line length2="1.5" end1="none" y2="14.75" x1="10" y1="4.75" length1="1.5" end2="none" antialias="false" style="line-style:normal;line-weight:hight;filling:none;color:black" x2="-10"/>
+                                    <terminal x="-20" y="9.75" orientation="w"/>
+                                    <terminal x="-20" y="-10.25" orientation="w"/>
+                                    <terminal x="20" y="-0.25" orientation="e"/>
+                                </description>
+                            </definition>
+                        </element>
+                        <element name="pinball_em_williams_switch_mb_sm_center_mi.elmt">
+                            <definition width="50" type="element" orientation="dyyy" hotspot_x="24" hotspot_y="25" version="0.70" link_type="simple" height="50">
+                                <uuid uuid="{a5464c2a-4620-41a8-a18f-e34f0e0fa5ee}"/>
+                                <names>
+                                    <name lang="en">Switch on Score Motor (M.B.) - Center input - Mirrored and inverted</name>
+                                    <name lang="nl">Schakelaar op Score Motor (M.B.) - Input midden - Gespiegeld en omgekeerd</name>
+                                </names>
+                                <elementInformations/>
+                                <informations/>
+                                <description>
+                                    <arc width="20" x="-10" y="-20" start="0" antialias="true" style="line-style:normal;line-weight:normal;filling:none;color:black" height="20" angle="180"/>
+                                    <rect rx="0" width="3" x="2" y="-15" ry="0" antialias="false" style="line-style:normal;line-weight:normal;filling:black;color:black" height="30"/>
+                                    <line length2="1.5" end1="none" y2="-10" x1="-20" y1="-10" length1="1.5" end2="none" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" x2="-5"/>
+                                    <line length2="1.5" end1="none" y2="10" x1="-10" y1="-10" length1="1.5" end2="none" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" x2="-10"/>
+                                    <rect rx="0" width="3" x="-5" y="3" ry="0" antialias="false" style="line-style:normal;line-weight:normal;filling:black;color:black" height="12"/>
+                                    <line length2="1.5" end1="none" y2="10" x1="10" y1="-10" length1="1.5" end2="none" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" x2="10"/>
+                                    <arc width="20" x="-10" y="0" start="180" antialias="true" style="line-style:normal;line-weight:normal;filling:none;color:black" height="20" angle="180"/>
+                                    <rect rx="0" width="3" x="-5" y="-15" ry="0" antialias="false" style="line-style:normal;line-weight:normal;filling:black;color:black" height="12"/>
+                                    <line length2="1.5" end1="none" y2="0" x1="5" y1="0" length1="1.5" end2="none" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" x2="20"/>
+                                    <line length2="1.5" end1="none" y2="10" x1="-20" y1="10" length1="1.5" end2="none" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" x2="-5"/>
+                                    <line length2="1.5" end1="none" y2="-5" x1="10" y1="-15" length1="1.5" end2="none" antialias="false" style="line-style:normal;line-weight:hight;filling:none;color:black" x2="-10"/>
+                                    <terminal x="-20" y="10" orientation="w"/>
+                                    <terminal x="-20" y="-10" orientation="w"/>
+                                    <terminal x="20" y="0" orientation="e"/>
+                                </description>
+                            </definition>
+                        </element>
+                        <element name="pinball_em_williams_switch_mb_sm_top_m.elmt">
+                            <definition width="50" type="element" orientation="dyyy" hotspot_x="24" hotspot_y="15" version="0.70" link_type="simple" height="50">
+                                <uuid uuid="{118827a9-bf0b-49d4-9c37-9679a3014ff2}"/>
+                                <names>
+                                    <name lang="en">Switch on Score Motor (M.B.) - Top input - Mirrored</name>
+                                    <name lang="nl">Schakelaar op Score Motor (M.B.) - Input boven - Gespiegeld</name>
+                                </names>
+                                <elementInformations/>
+                                <informations/>
+                                <description>
+                                    <rect rx="0" width="3" x="2" y="-5" ry="0" antialias="false" style="line-style:normal;line-weight:normal;filling:black;color:black" height="30"/>
+                                    <arc width="20" x="-10" y="-10" start="0" antialias="true" style="line-style:normal;line-weight:normal;filling:none;color:black" height="20" angle="180"/>
+                                    <line length2="1.5" end1="none" y2="20" x1="-10" y1="0" length1="1.5" end2="none" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" x2="-10"/>
+                                    <line length2="1.5" end1="none" y2="0" x1="-20" y1="0" length1="1.5" end2="none" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" x2="-5"/>
+                                    <rect rx="0" width="3" x="-5" y="13" ry="0" antialias="false" style="line-style:normal;line-weight:normal;filling:black;color:black" height="12"/>
+                                    <line length2="1.5" end1="none" y2="20" x1="10" y1="0" length1="1.5" end2="none" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" x2="10"/>
+                                    <rect rx="0" width="3" x="-5" y="-5" ry="0" antialias="false" style="line-style:normal;line-weight:normal;filling:black;color:black" height="12"/>
+                                    <arc width="20" x="-10" y="10" start="180" antialias="true" style="line-style:normal;line-weight:normal;filling:none;color:black" height="20" angle="180"/>
+                                    <line length2="1.5" end1="none" y2="0" x1="5" y1="0" length1="1.5" end2="none" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" x2="20"/>
+                                    <line length2="1.5" end1="none" y2="20" x1="-20" y1="20" length1="1.5" end2="none" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" x2="-5"/>
+                                    <line length2="1.5" end1="none" y2="25" x1="10" y1="15" length1="1.5" end2="none" antialias="false" style="line-style:normal;line-weight:hight;filling:none;color:black" x2="-10"/>
+                                    <terminal x="-20" y="20" orientation="w"/>
+                                    <terminal x="20" y="0" orientation="e"/>
+                                    <terminal x="-20" y="0" orientation="w"/>
+                                </description>
+                            </definition>
+                        </element>
+                        <element name="pinball_em_williams_switch_mb_sm_top_mi.elmt">
+                            <definition width="50" type="element" orientation="dyyy" hotspot_x="24" hotspot_y="15" version="0.70" link_type="simple" height="50">
+                                <uuid uuid="{d2347a8a-0c35-45a6-95e4-8a3a3100964f}"/>
+                                <names>
+                                    <name lang="en">Switch on Score Motor (M.B.) - Top input - Mirrored and inverted</name>
+                                    <name lang="nl">Schakelaar op Score Motor (M.B.) - Input boven - Gespiegeld en omgekeerd</name>
+                                </names>
+                                <elementInformations/>
+                                <informations/>
+                                <description>
+                                    <arc width="20" x="-10" y="-10" start="0" antialias="true" style="line-style:normal;line-weight:normal;filling:none;color:black" height="20" angle="180"/>
+                                    <rect rx="0" width="3" x="2" y="-5" ry="0" antialias="false" style="line-style:normal;line-weight:normal;filling:black;color:black" height="30"/>
+                                    <line length2="1.5" end1="none" y2="0" x1="-20" y1="0" length1="1.5" end2="none" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" x2="-5"/>
+                                    <line length2="1.5" end1="none" y2="20" x1="-10" y1="0" length1="1.5" end2="none" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" x2="-10"/>
+                                    <line length2="1.5" end1="none" y2="20" x1="10" y1="0" length1="1.5" end2="none" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" x2="10"/>
+                                    <rect rx="0" width="3" x="-5" y="13" ry="0" antialias="false" style="line-style:normal;line-weight:normal;filling:black;color:black" height="12"/>
+                                    <arc width="20" x="-10" y="10" start="180" antialias="true" style="line-style:normal;line-weight:normal;filling:none;color:black" height="20" angle="180"/>
+                                    <rect rx="0" width="3" x="-5" y="-5" ry="0" antialias="false" style="line-style:normal;line-weight:normal;filling:black;color:black" height="12"/>
+                                    <line length2="1.5" end1="none" y2="0" x1="5" y1="0" length1="1.5" end2="none" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" x2="20"/>
+                                    <line length2="1.5" end1="none" y2="20" x1="-20" y1="20" length1="1.5" end2="none" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" x2="-5"/>
+                                    <line length2="1.5" end1="none" y2="5" x1="10" y1="-5" length1="1.5" end2="none" antialias="false" style="line-style:normal;line-weight:hight;filling:none;color:black" x2="-10"/>
+                                    <terminal x="-20" y="20" orientation="w"/>
+                                    <terminal x="20" y="0" orientation="e"/>
+                                    <terminal x="-20" y="0" orientation="w"/>
+                                </description>
+                            </definition>
+                        </element>
+                    </category>
+                </category>
+                <category name="units">
+                    <names>
+                        <name lang="en">Units</name>
+                        <name lang="nl">Units</name>
+                    </names>
+                    <category name="wiper_between">
+                        <names>
+                            <name lang="en">Wiper between</name>
+                            <name lang="nl">Sleepcontact tussen</name>
+                        </names>
+                        <element name="pinball_em_williams_unit_wiper_between_04.elmt">
+                            <definition width="70" type="element" orientation="dyyy" hotspot_x="34" hotspot_y="15" version="0.70" link_type="simple" height="90">
+                                <uuid uuid="{aac95ab4-e46a-401d-90c6-0564253d0711}"/>
+                                <names>
+                                    <name lang="en">Wiper between 4 contact pairs</name>
+                                    <name lang="nl">Sleepcontact tussen 4 contactparen</name>
+                                </names>
+                                <elementInformations/>
+                                <informations/>
+                                <description>
+                                    <circle x="5" y="35" diameter="10" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black"/>
+                                    <circle x="5" y="-5" diameter="10" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black"/>
+                                    <circle x="5" y="55" diameter="10" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black"/>
+                                    <circle x="5" y="15" diameter="10" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black"/>
+                                    <rect rx="0" width="40" x="-20" y="-10" ry="0" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" height="80"/>
+                                    <circle x="-15" y="55" diameter="10" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black"/>
+                                    <circle x="-15" y="35" diameter="10" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black"/>
+                                    <circle x="-15" y="-5" diameter="10" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black"/>
+                                    <circle x="-15" y="15" diameter="10" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black"/>
+                                    <line length2="1.5" end1="none" y2="0" x1="-5" y1="0" length1="1.5" end2="none" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" x2="5"/>
+                                    <line length2="1.5" end1="none" y2="0" x1="15" y1="0" length1="1.5" end2="none" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" x2="30"/>
+                                    <line length2="1.5" end1="none" y2="20" x1="15" y1="20" length1="1.5" end2="none" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" x2="30"/>
+                                    <line length2="1.5" end1="none" y2="40" x1="15" y1="40" length1="1.5" end2="none" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" x2="30"/>
+                                    <line length2="1.5" end1="none" y2="60" x1="15" y1="60" length1="1.5" end2="none" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" x2="30"/>
+                                    <line length2="1.5" end1="none" y2="0" x1="-30" y1="0" length1="1.5" end2="none" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" x2="-16"/>
+                                    <line length2="1.5" end1="none" y2="20" x1="-30" y1="20" length1="1.5" end2="none" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" x2="-15"/>
+                                    <line length2="1.5" end1="none" y2="40" x1="-30" y1="40" length1="1.5" end2="none" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" x2="-16"/>
+                                    <line length2="1.5" end1="none" y2="60" x1="-30" y1="60" length1="1.5" end2="none" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" x2="-16"/>
+                                    <polygon y2="-3" x4="-5" x1="-5" y4="0" y1="0" y3="3" antialias="false" style="line-style:normal;line-weight:normal;filling:black;color:black" x2="-2" x3="-2"/>
+                                    <polygon y2="0" x1="2" y1="-3" y3="3" antialias="false" style="line-style:normal;line-weight:normal;filling:black;color:black" x2="5" x3="2"/>
+                                    <terminal x="30" y="0" orientation="e"/>
+                                    <terminal x="30" y="60" orientation="e"/>
+                                    <terminal x="-30" y="20" orientation="w"/>
+                                    <terminal x="30" y="20" orientation="e"/>
+                                    <terminal x="30" y="40" orientation="e"/>
+                                    <terminal x="-30" y="0" orientation="w"/>
+                                    <terminal x="-30" y="60" orientation="w"/>
+                                    <terminal x="-30" y="40" orientation="w"/>
+                                </description>
+                            </definition>
+                        </element>
+                        <element name="pinball_em_williams_unit_wiper_between_10.elmt">
+                            <definition width="70" type="element" orientation="dyyy" hotspot_x="34" hotspot_y="15" version="0.70" link_type="simple" height="210">
+                                <uuid uuid="{a7798588-80e2-4689-8a35-5a1b9459b69b}"/>
+                                <names>
+                                    <name lang="en">Wiper between 10 contact pairs</name>
+                                    <name lang="nl">Sleepcontact tussen 10 contactparen</name>
+                                </names>
+                                <elementInformations/>
+                                <informations/>
+                                <description>
+                                    <circle x="5" y="155" diameter="10" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black"/>
+                                    <circle x="5" y="35" diameter="10" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black"/>
+                                    <circle x="5" y="95" diameter="10" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black"/>
+                                    <circle x="5" y="115" diameter="10" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black"/>
+                                    <circle x="5" y="175" diameter="10" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black"/>
+                                    <circle x="5" y="-5" diameter="10" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black"/>
+                                    <circle x="5" y="135" diameter="10" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black"/>
+                                    <circle x="5" y="55" diameter="10" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black"/>
+                                    <circle x="5" y="75" diameter="10" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black"/>
+                                    <circle x="5" y="15" diameter="10" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black"/>
+                                    <circle x="-15" y="115" diameter="10" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black"/>
+                                    <circle x="-15" y="175" diameter="10" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black"/>
+                                    <circle x="-15" y="95" diameter="10" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black"/>
+                                    <rect rx="0" width="40" x="-20" y="-10" ry="0" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" height="200"/>
+                                    <circle x="-15" y="155" diameter="10" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black"/>
+                                    <circle x="-15" y="135" diameter="10" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black"/>
+                                    <circle x="-15" y="75" diameter="10" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black"/>
+                                    <circle x="-15" y="55" diameter="10" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black"/>
+                                    <line length2="1.5" end1="none" y2="140" x1="15" y1="140" length1="1.5" end2="none" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" x2="30"/>
+                                    <circle x="-15" y="35" diameter="10" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black"/>
+                                    <line length2="1.5" end1="none" y2="80" x1="15" y1="80" length1="1.5" end2="none" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" x2="30"/>
+                                    <circle x="-15" y="-5" diameter="10" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black"/>
+                                    <line length2="1.5" end1="none" y2="160" x1="15" y1="160" length1="1.5" end2="none" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" x2="30"/>
+                                    <line length2="1.5" end1="none" y2="100" x1="15" y1="100" length1="1.5" end2="none" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" x2="30"/>
+                                    <circle x="-15" y="15" diameter="10" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black"/>
+                                    <line length2="1.5" end1="none" y2="180" x1="15" y1="180" length1="1.5" end2="none" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" x2="30"/>
+                                    <line length2="1.5" end1="none" y2="120" x1="15" y1="120" length1="1.5" end2="none" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" x2="30"/>
+                                    <line length2="1.5" end1="none" y2="0" x1="-5" y1="0" length1="1.5" end2="none" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" x2="5"/>
+                                    <line length2="1.5" end1="none" y2="80" x1="-30" y1="80" length1="1.5" end2="none" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" x2="-15"/>
+                                    <line length2="1.5" end1="none" y2="140" x1="-30" y1="140" length1="1.5" end2="none" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" x2="-15"/>
+                                    <line length2="1.5" end1="none" y2="160" x1="-30" y1="160" length1="1.5" end2="none" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" x2="-16"/>
+                                    <line length2="1.5" end1="none" y2="100" x1="-30" y1="100" length1="1.5" end2="none" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" x2="-16"/>
+                                    <line length2="1.5" end1="none" y2="0" x1="15" y1="0" length1="1.5" end2="none" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" x2="30"/>
+                                    <line length2="1.5" end1="none" y2="120" x1="-30" y1="120" length1="1.5" end2="none" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" x2="-16"/>
+                                    <line length2="1.5" end1="none" y2="180" x1="-30" y1="180" length1="1.5" end2="none" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" x2="-16"/>
+                                    <line length2="1.5" end1="none" y2="20" x1="15" y1="20" length1="1.5" end2="none" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" x2="30"/>
+                                    <line length2="1.5" end1="none" y2="40" x1="15" y1="40" length1="1.5" end2="none" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" x2="30"/>
+                                    <line length2="1.5" end1="none" y2="60" x1="15" y1="60" length1="1.5" end2="none" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" x2="30"/>
+                                    <line length2="1.5" end1="none" y2="0" x1="-30" y1="0" length1="1.5" end2="none" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" x2="-16"/>
+                                    <line length2="1.5" end1="none" y2="20" x1="-30" y1="20" length1="1.5" end2="none" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" x2="-15"/>
+                                    <line length2="1.5" end1="none" y2="40" x1="-30" y1="40" length1="1.5" end2="none" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" x2="-16"/>
+                                    <line length2="1.5" end1="none" y2="60" x1="-30" y1="60" length1="1.5" end2="none" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" x2="-16"/>
+                                    <polygon y2="-3" x4="-5" x1="-5" y4="0" y1="0" y3="3" antialias="false" style="line-style:normal;line-weight:normal;filling:black;color:black" x2="-2" x3="-2"/>
+                                    <polygon y2="0" x1="2" y1="-3" y3="3" antialias="false" style="line-style:normal;line-weight:normal;filling:black;color:black" x2="5" x3="2"/>
+                                    <terminal x="30" y="120" orientation="e"/>
+                                    <terminal x="-30" y="80" orientation="w"/>
+                                    <terminal x="-30" y="120" orientation="w"/>
+                                    <terminal x="-30" y="100" orientation="w"/>
+                                    <terminal x="30" y="80" orientation="e"/>
+                                    <terminal x="30" y="100" orientation="e"/>
+                                    <terminal x="-30" y="0" orientation="w"/>
+                                    <terminal x="30" y="0" orientation="e"/>
+                                    <terminal x="-30" y="20" orientation="w"/>
+                                    <terminal x="-30" y="60" orientation="w"/>
+                                    <terminal x="-30" y="40" orientation="w"/>
+                                    <terminal x="30" y="20" orientation="e"/>
+                                    <terminal x="30" y="60" orientation="e"/>
+                                    <terminal x="30" y="40" orientation="e"/>
+                                    <terminal x="-30" y="160" orientation="w"/>
+                                    <terminal x="-30" y="180" orientation="w"/>
+                                    <terminal x="30" y="140" orientation="e"/>
+                                    <terminal x="30" y="180" orientation="e"/>
+                                    <terminal x="30" y="160" orientation="e"/>
+                                    <terminal x="-30" y="140" orientation="w"/>
+                                </description>
+                            </definition>
+                        </element>
+                        <element name="pinball_em_williams_wiper_3_between_3.elmt">
+                            <definition width="70" type="element" orientation="dyyy" hotspot_x="34" hotspot_y="15" version="0.70" link_type="simple" height="130">
+                                <uuid uuid="{e2c18efc-1f4f-45cb-a814-09c1b5554535}"/>
+                                <names>
+                                    <name lang="en">3 wipers between 3 contact pairs</name>
+                                    <name lang="nl">3 sleepcontacten tussen 3 contactparen</name>
+                                </names>
+                                <elementInformations/>
+                                <informations/>
+                                <description>
+                                    <line length2="1.5" end1="none" y2="40" x1="-5" y1="40" length1="1.5" end2="none" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" x2="5"/>
+                                    <line length2="1.5" end1="none" y2="20" x1="-5" y1="20" length1="1.5" end2="none" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" x2="5"/>
+                                    <circle x="5" y="75" diameter="10" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black"/>
+                                    <polygon y2="17" x4="-5" x1="-5" y4="20" y1="20" y3="23" antialias="false" style="line-style:normal;line-weight:normal;filling:black;color:black" x2="-2" x3="-2"/>
+                                    <polygon y2="37" x4="-5" x1="-5" y4="40" y1="40" y3="43" antialias="false" style="line-style:normal;line-weight:normal;filling:black;color:black" x2="-2" x3="-2"/>
+                                    <polygon y2="40" x1="2" y1="37" y3="43" antialias="false" style="line-style:normal;line-weight:normal;filling:black;color:black" x2="5" x3="2"/>
+                                    <polygon y2="20" x1="2" y1="17" y3="23" antialias="false" style="line-style:normal;line-weight:normal;filling:black;color:black" x2="5" x3="2"/>
+                                    <circle x="5" y="95" diameter="10" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black"/>
+                                    <circle x="5" y="55" diameter="10" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black"/>
+                                    <rect rx="0" width="40" x="-20" y="-10" ry="0" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" height="120"/>
+                                    <circle x="-15" y="95" diameter="10" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black"/>
+                                    <circle x="-15" y="75" diameter="10" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black"/>
+                                    <circle x="-15" y="55" diameter="10" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black"/>
+                                    <line length2="1.5" end1="none" y2="0" x1="-5" y1="0" length1="1.5" end2="none" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" x2="5"/>
+                                    <line length2="1.5" end1="none" y2="60" x1="15" y1="60" length1="1.5" end2="none" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" x2="30"/>
+                                    <line length2="1.5" end1="none" y2="80" x1="15" y1="80" length1="1.5" end2="none" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" x2="30"/>
+                                    <line length2="1.5" end1="none" y2="100" x1="15" y1="100" length1="1.5" end2="none" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" x2="30"/>
+                                    <line length2="1.5" end1="none" y2="60" x1="-30" y1="60" length1="1.5" end2="none" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" x2="-15"/>
+                                    <line length2="1.5" end1="none" y2="80" x1="-30" y1="80" length1="1.5" end2="none" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" x2="-16"/>
+                                    <line length2="1.5" end1="none" y2="100" x1="-30" y1="100" length1="1.5" end2="none" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" x2="-16"/>
+                                    <polygon y2="-3" x4="-5" x1="-5" y4="0" y1="0" y3="3" antialias="false" style="line-style:normal;line-weight:normal;filling:black;color:black" x2="-2" x3="-2"/>
+                                    <polygon y2="0" x1="2" y1="-3" y3="3" antialias="false" style="line-style:normal;line-weight:normal;filling:black;color:black" x2="5" x3="2"/>
+                                    <terminal x="30" y="100" orientation="e"/>
+                                    <terminal x="-30" y="80" orientation="w"/>
+                                    <terminal x="-30" y="60" orientation="w"/>
+                                    <terminal x="30" y="60" orientation="e"/>
+                                    <terminal x="30" y="80" orientation="e"/>
+                                    <terminal x="-30" y="100" orientation="w"/>
+                                </description>
+                            </definition>
+                        </element>
+                    </category>
+                    <category name="wiper_to">
+                        <names>
+                            <name lang="en">Wiper to</name>
+                            <name lang="nl">Sleepcontact naar</name>
+                        </names>
+                        <element name="pinball_em_williams_unit_wiper_to_02.elmt">
+                            <definition width="70" type="element" orientation="dyyy" hotspot_x="34" hotspot_y="15" version="0.70" link_type="simple" height="50">
+                                <uuid uuid="{292efe3b-b14f-4bf4-b666-7edcff8c76e6}"/>
+                                <names>
+                                    <name lang="en">Wiper to 2 contacts</name>
+                                    <name lang="nl">Sleepcontact naar 2 polen</name>
+                                </names>
+                                <elementInformations/>
+                                <informations/>
+                                <description>
+                                    <circle x="-15" y="15" diameter="10" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black"/>
+                                    <rect rx="0" width="40" x="-20" y="-10" ry="0" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" height="40"/>
+                                    <circle x="-15" y="-5" diameter="10" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black"/>
+                                    <line length2="1.5" end1="none" y2="0" x1="-30" y1="0" length1="1.5" end2="none" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" x2="-15"/>
+                                    <line length2="1.5" end1="none" y2="20" x1="-30" y1="20" length1="1.5" end2="none" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" x2="-15"/>
+                                    <line length2="1.5" end1="none" y2="0" x1="-5" y1="0" length1="1.5" end2="none" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" x2="30"/>
+                                    <polygon y2="3" x4="-2" x1="-2" y4="-3" y1="-3" y3="0" antialias="false" style="line-style:normal;line-weight:normal;filling:black;color:black" x2="-2" x3="-5"/>
+                                    <terminal x="30" y="0" orientation="e"/>
+                                    <terminal x="-30" y="20" orientation="w"/>
+                                    <terminal x="-30" y="0" orientation="w"/>
+                                </description>
+                            </definition>
+                        </element>
+                        <element name="pinball_em_williams_unit_wiper_to_03.elmt">
+                            <definition width="70" type="element" orientation="dyyy" hotspot_x="34" hotspot_y="15" version="0.70" link_type="simple" height="70">
+                                <uuid uuid="{b1ae72b5-69cf-4f1a-b618-8f5d4e0b55c6}"/>
+                                <names>
+                                    <name lang="en">Wiper to 3 contacts</name>
+                                    <name lang="nl">Sleepcontact naar 3 polen</name>
+                                </names>
+                                <elementInformations/>
+                                <informations/>
+                                <description>
+                                    <circle x="-15" y="15" diameter="10" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black"/>
+                                    <circle x="-15" y="35" diameter="10" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black"/>
+                                    <rect rx="0" width="40" x="-20" y="-10" ry="0" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" height="60"/>
+                                    <line length2="1.5" end1="none" y2="40" x1="-30" y1="40" length1="1.5" end2="none" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" x2="-15"/>
+                                    <circle x="-15" y="-5" diameter="10" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black"/>
+                                    <line length2="1.5" end1="none" y2="0" x1="-30" y1="0" length1="1.5" end2="none" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" x2="-15"/>
+                                    <line length2="1.5" end1="none" y2="20" x1="-30" y1="20" length1="1.5" end2="none" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" x2="-15"/>
+                                    <line length2="1.5" end1="none" y2="0" x1="-5" y1="0" length1="1.5" end2="none" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" x2="30"/>
+                                    <polygon y2="3" x4="-2" x1="-2" y4="-3" y1="-3" y3="0" antialias="false" style="line-style:normal;line-weight:normal;filling:black;color:black" x2="-2" x3="-5"/>
+                                    <terminal x="30" y="0" orientation="e"/>
+                                    <terminal x="-30" y="20" orientation="w"/>
+                                    <terminal x="-30" y="0" orientation="w"/>
+                                    <terminal x="-30" y="40" orientation="w"/>
+                                </description>
+                            </definition>
+                        </element>
+                        <element name="pinball_em_williams_unit_wiper_to_04.elmt">
+                            <definition width="70" type="element" orientation="dyyy" hotspot_x="34" hotspot_y="15" version="0.70" link_type="simple" height="90">
+                                <uuid uuid="{c8f0c752-3215-409d-96f5-0dee5f6f89c5}"/>
+                                <names>
+                                    <name lang="en">Wiper to 4 contacts</name>
+                                    <name lang="nl">Sleepcontact naar 4 polen</name>
+                                </names>
+                                <elementInformations/>
+                                <informations/>
+                                <description>
+                                    <circle x="-15" y="55" diameter="10" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black"/>
+                                    <circle x="-15" y="15" diameter="10" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black"/>
+                                    <circle x="-15" y="35" diameter="10" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black"/>
+                                    <line length2="1.5" end1="none" y2="60" x1="-30" y1="60" length1="1.5" end2="none" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" x2="-15"/>
+                                    <rect rx="0" width="40" x="-20" y="-10" ry="0" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" height="80"/>
+                                    <line length2="1.5" end1="none" y2="40" x1="-30" y1="40" length1="1.5" end2="none" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" x2="-15"/>
+                                    <circle x="-15" y="-5" diameter="10" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black"/>
+                                    <line length2="1.5" end1="none" y2="0" x1="-30" y1="0" length1="1.5" end2="none" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" x2="-15"/>
+                                    <line length2="1.5" end1="none" y2="20" x1="-30" y1="20" length1="1.5" end2="none" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" x2="-15"/>
+                                    <line length2="1.5" end1="none" y2="0" x1="-5" y1="0" length1="1.5" end2="none" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" x2="30"/>
+                                    <polygon y2="3" x4="-2" x1="-2" y4="-3" y1="-3" y3="0" antialias="false" style="line-style:normal;line-weight:normal;filling:black;color:black" x2="-2" x3="-5"/>
+                                    <terminal x="-30" y="60" orientation="w"/>
+                                    <terminal x="-30" y="20" orientation="w"/>
+                                    <terminal x="30" y="0" orientation="e"/>
+                                    <terminal x="-30" y="40" orientation="w"/>
+                                    <terminal x="-30" y="0" orientation="w"/>
+                                </description>
+                            </definition>
+                        </element>
+                        <element name="pinball_em_williams_unit_wiper_to_05.elmt">
+                            <definition width="70" type="element" orientation="dyyy" hotspot_x="34" hotspot_y="15" version="0.70" link_type="simple" height="110">
+                                <uuid uuid="{4f2df3dd-0521-4ed2-879c-e2ad597ab05a}"/>
+                                <names>
+                                    <name lang="en">Wiper to 5 contacts</name>
+                                    <name lang="nl">Sleepcontact naar 5 polen</name>
+                                </names>
+                                <elementInformations/>
+                                <informations/>
+                                <description>
+                                    <circle x="-15" y="75" diameter="10" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black"/>
+                                    <circle x="-15" y="55" diameter="10" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black"/>
+                                    <line length2="1.5" end1="none" y2="80" x1="-30" y1="80" length1="1.5" end2="none" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" x2="-15"/>
+                                    <circle x="-15" y="15" diameter="10" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black"/>
+                                    <circle x="-15" y="35" diameter="10" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black"/>
+                                    <line length2="1.5" end1="none" y2="60" x1="-30" y1="60" length1="1.5" end2="none" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" x2="-15"/>
+                                    <rect rx="0" width="40" x="-20" y="-10" ry="0" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" height="100"/>
+                                    <line length2="1.5" end1="none" y2="40" x1="-30" y1="40" length1="1.5" end2="none" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" x2="-15"/>
+                                    <circle x="-15" y="-5" diameter="10" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black"/>
+                                    <line length2="1.5" end1="none" y2="0" x1="-30" y1="0" length1="1.5" end2="none" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" x2="-15"/>
+                                    <line length2="1.5" end1="none" y2="20" x1="-30" y1="20" length1="1.5" end2="none" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" x2="-15"/>
+                                    <line length2="1.5" end1="none" y2="0" x1="-5" y1="0" length1="1.5" end2="none" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" x2="30"/>
+                                    <polygon y2="3" x4="-2" x1="-2" y4="-3" y1="-3" y3="0" antialias="false" style="line-style:normal;line-weight:normal;filling:black;color:black" x2="-2" x3="-5"/>
+                                    <terminal x="-30" y="40" orientation="w"/>
+                                    <terminal x="-30" y="0" orientation="w"/>
+                                    <terminal x="-30" y="20" orientation="w"/>
+                                    <terminal x="30" y="0" orientation="e"/>
+                                    <terminal x="-30" y="60" orientation="w"/>
+                                    <terminal x="-30" y="80" orientation="w"/>
+                                </description>
+                            </definition>
+                        </element>
+                        <element name="pinball_em_williams_unit_wiper_to_06.elmt">
+                            <definition width="70" type="element" orientation="dyyy" hotspot_x="34" hotspot_y="15" version="0.70" link_type="simple" height="130">
+                                <uuid uuid="{eb3e79b4-1f02-4044-a625-4bdd2440e827}"/>
+                                <names>
+                                    <name lang="en">Wiper to 6 contacts</name>
+                                    <name lang="nl">Sleepcontact naar 6 polen</name>
+                                </names>
+                                <elementInformations/>
+                                <informations/>
+                                <description>
+                                    <circle x="-15" y="75" diameter="10" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black"/>
+                                    <circle x="-15" y="95" diameter="10" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black"/>
+                                    <circle x="-15" y="55" diameter="10" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black"/>
+                                    <line length2="1.5" end1="none" y2="100" x1="-30" y1="100" length1="1.5" end2="none" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" x2="-15"/>
+                                    <line length2="1.5" end1="none" y2="80" x1="-30" y1="80" length1="1.5" end2="none" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" x2="-15"/>
+                                    <circle x="-15" y="15" diameter="10" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black"/>
+                                    <circle x="-15" y="35" diameter="10" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black"/>
+                                    <line length2="1.5" end1="none" y2="60" x1="-30" y1="60" length1="1.5" end2="none" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" x2="-15"/>
+                                    <rect rx="0" width="40" x="-20" y="-10" ry="0" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" height="120"/>
+                                    <line length2="1.5" end1="none" y2="40" x1="-30" y1="40" length1="1.5" end2="none" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" x2="-15"/>
+                                    <circle x="-15" y="-5" diameter="10" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black"/>
+                                    <line length2="1.5" end1="none" y2="0" x1="-30" y1="0" length1="1.5" end2="none" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" x2="-15"/>
+                                    <line length2="1.5" end1="none" y2="20" x1="-30" y1="20" length1="1.5" end2="none" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" x2="-15"/>
+                                    <line length2="1.5" end1="none" y2="0" x1="-5" y1="0" length1="1.5" end2="none" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" x2="30"/>
+                                    <polygon y2="3" x4="-2" x1="-2" y4="-3" y1="-3" y3="0" antialias="false" style="line-style:normal;line-weight:normal;filling:black;color:black" x2="-2" x3="-5"/>
+                                    <terminal x="-30" y="100" orientation="w"/>
+                                    <terminal x="-30" y="40" orientation="w"/>
+                                    <terminal x="-30" y="0" orientation="w"/>
+                                    <terminal x="-30" y="20" orientation="w"/>
+                                    <terminal x="30" y="0" orientation="e"/>
+                                    <terminal x="-30" y="80" orientation="w"/>
+                                    <terminal x="-30" y="60" orientation="w"/>
+                                </description>
+                            </definition>
+                        </element>
+                        <element name="pinball_em_williams_unit_wiper_to_10.elmt">
+                            <definition width="70" type="element" orientation="dyyy" hotspot_x="34" hotspot_y="15" version="0.70" link_type="simple" height="210">
+                                <uuid uuid="{f152f6a0-17e9-4590-879e-9c6a360d2903}"/>
+                                <names>
+                                    <name lang="en">Wiper to 10 contacts</name>
+                                    <name lang="nl">Sleepcontact naar 10 polen</name>
+                                </names>
+                                <elementInformations/>
+                                <informations/>
+                                <description>
+                                    <circle x="-15" y="155" diameter="10" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black"/>
+                                    <circle x="-15" y="75" diameter="10" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black"/>
+                                    <circle x="-15" y="175" diameter="10" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black"/>
+                                    <circle x="-15" y="95" diameter="10" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black"/>
+                                    <circle x="-15" y="135" diameter="10" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black"/>
+                                    <circle x="-15" y="55" diameter="10" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black"/>
+                                    <line length2="1.5" end1="none" y2="100" x1="-30" y1="100" length1="1.5" end2="none" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" x2="-15"/>
+                                    <line length2="1.5" end1="none" y2="180" x1="-30" y1="180" length1="1.5" end2="none" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" x2="-15"/>
+                                    <line length2="1.5" end1="none" y2="160" x1="-30" y1="160" length1="1.5" end2="none" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" x2="-15"/>
+                                    <line length2="1.5" end1="none" y2="80" x1="-30" y1="80" length1="1.5" end2="none" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" x2="-15"/>
+                                    <circle x="-15" y="115" diameter="10" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black"/>
+                                    <circle x="-15" y="15" diameter="10" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black"/>
+                                    <line length2="1.5" end1="none" y2="140" x1="-30" y1="140" length1="1.5" end2="none" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" x2="-15"/>
+                                    <circle x="-15" y="35" diameter="10" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black"/>
+                                    <line length2="1.5" end1="none" y2="120" x1="-30" y1="120" length1="1.5" end2="none" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" x2="-15"/>
+                                    <line length2="1.5" end1="none" y2="60" x1="-30" y1="60" length1="1.5" end2="none" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" x2="-15"/>
+                                    <rect rx="0" width="40" x="-20" y="-10" ry="0" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" height="200"/>
+                                    <line length2="1.5" end1="none" y2="40" x1="-30" y1="40" length1="1.5" end2="none" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" x2="-15"/>
+                                    <circle x="-15" y="-5" diameter="10" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black"/>
+                                    <line length2="1.5" end1="none" y2="0" x1="-30" y1="0" length1="1.5" end2="none" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" x2="-15"/>
+                                    <line length2="1.5" end1="none" y2="20" x1="-30" y1="20" length1="1.5" end2="none" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" x2="-15"/>
+                                    <line length2="1.5" end1="none" y2="0" x1="-5" y1="0" length1="1.5" end2="none" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" x2="30"/>
+                                    <polygon y2="3" x4="-2" x1="-2" y4="-3" y1="-3" y3="0" antialias="false" style="line-style:normal;line-weight:normal;filling:black;color:black" x2="-2" x3="-5"/>
+                                    <terminal x="-30" y="40" orientation="w"/>
+                                    <terminal x="-30" y="20" orientation="w"/>
+                                    <terminal x="30" y="0" orientation="e"/>
+                                    <terminal x="-30" y="0" orientation="w"/>
+                                    <terminal x="-30" y="60" orientation="w"/>
+                                    <terminal x="-30" y="80" orientation="w"/>
+                                    <terminal x="-30" y="100" orientation="w"/>
+                                    <terminal x="-30" y="120" orientation="w"/>
+                                    <terminal x="-30" y="140" orientation="w"/>
+                                    <terminal x="-30" y="160" orientation="w"/>
+                                    <terminal x="-30" y="180" orientation="w"/>
+                                </description>
+                            </definition>
+                        </element>
+                        <element name="pinball_em_williams_unit_wiper_to_11.elmt">
+                            <definition width="70" type="element" orientation="dyyy" hotspot_x="34" hotspot_y="15" version="0.70" link_type="simple" height="230">
+                                <uuid uuid="{36c95bf0-254c-4d0a-81af-866db548ae97}"/>
+                                <names>
+                                    <name lang="en">Wiper to 11 contacts</name>
+                                    <name lang="nl">Sleepcontact naar 11 polen</name>
+                                </names>
+                                <elementInformations/>
+                                <informations/>
+                                <description>
+                                    <circle x="-15" y="195" diameter="10" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black"/>
+                                    <circle x="-15" y="155" diameter="10" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black"/>
+                                    <circle x="-15" y="75" diameter="10" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black"/>
+                                    <line length2="1.5" end1="none" y2="200" x1="-30" y1="200" length1="1.5" end2="none" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" x2="-15"/>
+                                    <circle x="-15" y="175" diameter="10" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black"/>
+                                    <circle x="-15" y="95" diameter="10" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black"/>
+                                    <circle x="-15" y="135" diameter="10" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black"/>
+                                    <circle x="-15" y="55" diameter="10" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black"/>
+                                    <line length2="1.5" end1="none" y2="100" x1="-30" y1="100" length1="1.5" end2="none" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" x2="-15"/>
+                                    <line length2="1.5" end1="none" y2="180" x1="-30" y1="180" length1="1.5" end2="none" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" x2="-15"/>
+                                    <line length2="1.5" end1="none" y2="160" x1="-30" y1="160" length1="1.5" end2="none" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" x2="-15"/>
+                                    <line length2="1.5" end1="none" y2="80" x1="-30" y1="80" length1="1.5" end2="none" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" x2="-15"/>
+                                    <circle x="-15" y="115" diameter="10" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black"/>
+                                    <circle x="-15" y="15" diameter="10" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black"/>
+                                    <line length2="1.5" end1="none" y2="140" x1="-30" y1="140" length1="1.5" end2="none" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" x2="-15"/>
+                                    <circle x="-15" y="35" diameter="10" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black"/>
+                                    <line length2="1.5" end1="none" y2="120" x1="-30" y1="120" length1="1.5" end2="none" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" x2="-15"/>
+                                    <line length2="1.5" end1="none" y2="60" x1="-30" y1="60" length1="1.5" end2="none" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" x2="-15"/>
+                                    <rect rx="0" width="40" x="-20" y="-10" ry="0" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" height="220"/>
+                                    <line length2="1.5" end1="none" y2="40" x1="-30" y1="40" length1="1.5" end2="none" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" x2="-15"/>
+                                    <circle x="-15" y="-5" diameter="10" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black"/>
+                                    <line length2="1.5" end1="none" y2="0" x1="-30" y1="0" length1="1.5" end2="none" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" x2="-15"/>
+                                    <line length2="1.5" end1="none" y2="20" x1="-30" y1="20" length1="1.5" end2="none" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" x2="-15"/>
+                                    <line length2="1.5" end1="none" y2="0" x1="-5" y1="0" length1="1.5" end2="none" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" x2="30"/>
+                                    <polygon y2="3" x4="-2" x1="-2" y4="-3" y1="-3" y3="0" antialias="false" style="line-style:normal;line-weight:normal;filling:black;color:black" x2="-2" x3="-5"/>
+                                    <terminal x="-30" y="140" orientation="w"/>
+                                    <terminal x="-30" y="160" orientation="w"/>
+                                    <terminal x="30" y="0" orientation="e"/>
+                                    <terminal x="-30" y="60" orientation="w"/>
+                                    <terminal x="-30" y="80" orientation="w"/>
+                                    <terminal x="-30" y="0" orientation="w"/>
+                                    <terminal x="-30" y="40" orientation="w"/>
+                                    <terminal x="-30" y="120" orientation="w"/>
+                                    <terminal x="-30" y="100" orientation="w"/>
+                                    <terminal x="-30" y="20" orientation="w"/>
+                                    <terminal x="-30" y="180" orientation="w"/>
+                                    <terminal x="-30" y="200" orientation="w"/>
+                                </description>
+                            </definition>
+                        </element>
+                    </category>
+                </category>
+            </category>
+        </category>
+    </collection>
+</project>


### PR DESCRIPTION
A pull request for adding Williams EM symbols to QET.

A few questions:

1. Do you want these symbols directly in the `pinball` directory? I would say that having them in `pinball/williams_em` would make more sense, as it allows for other symbol sets to be put in the `pinball` directory.
2. How do you handle documentation for your symbol libraries? See the original repo (linked below).

Additional info:

- [Reddit thread](https://www.reddit.com/r/pinball/comments/lc0ilc/i_made_a_williams_em_schematic_symbols_library/)
- [QET forums thread](https://qelectrotech.org/forum/viewtopic.php?pid=14264)
- [Original repository](https://github.com/ThomasGravekamp/pinball_em_williams_schematic)