### PR TITLE
Add 'Other' option for slave device contact type

### DIFF
--- a/sources/editor/ui/elementpropertieseditorwidget.cpp
+++ b/sources/editor/ui/elementpropertieseditorwidget.cpp
@@ -128,6 +128,7 @@ void ElementPropertiesEditorWidget::setUpInterface()
 	ui->m_state_cb->addItem(tr("Normalement ouvert"),       ElementData::NO);
 	ui->m_state_cb->addItem(tr("Normalement fermé"),        ElementData::NC);
 	ui->m_state_cb->addItem(tr("Inverseur"),                ElementData::SW);
+	ui->m_state_cb->addItem(tr("Other"),                    ElementData::Other);
 	ui->m_type_cb->addItem(tr("Simple"),                    ElementData::SSimple);
 	ui->m_type_cb->addItem(tr("Puissance"),                 ElementData::Power);
 	ui->m_type_cb->addItem(tr("Temporisé travail"),         ElementData::DelayOn);

--- a/sources/properties/elementdata.cpp
+++ b/sources/properties/elementdata.cpp
@@ -425,6 +425,8 @@ QString ElementData::slaveStateToString(ElementData::SlaveState type)
 			return QStringLiteral("NC");
 		case SW:
 			return QStringLiteral("SW");
+		case Other:
+			return QStringLiteral("Other");
 	}
 }
 
@@ -436,7 +438,9 @@ ElementData::SlaveState ElementData::slaveStateFromString(const QString &string)
 		return ElementData::NC;
 	} else if (string == QLatin1String("SW")) {
 		return ElementData::SW;
-	}
+	} else if (string == QLatin1String("Other")){
+		return ElementData::Other;
+    }
 
 	qDebug() << "ElementData::slaveStateFromString : string : "
 			 << string

--- a/sources/properties/elementdata.h
+++ b/sources/properties/elementdata.h
@@ -64,7 +64,8 @@ class ElementData : public PropertiesInterface
 		enum SlaveState {
 			NO,
 			NC,
-			SW
+			SW,
+			Other
 		};
 		Q_ENUM(SlaveState)
 

--- a/sources/qetgraphicsitem/crossrefitem.cpp
+++ b/sources/qetgraphicsitem/crossrefitem.cpp
@@ -614,6 +614,7 @@ void CrossRefItem::drawAsContacts(QPainter &painter)
 				 if (state == "NO") option = NO;
 			else if (state == "NC") option = NC;
 			else if (state == "SW") option = SW;
+			else if (state == "Other") option = Other;
 
 			QString type = info["type"].toString();
 				 if (type == "power")    option += Power;
@@ -644,7 +645,7 @@ QRectF CrossRefItem::drawContact(QPainter &painter, int flags, Element *elmt)
 {
 	QString str = elementPositionText(elmt);
 	int offset = m_drawed_contacts*10;
-	QRectF bounding_rect;
+	QRectF bounding_rect = QRectF(0, offset, 24, 10);
 
 	QPen pen = painter.pen();
 	m_hovered_contact == elmt ? pen.setColor(Qt::blue) :pen.setColor(Qt::black);
@@ -819,6 +820,23 @@ QRectF CrossRefItem::drawContact(QPainter &painter, int flags, Element *elmt)
 
 			//a switch contact take place of two normal contact
 		m_drawed_contacts += 2;
+	}else if(flags &Other){
+		//Draw position text
+		QRectF text_rect = painter.boundingRect(
+					QRectF(30, offset+5, 5, 10),
+					Qt::AlignLeft | Qt::AlignVCenter,
+					str);
+		painter.drawText(text_rect,
+				 Qt::AlignLeft | Qt::AlignVCenter,
+				 str);
+		bounding_rect = bounding_rect.united(text_rect);
+
+		if (m_hovered_contacts_map.contains(elmt)) {
+			m_hovered_contacts_map.insert(elmt, bounding_rect);
+		}
+		else {
+			m_hovered_contacts_map.insert(elmt, bounding_rect);
+		}
 	}
 
 	return bounding_rect;

--- a/sources/qetgraphicsitem/crossrefitem.h
+++ b/sources/qetgraphicsitem/crossrefitem.h
@@ -75,7 +75,8 @@ class CrossRefItem : public QGraphicsObject
 			DelayOn		= 16,
 			DelayOff	= 32,
 			DelayOnOff	= 64,
-			Delay		= 112
+			Delay		= 112,
+			Other	   = 128
 		};
 
 		QRectF boundingRect() const override;


### PR DESCRIPTION
Master - slave elements are super useful for splitting one part into multiple logical elements. This makes schematic much more readable.
My issue is, QET always assumes the slave is a switch. And draws appropriate switch symbol next to the slave link(see pic.). I would like to use the master-slave elements for other parts as well. My specific use-case has power meters with digital outputs. It makes sense to separate the low voltage digital part into second sheet.

There is demand for this among the community. I am not the first one to stumble upon this issue.
[link1](https://qelectrotech.org/forum/viewtopic.php?id=1093)
[link2](https://qelectrotech.org/forum/viewtopic.php?id=1223)

This PR adds `Other` option into the slave switch state selection. If you select this option, and your `Cross reference`->`XRef slave position` is set to `View contacts`, QET will only draw the XRef without contact type. This change doesn't make sense for `cross` style of contacts. In that case, no link will be shown.

![image](https://user-images.githubusercontent.com/69154224/175080658-d973a166-4f52-4aba-a7ea-ecdad14da6d0.png)


Before:
![image](https://user-images.githubusercontent.com/69154224/175079196-cff57f34-d5f2-4dc9-8bbd-76f4c0521818.png)

After:
![image](https://user-images.githubusercontent.com/69154224/175079837-321a64f7-8ff5-44b6-babb-d3a5c8e28109.png)
