### PR TITLE
Fix various typos in source documentation and comments

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,7 +31,7 @@ set(QET_DIR ${PROJECT_SOURCE_DIR})
 # Add sub directories
 option(PACKAGE_TESTS "Build the tests" ON)
 if(PACKAGE_TESTS)
-  message("Add sub directorie tests")
+  message("Add sub directory tests")
   add_subdirectory(tests)
 endif()
 

--- a/README.md
+++ b/README.md
@@ -16,11 +16,11 @@ The main goal of the developers is to provide a libre, easy to use and effective
 ### Version
 
 The current stable version is 0.80 and was released on 2021.02.21.  
-Once it has been officialy released, the stable version is always frozen and is no longer developed.
+Once it has been officially released, the stable version is always frozen and is no longer developed.
 
 New functionalities, bug and issue fixings are further made in the development version (currently 0.9), which can also be [downloaded](https://qelectrotech.org/download.html).
 
-Users who want to test and take benefits from the last software implementations should use the development version. But... use it at your own risk, since things are sometimes broken or only partialy implemented until they are done!
+Users who want to test and take benefits from the last software implementations should use the development version. But... use it at your own risk, since things are sometimes broken or only partially implemented until they are done!
 
 ### License
 
@@ -28,7 +28,7 @@ The software is licensed under [GNU/GPL](https://www.gnu.org/licenses/old-licens
 You are free to use, copy, modify and redistribute it under the terms of the license.
 
 
-Like many other open source softwares, QElectroTech is provided as it is, without any warranty.
+Like many other open source software, QElectroTech is provided as is, without any warranty.
 
 ### Development / technical choices
 

--- a/sources/bordertitleblock.cpp
+++ b/sources/bordertitleblock.cpp
@@ -108,15 +108,15 @@ DiagramContext BorderTitleBlock::titleblockInformation() const
 
 /**
 	@brief BorderTitleBlock::titleBlockRectForQPainter
-	@return The title block rect to use with the QPainter in the method draw.
-	The returned rect is alway horizontal
-	(like displayed at the bottom of rect) only the top left change of pos
-	according to the edge where the title block need to be displayed.
+	@return The title block rect to use with the QPainter in the draw method.
+	The returned rect is always horizontal
+	(as displayed at the bottom of rect) only the top left change of pos
+	according to the edge where the title block needs to be displayed.
 	Rect according to edge:
 	Bottom : top left is at the bottom left edge of the diagram rect.
 	Right : top left is at the bottom right of diagram rect.
-	Befor use this rect you need to rotate the QPainter by -90°
-	for snap the rect at the right edge of diagram.
+	Before using this rect you need to rotate the QPainter by -90°
+	to snap the rect at the right edge of diagram.
 */
 QRectF BorderTitleBlock::titleBlockRectForQPainter() const
 {

--- a/sources/conductornumexport.cpp
+++ b/sources/conductornumexport.cpp
@@ -90,7 +90,7 @@ bool ConductorNumExport::toCsv()
 
 /**
 	@brief ConductorNumExport::wiresNum
-	@return the wire num formated in csv
+	@return the wire num formatted in csv
 */
 QString ConductorNumExport::wiresNum() const
 {
@@ -126,7 +126,7 @@ void ConductorNumExport::fillHash()
 				continue;
 			}
 
-			//We must to define if the connected terminal is a folio report, if it is the case
+			//We must define if the connected terminal is a folio report, if it is the case
 			//we don't add the num to the hash because the terminal doesn't represent a real terminal.
 			if(!(c->terminal1->parentElement()->linkType() & Element::AllReport))
 			{

--- a/sources/conductorproperties.cpp
+++ b/sources/conductorproperties.cpp
@@ -263,7 +263,7 @@ ConductorProperties::~ConductorProperties()
 
 /**
 	@brief ConductorProperties::toXml
-	Export conductor propertie, in the XML element 'e'
+	Export conductor properties to the XML element 'e'
 	@param e the xml element
 */
 void ConductorProperties::toXml(QDomElement &e) const
@@ -308,7 +308,7 @@ void ConductorProperties::toXml(QDomElement &e) const
 
 /**
 	@brief ConductorProperties::fromXml
-	Import conductor propertie, from the attribute of the xml element 'e'
+	Import conductor properties from the attribute of the xml element 'e'
 	@param e the xml document
 */
 void ConductorProperties::fromXml(QDomElement &e)

--- a/sources/diagram.cpp
+++ b/sources/diagram.cpp
@@ -890,8 +890,8 @@ QDomDocument Diagram::toXml(bool whole_content) {
 				if (whole_content)
 					list_conductors << cond;
 					/* When we did not export the whole diagram,
-					 * we must to remove the non selected conductors.
-					 * At this step that mean a conductor which one
+					 * we must remove the non-selected conductors.
+					 * At this step that means a conductor which one
 					 * of these two element are not selected
 					 */
 				else if (cond->terminal1->parentItem()->isSelected()
@@ -1279,8 +1279,8 @@ bool Diagram::fromXml(QDomElement &document,
 																   QStringLiteral("-1")).toInt());
 
 		/* We try to paste from another project,
-		 *  then befor paste elements,
-		 *  we must to import the definition of the pasted elements
+		 *  then before paste elements,
+		 *  we must import the definition of the pasted elements
 		 *  (owned by other project)
 		 *  in the embedded collection of this project
 		 */
@@ -1547,7 +1547,7 @@ void Diagram::refreshContents()
 /**
 	@brief Diagram::addItem
 	Réimplemented from QGraphicsScene::addItem(QGraphicsItem *item)
-	Do some specific operation if item need it (for exemple an element)
+	Do some specific operation if item need it (for example an element)
 	@param item
 */
 void Diagram::addItem(QGraphicsItem *item)
@@ -1578,7 +1578,7 @@ void Diagram::addItem(QGraphicsItem *item)
 /**
 	@brief Diagram::removeItem
 	Reimplemented from QGraphicsScene::removeItem(QGraphicsItem *item)
-	Do some specific operation if item need it (for exemple an element)
+	Do some specific operation if item need it (for example an element)
 	@param item
 */
 void Diagram::removeItem(QGraphicsItem *item)
@@ -2268,7 +2268,7 @@ DiagramPosition Diagram::convertPosition(const QPointF &pos) {
 /**
 	@brief Diagram::snapToGrid
 	Return a nearest snap point of p
-	@param p point to find the nearest snaped point
+	@param p point to find the nearest snapped point
 	@return
 */
 QPointF Diagram::snapToGrid(const QPointF &p)

--- a/sources/diagram.h
+++ b/sources/diagram.h
@@ -341,7 +341,7 @@ inline bool Diagram::displayGrid() {
 
 /**
 	@brief Diagram::setUseBorder
-	Set whether the diagram border (including rows/colums headers and the title
+	Set whether the diagram border (including rows/columns headers and the title
 	block) should be rendered along with the diagram. When set to false, the size
 	of the smallest rectangle containing all items is considered as the diagram
 	size.
@@ -362,7 +362,7 @@ inline bool Diagram::useBorder() {
 
 /**
 	@brief Diagram::setBorderOptions
-	Set the rendering options for the diagram border (including rows/colums
+	Set the rendering options for the diagram border (including rows/columns
 	headers and the title block)
 	@param bo Enabled options ORed together
 	@see BorderOptions
@@ -375,7 +375,7 @@ inline void Diagram::setBorderOptions(Diagram::BorderOptions bo) {
 
 /**
 	@brief Diagram::borderOptions
-	@return The rendering optios for the diagram border
+	@return The rendering options for the diagram border
 	@see setBorderOptions
 */
 inline Diagram::BorderOptions Diagram::borderOptions() {

--- a/sources/diagramcommands.cpp
+++ b/sources/diagramcommands.cpp
@@ -26,8 +26,8 @@
 /**
 	@brief PasteDiagramCommand::PasteDiagramCommand
 	Constructor
-	@param dia : diagram where we must to paste
-	@param c : content to past
+	@param dia : diagram where we must paste
+	@param c : content to paste
 	@param parent : parent undo command
 */
 PasteDiagramCommand::PasteDiagramCommand( Diagram *dia, const DiagramContent &c, QUndoCommand *parent) :
@@ -64,7 +64,7 @@ void PasteDiagramCommand::undo()
 
 /**
 	@brief PasteDiagramCommand::redo
-	Redo this commnand
+	Redo this command
 */
 void PasteDiagramCommand::redo()
 {
@@ -244,7 +244,7 @@ void MoveElementsCommand::move(const QPointF &actual_movement)
 							| dc::ElementTextFields
 							| dc::Tables))
 	{
-		//If curent item have parent, and parent item is in content_to_move
+		//If current item has parent, and parent item is in content_to_move
 		//we don't apply movement to this item, because this item will be moved by is parent.
 		if (qgi->parentItem())
 			if (content_to_move.items().contains(qgi->parentItem()))

--- a/sources/diagramcommands.h
+++ b/sources/diagramcommands.h
@@ -145,7 +145,7 @@ class MoveConductorsTextsCommand : public QUndoCommand {
 
 /**
 	@brief The ChangeDiagramTextCommand class
-	This commad modifies a text item.
+	This command modifies a text item.
 */
 class ChangeDiagramTextCommand : public QUndoCommand {
 	// constructors, destructor

--- a/sources/diagramcontent.cpp
+++ b/sources/diagramcontent.cpp
@@ -356,7 +356,7 @@ bool DiagramContent::potentialIsManaged(QList<Conductor *> conductors)
 
 /**
 	@brief DiagramContent::hasTextEditing
-	@return true if handle a text currently in editing intercation
+	@return true if handle a text currently in editing interaction
 */
 bool DiagramContent::hasTextEditing()
 {
@@ -436,7 +436,7 @@ int DiagramContent::count(int filter) const
 	@param filter
 	@return A string that describe the items of the diagram
 	content according to filter.
-	Exemple : X elements, Y conductors etc....
+	Example : X elements, Y conductors etc....
 */
 QString DiagramContent::sentence(int filter) const
 {

--- a/sources/diagramcontext.h
+++ b/sources/diagramcontext.h
@@ -39,7 +39,7 @@
  * designation                    -> exhaustive comment used to explain what the element does.
  * description                    -> exhaustive description used to explain what the element does.
  * plant                          -> the plant assigned to the element
- * comment                        -> a little comment wich can be displayed in the folio
+ * comment                        -> a little comment which can be displayed in the folio
  * manufacturer                   -> the manufacturer of the element
  * manufacturer_reference         -> the manufacturer reference of the element
  * quantity                       -> quantity of the element

--- a/sources/diagramview.cpp
+++ b/sources/diagramview.cpp
@@ -914,7 +914,7 @@ void DiagramView::adjustSceneRect()
 	QSettings settings;
 	if (settings.value("diagrameditor/zoom-out-beyond-of-folio", false).toBool())
 	{
-			//When zoom out beyong of folio is active,
+			//When zoom out beyond of folio is active,
 			//we always adjust the scene rect to be 1/3 bigger than the wiewport
 		QRectF vpbr = mapToScene(viewport()->rect()).boundingRect();
 		vpbr.adjust(0, 0, vpbr.width()/3, vpbr.height()/3);
@@ -1225,7 +1225,7 @@ void DiagramView::contextMenuEvent(QContextMenuEvent *e)
 			m_diagram->clearSelection();
 		}
 
-			// At this step qgi can be deleted for exemple if qgi is a QetGraphicsHandlerItem.
+			// At this step qgi can be deleted for example if qgi is a QetGraphicsHandlerItem.
 			// When we call clearSelection the parent item of the handler
 			// is deselected and so delete all handlers, in this case,
 			// qgi become a dangling pointer.

--- a/sources/diagramview.h
+++ b/sources/diagramview.h
@@ -109,9 +109,9 @@ class DiagramView : public QGraphicsView
 		void titleChanged(DiagramView *, const QString &);
 			/// Signal emitted when users wish to locate an element from the diagram within elements collection
 		void findElementRequired(const ElementsLocation &);
-			/// Signal emmitted when diagram must be show
+			/// Signal emitted when diagram must be show
 		void showDiagram (Diagram *);
-			/// Signal emmtted when free rubberband changed.
+			/// Signal emitted when free rubberband changed.
 			/// When free rubberband selection ends this signal will be emitted with null value.
 		void freeRubberBandChanged(QPolygonF polygon);
 	

--- a/sources/elementdialog.cpp
+++ b/sources/elementdialog.cpp
@@ -238,7 +238,7 @@ void ElementDialog::checkAccept()
 /**
 	@brief ElementDialog::location
 	@return The selected location or a null location if user has selected nothing
-	or selection isn't compatible with the curent mode
+	or selection isn't compatible with the current mode
 */
 ElementsLocation ElementDialog::location() const
 {

--- a/sources/elementprovider.cpp
+++ b/sources/elementprovider.cpp
@@ -58,7 +58,7 @@ QVector <QPointer<Element>> ElementProvider::freeElement(ElementData::Types filt
 	QVector<QPointer<Element>> free_elmt;
 	QList<Element *> elmt_list;
 
-		//serch in all diagram
+		//search in all diagram
 	for (const auto &diagram_ : qAsConst(m_diagram_list))
 	{
 			//get all element in diagram d
@@ -124,7 +124,7 @@ QVector<QPointer<Element>> ElementProvider::find(ElementData::Types elmt_type) c
 	@brief ElementProvider::table
 	@param table
 	@param model
-	@return All tables wich display the derivated class of model (if set)
+	@return All tables which display the derivated class of model (if set)
 	and not already in all the chain of next/previous table of table (if set)
 	If table and model are nullptr, return every tables
 */

--- a/sources/elementscategoryeditor.cpp
+++ b/sources/elementscategoryeditor.cpp
@@ -141,7 +141,7 @@ void ElementsCategoryEditor::acceptCreation()
 		return;
 	}
 	
-		//User must enter a directorie name
+		//User must enter a directory name
 	if (!m_file_line_edit -> isValid()) {
 		QET::QetMessageBox::critical(this,
 									 tr("Nom interne manquant", "message box title"),

--- a/sources/elementsmover.cpp
+++ b/sources/elementsmover.cpp
@@ -138,16 +138,16 @@ void ElementsMover::continueMovement(const QPointF &movement)
 	for (auto &conductor : m_moved_content.m_conductors_to_update)
 	{
 #if TODO_LIST
-#pragma message("@TODO fix this problem correctly, probably we must to see conductor class.")
+#pragma message("@TODO fix this problem correctly, probably we must see conductor class.")
 #endif
-			//Due to a weird behavior, we must to ensure that the position of the conductor is to (0,0).
+			//Due to a weird behavior, we must ensure that the position of the conductor is (0,0).
 			//If not, in some unknown case the function QGraphicsScene::itemsBoundingRect() return a rectangle
-			//that take in acount the pos() of the conductor, even if the bounding rect returned by the conductor is not in the pos().
-			//For the user this situation appear when the top right of the folio is not at the top right of the graphicsview,
+			//that take into account the pos() of the conductor, even if the bounding rect returned by the conductor is not in the pos().
+			//For the user this situation appears when the top right of the folio is not at the top right of the graphicsview,
 			//but displaced to the right and/or bottom.
 
-	//@TODO fix this problem correctly, probably we must to see conductor class.
-//		if (c->pos() != QPointF(0,0)) { //<- they work, but the conductor text return to her original pos when the pos is set by user and not auto
+	//@TODO fix this problem correctly, probably we must see conductor class.
+//		if (c->pos() != QPointF(0,0)) { //<- they work, but the conductor text return to its original pos when the pos is set by user and not auto
 //			c->setPos(0,0);				// because set the pos to 0,0 so text move to, and after call updatePath but because text pos is user defined
 //		}								// we don't move it.
 		conductor->updatePath();

--- a/sources/elementsmover.h
+++ b/sources/elementsmover.h
@@ -32,11 +32,11 @@ class QStatusBar;
 
 	A movement work in 3 steps:
 	1: beginMovement    -> init a new movement
-	2: continueMovement -> continue the curent movement
-	3: endMovement      -> finish the curent movement
+	2: continueMovement -> continue the current movement
+	3: endMovement      -> finish the current movement
 
-	A movement in progress must finish befor start a new movement. We can know if
-	element mover is ready for a new movement by calling isReady().
+	A movement in progress must finish before starting a new movement. We can
+	know if element mover is ready for a new movement by calling isReady().
 */
 class ElementsMover {
 		// constructors, destructor

--- a/sources/elementtextpattern.cpp
+++ b/sources/elementtextpattern.cpp
@@ -150,7 +150,7 @@ ImportElementTextPattern::ImportElementTextPattern(Element *elmt):
 	
 	bool ok=false;
 	bool erase = false;
-		//Remove the .xml extention of the files
+		//Remove the .xml extension of the files
 	result.replaceInStrings(".xml", "");
 	QString name = getName(result, &ok, &erase);
 	

--- a/sources/newelementwizard.cpp
+++ b/sources/newelementwizard.cpp
@@ -239,7 +239,7 @@ bool NewElementWizard::validStep2()
 
 /**
 	@brief NewElementWizard::createNewElement
-	Lauch an element editor for create the new element
+	Launch an element editor to create the new element
 */
 void NewElementWizard::createNewElement()
 {

--- a/sources/projectview.cpp
+++ b/sources/projectview.cpp
@@ -761,13 +761,13 @@ void ProjectView::initWidgets()
 	connect(m_tab, SIGNAL(tabBarDoubleClicked(int)), this, SLOT(tabDoubleClicked(int)));
 	connect(m_tab->tabBar(), SIGNAL(tabMoved(int, int)), this, SLOT(tabMoved(int, int)), Qt::QueuedConnection);
 	
-	//arrows buttton to return on first view
+	//arrows button to return on first view
 	QToolButton *m_first_view_button =new QToolButton;
 	m_first_view_button->setDefaultAction(m_first_view);
 	m_first_view_button->setAutoRaise(true);
 	m_tab->setCornerWidget(m_first_view_button, Qt::TopLeftCorner);
 	
-	//arrows buttton to go on last view
+	//arrows button to go on last view
 	QToolButton *m_end_view_button =new QToolButton;
 	m_end_view_button->setDefaultAction(m_end_view);
 	m_end_view_button->setAutoRaise(true);

--- a/sources/qet.h
+++ b/sources/qet.h
@@ -79,7 +79,7 @@ namespace QET {
 	
 	/// Supported types of interactive scaling, typically for a single element primitive
 	enum ScalingMethod {
-		FreeScaling,              ///< do not interfer with the default scaling process
+		FreeScaling,              ///< do not interfere with the default scaling process
 		SnapScalingPointToGrid,   ///< snap the point used to define the new bounding rectangle to the grid
 		RoundScaleRatios          ///< adjust the scaling movement so that the induced scaling ratios are rounded
 	};
@@ -128,7 +128,7 @@ namespace QET {
 		Retry,   ///< The operation must be tried again
 		Ignore,  ///< Skip the current item
 		Erase,   ///< Erase the target content
-		Abort,   ///< abort the whole operation, ignoring the curent item
+		Abort,   ///< abort the whole operation, ignoring the current item
 		Managed, ///< the current item was handled by the Strategy object: do not treat it and continue
 		Rename   ///< the target has to be renamed
 	};
@@ -152,7 +152,7 @@ namespace QET {
 	enum QetCollection {
 		Common,		///< From common collection
 		Custom,		///< From user collection
-		Embedded	///< From an embedded collection (a project for exemple)
+		Embedded	///< From an embedded collection (a project for example)
 	};
 
 	QString qetCollectionToString (const QetCollection &c);

--- a/sources/qetapp.cpp
+++ b/sources/qetapp.cpp
@@ -452,7 +452,7 @@ TitleBlockTemplatesFilesCollection *QETApp::customTitleBlockTemplatesCollection(
 
 /**
 	@brief QETApp::availableTitleBlockTemplatesCollections
-	@return the list of all available title block tempaltes collections,
+	@return the list of all available title block templates collections,
 	beginning with the common and custom ones, plus the projects-embedded ones.
 */
 QList<TitleBlockTemplatesCollection *> QETApp::availableTitleBlockTemplatesCollections()
@@ -554,7 +554,8 @@ QString QETApp::commonElementsDir()
 
 /**
 	@brief QETApp::customElementsDir
-	@return the dir path of user elements collection ened by a "/" separator
+	@return the dir path of user elements collection appended with a
+	"/" separator
 */
 QString QETApp::customElementsDir()
 {
@@ -905,7 +906,7 @@ void QETApp::overrideCommonElementsDir(const QString &new_ced) {
 /**
 	@brief QETApp::overrideCommonTitleBlockTemplatesDir
 	Define the path of the directory containing the common title block
-	tempaltes collection.
+	templates collection.
 	@param new_ctbtd
 */
 void QETApp::overrideCommonTitleBlockTemplatesDir(const QString &new_ctbtd) {
@@ -2121,8 +2122,8 @@ void QETApp::checkBackupFiles()
 	{
 		for (QETProject *project : registeredProjects().values())
 		{
-			/* We must to adjust with the flag
-			 * QUrl::StripTrailingSlash to compar a path formated
+			/* We must adjust with the flag
+			 * QUrl::StripTrailingSlash to compare a path formatted
 			 * like the path returned by KAutoSaveFile
 			 */
 			const QString path = QUrl::fromLocalFile(
@@ -2166,7 +2167,7 @@ void QETApp::checkBackupFiles()
 					 )
 			== QMessageBox::Ok)
 	{
-		//If there is opened editors, we find those who are visible
+		//If there are open editors, find those that are visible
 		if (diagramEditors().count())
 		{
 			diagramEditors().first()->setVisible(true);

--- a/sources/qetapp.h
+++ b/sources/qetapp.h
@@ -191,7 +191,7 @@ class QETApp : public QObject
 		bool every_template_reduced;
 		bool every_template_visible;
 		QSignalMapper signal_map;
-		QETArguments qet_arguments_; ///< Comand-line arguments parser
+		QETArguments qet_arguments_; ///< Command-line arguments parser
 		/**
 			@brief non_interactive_execution_
 			Whether the application will end

--- a/sources/qetdiagrameditor.cpp
+++ b/sources/qetdiagrameditor.cpp
@@ -451,7 +451,7 @@ void QETDiagramEditor::setUpActions()
 		}
 	});
 
-		//Lauch the plugin of terminal generator
+		//Launch the plugin of terminal generator
 	m_project_terminalBloc = new QAction(QET::Icons::TerminalStrip, tr("Lancer le plugin de création de borniers"), this);
 	connect(m_project_terminalBloc, &QAction::triggered, this, &QETDiagramEditor::generateTerminalBlock);
 
@@ -1390,7 +1390,7 @@ void QETDiagramEditor::selectGroupTriggered(QAction *action)
 
 /**
 	@brief QETDiagramEditor::addItemGroupTriggered
-	This slot is called when an item must be added to the curent diagram,
+	This slot is called when an item must be added to the current diagram,
 	this slot use the DVEventInterface to add item
 	@param action : Action that describe the item to add.
 */
@@ -1809,7 +1809,7 @@ void QETDiagramEditor::addProjectView(ProjectView *project_view)
 	sub_window -> setWindowIcon(project_view -> windowIcon());
 	sub_window -> systemMenu() -> clear();
 
-	//By defaut QMdiSubWindow have a QAction "close" with shortcut QKeySequence::Close
+	//By default QMdiSubWindow have a QAction "close" with shortcut QKeySequence::Close
 	//But the QAction m_close_file of this class have the same shortcut too.
 	//We remove the shortcut of the QAction of QMdiSubWindow for avoid conflic
 	for(QAction *act : sub_window->actions())
@@ -2062,7 +2062,7 @@ void QETDiagramEditor::projectWasClosed(ProjectView *project_view)
 		undo_group.removeStack(project -> undoStack());
 		QETApp::unregisterProject(project);
 	}
-	//When project is closed, a lot of signal are emited, notably if there is an item selected in a diagram.
+	//When project is closed, a lot of signal are emitted, notably if there is an item selected in a diagram.
 	//In some special case, since signal/slot connection can be direct or queued, some signal are handled after QObject is deleted, and crash qet
 	//notably in the function Diagram::elements when she call items() (I don't know exactly why).
 	//set nullptr to "m_selection_properties_editor->setDiagram()" fix this crash

--- a/sources/qetdiagrameditor.h
+++ b/sources/qetdiagrameditor.h
@@ -187,12 +187,12 @@ class QETDiagramEditor : public QETMainWindow
 		*m_project_edit_properties,	///< Edit the properties of the current project.
 		*m_project_add_diagram,		///< Add a diagram to the current project.
 		*m_remove_diagram_from_project,	///< Delete a diagram from the current project
-		*m_clean_project,		///< Clean the content of the curent project by removing useless items
+		*m_clean_project,		///< Clean the content of the current project by removing useless items
 		*m_project_folio_list,		///< Sommaire des schemas
 		*m_csv_export,			///< generate nomenclature
 		*m_add_nomenclature,		///< Add nomenclature graphics item;
 		*m_add_summary,			///<Add summary graphics item
-		*m_terminal_strip_dialog = nullptr, ///<Lauch terminal strip dialog
+		*m_terminal_strip_dialog = nullptr, ///<Launch terminal strip dialog
 		*m_project_terminalBloc,	///< generate terminal block
 		*m_project_export_conductor_num,///<Export the wire num to csv
 		*m_export_project_db,		///Export to file the internal database of the current project

--- a/sources/qeticons.h
+++ b/sources/qeticons.h
@@ -19,7 +19,7 @@
 #define QET_ICONS_H
 #include <QIcon>
 /**
-	This namespace is meant to delare icons used within the QElectroTech
+	This namespace is meant to declare icons used within the QElectroTech
 	application.
 */
 namespace QET {

--- a/sources/qetinformation.cpp
+++ b/sources/qetinformation.cpp
@@ -177,7 +177,7 @@ QString QETInformation::elementInfoToVar(const QString &info)
  * @brief QETInformation::infoToVar
  * @param info
  * @return return the string @info prepended by %{ ans appended by }
- * exemple : if info is label, the returned string is %{label}
+ * example : if info is label, the returned string is %{label}
  */
 QString QETInformation::infoToVar(const QString &info)
 {

--- a/sources/qetinformation.h
+++ b/sources/qetinformation.h
@@ -25,10 +25,10 @@
  * Inside this namespace you will fin all information used in QElectrotech for
  * element, conductor and diagram.
  * Each information have 3 values :
- * #1 the info key = the key of an information as a QString used in the code (exemple : label)
+ * #1 the info key = the key of an information as a QString used in the code (example : label)
  * #2 the info key to variable = the key in form of a variable.
- * This is used by the user to replace a variable by the string of this variable (exemple : %{label})
- * #3 the info key translated to the current local (exemple label in dutch = Betriebsmittelkennzeichen)
+ * This is used by the user to replace a variable by the string of this variable (example : %{label})
+ * #3 the info key translated to the current local (example label in dutch = Betriebsmittelkennzeichen)
  */
 namespace QETInformation
 {

--- a/sources/qetproject.cpp
+++ b/sources/qetproject.cpp
@@ -629,7 +629,7 @@ QHash <QString, NumerotationContext> QETProject::folioAutoNum() const
 /**
 	@brief QETProject::addConductorAutoNum
 	Add a new conductor numerotation context. If key already exist,
-	replace old context by the new context
+	replace old context with the new context
 	@param key
 	@param context
 */
@@ -640,7 +640,7 @@ void QETProject::addConductorAutoNum(const QString& key, const NumerotationConte
 /**
 	@brief QETProject::addElementAutoNum
 	Add a new element numerotation context. If key already exist,
-	replace old context by the new context
+	replace old context with the new context
 	@param key
 	@param context
 */
@@ -653,7 +653,7 @@ void QETProject::addElementAutoNum(const QString& key, const NumerotationContext
 /**
 	@brief QETProject::addFolioAutoNum
 	Add a new folio numerotation context. If key already exist,
-	replace old context by the new context
+	replace old context with the new context
 	@param key
 	@param context
 */
@@ -1045,7 +1045,7 @@ bool QETProject::isEmpty() const
 /**
 	@brief QETProject::importElement
 	Import the element represented by location
-	to the embbeded collection of this project
+	to the embedded collection of this project
 	@param location
 	@return the location of the imported element, location can be null.
 */
@@ -1082,7 +1082,7 @@ ElementsLocation QETProject::importElement(ElementsLocation &location)
 		if (ied.exec() == QDialog::Accepted) {
 			QET::Action action = ied.action();
 
-			//Use the exisitng element
+			//Use the exisiting element
 			if (action == QET::Ignore) {
 				return existing_location;
 			}
@@ -1211,7 +1211,7 @@ QList<ElementsLocation> QETProject::unusedElements() const
 	within this project, false otherwise
 */
 bool QETProject::usesTitleBlockTemplate(const TitleBlockTemplateLocation &location) {
-	// a diagram can only use a title block template embedded wihtin its parent project
+	// a diagram can only use a title block template embedded within its parent project
 	if (location.parentProject() != this) return(false);
 
 	foreach (Diagram *diagram, diagrams()) {
@@ -1641,7 +1641,7 @@ void QETProject::writeProjectPropertiesXml(QDomElement &xml_element) {
 	default conductor
 	defaut folio report
 	default Xref
-	@param xml_element : xml element to use for store default propertie.
+	@param xml_element : xml element to use to store default properties.
 */
 void QETProject::writeDefaultPropertiesXml(QDomElement &xml_element)
 {
@@ -1720,7 +1720,7 @@ void QETProject::writeDefaultPropertiesXml(QDomElement &xml_element)
 	@brief QETProject::addDiagram
 	Add a diagram in this project
 	@param diagram added diagram
-	@param pos postion of the new diagram, by default at the end
+	@param pos position of the new diagram, by default at the end
 */
 void QETProject::addDiagram(Diagram *diagram, int pos)
 {

--- a/sources/qetxml.cpp
+++ b/sources/qetxml.cpp
@@ -165,7 +165,7 @@ QBrush QETXML::brushFromXml(const QDomElement &element)
 	@brief QETXML::fileSystemDirToXmlCollectionDir
 	@param document : owner document of returned QDomElement,
 	use to create the QDomElement.
-	@param dir : file system direcory to convert to QDomElement directory
+	@param dir : file system directory to convert to QDomElement directory
 	@param rename : by default the attribute "name" of the returned
 	QDomElement is the same name of @dir
 	but we can override itwith rename
@@ -656,7 +656,7 @@ QDomElement createXmlProperty(const QString& name, const char* value) {
 
 /*!
  * \brief propertyInteger
- * Reads an interger from the XML element.
+ * Reads an integer from the XML element.
  * \param e DomElement which contains the property attribute
  * \param attribute_name Name of the attribute
  * \param entier Return value if success
@@ -710,7 +710,7 @@ QDomElement createXmlProperty(const QString& name, const QColor value) {
 
 /*!
  * \brief PropertiesInterface::propertyInteger
- * Reads an interger from the XML element.
+ * Reads an integer from the XML element.
  * \param e DomElement which contains the property attribute
  * \param attribute_name Name of the attribute
  * \param entier Return value if success

--- a/sources/qtextorientationwidget.cpp
+++ b/sources/qtextorientationwidget.cpp
@@ -36,7 +36,7 @@ QTextOrientationWidget::QTextOrientationWidget(QWidget *parent) :
 {
 	// chaines par defaut
 	text_size_hash_.insert(tr("Ex.",     "Short example string"),  -1);
-	text_size_hash_.insert(tr("Exemple", "Longer example string"), -1);
+	text_size_hash_.insert(tr("Example", "Longer example string"), -1);
 
 	// definit la politique de gestion de la taille de ce widget :
 	// on prefere la sizeHint()


### PR DESCRIPTION
Found via `codespell`