### PR TITLE
Only display git revision when available

### DIFF
--- a/qelectrotech.pro
+++ b/qelectrotech.pro
@@ -74,7 +74,7 @@ include(sources/QWidgetAnimation/QWidgetAnimation.pri)
 
 DEFINES += QAPPLICATION_CLASS=QApplication
 DEFINES += QT_MESSAGELOGCONTEXT
-DEFINES += GIT_COMMIT_SHA="\\\"$(shell git -C \""$$_PRO_FILE_PWD_"\" rev-parse --verify HEAD)\\\""
+DEFINES += GIT_COMMIT_SHA="\\\"$(shell git -C \""$$_PRO_FILE_PWD_"\" rev-parse --verify HEAD 2>/dev/null || true)\\\""
 
 # You can make your code fail to compile if it uses deprecated APIs.
 # In order to do so, uncomment the following line.

--- a/sources/machine_info.cpp
+++ b/sources/machine_info.cpp
@@ -122,7 +122,9 @@ void MachineInfo::send_info_to_debug()
 		<< QLibraryInfo::path(QLibraryInfo::SettingsPath);
 #endif
 #endif
-	qInfo() << "GitRevision " + QString(GIT_COMMIT_SHA);
+	if (strlen(GIT_COMMIT_SHA)) {
+		qInfo() << "GitRevision " + QString(GIT_COMMIT_SHA);
+	}
     qInfo()<< "QElectroTech V " + QetVersion::displayedVersion();
 	qInfo()<< QObject::tr("Compilation : ") + pc.built.version;
 	qInfo()<< "Built with Qt " + pc.built.QT
@@ -383,7 +385,9 @@ QString MachineInfo::compilation_info()
 	compilation_info += " - " + pc.built.arch;
 	compilation_info += " - Date : " + pc.built.date;
 	compilation_info += " : " + pc.built.time;
-	compilation_info += "<br> Git Revision : " + QString(GIT_COMMIT_SHA);
+	if (strlen(GIT_COMMIT_SHA)) {
+		compilation_info += "<br> Git Revision : " + QString(GIT_COMMIT_SHA);
+	}
 	compilation_info += " <br>Run with Qt " + QString(qVersion());
 	compilation_info += " using"
 			+ QString(" %1 thread(s)").arg(pc.cpu.ThreadCount);


### PR DESCRIPTION
1/ avoid tons of warnings during the build such as (git not installed)

`/bin/sh: ligne 1: git : commande introuvable`

or (when build from sources archive)

`/bin/sh: ligne 1: fatal: not a git repository (or any of the parent directories): .git`

2/ display git revision when available
