### PR TITLE
fix segfault on load cancelled

### DIFF
--- a/sources/qetproject.cpp
+++ b/sources/qetproject.cpp
@@ -225,7 +225,7 @@ QETProject::ProjectState QETProject::openFile(QFile *file)
 	if(opened_here) {
 		file->close();
 	}
-    return ProjectState::Ok;
+    return m_state;
 }
 
 /**
@@ -1392,6 +1392,7 @@ void QETProject::readProjectXml(QDomDocument &xml_project)
 	else
 	{
 		m_state = ProjectParsingFailed;
+		return;
 	}
 
 	m_data_base.blockSignals(true);


### PR DESCRIPTION
Test:
Je prends `affuteuse_250h.qet` et je le modifie pour avoir ` version="0.91"`

à l'ouverture si je choisie cancel, j'ai un segfault:

```
#0  0x00007ffff7bd876d in QDomDocument::documentElement() const () at /lib64/libQt5Xml.so.5
#1  0x00005555556cc59a in XmlElementCollection::root() const (this=<optimized out>) at sources/ElementsCollection/xmlelementcollection.cpp:214
#2  QETProject::toXml() (this=0x55555627d020) at sources/qetproject.cpp:944
#3  0x00005555556cd57c in QETProject::writeBackup() (this=0x55555627d020) at sources/qetproject.cpp:1899
#4  0x00005555556c0c3e in QETProject::init() (this=0x55555627d020) at sources/qetproject.cpp:176
#5  0x00005555558da0b0 in QETProject::QETProject(QString const&, QObject*) (parent=0x0, path=..., this=0x55555627d020) at sources/qetproject.cpp:79
#6  QETDiagramEditor::openAndAddProject(QString const&, bool) [clone .constprop.0] (this=this@entry=0x55555641f500, filepath=..., interactive=<optimized out>) at sources/qetdiagrameditor.cpp:1111
#7  0x00005555556a47df in QETDiagramEditor::openProject() (this=0x55555641f500) at sources/qetdiagrameditor.cpp:994
#8  0x00007ffff66dbc26 in void doActivate<false>(QObject*, int, void**) () at /lib64/libQt5Core.so.5
#9  0x00007ffff75a82f6 in QAction::triggered(bool) () at /lib64/libQt5Widgets.so.5
#10 0x00007ffff75aafb3 in QAction::activate(QAction::ActionEvent) () at /lib64/libQt5Widgets.so.5
#11 0x00007ffff77350a2 in QMenuPrivate::activateCausedStack(QVector<QPointer<QWidget> > const&, QAction*, QAction::ActionEvent, bool) () at /lib64/libQt5Widgets.so.5
#12 0x00007ffff773cf7c in QMenuPrivate::activateAction(QAction*, QAction::ActionEvent, bool) () at /lib64/libQt5Widgets.so.5
#13 0x00007ffff75f1938 in QWidget::event(QEvent*) () at /lib64/libQt5Widgets.so.5
#14 0x00007ffff75aed62 in QApplicationPrivate::notify_helper(QObject*, QEvent*) () at /lib64/libQt5Widgets.so.5
#15 0x00007ffff75b73d2 in QApplication::notify(QObject*, QEvent*) () at /lib64/libQt5Widgets.so.5
#16 0x00007ffff66a8278 in QCoreApplication::notifyInternal2(QObject*, QEvent*) () at /lib64/libQt5Core.so.5
#17 0x00007ffff773dc61 in QMenuPrivate::mouseEventTaken(QMouseEvent*) () at /lib64/libQt5Widgets.so.5
#18 0x00007ffff773e0f6 in QMenu::mouseReleaseEvent(QMouseEvent*) () at /lib64/libQt5Widgets.so.5
#19 0x00007ffff75f1938 in QWidget::event(QEvent*) () at /lib64/libQt5Widgets.so.5
#20 0x00007ffff75aed62 in QApplicationPrivate::notify_helper(QObject*, QEvent*) () at /lib64/libQt5Widgets.so.5
#21 0x00007ffff75b73d2 in QApplication::notify(QObject*, QEvent*) () at /lib64/libQt5Widgets.so.5
#22 0x00007ffff66a8278 in QCoreApplication::notifyInternal2(QObject*, QEvent*) () at /lib64/libQt5Core.so.5
#23 0x00007ffff75b54d2 in QApplicationPrivate::sendMouseEvent(QWidget*, QMouseEvent*, QWidget*, QWidget*, QWidget**, QPointer<QWidget>&, bool, bool) () at /lib64/libQt5Widgets.so.5
#24 0x00007ffff760b0f5 in QWidgetWindow::handleMouseEvent(QMouseEvent*) () at /lib64/libQt5Widgets.so.5
#25 0x00007ffff760e060 in QWidgetWindow::event(QEvent*) () at /lib64/libQt5Widgets.so.5
#26 0x00007ffff75aed62 in QApplicationPrivate::notify_helper(QObject*, QEvent*) () at /lib64/libQt5Widgets.so.5
#27 0x00007ffff66a8278 in QCoreApplication::notifyInternal2(QObject*, QEvent*) () at /lib64/libQt5Core.so.5
#28 0x00007ffff6d6ad6d in QGuiApplicationPrivate::processMouseEvent(QWindowSystemInterfacePrivate::MouseEvent*) () at /lib64/libQt5Gui.so.5
#29 0x00007ffff6d49f1c in QWindowSystemInterface::sendWindowSystemEvents(QFlags<QEventLoop::ProcessEventsFlag>) () at /lib64/libQt5Gui.so.5
#30 0x00007fffec11690e in xcbSourceDispatch(_GSource*, int (*)(void*), void*) () at /lib64/libQt5XcbQpa.so.5
#31 0x00007ffff5586cbf in g_main_context_dispatch () at /lib64/libglib-2.0.so.0
#32 0x00007ffff55dc598 in g_main_context_iterate.constprop () at /lib64/libglib-2.0.so.0
#33 0x00007ffff5583f40 in g_main_context_iteration () at /lib64/libglib-2.0.so.0
#34 0x00007ffff66f938a in QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) () at /lib64/libQt5Core.so.5
#35 0x00007ffff66a6cca in QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) () at /lib64/libQt5Core.so.5
#36 0x00007ffff66aed92 in QCoreApplication::exec() () at /lib64/libQt5Core.so.5
#37 0x000055555562d641 in main(int, char**) (argc=<optimized out>, argv=<optimized out>) at sources/main.cpp:227

```


Also needed in 0.9 branch