### PR TITLE
Build fix for non-C++17 compatible systems

### DIFF
--- a/sources/editor/graphicspart/customelementgraphicpart.cpp
+++ b/sources/editor/graphicspart/customelementgraphicpart.cpp
@@ -21,7 +21,6 @@
 #include "../elementscene.h"
 
 #include <QRegularExpression>
-#include <variant>
 
 /**
 	@brief CustomElementGraphicPart::CustomElementGraphicPart
@@ -938,7 +937,7 @@ void CustomElementGraphicPart::applyStylesToQPainter(QPainter &painter) const
 	else if (_filling == FdiagFilling) brush.setStyle(Qt::FDiagPattern);
 	else
 	{
-		static const QMap<Filling, std::variant<Qt::GlobalColor, QColor>>
+		static const QMap<Filling, QColor>
 			filling_style_map = {
 				{BlackFilling, Qt::black},
 				{WhiteFilling, Qt::white},
@@ -1096,14 +1095,11 @@ void CustomElementGraphicPart::applyStylesToQPainter(QPainter &painter) const
 
 		brush.setStyle(Qt::SolidPattern);
 		auto color = filling_style_map.find(_filling);
-		if (color != filling_style_map.end())
-		{
-			std::visit([&](auto&& color) { brush.setColor(color); }, *color);
-		}
+		if (color != filling_style_map.end()) { brush.setColor(*color); }
 	}
 
 	// Apply pen color
-	static const QMap<Color, std::variant<Qt::GlobalColor, QColor>> color_map =
+	static const QMap<Color, QColor> color_map =
 		{{GreenColor, Qt::green},
 		 {RedColor, Qt::red},
 		 {BlueColor, Qt::blue},
@@ -1268,10 +1264,7 @@ void CustomElementGraphicPart::applyStylesToQPainter(QPainter &painter) const
 	else
 	{
 		auto style_ = color_map.find(_color);
-		if (style_ != color_map.end())
-		{
-			std::visit([&](auto&& color) { pen.setColor(color); }, *style_);
-		}
+		if (style_ != color_map.end()) { pen.setColor(*style_); }
 	}
 
 	//Apply antialiasing

--- a/sources/factory/elementpicturefactory.cpp
+++ b/sources/factory/elementpicturefactory.cpp
@@ -30,7 +30,6 @@
 #include <QRegularExpression>
 #include <QTextDocument>
 #include <iostream>
-#include <variant>
 
 ElementPictureFactory* ElementPictureFactory::m_factory = nullptr;
 
@@ -605,11 +604,7 @@ void ElementPictureFactory::setPainterStyle(const QDomElement &dom, QPainter &pa
 				else if (style_value == "eleve") pen.setWidthF(5.0);
 
 			} else if (style_name == "filling") {
-				static const QMap<
-					QString,
-					QPair<
-						Qt::BrushStyle,
-						std::variant<Qt::GlobalColor, QColor>>>
+				static const QMap<QString, QPair<Qt::BrushStyle, QColor>>
 					filling_style_map = {
 						{"white", {Qt::SolidPattern, Qt::white}},
 						{"black", {Qt::SolidPattern, Qt::black}},
@@ -912,12 +907,10 @@ void ElementPictureFactory::setPainterStyle(const QDomElement &dom, QPainter &pa
 					if (style_ == filling_style_map.end()) { continue; }
 
 					brush.setStyle(style_->first);
-					std::visit(
-						[&](auto&& color) { brush.setColor(color); },
-						style_->second);
+	 				brush.setColor(style_->second);
 				}
 			} else if (style_name == "color") {
-				static const QMap<QString, std::variant<Qt::GlobalColor, QColor>> color_style_map = {
+				static const QMap<QString, QColor> color_style_map = {
 					{"red", Qt::red},
 					{"blue", Qt::blue},
 					{"green", Qt::green},
@@ -1085,9 +1078,7 @@ void ElementPictureFactory::setPainterStyle(const QDomElement &dom, QPainter &pa
 					auto style_ = color_style_map.find(style_value);
 					if (style_ == color_style_map.end()) { continue; }
 
-					std::visit(
-						[&](auto&& color) { pen.setColor(color); },
-						*style_);
+					pen.setColor(*style_);
 				}
 			}
 		}


### PR DESCRIPTION
std::variant/std::visit was only introduced with C++17. Remove its usage.
We don't even need it in these cases since QColor has an implicit constructor accepting Qt::GlobalColor.

Follow-up for b69c7b10277257fcd2b4b993e303049f41061a6f