### PR TITLE
projectview: Re-enable appending qet suffix if not running as flatpak

### DIFF
--- a/sources/projectview.cpp
+++ b/sources/projectview.cpp
@@ -339,8 +339,8 @@ QString ProjectView::askUserForFilePath(bool assign) {
 	// if no filepath is provided, return an empty string
 	if (filepath.isEmpty()) return(filepath);
 
-//	// if the name does not end with the .qet extension, append it
-//	if (!filepath.endsWith(".qet", Qt::CaseInsensitive)) filepath += ".qet";
+	// if the name does not end with the .qet extension and we're _not_ running as a flatpak, append it
+	if (!filepath.endsWith(".qet", Qt::CaseInsensitive) && !qEnvironmentVariableIsSet("FLATPAK_ID")) filepath += ".qet";
 
 	if (assign) {
 		// assign the provided filepath to the currently edited project


### PR DESCRIPTION
It was removed in b121dad for all platforms.
Only disable appending the suffix for the flatpak platform
by testing for the FLATPAK_ID environment variable.

Fixes #206 