### PR TITLE
Fix various typos in source documentation and comments (cont.)

### DIFF
--- a/sources/ElementsCollection/elementcollectionhandler.cpp
+++ b/sources/ElementsCollection/elementcollectionhandler.cpp
@@ -257,7 +257,7 @@ ElementsLocation ECHSXmlToFile::copyElement(ElementsLocation &source, ElementsLo
 	
 	QString new_element_name = rename.isEmpty() ? source.fileName() : rename;
 	
-	//Get the xml descrption of the element
+	//Get the xml description of the element
 	QDomDocument document;
 	document.appendChild(document.importNode(source.xml(), true));
 	
@@ -336,22 +336,22 @@ ElementsLocation ElementCollectionHandler::copy(ElementsLocation &source, Elemen
 
 /**
 	@brief ElementCollectionHandler::createDir
-	Create a directorie with name as child of parent.
+	Create a directory with name as child of parent.
 	Parent must be a directory
 	@param parent : parent of the dir to create
-	@param name : name of directorie to create
-	@param name_list : translations of the directorie name
-	@return : ElementsLocation that represent the new directorie, location can be null if an error was occurred
+	@param name : name of directory to create
+	@param name_list : translations of the directory name
+	@return : ElementsLocation that represent the new directory, location can be null if an error was occurred
 */
 ElementsLocation ElementCollectionHandler::createDir(ElementsLocation &parent, const QString &name, const NamesList &name_list)
 {
-	//Parent must be a directorie and writable
+	//Parent must be a directory and writable
 	if (!(parent.isDirectory() && parent.isWritable() && parent.exist())) {
 		qDebug() << "ElementCollectionHandler::createDir : the prerequisites are not valid. " << parent;
 		return ElementsLocation();
 	}
 	
-	//Directorie to create must not already exist
+	//Directory to create must not already exist
 	ElementsLocation created_dir = parent;
 	created_dir.addToPath(name);
 	if (created_dir.exist()) {

--- a/sources/ElementsCollection/elementscollectionmodel.cpp
+++ b/sources/ElementsCollection/elementscollectionmodel.cpp
@@ -128,7 +128,7 @@ bool ElementsCollectionModel::canDropMimeData(const QMimeData *data,
 	if (!qsi)
 		qsi = itemFromIndex(parent);
 
-		//Drop in the common collection is forbiden
+		//Drop in the common collection is forbidden
 	if (qsi->type() == FileElementCollectionItem::Type)
 		if (static_cast<FileElementCollectionItem *>(qsi)->isCommonCollection())
 			return false;
@@ -193,7 +193,7 @@ bool ElementsCollectionModel::dropMimeData(const QMimeData *data,
 		if (location.exist())
 		{
 				//If feci have a child with the same path of location,
-				//we remove the existing child befor insert new child
+				//we remove the existing child before insert new child
 			for (int i=0 ; i<feci->rowCount() ; i++) {
 				if (static_cast<FileElementCollectionItem *>(
 							feci->child(i))->collectionPath()

--- a/sources/ElementsCollection/elementscollectionwidget.cpp
+++ b/sources/ElementsCollection/elementscollectionwidget.cpp
@@ -585,7 +585,7 @@ void ElementsCollectionWidget::resetShowThisDir()
 
 /**
 	@brief ElementsCollectionWidget::dirProperties
-	Open an informative dialog about the curent index
+	Open an informative dialog about the current index
 */
 void ElementsCollectionWidget::dirProperties()
 {

--- a/sources/ElementsCollection/elementslocation.cpp
+++ b/sources/ElementsCollection/elementslocation.cpp
@@ -140,7 +140,7 @@ bool ElementsLocation::operator!=(const ElementsLocation &other) const
 	@return The base name of the element or directory.
 	Unlike ElementsLocation::fileName,
 	this method don't return the extension name.
-	For exemple if this location represent an element they return myElement.
+	For example if this location represent an element they return myElement.
 	@see fileName()
 */
 QString ElementsLocation::baseName() const

--- a/sources/ElementsCollection/xmlelementcollection.cpp
+++ b/sources/ElementsCollection/xmlelementcollection.cpp
@@ -160,7 +160,7 @@ QDomElement XmlElementCollection::root() const
 
 /**
 	@brief XmlElementCollection::importCategory
-	@return The QDomElement import (the begining of a xml collection) or
+	@return The QDomElement import (the beginning of an xml collection) or
 	a null QDomElement if doesn't exist.
 */
 QDomElement XmlElementCollection::importCategory() const
@@ -511,7 +511,7 @@ QString XmlElementCollection::addElement(ElementsLocation &location)
 
 /**
 	@brief XmlElementCollection::addElementDefinition
-	Add the élément defintion xml_definition
+	Add the element definition xml_definition
 	in the directory at path dir_path with the name elmt_name.
 	@param dir_path :
 	the path of the directory where we must add the element.
@@ -624,13 +624,13 @@ bool XmlElementCollection::exist(const QString &path) const
 
 /**
 	@brief XmlElementCollection::createDir
-	Create a child directorie at path path with the name name.
+	Create a child directory at path path with the name name.
 	Emit directorieAdded if success.
 	@param path : path of parent diectorie
 	@param name : name of the directori to create.
-	@param name_list : translation of the directorie name.
+	@param name_list : translation of the directory name.
 	@return true if creation success,
-	if directorie already exist return true.
+	if directory already exists, return true.
 */
 bool XmlElementCollection::createDir(const QString& path,
 				     const QString& name,
@@ -644,7 +644,7 @@ bool XmlElementCollection::createDir(const QString& path,
 
 	QDomElement parent_dir = directory(path);
 	if (parent_dir.isNull()) {
-		qDebug() << "XmlElementCollection::createDir : directorie at path doesn't exist";
+		qDebug() << "XmlElementCollection::createDir : directory at path doesn't exist";
 		return false;
 	}
 
@@ -663,7 +663,7 @@ bool XmlElementCollection::createDir(const QString& path,
 	@brief XmlElementCollection::removeDir
 	Remove the directory at path path.
 	@param path
-	@return true if successfuly removed and emit directoryRemoved(QString),
+	@return true if successfully removed and emit directoryRemoved(QString),
 	else false.
 */
 bool XmlElementCollection::removeDir(const QString& path)
@@ -682,7 +682,7 @@ bool XmlElementCollection::removeDir(const QString& path)
 	Return all locations stored in dom_element (element and directory).
 	If dom_element is null, return all location owned by this collection
 	dom_element must be a child of this collection.
-	@param dom_element : dom_element where we must to search location.
+	@param dom_element : dom_element where we must search location.
 	@param childs = if true return all childs location of dom_element,
 	if false, only return the direct childs location of dom_element.
 	@return
@@ -867,7 +867,7 @@ ElementsLocation XmlElementCollection::copyDirectory(
 		QDomNode other_collection_node = source.projectCollection()->child(source.collectionPath(false)).cloneNode(deep_copy);
 
 		//We don't make a deep copy,
-		// but we must to get the local names of the copied directory
+		// but we must get the local names of the copied directory
 		if (!deep_copy) {
 			QDomNode names = source.projectCollection()->child(source.collectionPath(false)).namedItem("names");
 			if (!names.isNull() && names.isElement())

--- a/sources/ElementsCollection/xmlelementcollection.h
+++ b/sources/ElementsCollection/xmlelementcollection.h
@@ -90,31 +90,31 @@ class XmlElementCollection : public QObject
 	signals:
 		/**
 			@brief elementAdded
-			This signal is emited when a element is added to this collection
+			This signal is emitted when a element is added to this collection
 			@param collection_path : the path of element in this collection
 		*/
 		void elementAdded(QString collection_path);
 		/**
 			@brief elementChanged
-			This signal is emited when the defintion of the element at path was changed
+			This signal is emitted when the definition of the element at path was changed
 			@param collection_path : the path of this element in this collection
 		*/
 		void elementChanged (QString collection_path);
 		/**
 			@brief elementRemoved
-			This signal is emited when an element is removed to this collection
+			This signal is emitted when an element is removed from this collection
 			@param collection_path : the path of the removed element in this collection
 		*/
 		void elementRemoved(QString collection_path);
 		/**
 			@brief directorieAdded
-			This signal is emited when a directorie is added to this collection
-			@param collection_path : the path of the new directorie
+			This signal is emitted when a directory is added to this collection
+			@param collection_path : the path of the new directory
 		*/
 		void directorieAdded(QString collection_path);
 		/**
 			@brief directoryRemoved
-			This signal is emited when a directory is removed to this collection
+			This signal is emitted when a directory is removed from this collection
 			@param collection_path : the path of the removed directory
 		*/
 		void directoryRemoved(QString collection_path);

--- a/sources/NameList/nameslist.cpp
+++ b/sources/NameList/nameslist.cpp
@@ -137,8 +137,8 @@ void NamesList::fromXml(const QDomElement &xml_element, const QHash<QString, QSt
 	@brief NamesList::fromXml
 	Load the list of lang <-> name from an xml description.
 	xml_element must be the parent of a child element tagged "names"
-	If a couple lang <-> name already exist, they will overwrited, else
-	they will be appened.
+	If a couple lang <-> name already exist, they will overwritten, else
+	they will be appended.
 	@param xml_element : xml element to analyze
 	@param xml_options : A set of options related to XML parsing.
 	@see getXmlOptions()

--- a/sources/NameList/ui/namelistwidget.cpp
+++ b/sources/NameList/ui/namelistwidget.cpp
@@ -146,7 +146,7 @@ void NameListWidget::setClipboardValue(QHash<QString, QString> value)
 
 /**
 	@brief NameListWidget::clean
-	Clean the lists of names by removing the emtpy lines
+	Clean the lists of names by removing the empty lines
 */
 void NameListWidget::clean()
 {

--- a/sources/PropertiesEditor/propertieseditordialog.h
+++ b/sources/PropertiesEditor/propertieseditordialog.h
@@ -29,7 +29,7 @@
 	Only create a instance of this class and call exec,
 	all is done for you in this class.
 	The first argument (a template) must be a subclass
-	of QWidget and provide the 3 methods bellow :
+	of QWidget and provide the 3 methods below :
 	QString::title()
 	void::apply()
 	void::reset()

--- a/sources/PropertiesEditor/propertieseditorwidget.cpp
+++ b/sources/PropertiesEditor/propertieseditorwidget.cpp
@@ -51,13 +51,13 @@ QString PropertiesEditorWidget::title() const
 	Set the editor in live edit mode.
 	When an editor is in live edit mode,
 	every change is applied immediately (no need to call apply).
-	If live edit can be enable, return true, else false.
-	By default this method do nothing and return false
-	(live edit is disable).
-	Herited class of PropertiesEditorWidget must reimplemente
-	this methode to manage the live edit mode.
+	If live edit can be enabled, return true, or else false.
+	By default this method does nothing and returns false
+	(live edit is disabled).
+	Inherited class of PropertiesEditorWidget must reimplement
+	this method to manage the live edit mode.
 	@param live_edit true to enable live edit
-	@return true if live edit is enable, else false.
+	@return true if live edit is enabled, else false.
 */
 bool PropertiesEditorWidget::setLiveEdit(bool live_edit) {
 	Q_UNUSED(live_edit);
@@ -67,7 +67,7 @@ bool PropertiesEditorWidget::setLiveEdit(bool live_edit) {
 /**
 	@brief PropertiesEditorWidget::isLiveEdit
 	@return true if this editor is in live edit mode
-	else return fasle.
+	else return false.
 */
 bool PropertiesEditorWidget::isLiveEdit() const
 {

--- a/sources/PropertiesEditor/propertieseditorwidget.h
+++ b/sources/PropertiesEditor/propertieseditorwidget.h
@@ -24,8 +24,8 @@ class QUndoCommand;
 
 /**
 	@brief The PropertiesEditorWidget class
-	This class extend QWidget method for have common way
-	to edit propertie.
+	This class extend QWidget method to have a common way
+	to edit properties.
 */
 class PropertiesEditorWidget : public QWidget
 {

--- a/sources/QWidgetAnimation/qwidgetanimation.h
+++ b/sources/QWidgetAnimation/qwidgetanimation.h
@@ -1,4 +1,4 @@
-﻿/*
+/*
 	Copyright 2006-2021 The QElectroTech Team
 	This file is part of QElectroTech.
 
@@ -28,19 +28,19 @@
 
 	The role of behavior is to calcul as best the animation process
 	when widget is show.
-	Because this class don't change the current and final size
-	of the widget but her maximum size during the animation process,
-	we must to know in advance the final size of the widget.
+	Because this class doesn't change the current and final size
+	of the widget but its maximum size during the animation process,
+	we need to know in advance the final size of the widget.
 	Behavior minimumSizeHint : the final size of the widget
-	will be his minimum size hint.
+	will be its minimum size hint.
 	Behavior availableSpace : the final size of widget will be
-	the available size of her parent.
+	the available size of its parent.
 	Since parent can have other widgets you can add a QVector of widget
-	to subtract of the final size.
+	to subtract from the final size.
 	Because we suppose the animated widget will take the maximum
 	available space, we subtract the minimum size hint of widgets in QVector.
 	Behavior lastSize :
-	The widget will have the same size as the last time he was showed.
+	The widget will have the same size as the last time it was displayed.
 */
 class QWidgetAnimation : public QPropertyAnimation
 {

--- a/sources/QetGraphicsItemModeler/qetgraphicshandlerutility.cpp
+++ b/sources/QetGraphicsItemModeler/qetgraphicshandlerutility.cpp
@@ -93,7 +93,7 @@ QVector<QPointF> QetGraphicsHandlerUtility::pointsForArc(const QRectF &rect,
 	@brief QetGraphicsHandlerUtility::rectForPosAtIndex
 	Return a rectangle after modification
 	of the point 'pos' at index 'index' of original rectangle 'old_rect'.
-	@param old_rect - the rectangle befor modification
+	@param old_rect - the rectangle before modification
 	@param pos - the new position of a key point
 	@param index - the index of the key point to modifie
 	@see QetGraphicsHandlerUtility::pointsForRect to know
@@ -126,7 +126,7 @@ QRectF QetGraphicsHandlerUtility::rectForPosAtIndex(const QRectF &old_rect,
 	Return a rectangle after modification of the point 'pos'
 	at index 'index' of original rectangle 'old_rect'.
 	the opposite edge is modified inversely (like a mirror)
-	@param old_rect : the rectangle befor modification
+	@param old_rect : the rectangle before modification
 	@param pos : the new position of a key point
 	@param index : the index of the key point to modifie
 	@see QetGraphicsHandlerUtility::pointsForRect to know

--- a/sources/QetGraphicsItemModeler/qetgraphicshandlerutility.h
+++ b/sources/QetGraphicsItemModeler/qetgraphicshandlerutility.h
@@ -28,7 +28,7 @@ class QPainter;
 	@brief The QetGraphicsHandlerUtility class
 	This class provide some methods to create and use handler for
 	modify graphics shape like line rectangle etc...
-	They also provide some conveniance static method.
+	They also provide some convenience static method.
 */
 class QetGraphicsHandlerUtility
 {

--- a/sources/SearchAndReplace/searchandreplaceworker.cpp
+++ b/sources/SearchAndReplace/searchandreplaceworker.cpp
@@ -35,7 +35,7 @@ SearchAndReplaceWorker::SearchAndReplaceWorker()
 /**
 	@brief SearchAndReplaceWorker::replaceDiagram
 	Replace all properties of each diagram in diagram_list,
-	by the current titleblock propertie of this worker
+	by the current titleblock properties of this worker
 	@param diagram_list : list of diagram to be changed,
 	all diagrams must belong to the same project;
 */

--- a/sources/SearchAndReplace/ui/searchandreplacewidget.cpp
+++ b/sources/SearchAndReplace/ui/searchandreplacewidget.cpp
@@ -447,7 +447,7 @@ void SearchAndReplaceWidget::search()
 				    : QColor("#FFE0EF"));
 		ui->m_search_le->setPalette(background);
 
-			//Go to the first occurence
+			//Go to the first occurrence
 		ui->m_tree_widget->setCurrentItem(m_root_qtwi);
 		on_m_next_pb_clicked();
 	}

--- a/sources/TerminalStrip/UndoCommand/bridgeterminalscommand.h
+++ b/sources/TerminalStrip/UndoCommand/bridgeterminalscommand.h
@@ -27,7 +27,7 @@
 
 /**
  * @brief The BridgeTerminalsCommand class
- * UndoCommand use to create bridge betwen terminals
+ * UndoCommand use to create bridge between terminals
  * of a terminals strip
  */
 class BridgeTerminalsCommand : public QUndoCommand
@@ -48,7 +48,7 @@ class BridgeTerminalsCommand : public QUndoCommand
 
 /**
  * @brief The UnBridgeTerminalsCommand class
- * UndoCommand use to remove bridge betwen terminals
+ * UndoCommand use to remove bridge between terminals
  * of a terminals strip
  */
 class UnBridgeTerminalsCommand : public QUndoCommand

--- a/sources/TerminalStrip/physicalterminal.cpp
+++ b/sources/TerminalStrip/physicalterminal.cpp
@@ -108,7 +108,7 @@ void PhysicalTerminal::addTerminal(const QSharedPointer<RealTerminal> &terminal)
  * @brief removeTerminal
  * Remove @a terminal from the list of real terminal
  * @param terminal
- * @return true if sucessfully removed
+ * @return true if successfully removed
  */
 bool PhysicalTerminal::removeTerminal(const QSharedPointer<RealTerminal> &terminal)
 {

--- a/sources/TerminalStrip/realterminal.cpp
+++ b/sources/TerminalStrip/realterminal.cpp
@@ -143,8 +143,8 @@ QString RealTerminal::label() const {
 
 /**
  * @brief RealTerminal::Xref
- * @return Conveniant method to get the XRef
- * formated to string
+ * @return Convenient method to get the XRef
+ * formatted to string
  */
 QString RealTerminal::Xref() const
 {

--- a/sources/TerminalStrip/realterminal.h
+++ b/sources/TerminalStrip/realterminal.h
@@ -31,7 +31,7 @@ class TerminalStripBridge;
 /**
  * @brief The RealTerminal class
  * Represent a real terminal.
- * A real terminal can be a drawed terminal in a folio
+ * A real terminal can be a drawn terminal in a folio
  * or a terminal set by user but not present
  * on any folio (for example a reserved terminal).
  *

--- a/sources/TerminalStrip/terminalstrip.cpp
+++ b/sources/TerminalStrip/terminalstrip.cpp
@@ -477,7 +477,7 @@ QVector<QSharedPointer<RealTerminal>> TerminalStrip::realTerminals() const
  * @brief TerminalStrip::setSortedTo
  * Sort the physical terminal owned by this strip in the same order
  * as \p sorted_vector.
- * \p sorted_vector must contain exaclty the same physical terminal as this strip
+ * \p sorted_vector must contain exactly the same physical terminal as this strip
  * else this function do nothing.
  *
  * To avoid any mistake, you should call TerminalStrip::physicalTerminal()
@@ -715,7 +715,7 @@ bool TerminalStrip::isBridgeable(QSharedPointer<TerminalStripBridge> bridge, con
 
 /**
  * @brief TerminalStrip::setBridge
- * Set a bridge betwen all real terminal of @a real_terminals
+ * Set a bridge between all real terminal of @a real_terminals
  * @sa TerminalStrip::isBridgeable
  * @return true if bridge was successfully created
  */
@@ -975,7 +975,7 @@ QDomElement TerminalStrip::toXml(QDomDocument &parent_document)
 
 	root_elmt.appendChild(m_data.toXml(parent_document));
 
-		//Undrawed terminals
+		//Undrawn terminals
 	auto xml_layout = parent_document.createElement("layout");
 	for (auto &phy_t : m_physical_terminals) {
 		xml_layout.appendChild(phy_t->toXml(parent_document));

--- a/sources/TerminalStrip/ui/terminalstripcreatordialog.cpp
+++ b/sources/TerminalStrip/ui/terminalstripcreatordialog.cpp
@@ -91,7 +91,7 @@ TerminalStrip *TerminalStripCreatorDialog::generatedTerminalStrip() const
 /**
  * @brief TerminalStripCreatorDialog::setCursorToEmptyLine
  * Set the cursor to the first empty field.
- * It's usefull when user create a new terminal strip
+ * It's useful when user creates a new terminal strip
  * with some value prefilled, to increase productivity.
  */
 void TerminalStripCreatorDialog::setCursorToEmptyLine()

--- a/sources/autoNum/numerotationcontext.cpp
+++ b/sources/autoNum/numerotationcontext.cpp
@@ -102,7 +102,7 @@ int NumerotationContext::size() const
 
 /**
 	@brief NumerotationContext::isEmpty
-	@return true if numerotation contet is empty
+	@return true if numerotation content is empty
 */
 bool NumerotationContext::isEmpty() const
 {
@@ -148,7 +148,7 @@ bool NumerotationContext::keyIsAcceptable(const QString &type) const
 
 /**
 	@brief NumerotationContext::keyIsNumber
-	@return true if type represent a number
+	@return true if type represents a number
 */
 bool NumerotationContext::keyIsNumber(const QString &type) const
 {

--- a/sources/autoNum/ui/selectautonumw.cpp
+++ b/sources/autoNum/ui/selectautonumw.cpp
@@ -198,7 +198,7 @@ void SelectAutonumW::on_buttonBox_clicked(QAbstractButton *button)
 	//transform button to int
 	int answer = ui -> buttonBox -> buttonRole(button);
 	switch (answer) {
-			//Reset the curent context
+			//Reset the current context
 		case QDialogButtonBox::ResetRole:
 			setContext(m_context);
 			break;

--- a/sources/dataBase/projectdatabase.h
+++ b/sources/dataBase/projectdatabase.h
@@ -34,7 +34,7 @@ class sqlite3;
 	This class wrap a sqlite data base where you can find several thing
 	about the content of a project.
  *
-	@note this class is still in developement.
+	@note this class is still in development.
 */
 class projectDataBase : public QObject
 {

--- a/sources/dataBase/ui/elementquerywidget.cpp
+++ b/sources/dataBase/ui/elementquerywidget.cpp
@@ -288,7 +288,7 @@ QString ElementQueryWidget::queryStr() const
 	if (ui->m_edit_sql_query_cb->isChecked()) {
 		return ui->m_sql_query->text();
 	}
-		//Made a string list with the colomns (keys) choosen by the user
+		//Made a string list with the columns (keys) chosen by the user
 	QStringList keys = selectedKeys();
 
 	QString select ="SELECT ";
@@ -405,7 +405,7 @@ void ElementQueryWidget::setGroupBy(QString text, bool set)
 /**
 	@brief ElementQueryWidget::setCount
 	Add the query instruction COUNT.
-	Unlike setGroupBy, you have to write the entire sentance.
+	Unlike setGroupBy, you have to write the entire sentence.
 	ex : text = "COUNT(*) AS designation_qty".
 	the query will contain what you write.
 	@param text : the count instruction
@@ -437,7 +437,7 @@ void ElementQueryWidget::updateQueryLine()
 */
 QStringList ElementQueryWidget::selectedKeys() const
 {
-		//Made a string list with the colomns (keys) choosen by the user
+		//Made a string list with the columns (keys) chosen by the user
 	QStringList keys;
 	int row = 0;
 	while (auto *item = ui->m_choosen_list->item(row))

--- a/sources/dataBase/ui/summaryquerywidget.cpp
+++ b/sources/dataBase/ui/summaryquerywidget.cpp
@@ -59,7 +59,7 @@ QString SummaryQueryWidget::queryStr() const
 		return ui->m_user_query_le->text();
 	}
 
-		//Made a string list with the colomns (keys) choosen by the user
+		//Made a string list with the columns (keys) choosen by the user
 	QStringList keys = selectedKeys();
 
 	QString select ="SELECT ";
@@ -169,7 +169,7 @@ void SummaryQueryWidget::updateQueryLine()
 */
 QStringList SummaryQueryWidget::selectedKeys() const
 {
-		//Made a string list with the colomns (keys) choosen by the user
+		//Made a string list with the columns (keys) choosen by the user
 	QStringList keys;
 	int row = 0;
 	while (auto *item = ui->m_choosen_list->item(row))

--- a/sources/diagramevent/diagrameventaddimage.cpp
+++ b/sources/diagramevent/diagrameventaddimage.cpp
@@ -108,8 +108,8 @@ void DiagramEventAddImage::mouseMoveEvent(QGraphicsSceneMouseEvent *event)
 
 /**
 	@brief DiagramEventAddImage::mouseDoubleClickEvent
-	This method is only use to overwrite double click.
-	When double click, image propertie dialog isn't open.
+	This method is used only to overwrite double click.
+	When double click, image properties dialog isn't open.
 	@param event : event of mouse double click.
 */
 void DiagramEventAddImage::mouseDoubleClickEvent(QGraphicsSceneMouseEvent *event) {
@@ -118,7 +118,7 @@ void DiagramEventAddImage::mouseDoubleClickEvent(QGraphicsSceneMouseEvent *event
 
 /**
 	@brief DiagramEventAddImage::wheelEvent
-	Action when mouse wheel is rotate
+	Action when mouse wheel is rotated
 	@param event: evet of mouse wheel
 */
 void DiagramEventAddImage::wheelEvent(QGraphicsSceneWheelEvent *event)
@@ -148,13 +148,13 @@ bool DiagramEventAddImage::isNull() const
 
 /**
 	@brief DiagramEventAddImage::openDialog
-	Open dialog for select the image to add.
+	Open dialog to select the image to add.
 */
 void DiagramEventAddImage::openDialog()
 {
 	if (m_diagram -> isReadOnly()) return;
 	
-	//Open dialog for select image
+	//Open dialog to select image
 	QString pathPictures = QStandardPaths::writableLocation(QStandardPaths::PicturesLocation);
 	QString fileName = QFileDialog::getOpenFileName(m_diagram->views().isEmpty()? nullptr : m_diagram->views().first(), QObject::tr("Selectionner une image..."), pathPictures, QObject::tr("Image Files (*.png *.jpg  *.jpeg *.bmp *.svg)"));
 	

--- a/sources/diagramevent/diagrameventinterface.cpp
+++ b/sources/diagramevent/diagrameventinterface.cpp
@@ -54,7 +54,7 @@ void DiagramEventInterface::wheelEvent(QGraphicsSceneWheelEvent *event) {
 
 /**
 	@brief DiagramEventInterface::keyPressEvent
-	By default, press escape key abort the curent action
+	By default, press escape key abort the current action
 	@param event
 */
 void DiagramEventInterface::keyPressEvent(QKeyEvent *event)

--- a/sources/diagramevent/diagrameventinterface.h
+++ b/sources/diagramevent/diagrameventinterface.h
@@ -36,7 +36,7 @@ class Diagram;
 	This interface work like this :
 	You need to create an interface and call diagram::setEventInterface(pointer_of_your_interface).
 	When a diagram get an event (mouse or key) if they have an event interface,
-	they send the event (with the status accepted to false) to the interface (for exemple mousePressEvent).
+	they send the event (with the status accepted to false) to the interface (for example mousePressEvent).
 	If the interface do something with this event, you need to set to true the accepted status of the event, then diagram do nothing.
 	When the interface job is done, we need to emit the signal finish(), the diagram use this signal to delete the interface.
 	Be carreful with the destructor, diagram can at any time (even if interface is still running) delete the interface,
@@ -61,7 +61,7 @@ class DiagramEventInterface : public QObject
 		virtual void init();
 
 	signals:
-		void finish(); //Emited when the interface finish is job.
+		void finish(); //Emitted when the interface finishes its job.
 
 	protected:
         QPointer<Diagram> m_diagram;

--- a/sources/dvevent/dveventinterface.cpp
+++ b/sources/dvevent/dveventinterface.cpp
@@ -61,7 +61,7 @@ bool DVEventInterface::wheelEvent(QWheelEvent *event) {
 
 /**
 	@brief DVEventInterface::keyPressEvent
-	By default, press escape key abort the curent action.
+	By default, press escape key abort the current action.
 	isFinish return true, and emit finish
 	@param event
 	@return

--- a/sources/dvevent/dveventinterface.h
+++ b/sources/dvevent/dveventinterface.h
@@ -29,15 +29,15 @@ class Diagram;
 /**
 	@brief The DVEventInterface class
 	This class is the main interface for manage event of a Diagram View.
-	This do nothing, for create new event behavior,
-	we must to create new class from this.
-	Each method return a bool:
-	True if the methode do something else return false.
-	Each method of DVEventInterface return false;
-	isRunning() return true if action is started but not finish.
-	By default return false.
-	isFinish() return true when the action is finish, or not started.
-	By default return true.
+	This does nothing, to create new event behavior,
+	we must create new class from this.
+	Each method returns a bool:
+	True if the method does something, else return false.
+	Each method of DVEventInterface returns false;
+	isRunning() returns true if action is started but not finished.
+	By default: return false.
+	isFinish() returns true when the action is finished, or not started.
+	By default: return true.
 */
 class DVEventInterface : public QObject
 {
@@ -59,7 +59,7 @@ class DVEventInterface : public QObject
 	signals:
 		/**
 			@brief finish
-			emited when the interface finish is work
+			emitted when the interface finishes its job
 		 */
 		void finish();
 

--- a/sources/editor/UndoCommand/openelmtcommand.cpp
+++ b/sources/editor/UndoCommand/openelmtcommand.cpp
@@ -63,7 +63,7 @@ void OpenElmtCommand::redo()
 		m_scene->addItems(m_graphics_item.toVector());
 	}
 
-#pragma message("@TODO uncommante slot_select when fixed, see itemChange function for each primitve")
+#pragma message("@TODO uncommante slot_select when fixed, see itemChange function for each primitive")
 		//Commented because take a lot of time
 		//when a lot of primitive are loaded
 		//need work

--- a/sources/editor/arceditor.cpp
+++ b/sources/editor/arceditor.cpp
@@ -143,7 +143,7 @@ bool ArcEditor::setParts(QList <CustomElementPart *> parts)
 
 /**
 	@brief ArcEditor::currentPart
-	@return the curent edited part, or 0 if there is no edited part
+	@return the current edited part, or 0 if there is no edited part
 */
 CustomElementPart *ArcEditor::currentPart() const
 {

--- a/sources/editor/editorcommands.cpp
+++ b/sources/editor/editorcommands.cpp
@@ -483,8 +483,8 @@ void ScalePartsCommand::adjustText()
 
 /**
  * @brief changeElementDataCommand::changeElementDataCommand
- * Change the properties of the drawed element
- * @param scene : scene to belong the property
+ * Change the properties of the drawn element
+ * @param scene : scene belonging to the property
  * @param old_data : old data
  * @param new_data : new data
  * @param parent : parent undo command

--- a/sources/editor/elementprimitivedecorator.cpp
+++ b/sources/editor/elementprimitivedecorator.cpp
@@ -47,14 +47,14 @@ ElementPrimitiveDecorator::~ElementPrimitiveDecorator()
 }
 
 /**
-	@return the internal bouding rect, i.e. the smallest rectangle containing
+	@return the internal bounding rect, i.e. the smallest rectangle containing
 	the bounding rectangle of every selected item.
 */
 QRectF ElementPrimitiveDecorator::internalBoundingRect() const
 {
 	if (!decorated_items_.count() || !scene()) return(QRectF());
 
-	//if @decorated_items_ contain one item and if this item is a vertical or horizontal partline, apply a specific methode
+	//if @decorated_items_ contains one item and if this item is a vertical or horizontal partline, apply a specific method
 	if ((decorated_items_.count() == 1) && (decorated_items_.first() -> xmlName() == "line")) {
 		QRectF horto = decorated_items_.first() -> sceneGeometricRect();
 		if (!horto.width() || !horto.height()) {
@@ -102,7 +102,7 @@ void ElementPrimitiveDecorator::paint(QPainter *painter,
 	painter -> setPen(pen);
 	painter -> drawRect(modified_bounding_rect_);
 	
-	// uncomment to draw the real bouding rect (=adjusted internal bounding rect)
+	// uncomment to draw the real bounding rect (=adjusted internal bounding rect)
 	// painter -> setBrush(QBrush(QColor(240, 0, 0, 127)));
 	// painter -> drawRect(boundingRect());
 	painter -> restore();
@@ -349,7 +349,7 @@ void ElementPrimitiveDecorator::saveOriginalBoundingRect()
 
 /**
 	Adjust the effective bounding rect. This method should be called after the
-	modified_bouding_rect_ attribute was modified.
+	modified_bounding_rect_ attribute was modified.
 */
 void ElementPrimitiveDecorator::adjustEffectiveBoundingRect()
 {

--- a/sources/editor/elementscene.cpp
+++ b/sources/editor/elementscene.cpp
@@ -332,8 +332,8 @@ void ElementScene::setEventInterface(ESEventInterface *event_interface)
 	if (m_event_interface)
 	{
 		delete m_event_interface;
-		//We must to re-init because previous interface
-		//Reset his own init when deleted
+		//We must re-init because previous interface
+		//Reset its own init when deleted
 		event_interface->init();
 	}
 	m_event_interface = event_interface;
@@ -772,11 +772,11 @@ void ElementScene::slot_select(const ElementContent &content)
 {
 	blockSignals(true);
 
-	/* Befor clear selection,
-	 * we must to remove the handlers items in @content,
+	/* Before clearing selection,
+	 * we must remove the handlers items in @content,
 	 * because if in @content there are a selected item,
 	 * but also its handlers items, When item is deselected,
-	 * the item delete its handlers items,
+	 * the item deletes its handlers items,
 	 * then handlers in content doesn't exist anymore and cause segfault
 	 */
 	QList<QGraphicsItem*> items_list;

--- a/sources/editor/elementscene.h
+++ b/sources/editor/elementscene.h
@@ -35,7 +35,7 @@ class QKeyEvent;
 class CustomElementGraphicPart;
 /**
 	@brief The ElementScene class
-	This class is the canvas allowing the visual edition of an electrial element.
+	This class is the canvas allowing the visual edition of an electrical element.
 	It displays the various primitives composing the drawing of the element,
 	the border due to its fixed size and its hotspot.
 
@@ -70,7 +70,7 @@ class ElementScene : public QGraphicsScene
 	
 		// attributes
 	private:
-		ElementData m_element_data; ///ElementData. Actualy in transition with old data storage
+		ElementData m_element_data; ///ElementData. Actually in transition with old data storage
 		QGIManager m_qgi_manager;
 		QUndoStack m_undo_stack;
 

--- a/sources/editor/esevent/eseventaddarc.cpp
+++ b/sources/editor/esevent/eseventaddarc.cpp
@@ -126,7 +126,7 @@ bool ESEventAddArc::keyPressEvent(QKeyEvent *event) {
 
 /**
 	@brief ESEventAddArc::updateArc
-	Redraw the arc with curent value
+	Redraw the arc with current value
 */
 void ESEventAddArc::updateArc()
 {

--- a/sources/editor/esevent/eseventinterface.cpp
+++ b/sources/editor/esevent/eseventinterface.cpp
@@ -84,7 +84,7 @@ bool ESEventInterface::wheelEvent(QGraphicsSceneWheelEvent *event) {
 
 /**
 	@brief ESEventInterface::keyPressEvent
-	By default, press escape key abort the curent action
+	By default, press escape key abort the current action
 	@param event
 	@return
 */

--- a/sources/editor/graphicspart/customelementgraphicpart.cpp
+++ b/sources/editor/graphicspart/customelementgraphicpart.cpp
@@ -156,7 +156,7 @@ void CustomElementGraphicPart::setAntialiased(const bool b)
 
 /**
 	@brief CustomElementGraphicPart::stylesToXml
-	Write the curent style to xml element.
+	Write the current style to xml element.
 	The style are stored like this:
 	name-of-style:value;name-of-style:value
 	Each style separate by ; and name-style/value are separate by :
@@ -893,7 +893,7 @@ void CustomElementGraphicPart::stylesFromXml(const QDomElement &qde)
 
 /**
 	@brief CustomElementGraphicPart::resetStyles
-	Reset the curent style to default,
+	Reset the current style to default,
 	same style of default constructor
 */
 void CustomElementGraphicPart::resetStyles()

--- a/sources/editor/graphicspart/partline.cpp
+++ b/sources/editor/graphicspart/partline.cpp
@@ -606,7 +606,7 @@ QPainterPath PartLine::path() const
 
 	//debugPaint(painter);
 
-		//Determine if we must to draw extremity
+		//Determine if we must draw extremity
 	qreal reduced_line_length = line_length - (length1 * requiredLengthForEndType(first_end));
 	bool draw_1st_end = first_end && reduced_line_length >= 0;
 
@@ -685,7 +685,7 @@ QPainterPath PartLine::path() const
 			stop_point = four_points2[0];
 		}
 
-			//Adjust the end point accordint to the pen width
+			//Adjust the end point according to the pen width
 		if (pen_width && (second_end == Qet::Simple || second_end == Qet::Circle))
 			stop_point = QLineF(point1, stop_point).pointAt((line_length - (pen_width / 2.0)) / line_length);
 	}

--- a/sources/editor/graphicspart/partpolygon.cpp
+++ b/sources/editor/graphicspart/partpolygon.cpp
@@ -499,7 +499,7 @@ void PartPolygon::removeHandler()
 
 /**
 	@brief PartPolygon::insertPoint
-	Insert a point in this polygone
+	Insert a point in this polygon
 */
 void PartPolygon::insertPoint()
 {

--- a/sources/editor/ui/dynamictextfieldeditor.cpp
+++ b/sources/editor/ui/dynamictextfieldeditor.cpp
@@ -226,7 +226,7 @@ void DynamicTextFieldEditor::fillInfoComboBox()
 	else {
 		strl = QETInformation::elementInfoKeys();
 	}
-		//We use a QMap because the keys of the map are sorted, then no matter the curent local,
+		//We use a QMap because the keys of the map are sorted, then no matter the current local,
 		//the value of the combo box are always alphabetically sorted
 	QMap <QString, QString> info_map;
 	for(const QString& str : strl)

--- a/sources/editor/ui/elementpropertieseditorwidget.cpp
+++ b/sources/editor/ui/elementpropertieseditorwidget.cpp
@@ -76,7 +76,7 @@ ElementPropertiesEditorWidget::~ElementPropertiesEditorWidget()
 
 /**
 	@brief ElementPropertiesEditorWidget::upDateInterface
-	Update the interface with the curent value
+	Update the interface with the current value
 */
 void ElementPropertiesEditorWidget::upDateInterface()
 {

--- a/sources/editor/ui/polygoneditor.cpp
+++ b/sources/editor/ui/polygoneditor.cpp
@@ -117,7 +117,7 @@ bool PolygonEditor::setPart(CustomElementPart *new_part)
 
 /**
 	@brief PolygonEditor::currentPart
-	@return the curent edited part
+	@return the current edited part
 */
 CustomElementPart *PolygonEditor::currentPart() const
 {

--- a/sources/editor/ui/qetelementeditor.cpp
+++ b/sources/editor/ui/qetelementeditor.cpp
@@ -329,7 +329,7 @@ void QETElementEditor::fromLocation(const ElementsLocation &location)
  * @brief QETElementEditor::toLocation
  * Save the edited element into @location
  * @param location
- * @return true if succesfully saved
+ * @return true if successfully saved
  */
 bool QETElementEditor::toLocation(const ElementsLocation &location)
 {
@@ -1259,7 +1259,7 @@ bool QETElementEditor::on_m_save_action_triggered()
  */
 bool QETElementEditor::on_m_save_as_action_triggered()
 {
-	// Check element befor writing
+	// Check element before writing
 	if (checkElement()) {
 		//Ask a location to user
 		ElementsLocation location = ElementDialog::getSaveElementLocation(this);
@@ -1328,7 +1328,7 @@ void QETElementEditor::on_m_open_dxf_action_triggered()
 
 bool QETElementEditor::on_m_save_as_file_action_triggered()
 {
-	// Check element befor writing
+	// Check element before writing
 	if (checkElement()) {
 		//Ask a filename to user, for save the element
 		QString fn = QFileDialog::getSaveFileName(

--- a/sources/factory/elementfactory.cpp
+++ b/sources/factory/elementfactory.cpp
@@ -29,7 +29,7 @@ ElementFactory* ElementFactory::factory_ = nullptr;
 /**
 	@brief ElementFactory::createElement
 	@param location create element at this location
-	@param qgi parent item for this elemnt
+	@param qgi parent item for this element
 	@param state state of the creation
 	@return the element or 0
 */

--- a/sources/factory/elementpicturefactory.cpp
+++ b/sources/factory/elementpicturefactory.cpp
@@ -153,7 +153,7 @@ bool ElementPictureFactory::build(const ElementsLocation &location,
 {
 	QDomElement dom = location.xml();
 
-		//Check if the curent version can read the xml description
+		//Check if the current version can read the xml description
 	if (dom.hasAttribute("version"))
 	{
 		bool conv_ok;
@@ -292,7 +292,7 @@ void ElementPictureFactory::parseLine(const QDomElement &dom, QPainter &painter,
 	qreal line_length(line.length());
 	qreal pen_width = painter.pen().widthF();
 
-		//Check if we must to draw extremity
+		//Check if we must draw extremity
 	bool draw_1st_end, draw_2nd_end;
 	qreal reduced_line_length = line_length - (length1 * PartLine::requiredLengthForEndType(first_end));
 	draw_1st_end = first_end && reduced_line_length >= 0;
@@ -322,7 +322,7 @@ void ElementPictureFactory::parseLine(const QDomElement &dom, QPainter &painter,
 			start_point = four_points1[0];
 		}
 
-			//Adjust the begining according to the width of the pen
+			//Adjust the beginning according to the width of the pen
 		if (pen_width && (first_end == Qet::Simple || first_end == Qet::Circle)) {
 			start_point = QLineF(start_point, point2).pointAt(pen_width / 2.0 / line_length);
 		}
@@ -511,7 +511,7 @@ void ElementPictureFactory::parseText(const QDomElement &dom, QPainter &painter,
 
 	QColor text_color(dom.attribute("color", "#000000"));
 
-		//Instanciate a QTextDocument (like the QGraphicsTextItem class)
+		//Instantiate a QTextDocument (like the QGraphicsTextItem class)
 		//for generate the graphics rendering of the text
 	QTextDocument text_document;
 	text_document.setDefaultFont(font_);

--- a/sources/factory/ui/addtabledialog.h
+++ b/sources/factory/ui/addtabledialog.h
@@ -28,8 +28,8 @@ class AddTableDialog;
 
 /**
 	@brief The AddTableDialog class
-	Provide a dialog used to edit the properties of table befor adding to a diagram.
-	The main difference betwen this dialog and the widget used to edit the properties of table
+	Provide a dialog used to edit the properties of table before adding to a diagram.
+	The main difference between this dialog and the widget used to edit the properties of table
 	is that the dialog have two extra check box.
 	One for adjust the size of the table to diagram
 	Second for add new tables on new folios if the table can't fit into diagram

--- a/sources/print/projectprintwindow.cpp
+++ b/sources/print/projectprintwindow.cpp
@@ -38,7 +38,7 @@
 
 /**
  * @brief ProjectPrintWindow::ProjectPrintWindow
- * Use this static function to properly lauch the print dialog.
+ * Use this static function to properly launch the print dialog.
  * @param project : project to print
  * @param format : native format to print in physical printer, or pdf format to export in pdf
  * @param parent : parent widget
@@ -242,7 +242,7 @@ void ProjectPrintWindow::printDiagram(Diagram *diagram, bool fit_page, QPainter 
 			qgi->setFlag(QGraphicsItem::ItemIsFocusable, false);
 		}
 	}
-		//Disable intercation
+		//Disable interaction
 	for (auto view : diagram->views()) {
 		view->setInteractive(false);
 	}
@@ -636,7 +636,7 @@ void ProjectPrintWindow::savePageSetupForCurrentPrinter()
 
 /**
  * @brief ProjectPrintWindow::saveReloadDiagramParameters
- * Save or restor the parameter of @diagram
+ * Save or restore the parameter of @diagram
  * @param diagram
  * @param options
  * @param save

--- a/sources/print/projectprintwindow.h
+++ b/sources/print/projectprintwindow.h
@@ -36,7 +36,7 @@ class QCheckBox;
 
 /**
  * @brief The ProjectPrintWindow class
- * Windows used to configur and view diagram befor print
+ * Windows used to configure and view diagram before print
  */
 class ProjectPrintWindow : public QMainWindow
 {

--- a/sources/properties/elementdata.cpp
+++ b/sources/properties/elementdata.cpp
@@ -40,7 +40,7 @@ QDomElement ElementData::toXml(QDomDocument &xml_element) const {
  * The tag name of xml_element must be definition
  * and have an attribute "type"
  * @param xml_element : tagName must be 'definition'
- * @return true is successfuly loaded
+ * @return true is successfully loaded
  */
 bool ElementData::fromXml(const QDomElement &xml_element)
 {

--- a/sources/properties/propertiesinterface.h
+++ b/sources/properties/propertiesinterface.h
@@ -36,7 +36,7 @@ class PropertiesInterface
 			@brief toSettings
 			Save properties to setting file.
 			@param settings : is use for prefix a word
-			befor the name of each paramètre
+			before the name of each parameter
 			@param QString
 		*/
 		virtual void toSettings (QSettings &settings,
@@ -45,7 +45,7 @@ class PropertiesInterface
 			@brief fromSettings
 			load properties to setting file.
 			@param settings : is use for prefix a word
-			befor the name of each paramètre
+			before the name of each parameter
 			@param QString
 		*/
 		virtual void fromSettings (const QSettings &settings,

--- a/sources/properties/terminaldata.cpp
+++ b/sources/properties/terminaldata.cpp
@@ -53,9 +53,9 @@ void TerminalData::setParent(QGraphicsObject* parent)
 
 /**
 	@brief TerminalData::toSettings
-	Save properties to setting file.
+	Save properties to settings file.
 
-	QString is use for prefix a word befor the name of each paramètre
+	QString is used to prefix a word before the name of each parameter
 	@param settings UNUSED
 	@param prefix UNUSED
 */
@@ -68,9 +68,9 @@ void TerminalData::toSettings(QSettings &settings, const QString prefix) const
 
 /**
 	@brief TerminalData::fromSettings
-	load properties to setting file.
+	load properties to settings file.
 
-	QString is use for prefix a word befor the name of each paramètre
+	QString is used to prefix a word before the name of each parameter
 	@param settings UNUSED
 	@param prefix UNUSED
 */
@@ -87,7 +87,7 @@ void TerminalData::fromSettings(const QSettings &settings, const QString prefix)
 	to xml_element
 
 	@note This method is only called from the PartTerminal
-	and should never called from the Terminal class
+	and should never be called from the Terminal class
 	@param xml_document
 	@return xml_element : DomElement with
 	the name, number, position and orientation of the terminal
@@ -115,7 +115,7 @@ QDomElement TerminalData::toXml(QDomDocument &xml_document) const
 	load properties to xml element
 
 	@note This method is only called from the PartTerminal
-	and should never called from the Terminal class
+	and should never be called from the Terminal class
 	@param xml_element
 	@return true if succeeded / false if the attribute is not real
 */

--- a/sources/properties/userproperties.cpp
+++ b/sources/properties/userproperties.cpp
@@ -68,7 +68,7 @@ QDomElement UserProperties::toXml(QDomDocument &xml_document) const
  * @brief UserProperties::fromXml
  * @param xml_element
  * @return load user properties from xml
- * Take car befor use this function that the tagName of this class
+ * Take care before using this function that the tagName of this class
  * is the same as the tag of xml_element given in parameter.
  */
 bool UserProperties::fromXml(const QDomElement &xml_element)

--- a/sources/properties/xrefproperties.cpp
+++ b/sources/properties/xrefproperties.cpp
@@ -163,7 +163,7 @@ bool XRefProperties::fromXml(const QDomElement &xml_element) {
 /**
 	@brief XRefProperties::defaultProperties
 	@return the default properties stored in the setting file
-	For the xref, there is 2 propreties.
+	For the xref, there are 2 properties.
 	For coil, stored with the string "coil" in the returned QHash.
 	For protection, stored with the string "protection" in the returned QHash.
 */

--- a/sources/qetgraphicsitem/ViewItem/projectdbmodel.cpp
+++ b/sources/qetgraphicsitem/ViewItem/projectdbmodel.cpp
@@ -177,7 +177,7 @@ QVariant ProjectDBModel::data(const QModelIndex &index, int role) const
 
 /**
 	@brief ProjectDBModel::setQuery
-	Query the internall bd with query.
+	Query the internal bd with query.
 	@param query
 */
 void ProjectDBModel::setQuery(const QString &query)

--- a/sources/qetgraphicsitem/ViewItem/projectdbmodel.h
+++ b/sources/qetgraphicsitem/ViewItem/projectdbmodel.h
@@ -34,7 +34,7 @@ class QETProject;
 	void ProjectDBModel::setQuery(const QString &query).
 	The indentifier method is used by widget editor to retrieve
 	the good widget for edit the query.
-	By defaut identifer return the string 'unknow'.
+	By default identifer returns the string 'unknow'.
 	You should use setIdentfier method to set your custom identifier.
 	At the time this sentence is written, there is two identifier :
 	nomenclature

--- a/sources/qetgraphicsitem/ViewItem/qetgraphicsheaderitem.cpp
+++ b/sources/qetgraphicsitem/ViewItem/qetgraphicsheaderitem.cpp
@@ -39,7 +39,7 @@ QetGraphicsHeaderItem::QetGraphicsHeaderItem(QGraphicsItem *parent) :
 	@brief QetGraphicsHeaderItem::setModel
 	Set the model presented by this item
 	Since QetGraphicsHeaderItem don't take ownership of model,
-	if item already have a model, it's your responsability to delete it.
+	if item already have a model, it's your responsibility to delete it.
 	@param model
 */
 void QetGraphicsHeaderItem::setModel(QAbstractItemModel *model)

--- a/sources/qetgraphicsitem/ViewItem/qetgraphicsheaderitem.h
+++ b/sources/qetgraphicsitem/ViewItem/qetgraphicsheaderitem.h
@@ -32,7 +32,7 @@ class QAbstractItemModel;
 	Margins, to edit the margin between the cell and the text.
 	Text font.
 	Text alignment in the cell
-	These three parameters are not settable directly with the header but trough the model to be displayed by the header.
+	These three parameters are not settable directly with the header but through the model to be displayed by the header.
 	Header search these parameters only in the section 0 for cell of header.
 	By consequence, set data in other section is useless also these parameter can't be set individually for each cell.
 	The margins is stored in the model in index Qt::UserRole+1 and for value a QString. See QETUtils::marginsFromString and  QETUtils::marginsToString

--- a/sources/qetgraphicsitem/ViewItem/qetgraphicstableitem.h
+++ b/sources/qetgraphicsitem/ViewItem/qetgraphicstableitem.h
@@ -34,7 +34,7 @@ class QetGraphicsHeaderItem;
 	Margins, to edit the margin between the cell and the text.
 	Text font.
 	Text alignment in the cell
-	These three parameters are not settable directly with the table but trough the model to be displayed by the table.
+	These three parameters are not settable directly with the table but through the model to be displayed by the table.
 	The table search these parameters only in the index(0,0) for all the table.
 	By consequence, set data in other index than 0,0 is useless also these parameter can't be set individually for each cell.
 	The margins is stored in the model in index Qt::UserRole+1 and for value a QString. See QETUtils::marginsFromString and  QETUtils::marginsToString

--- a/sources/qetgraphicsitem/conductor.cpp
+++ b/sources/qetgraphicsitem/conductor.cpp
@@ -92,13 +92,13 @@ Conductor::Conductor(Terminal *p1, Terminal* p2) :
 	setZValue(11);
 	m_previous_z_value = zValue();
 
-		//Add this conductor to the list of conductor of each of the two terminal
+		//Add this conductor to the list of conductors of each of the two terminals
 	bool ajout_p1 = terminal1 -> addConductor(this);
 	bool ajout_p2 = terminal2 -> addConductor(this);
 		//m_valid become false if the conductor can't be added to terminal (conductor already exist)
 	m_valid = (!ajout_p1 || !ajout_p2) ? false : true;
 
-		//Default attribut for paint a conductor
+		//Default attribute to paint a conductor
 	if (!pen_and_brush_initialized)
 	{
 		conductor_pen.setJoinStyle(Qt::MiterJoin);
@@ -111,7 +111,7 @@ Conductor::Conductor(Terminal *p1, Terminal* p2) :
 		pen_and_brush_initialized = true;
 	}
 
-		//By default, the 4 profils are nuls -> we must to use priv_calculeConductor
+		//By default, the 4 profiles are nuls -> we must use priv_calculeConductor
 	conductor_profiles.insert(Qt::TopLeftCorner,     ConductorProfile());
 	conductor_profiles.insert(Qt::TopRightCorner,    ConductorProfile());
 	conductor_profiles.insert(Qt::BottomLeftCorner,  ConductorProfile());
@@ -135,7 +135,7 @@ Conductor::Conductor(Terminal *p1, Terminal* p2) :
 
 /**
 	@brief Conductor::~Conductor
-	Destructor. The conductor is removed from is terminal
+	Destructor. The conductor is removed from its terminal
 */
 Conductor::~Conductor()
 {
@@ -847,7 +847,7 @@ void Conductor::handlerMouseReleaseEvent(QetGraphicsHandlerItem *qghi, QGraphics
 		saveProfile();
 		has_to_save_profile = false;
 	}
-		//When handler is released, the conductor can have more segment than befor the handler was moved
+		//When handler is released, the conductor can have more segment than before the handler was moved
 		//then we remove all handles and new ones are added
 	removeHandler();
 	addHandler();
@@ -1036,7 +1036,7 @@ QDomElement Conductor::toXml(QDomDocument &dom_document,
 	// Terminal is uniquely identified by the uuid of the terminal and the element
 	if (terminal1->uuid().isNull()) {
 		// legacy method to identify the terminal
-		dom_element.setAttribute("terminal1", table_adr_id.value(terminal1)); // for backward compability
+		dom_element.setAttribute("terminal1", table_adr_id.value(terminal1)); // for backward compatibility
 	} else {
 		dom_element.setAttribute("element1", terminal1->parentElement()->uuid().toString());
 		dom_element.setAttribute("terminal1", terminal1->uuid().toString());
@@ -1044,7 +1044,7 @@ QDomElement Conductor::toXml(QDomDocument &dom_document,
 
 	if (terminal2->uuid().isNull()) {
 		// legacy method to identify the terminal
-		dom_element.setAttribute("terminal2", table_adr_id.value(terminal2)); // for backward compability
+		dom_element.setAttribute("terminal2", table_adr_id.value(terminal2)); // for backward compatibility
 	} else {
 		dom_element.setAttribute("element2", terminal2->parentElement()->uuid().toString());
 		dom_element.setAttribute("terminal2", terminal2->uuid().toString());
@@ -1242,7 +1242,7 @@ QPointF Conductor::posForText(Qt::Orientations &flag)
 	bool all_segment_is_vertical   = true;
 	bool all_segment_is_horizontal = true;
 
-		//Go to first segement
+		//Go to first segment
 	while (!segment->isFirstSegment()) {
 		segment = segment->previousSegment();
 	}
@@ -1265,7 +1265,7 @@ QPointF Conductor::posForText(Qt::Orientations &flag)
 		if (segment -> firstPoint().y() != segment -> secondPoint().y())
 			all_segment_is_horizontal = false;
 
-			//We must to compare length segment, but they can be negative
+			//We must compare length segment, but they can be negative
 			//so we multiply by -1 to make it positive.
 		int saved = biggest_segment -> length();
 		if (saved < 0) saved *= -1;
@@ -1517,7 +1517,7 @@ QPainterPath Conductor::path() const
 	@brief Conductor::setPropertiesToPotential
 	@param property
 	@param only_text
-	Set propertie to conductor and every conductors in
+	Set property to conductor and every conductors in
 	the same potential of conductor.
 	If only_text is true only formula, text,
 	function and tension/protocol is set
@@ -1760,7 +1760,7 @@ void Conductor::setUpConnectionForFormula(QString old_formula, QString new_formu
 	if (diagram())
 	{
 			//Because the variable %F is a reference to another text which can contain variables,
-			//we must to replace %F by the real text, to check if the real text contain the variable %id
+			//we must replace %F by the real text, to check if the real text contains the variable %id
 		if (old_formula.contains("%F"))
 			old_formula.replace("%F", diagram()->border_and_titleblock.folio());
 
@@ -2063,8 +2063,8 @@ Conductor * longuestConductorInPotential(Conductor *conductor, bool all_diagram)
 	@brief relatedConductors
 	@param conductor
 	@return return all conductors who share the same terminals
-	of conductor given as parametre,
-	except conductor himself.
+	of conductor given as parameter,
+	except conductor itself.
 */
 QList <Conductor *> relatedConductors(const Conductor *conductor) {
 	QList<Conductor *> other_conductors_list = conductor -> terminal1 -> conductors();

--- a/sources/qetgraphicsitem/conductor.h
+++ b/sources/qetgraphicsitem/conductor.h
@@ -188,7 +188,7 @@ class Conductor : public QGraphicsObject
 		ConductorTextItem *m_text_item;
 			/// Segments composing the conductor
 		ConductorSegment *segments;
-			/// Attributs related to mouse interaction
+			/// Attributes related to mouse interaction
 		bool m_moving_segment;
 		int moved_point;
 		qreal m_previous_z_value;

--- a/sources/qetgraphicsitem/crossrefitem.cpp
+++ b/sources/qetgraphicsitem/crossrefitem.cpp
@@ -165,7 +165,7 @@ QPainterPath CrossRefItem::shape() const{
 	@param add_prefix
 	@return the string corresponding to the position of elmt in the diagram.
 	if add_prefix is true,
-	prefix (for power and delay contact) is added to the poistion text.
+	prefix (for power and delay contact) is added to the position text.
 */
 QString CrossRefItem::elementPositionText(
 		const Element *elmt, const bool &add_prefix) const
@@ -190,7 +190,7 @@ QString CrossRefItem::elementPositionText(
 
 /**
 	@brief CrossRefItem::updateProperties
-	update the curent properties
+	update the current properties
 */
 void CrossRefItem::updateProperties()
 {
@@ -247,7 +247,7 @@ void CrossRefItem::updateLabel()
 
 /**
 	@brief CrossRefItem::autoPos
-	Calculate and set position automaticaly.
+	Calculate and set position automatically.
 */
 void CrossRefItem::autoPos()
 {
@@ -546,7 +546,7 @@ void CrossRefItem::setUpCrossBoundingRect(QPainter &painter)
 	}
 	//Adjust according to the NC
 	if (nc_bounding.height() > default_bounding.height() - header)
-		default_bounding.setHeight(nc_bounding.height() + header); //adjust the heigth
+		default_bounding.setHeight(nc_bounding.height() + header); //adjust the height
 	if (nc_bounding.width() > default_bounding.width()/2)
 		default_bounding.setWidth(nc_bounding.width()*2);//adjust the width
 
@@ -660,7 +660,7 @@ QRectF CrossRefItem::drawContact(QPainter &painter, int flags, Element *elmt)
 		painter.drawLine(0, offset+6, 8, offset+6);
 		painter.drawLine(16, offset+6, 24, offset+6);
 
-		///take exemple of this code for display the terminal text
+		///take example of this code for display the terminal text
 		/*QFont font = QETApp::diagramTextsFont(4);
 		font.setBold(true);
 		painter.setFont(font);
@@ -986,11 +986,11 @@ void CrossRefItem::AddExtraInfo(QPainter &painter, const QString& type)
 
 /**
 	@brief CrossRefItem::NOElements
-	@return The linked elements of m_element wich are open or switch contact.
+	@return The linked elements of m_element which are open or switch contact.
 	If linked element is a power contact,
-	xref propertie is set to don't show power contact
-	and this cross item must be drawed as cross,
-	the element is not append in the list.
+	xref property is set to not show power contact
+	and this cross item must be drawn as a cross,
+	the element is not appended in the list.
 */
 QList<Element *> CrossRefItem::NOElements() const
 {
@@ -998,8 +998,8 @@ QList<Element *> CrossRefItem::NOElements() const
 
 	foreach (Element *elmt, m_element->linkedElements())
 	{
-		//We continue if element is a power contact and xref propertie
-		//is set to don't show power contact
+		//We continue if element is a power contact and xref property
+		//is set to not show power contact
 		if (m_properties.displayHas() == XRefProperties::Cross &&
 			!m_properties.showPowerContact() &&
 			elmt -> kindInformations()["type"].toString() == "power")
@@ -1018,12 +1018,12 @@ QList<Element *> CrossRefItem::NOElements() const
 
 /**
 	@brief CrossRefItem::NCElements
-	@return The linked elements of m_element wich are close
+	@return The linked elements of m_element which are close
 	or switch contact
 	If linked element is a power contact,
-	xref propertie is set to don't show power contact
-	and this cross item must be drawed as cross,
-	the element is not append in the list.
+	xref property is set to not show power contact
+	and this cross item must be drawn as a cross,
+	the element is not appended in the list.
 */
 QList<Element *> CrossRefItem::NCElements() const
 {
@@ -1031,8 +1031,8 @@ QList<Element *> CrossRefItem::NCElements() const
 
 	foreach (Element *elmt, m_element->linkedElements())
 	{
-		//We continue if element is a power contact and xref propertie
-		//is set to don't show power contact
+		//We continue if element is a power contact and xref property
+		//is set to not show power contact
 		if (m_properties.displayHas() == XRefProperties::Cross &&
 			!m_properties.showPowerContact() &&
 			elmt -> kindInformations()["type"].toString() == "power")

--- a/sources/qetgraphicsitem/crossrefitem.h
+++ b/sources/qetgraphicsitem/crossrefitem.h
@@ -32,11 +32,11 @@ class ElementTextItemGroup;
 	@brief The CrossRefItem class
 	This clas provide an item, for show the cross reference,
 	like the contacts linked to a coil.
-	The item setpos automaticaly when parent move.
+	The item setpos automatically when parent move.
 	All slave displayed in cross ref will be updated
 	when folio position change in the project.
-	It's the responsability of the master element
-	to informe displayed slave are moved,
+	It's the responsibility of the master element
+	to inform displayed slave are moved,
 	by calling the slot updateLabel
 	By default master element is the parent graphics item of this Xref,
 	but if the Xref must be snap to the label of master,

--- a/sources/qetgraphicsitem/diagramimageitem.cpp
+++ b/sources/qetgraphicsitem/diagramimageitem.cpp
@@ -83,7 +83,7 @@ void DiagramImageItem::paint(QPainter *painter, const QStyleOptionGraphicsItem *
 
 /**
 	@brief DiagramImageItem::editProperty
-	Open the approriate dialog to edit this image
+	Open the appropriate dialog to edit this image
 */
 void DiagramImageItem::editProperty()
 {
@@ -129,9 +129,9 @@ QString DiagramImageItem::name() const
 
 /**
 	@brief DiagramImageItem::fromXml
-	Load this image fro xml elemebt e
+	Load this image from xml element e
 	@param e
-	@return true if succesfully load.
+	@return true if successfully loaded.
 */
 bool DiagramImageItem::fromXml(const QDomElement &e)
 {

--- a/sources/qetgraphicsitem/diagramtextitem.cpp
+++ b/sources/qetgraphicsitem/diagramtextitem.cpp
@@ -236,11 +236,11 @@ bool DiagramTextItem::isHtml() const
 
 /**
 	@brief DiagramTextItem::paint
-	Draw this text field. This method draw the text by calling QGraphicsTextItem::paint.
-	If text is hovered, this method draw the bounding rect in grey
+	Draw this text field. This method draws the text by calling QGraphicsTextItem::paint.
+	If text is hovered, this method draws the bounding rect in grey
 	@param painter : painter to use
 	@param option : style option
-	@param widget : widget where must to draw
+	@param widget : widget that is drawn to
 */
 void DiagramTextItem::paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget)
 {
@@ -413,7 +413,7 @@ void DiagramTextItem::prepareAlignment()
 
 /**
 	@brief DiagramTextItem::finishAlignment
-	Call this function after changing the bouding rect of this text
+	Call this function after changing the bounding rect of this text
 	to set the position of this text according to the alignment property.
 */
 void DiagramTextItem::finishAlignment()

--- a/sources/qetgraphicsitem/dynamicelementtextitem.cpp
+++ b/sources/qetgraphicsitem/dynamicelementtextitem.cpp
@@ -475,9 +475,9 @@ void DynamicElementTextItem::setCompositeText(const QString &text)
 	if (m_parent_element && (m_parent_element.data()->linkType() & Element::AllReport)) //special treatment for report
 	{
 			/*
-			 * May be in some case the old and new composite text have both the var %{label},
-			 * and so we don't have to remove connection and after set conection,
-			 * but for that we must to do several check and because I'm lazy,
+			 * May be in some case the old and new composite text both have the var %{label},
+			 * and so we don't have to remove connection and after set connection,
+			 * but for that we must do several checks and because I'm lazy,
 			 * in every case I remove connection and set it after ;)
 			 */
 		if(old_composite_text.contains("%{label}"))
@@ -691,7 +691,7 @@ void DynamicElementTextItem::paint(QPainter *painter, const QStyleOptionGraphics
 
 QVariant DynamicElementTextItem::itemChange(QGraphicsItem::GraphicsItemChange change, const QVariant &value)
 {
-		//The first time this text is added to a scene, we make several cheking and connection
+		//The first time this text is added to a scene, we make several checking and connection
 		//according to the link type of the parent element
 	if(change == QGraphicsItem::ItemSceneHasChanged && m_first_scene_change)
 	{
@@ -785,7 +785,7 @@ void DynamicElementTextItem::elementInfoChanged()
 
 	if (m_text_from == ElementInfo)
 	{
-			//If the info is the label, then we must to make some connection
+			//If the info is the label, then we must make some connection
 			//if the label is created from a formula
 		if(m_info_name == "label")
 		{
@@ -801,7 +801,7 @@ void DynamicElementTextItem::elementInfoChanged()
 	}
 	else if (m_text_from == CompositeText)
 	{
-			//If the composite have the label variable, we must to make some
+			//If the composite have the label variable, we must make some
 			//connection if the label is created from a formula
 		if (m_composite_text.contains("%{label}"))
 			setupFormulaConnection();
@@ -911,7 +911,7 @@ void DynamicElementTextItem::setConnectionForReportFormula(const QString &formul
 	Diagram *other_diagram = m_other_report.data()->diagram();
 	
 		//Because the variable %F is a reference to another text which can contain variables,
-		//we must to replace %F by the real text, to check if the real text contain the variable %id
+		//we must replace %F by the real text, to check if the real text contains the variable %id
 	if (other_diagram && string.contains("%F"))
 	{
 		m_F_str = other_diagram->border_and_titleblock.folio();
@@ -940,7 +940,7 @@ void DynamicElementTextItem::removeConnectionForReportFormula(const QString &for
 	Diagram *other_diagram = m_other_report.data()->diagram();
 	
 		//Because the variable %F is a reference to another text which can contain variables,
-		//we must to replace %F by the real text, to check if the real text contain the variable %id
+		//we must replace %F with the real text, to check if the real text contains the variable %id
 	if (other_diagram && string.contains("%F"))
 	{
 		string.replace("%F", m_F_str);

--- a/sources/qetgraphicsitem/element.cpp
+++ b/sources/qetgraphicsitem/element.cpp
@@ -78,7 +78,7 @@ class ElementXmlRetroCompatibility
 	@brief Element::Element
 	@param location : location of this element
 	@param parent : parent graphics item
-	@param state : state of the instanciation
+	@param state : state of the instantiation
 	@param link_type
 */
 Element::Element(
@@ -238,7 +238,7 @@ void Element::paint(
 		painter->drawPicture(0, 0, m_picture);
 	}
 
-	painter->restore(); //Restor the QPainter after use drawPicture
+	painter->restore(); //Restorr the QPainter after use drawPicture
 
 		//Draw the selection rectangle
 	if ( isSelected() || m_mouse_over ) {
@@ -426,7 +426,7 @@ bool Element::buildFromXml(const QDomElement &xml_def_elmt, int *state)
 		return(false);
 	}
 
-		//Check if the curent version can read the xml description
+		//Check if the current version can read the xml description
 	if (xml_def_elmt.hasAttribute(QStringLiteral("version")))
 	{
 		bool conv_ok;
@@ -627,7 +627,7 @@ bool Element::parseInput(const QDomElement &dom_element)
 
 /**
 	@brief Element::parseDynamicText
-	Create the dynamic text field describ in dom_element
+	Create the dynamic text field described in dom_element
 	@param dom_element
 	@return
 */
@@ -637,7 +637,7 @@ DynamicElementTextItem *Element::parseDynamicText(
 	DynamicElementTextItem *deti = new DynamicElementTextItem(this);
 		//Because the xml description of a .elmt file is the same as how a dynamic text field is save to xml in a .qet file
 		//wa call fromXml, we just change the tagg name (.elmt = dynamic_text, .qet = dynamic_elmt_text)
-		//and the uuid (because the uuid, is the uuid of the descritpion and not the uuid of instantiated dynamic text field)
+		//and the uuid (because the uuid, is the uuid of the description and not the uuid of instantiated dynamic text field)
 
 	QDomElement dom(dom_element.cloneNode(true).toElement());
 	dom.setTagName(DynamicElementTextItem::xmlTagName());
@@ -664,7 +664,7 @@ Terminal *Element::parseTerminal(const QDomElement &dom_element)
 	Terminal *new_terminal = new Terminal(data, this);
 	m_terminals << new_terminal;
 
-		//Sort from top to bottom and left to rigth
+		//Sort from top to bottom and left to right
 	std::sort(m_terminals.begin(),
 		  m_terminals.end(),
 		  [](Terminal *a,
@@ -747,7 +747,7 @@ bool Element::fromXml(QDomElement &e,
 	}
 
 
-		//Check that associated id/adress doesn't conflict with table_id_adr
+		//Check that associated id/address doesn't conflict with table_id_adr
 	for(auto found_id : priv_id_adr.keys())
 	{
 		if (table_id_adr.contains(found_id))
@@ -758,7 +758,7 @@ bool Element::fromXml(QDomElement &e,
 		}
 	}
 
-		//Copie the association id/adress
+		//Copie the association id/address
 	for(auto found_id : priv_id_adr.keys()) {
 		table_id_adr.insert(found_id,
 							priv_id_adr.value(found_id));
@@ -813,7 +813,7 @@ bool Element::fromXml(QDomElement &e,
 	}
 	setRotation(90*read_ori);
 
-		//Befor load the dynamic text field,
+		//Before loading the dynamic text field,
 		//we remove the dynamic text field created from the description of this element, to avoid doublons.
 	for(DynamicElementTextItem *deti : m_dynamic_text_list)
 		delete deti;
@@ -869,7 +869,7 @@ bool Element::fromXml(QDomElement &e,
 		}
 	}
 
-	//We must to block the update of the alignment when load the information
+	//We must block the update of the alignment when loading the information
 	//otherwise the pos of the text will not be the same as it was at save time.
 	for(DynamicElementTextItem *deti : m_dynamic_text_list)
 		deti->m_block_alignment = true;
@@ -1025,7 +1025,7 @@ QDomElement Element::toXml(
 		for(DynamicElementTextItem *deti : deti_list)
 			group->addToGroup(deti);
 
-			//Restor the alignement
+			//Restorr the alignment
 		group->setAlignment(al);
 
 			//Save the group to xml
@@ -1216,7 +1216,7 @@ QList<ElementTextItemGroup *> Element::textGroups() const
 	Add the text text to the group group;
 	If group isn't owned by this element return false.
 	The text must be a text of this element.
-	@return : true if the text was succesfully added to the group.
+	@return : true if the text was successfully added to the group.
 */
 bool Element::addTextToGroup(DynamicElementTextItem *text,
 				 ElementTextItemGroup *group)
@@ -1239,7 +1239,7 @@ bool Element::addTextToGroup(DynamicElementTextItem *text,
 	@brief Element::removeTextFromGroup
 	Remove the text text from the group group,
 	en reparent text to this element
-	@return true if text was succesfully removed
+	@return true if text was successfully removed
 */
 bool Element::removeTextFromGroup(DynamicElementTextItem *text,
 				  ElementTextItemGroup *group)
@@ -1568,7 +1568,7 @@ void Element::freezeNewAddedElement()
 /**
 	@brief Element::actualLabel
 	Always return the current label to be displayed.
-	This function is usefull when label is based on formula, because label can change at any time.
+	This function is useful when label is based on formula, because label can change at any time.
 	@return
 */
 QString Element::actualLabel()

--- a/sources/qetgraphicsitem/element.h
+++ b/sources/qetgraphicsitem/element.h
@@ -79,7 +79,7 @@ class Element : public QetGraphicsItem
 		int type() const override { return Type; }
 
 	signals:
-		void linkedElementChanged(); //This signal is emited when the linked elements with this element change
+		void linkedElementChanged(); //This signal is emitted when the linked elements with this element change
 		void elementInfoChange(
 				DiagramContext old_info,
 				DiagramContext new_info);

--- a/sources/qetgraphicsitem/elementtextitemgroup.cpp
+++ b/sources/qetgraphicsitem/elementtextitemgroup.cpp
@@ -72,7 +72,7 @@ void ElementTextItemGroup::addToGroup(QGraphicsItem *item)
 {
 	if(item->type() == DynamicElementTextItem::Type)
 	{
-		//Befor add text to this group we must to set the text at the same rotation of this group
+		//Before adding text to this group we must set the text at the same rotation of this group
 		if((item->rotation() != rotation()) && !m_block_alignment_update)
 			item->setRotation(rotation());
 		
@@ -111,8 +111,8 @@ void ElementTextItemGroup::addToGroup(QGraphicsItem *item)
 void ElementTextItemGroup::removeFromGroup(QGraphicsItem *item)
 {
 	QGraphicsItemGroup::removeFromGroup(item);
-	//the item transformation is not reseted, we must to do it,
-	// because for exemple if the group rotation is 45°
+	//the item transformation is not reset, we must do it ourselves,
+	// because for example if the group rotation is 45°
 	//When item is removed from group,
 	// visually the item is unchanged (so 45°)
 	// but if we call item->rotation() the returned value is 0.
@@ -257,7 +257,7 @@ void ElementTextItemGroup::updateAlignment()
 		}
 	}
 	
-		//Restor the rotation
+		//Restore the rotation
 	setRotation(rotation_);
 	
 	if(m_Xref_item)
@@ -309,7 +309,7 @@ void ElementTextItemGroup::setHoldToBottomPage(bool hold)
 		{
 			//We use timer to let the time of the parent element
 			// xref to be updated,
-			// befor update the position of this group
+			// before updating the position of this group
 			//because the position of this group is related
 			// to the size of the parent element Xref
 			m_linked_changed_timer = connect(

--- a/sources/qetgraphicsitem/masterelement.cpp
+++ b/sources/qetgraphicsitem/masterelement.cpp
@@ -86,7 +86,7 @@ void MasterElement::unlinkAllElements()
 
 /**
 	@brief MasterElement::unlinkElement
-	Unlink the given elmt in parametre
+	Unlink the given element in parameter
 	@param elmt element to unlink from this
 */
 void MasterElement::unlinkElement(Element *elmt)
@@ -159,7 +159,7 @@ void MasterElement::xrefPropertiesChanged()
 	If Xref item is deleted or already not used (nullptr) return true;
 	Else return false if Xref item is used
 	NOTICE : Xref can display nothing but not be deleted so far.
-	For exemple, if Xref is display has cross, only power contact are linked and
+	For example, if Xref is display has cross, only power contact are linked and
 	option show power contact is disable, the cross isn't draw.
 	@return
 */

--- a/sources/qetgraphicsitem/qetgraphicsitem.h
+++ b/sources/qetgraphicsitem/qetgraphicsitem.h
@@ -33,7 +33,7 @@ class QetGraphicsItem : public QGraphicsObject
 		QetGraphicsItem(QGraphicsItem *parent = nullptr);
 		~QetGraphicsItem() override = 0;
 
-		//public methode
+		//public method
 		Diagram *diagram () const;
 		virtual void setPos (const QPointF &p);
 		virtual void setPos (qreal x, qreal y);

--- a/sources/qetgraphicsitem/qetshapeitem.cpp
+++ b/sources/qetgraphicsitem/qetshapeitem.cpp
@@ -212,7 +212,7 @@ int QetShapeItem::pointsCount() const
 
 /**
 	@brief QetShapeItem::setNextPoint
-	Add a new point to the curent polygon
+	Add a new point to the current polygon
 	@param P the new point.
 */
 void QetShapeItem::setNextPoint(QPointF P)
@@ -994,7 +994,7 @@ void QetShapeItem::editProperty()
 
 /**
 	@brief QetShapeItem::name
-	@return the name of the curent shape.
+	@return the name of the current shape.
 */
 QString QetShapeItem::name() const
 {

--- a/sources/qetgraphicsitem/qgraphicsitemutility.cpp
+++ b/sources/qetgraphicsitem/qgraphicsitemutility.cpp
@@ -65,13 +65,13 @@ bool centerToBottomDiagram (QGraphicsItem *item_to_center, Element *element_to_f
 	point.setY(border.bottom() - item_to_center -> boundingRect().height() - offset );
 	point.rx() -= (item_to_center -> boundingRect().width()/2);
 	
-		//Apply the difference between the pos() of item and his bounding rect
+		//Apply the difference between the pos() of item and its bounding rect
 	QPointF tl = item_to_center->boundingRect().topLeft();
 	point.rx() -= tl.x();
 	point.ry() -= tl.y();
 	
-	item_to_center -> setPos(0,0);	  //Due to a weird behavior or bug, before set the new position and rotation,
-	item_to_center -> setRotation(0); //we must to set the position and rotation at 0.
+	item_to_center -> setPos(0,0);	  //Due to a weird behavior or bug, before setting the new position and rotation,
+	item_to_center -> setRotation(0); //we must set the position and rotation to 0.
 	
 	item_to_center->setPos(item_to_center->mapFromScene(point));
 	

--- a/sources/qetgraphicsitem/slaveelement.cpp
+++ b/sources/qetgraphicsitem/slaveelement.cpp
@@ -84,7 +84,7 @@ void SlaveElement::unlinkAllElements()
 
 /**
 	@brief SlaveElement::unlinkElement
-	Unlink the given elmt in parametre
+	Unlink the given element in parameter
 	@param elmt
 */
 void SlaveElement::unlinkElement(Element *elmt)

--- a/sources/titleblock/qettemplateeditor.cpp
+++ b/sources/titleblock/qettemplateeditor.cpp
@@ -475,7 +475,7 @@ void QETTitleBlockTemplateEditor::initMenus()
 }
 
 /**
-	Initalize toolbars.
+	Initialize toolbars.
 */
 void QETTitleBlockTemplateEditor::initToolbars()
 {

--- a/sources/titleblock/templatelocationsaver.cpp
+++ b/sources/titleblock/templatelocationsaver.cpp
@@ -101,7 +101,7 @@ void TitleBlockTemplateLocationSaver::updateTemplates()
 }
 
 /**
-	Enable or diable the "new name" text field depending of the selected
+	Enable or disable the "new name" text field depending of the selected
 	template.
 */
 void TitleBlockTemplateLocationSaver::updateNewName()

--- a/sources/titleblock/templatescollection.cpp
+++ b/sources/titleblock/templatescollection.cpp
@@ -561,7 +561,7 @@ QString TitleBlockTemplatesFilesCollection::toFileName(const QString &template_n
 }
 
 /**
-	Handle the changes occuring on the file system.
+	Handle the changes occurring on the file system.
 	@param str Path of the directory that changed.
 */
 void TitleBlockTemplatesFilesCollection::fileSystemChanged(const QString &str) {

--- a/sources/titleblock/templateview.cpp
+++ b/sources/titleblock/templateview.cpp
@@ -259,7 +259,7 @@ void TitleBlockTemplateView::paste()
 	TitleBlockCell *erased_cell = selected_cell -> cell();
 	if (!erased_cell) return;
 
-	// change num_row and num_col attributes of pasted cells so they get positionned relatively to selected_cell
+	// change num_row and num_col attributes of pasted cells so they get positioned relatively to selected_cell
 	normalizeCells(pasted_cells, erased_cell -> num_row, erased_cell -> num_col);
 
 	PasteTemplateCellsCommand *paste_command = new PasteTemplateCellsCommand(tbtemplate_);
@@ -657,7 +657,7 @@ void TitleBlockTemplateView::applyColumnsWidths(bool animate) {
 		total_width_helper_cell_ -> split_background_color = QColor(Qt::red);
 		total_width_helper_cell_ -> split_foreground_color = QColor(Qt::black);
 		total_width_helper_cell_ -> split_label = QString(
-			tr("[%1px]", "content of the extra helper cell added when the total width of cells is greather than the preview width")
+			tr("[%1px]", "content of the extra helper cell added when the total width of cells is greater than the preview width")
 		).arg(total_applied_width - preview_width_);
 		total_width_helper_cell_ -> split_size = total_applied_width - preview_width_;
 	}

--- a/sources/ui/compositetexteditdialog.cpp
+++ b/sources/ui/compositetexteditdialog.cpp
@@ -68,7 +68,7 @@ void CompositeTextEditDialog::setUpComboBox()
 		qstrl.removeAll("formula");
 	}
 	
-		//We use a QMap because the keys of the map are sorted, then no matter the curent local,
+		//We use a QMap because the keys of the map are sorted, then no matter the current local,
 		//the value of the combo box are always alphabetically sorted
 	QMap <QString, QString> info_map;
 	for(const QString& str : qstrl) {

--- a/sources/ui/conductorpropertiesdialog.cpp
+++ b/sources/ui/conductorpropertiesdialog.cpp
@@ -27,7 +27,7 @@
 /**
 	@brief ConductorPropertiesDialog::ConductorPropertiesDialog
 	Constructor
-	@param conductor : conductor to edit propertie
+	@param conductor : conductor to edit properties
 	@param parent : parent widget
 */
 ConductorPropertiesDialog::ConductorPropertiesDialog(
@@ -57,7 +57,7 @@ ConductorPropertiesDialog::~ConductorPropertiesDialog()
 /**
 	@brief ConductorPropertiesDialog::PropertiesDialog
 	Static method for open and apply properties.
-	@param conductor : conductor to edit propertie
+	@param conductor : conductor to edit properties
 	@param parent : parent widget
 */
 void ConductorPropertiesDialog::PropertiesDialog(Conductor *conductor,
@@ -101,7 +101,7 @@ ConductorProperties ConductorPropertiesDialog::properties() const
 /**
 	@brief ConductorPropertiesDialog::applyAll
 	@return
-	true -> must apply the propertie to all conductor at the same potential
+	true -> must apply properties to all conductors at the same potential
 	false -> must apply properties only for the edited conductor
 */
 bool ConductorPropertiesDialog::applyAll() const

--- a/sources/ui/configpage/configpages.cpp
+++ b/sources/ui/configpage/configpages.cpp
@@ -68,7 +68,7 @@ NewDiagramPage::NewDiagramPage(QETProject *project,
 	// default conductor properties
 	m_cpw = new ConductorPropertiesWidget(ConductorProperties::defaultProperties());
 	m_cpw->setHiddenAvailableAutonum(true);
-	// default propertie of report label
+	// default properties of report label
 	rpw = new ReportPropertieWidget(ReportProperties::defaultProperties());
 	// default properties of xref
 	xrefpw = new XRefPropertiesWidget(XRefProperties::defaultProperties(), this);
@@ -170,7 +170,7 @@ void NewDiagramPage::applyConf()
 		// proprietes par defaut des conducteurs
 		m_cpw -> properties().toSettings(settings, "diagrameditor/defaultconductor");
 
-		// default report propertie
+		// default report properties
 		rpw->toSettings(settings, "diagrameditor/defaultreport");
 
 		// default xref properties

--- a/sources/ui/configpage/configpages.h
+++ b/sources/ui/configpage/configpages.h
@@ -63,7 +63,7 @@ public slots:
 	// attributes
 	private:
 	ProjectPropertiesDialog    *ppd_;
-	QETProject                 *m_project; ///< Project to edit propertie
+	QETProject                 *m_project; ///< Project to edit properties
 	BorderPropertiesWidget     *bpw;       ///< Widget to edit default diagram dimensions
 	TitleBlockPropertiesWidget *ipw;       ///< Widget to edit default title block properties
 	ConductorPropertiesWidget  *m_cpw;       ///< Widget to edit default conductor properties

--- a/sources/ui/diagrampropertiesdialog.cpp
+++ b/sources/ui/diagrampropertiesdialog.cpp
@@ -27,7 +27,7 @@
 
 /**
 	@brief DiagramPropertiesDialog::DiagramPropertiesDialog
-	Deafult constructor
+	Default constructor
 	@param diagram : diagram to edit properties
 	@param parent : parent widget
 */

--- a/sources/ui/dynamicelementtextmodel.cpp
+++ b/sources/ui/dynamicelementtextmodel.cpp
@@ -87,7 +87,7 @@ DynamicElementTextModel::DynamicElementTextModel(Element *element, QObject *pare
 
 DynamicElementTextModel::~DynamicElementTextModel()
 {
-		//Connection is not destroy automaticaly,
+		//Connection is not destroy automatically,
 		//because was not connected to a slot, but a lambda
 	for(DynamicElementTextItem *deti : m_hash_text_connect.keys())
 		setConnection(deti, false);
@@ -1623,7 +1623,7 @@ QWidget *DynamicTextItemDelegate::createEditor(
 			if(!deti)
 				break;
 				
-				//We use a QMap because the keys of the map are sorted, then no matter the curent local,
+				//We use a QMap because the keys of the map are sorted, then no matter the current local,
 				//the value of the combo box are always alphabetically sorted
 			QMap <QString, QString> info_map;
 			for(const QString& str : availableInfo(deti)) {
@@ -1880,8 +1880,8 @@ bool DynamicTextItemDelegate::eventFilter(QObject *object, QEvent *event)
 	
 	//This is a bad hack, for change the normal behavior :
 	//in normal behavior,
-	//the value is commited when the spinbox lose focus or enter key is pressed
-	//With this hack the value is commited each time the value change without the need to validate.
+	//the value is committed when the spinbox lose focus or enter key is pressed
+	//With this hack the value is committed each time the value change without the need to validate.
 	//then the change is apply in live
 	if(object->objectName() == "pos_dialog" || object->objectName() == "font_size" || object->objectName() == "rot_spinbox" || \
 	   object->objectName() == "group_rotation" || object->objectName() == "group_v_adjustment" || object->objectName() == "width_spinbox" ||\

--- a/sources/ui/elementpropertieswidget.cpp
+++ b/sources/ui/elementpropertieswidget.cpp
@@ -154,7 +154,7 @@ void ElementPropertiesWidget::setDynamicText(DynamicElementTextItem *text)
 
 /**
 	@brief ElementPropertiesWidget::setTextsGroup
-	Conveniance function :
+	Convenience function :
 	same as call : ElementPropertiesWidget::setElement,
 	with parameter the parent element of group.
 	Set the dynamics text tab as current tab,

--- a/sources/ui/imagepropertieswidget.h
+++ b/sources/ui/imagepropertieswidget.h
@@ -28,7 +28,7 @@ namespace Ui {
 
 /**
 	@brief The ImagePropertiesWidget class
-	This class provide a widget to edit the propertie of a DiagramImageItem
+	This class provides a widget to edit the properties of a DiagramImageItem
 */
 class ImagePropertiesWidget : public PropertiesEditorWidget
 {

--- a/sources/ui/linksingleelementwidget.cpp
+++ b/sources/ui/linksingleelementwidget.cpp
@@ -365,9 +365,9 @@ bool LinkSingleElementWidget::setLiveEdit(bool live_edit)
 
 /**
 	@brief LinkSingleElementWidget::availableElements
-	@return A QList with all available element
+	@return A QList with all available elements
 	to be linked with the edited element.
-	This methode take care of the combo box "find in diagram"
+	This method takes care of the "find in diagram" combo box
 */
 QVector <QPointer<Element>> LinkSingleElementWidget::availableElements()
 {
@@ -495,9 +495,9 @@ void LinkSingleElementWidget::setUpHeaderLabels()
 void LinkSingleElementWidget::diagramWasRemovedFromProject()
 {
 	// We use a timer because if the removed diagram
-	// contain the master element linked to the edited element
-	// we must to wait for this elements be unlinked,
-	// else the list of available master isn't up to date
+	// contains the master element linked to the edited element
+	// we must wait for this elements to be unlinked,
+	// or else the list of available master isn't up to date
 	QTimer::singleShot(10, this, SLOT(updateUi()));
 }
 

--- a/sources/ui/linksingleelementwidget.h
+++ b/sources/ui/linksingleelementwidget.h
@@ -37,7 +37,7 @@ namespace Ui {
 	to the element given in the constructor.
 	The element given in constructor must be linked with only
 	one other element (like report or slave element).
-	This widget detect automaticaly the kind of element given in
+	This widget detect automatically the kind of element given in
 	the constructor and search all element that can be linked with it.
 	If the element is already linked, the widget ask user to unlink.
 	This widget embedded the diagram command for undo/redo the action

--- a/sources/ui/masterpropertieswidget.cpp
+++ b/sources/ui/masterpropertieswidget.cpp
@@ -165,7 +165,7 @@ void MasterPropertiesWidget::setElement(Element *element)
 
 /**
 	@brief MasterPropertiesWidget::apply
-	If link betwen edited element and other change,
+	If link between edited element and other change,
 	apply the change with a QUndoCommand (got with method associatedUndo)
 	pushed to the stack of element project.
 	Return true if link change, else false
@@ -179,7 +179,7 @@ void MasterPropertiesWidget::apply()
 
 /**
 	@brief MasterPropertiesWidget::reset
-	Reset curent widget, clear eveything and rebuild widget.
+	Reset current widget, clear eveything and rebuild widget.
 */
 void MasterPropertiesWidget::reset()
 {
@@ -346,11 +346,11 @@ void MasterPropertiesWidget::headerCustomContextMenuRequested(const QPoint &pos)
 
 /**
 	@brief MasterPropertiesWidget::on_link_button_clicked
-	move curent item in the free_list to linked_list
+	move current item in the free_list to linked_list
 */
 void MasterPropertiesWidget::on_link_button_clicked()
 {
-		//take the curent item from free_list and push it to linked_list
+		//take the current item from free_list and push it to linked_list
 	QTreeWidgetItem *qtwi = ui->m_free_tree_widget->currentItem();
 	if (qtwi)
 	{
@@ -365,11 +365,11 @@ void MasterPropertiesWidget::on_link_button_clicked()
 
 /**
 	@brief MasterPropertiesWidget::on_unlink_button_clicked
-	move curent item in linked_list to free_list
+	move current item in linked_list to free_list
 */
 void MasterPropertiesWidget::on_unlink_button_clicked()
 {
-		//take the curent item from linked_list and push it to free_list
+		//take the current item from linked_list and push it to free_list
 	QTreeWidgetItem *qtwi = ui->m_link_tree_widget->currentItem();
 	if(qtwi)
 	{
@@ -424,9 +424,9 @@ void MasterPropertiesWidget::showedElementWasDeleted()
 void MasterPropertiesWidget::diagramWasdeletedFromProject()
 {
 	// We use a timer because if the removed diagram
-	// contain slave element linked to the edited element
-	// we must to wait for this elements be unlinked,
-	// else the linked list provide deleted elements.
+	// contains slave element linked to the edited element
+	// we must wait for this elements be unlinked,
+	// or else the linked list provides deleted elements.
 	QTimer::singleShot(10, this, SLOT(updateUi()));
 }
 

--- a/sources/ui/potentialselectordialog.cpp
+++ b/sources/ui/potentialselectordialog.cpp
@@ -35,7 +35,7 @@
 
 /**
 	@brief The NewConductorPotentialSelector class
-	Use for get the conductor propertie when two potentials is linked by a conductor
+	Used for getting the conductor properties when two potentials are linked by a conductor
 */
 class NewConductorPotentialSelector : public AbstractPotentialSelector
 {
@@ -45,7 +45,7 @@ class NewConductorPotentialSelector : public AbstractPotentialSelector
 		{
 			Terminal *terminal_1 = conductor->terminal1;
 			Terminal *terminal_2 = conductor->terminal2;
-			//We temporarily remove the conductor of his two terminals,
+			//We temporarily remove the conductor of its two terminals,
 			//to get the two existing potential
 			terminal_1->removeConductor(conductor);
 			terminal_2->removeConductor(conductor);
@@ -75,7 +75,7 @@ class NewConductorPotentialSelector : public AbstractPotentialSelector
 
 		/**
 			@brief getPotential
-			Get the conductor propertie of the potential at terminal,
+			Get the conductor properties of the potential at terminal,
 			and the number of wire in this potential.
 			@param terminal
 			@param seq_num
@@ -140,7 +140,7 @@ class NewConductorPotentialSelector : public AbstractPotentialSelector
 
 /**
 	@brief The LinkReportPotentialSelector class
-	Use for get the conductor propertie when two potentials is linked with a folio report
+	Use for getting the conductor properties when two potentials are linked with a folio report
 */
 class LinkReportPotentialSelector : public AbstractPotentialSelector
 {

--- a/sources/ui/titleblockpropertieswidget.cpp
+++ b/sources/ui/titleblockpropertieswidget.cpp
@@ -434,7 +434,7 @@ void TitleBlockPropertiesWidget::updateTemplateList()
 
 /**
 	@brief TitleBlockPropertiesWidget::changeCurrentTitleBlockTemplate
-	Load the additionnal field of title block "text"
+	Load the additional field of title block "text"
 */
 void TitleBlockPropertiesWidget::changeCurrentTitleBlockTemplate(int index)
 {

--- a/sources/ui/xrefpropertieswidget.cpp
+++ b/sources/ui/xrefpropertieswidget.cpp
@@ -151,7 +151,7 @@ void XRefPropertiesWidget::saveProperties(int index) {
 
 /**
 	@brief XRefPropertiesWidget::updateDisplay
-	Update display with the curent displayed type.
+	Update display with the current displayed type.
 */
 void XRefPropertiesWidget::updateDisplay()
 {

--- a/sources/undocommand/addelementtextcommand.cpp
+++ b/sources/undocommand/addelementtextcommand.cpp
@@ -441,8 +441,8 @@ void AlignmentTextsGroupCommand::undo()
 	if(m_group)
 	{
 		m_group.data()->setAlignment(m_previous_alignment);
-		//The alignment befor this command was free, then we must
-		//to restor the pos of each texts
+		//The alignment before this command was free, then we must
+		//to restore the pos of each texts
 		if(!m_texts_pos.isEmpty())
 		{
 			for(DynamicElementTextItem *deti : m_group.data()->texts())

--- a/sources/undocommand/deleteqgraphicsitemcommand.cpp
+++ b/sources/undocommand/deleteqgraphicsitemcommand.cpp
@@ -31,7 +31,7 @@
 
 /**
 	@brief DeleteQGraphicsItemCommand::DeleteQGraphicsItemCommand
-	@param diagram : deigram where this undo work
+	@param diagram : diagram where this undo work
 	@param content : content to remove
 	@param parent : parent undo
 */
@@ -53,8 +53,8 @@ DeleteQGraphicsItemCommand::DeleteQGraphicsItemCommand(
 
 	}
 
-		//When remove a deti we must to know his parent item, for re-add deti as child of the parent
-		//when undo this command
+		//When removing a deti we must know its parent item, for re-adding deti as child of the parent
+		//when undoing this command
 	for(DynamicElementTextItem *deti : m_removed_contents.m_element_texts)
 	{
 		if(deti->parentGroup())

--- a/sources/undocommand/linkelementcommand.cpp
+++ b/sources/undocommand/linkelementcommand.cpp
@@ -259,12 +259,12 @@ void LinkElementCommand::setUpNewLink(
 /**
 	@brief LinkElementCommand::makeLink
 	Make the link between m_element and element_list;
-	This method unlink elements if needed.
+	This method unlinks elements if needed.
 	@param element_list
 */
 void LinkElementCommand::makeLink(const QList<Element *> &element_list)
 {
-	//List is empty, that mean m_element must be free, so we unlink all elements
+	//List is empty, that means m_element must be free, so we unlink all elements
 	if (element_list.isEmpty())
 	{
 		m_element->unlinkAllElements();
@@ -275,8 +275,8 @@ void LinkElementCommand::makeLink(const QList<Element *> &element_list)
 	foreach(Element *elmt, element_list)
 		m_element->linkToElement(elmt);
 
-	/* At this point may be there are unwanted linked elements to m_element.
-	 * We must to unlink it.
+	/* At this point there may be unwanted linked elements to m_element.
+	 * We must unlink it.
 	 * Elements from element_list are wanted so we compare element_list
 	 *  to current linked element of m_element
 	 */

--- a/sources/utils/conductorcreator.cpp
+++ b/sources/utils/conductorcreator.cpp
@@ -152,7 +152,7 @@ QList<Conductor *> ConductorCreator::existingPotential()
 		{
 			c_list.append(t->conductors().first());
 			
-				//We must to check m_terminals_list contain a terminal
+				//We must check if m_terminals_list contains a terminal
 				//in the same potential of c, and if true, exclude this terminal from the search.
 			for (Conductor *c : t->conductors().first()->relatedPotentialConductors(false))
 			{

--- a/sources/utils/qetsettings.cpp
+++ b/sources/utils/qetsettings.cpp
@@ -29,7 +29,7 @@ namespace QetSettings
 	* QElectroTech settings
 	* the value is in form of a string.
 	* @a policy can be : Round, Ceil, Floor, RoundPreferFloor, PassThrough
-	* In case of wrong policy, PassThrough is use as defaukt value.
+	* In case of wrong policy, PassThrough is use as default value.
 	* The value is stored with key : hdpi_scale_factor_rounding_policy
 	* @sa Qt::HighDpiScaleFactorRoundingPolicy
 	* @param policy

--- a/sources/utils/qetsettings.h
+++ b/sources/utils/qetsettings.h
@@ -23,7 +23,7 @@
 /**
  *Interface to use QSettings in QElectroTech
  *Prefer use this namespace instead of directly QSettings
- *It's notably usefull when some QSettings value are use in
+ *It's notably useful when some QSettings value are used in
  *different part of QElectroTech source code
  */
 namespace QetSettings

--- a/sources/utils/qetutils.cpp
+++ b/sources/utils/qetutils.cpp
@@ -93,9 +93,9 @@ qreal QETUtils::graphicsHandlerSize(QGraphicsItem *item)
  * Sort the string @a str_a and @a str_b and take in
  * count if string begin with an int to sort it
  * as int and not as string in this case.
- * For exemple if we have to sort the string :
+ * For example if we have to sort the string :
  * "3str", 10str", "100str", "2str", "20str".
- * The default behavior when sorting QString with the comparaison operator will be:
+ * The default behavior when sorting QString with the comparison operator will be:
  * "10str" "100str" "2str", "20str", "3str"
  * When sorting with this function, the result will be :
  * "10str", "2str", "3str", "20str", "100str"


### PR DESCRIPTION
Found via `codespell`