### PR TITLE
add terminal-names to connection in qet-file

### DIFF
--- a/sources/qetgraphicsitem/conductor.cpp
+++ b/sources/qetgraphicsitem/conductor.cpp
@@ -1048,6 +1048,7 @@ QDomElement Conductor::toXml(QDomDocument &dom_document,
 	} else {
 		dom_element.setAttribute("element1", terminal1->parentElement()->uuid().toString());
 		dom_element.setAttribute("terminal1", terminal1->uuid().toString());
+		dom_element.setAttribute("terminalname1", terminal1->name());
 	}
 
 	if (terminal2->uuid().isNull()) {
@@ -1056,6 +1057,7 @@ QDomElement Conductor::toXml(QDomDocument &dom_document,
 	} else {
 		dom_element.setAttribute("element2", terminal2->parentElement()->uuid().toString());
 		dom_element.setAttribute("terminal2", terminal2->uuid().toString());
+		dom_element.setAttribute("terminalname2", terminal2->name());
 	}
 	dom_element.setAttribute("freezeLabel", m_freeze_label? "true" : "false");
 

--- a/sources/qetgraphicsitem/terminal.cpp
+++ b/sources/qetgraphicsitem/terminal.cpp
@@ -744,6 +744,11 @@ QUuid Terminal::uuid() const
 	return d->m_uuid;
 }
 
+QString Terminal::name() const
+{
+	return d->m_name;
+}
+
 /**
 	@brief Conductor::relatedPotentialTerminal
 	Return terminal at the same potential from the same

--- a/sources/qetgraphicsitem/terminal.h
+++ b/sources/qetgraphicsitem/terminal.h
@@ -73,7 +73,8 @@ class Terminal : public QGraphicsObject
 		int       conductorsCount     () const;
 		Diagram  *diagram             () const;
 		Element  *parentElement       () const;
-		QUuid uuid                    () const;
+		QUuid     uuid                () const;
+		QString   name                () const;
 
 		QList<Conductor *> conductors() const;
 		Qet::Orientation orientation() const;


### PR DESCRIPTION
It may be a good idea to add the terminal-names to the connections in QET-file. 
This could make it easier for a programmer of an external tool or plugin to develop something...