### PR TITLE
avoid false warning for project created by qet >= 0.100

### DIFF
--- a/sources/qetproject.cpp
+++ b/sources/qetproject.cpp
@@ -1378,7 +1378,7 @@ void QETProject::readProjectXml(QDomDocument &xml_project)
 				//Qet 0.6 or lower is break;
 				//keep float here for very old version
 			qreal r_project_qet_version = root_elmt.attribute(QStringLiteral("version")).toDouble(&conv_ok);
-			if (conv_ok && r_project_qet_version <= 0.6)
+			if (conv_ok && m_project_qet_version < QVersionNumber(0, 100) && r_project_qet_version <= 0.6)
 			{
 				auto ret = QET::QetMessageBox::warning(
 							   nullptr,


### PR DESCRIPTION
When a project is saved with 0.100,
the conversion warning is wrongly displayed (as 0.100 < 0.6 using float)

