### PR TITLE
Force light mode in collections like projects

### DIFF
--- a/sources/ElementsCollection/elementstreeview.cpp
+++ b/sources/ElementsCollection/elementstreeview.cpp
@@ -35,7 +35,17 @@ static int MAX_DND_PIXMAP_HEIGHT = 375;
 */
 ElementsTreeView::ElementsTreeView(QWidget *parent) :
 	QTreeView(parent)
-{}
+{
+	// force du noir sur une alternance de blanc (comme le schema) et de gris
+	// clair, avec du blanc sur bleu pas trop fonce pour la selection
+	QPalette qp = palette();
+	qp.setColor(QPalette::Text,            Qt::black);
+	qp.setColor(QPalette::Base,            Qt::white);
+	qp.setColor(QPalette::AlternateBase,   QColor("#e8e8e8"));
+	qp.setColor(QPalette::Highlight,       QColor("#678db2"));
+	qp.setColor(QPalette::HighlightedText, Qt::black);
+	setPalette(qp);
+}
 
 /**
 	@brief ElementsTreeView::startDrag


### PR DESCRIPTION
When in dark mode, symbols shown in collections menu are very difficult to view.
Forcing bright palette (like projects tree already does) solves the issue for me.

This is probably not the best way to code it (duplicated code), this palette should ideally be created in one place and reused. Feel free to adapt my suggestions in any way you like.