### PR TITLE
Fix missing company-titleblocks in properties-dialog

### DIFF
--- a/sources/qetproject.cpp
+++ b/sources/qetproject.cpp
@@ -510,7 +510,7 @@ void QETProject::setDefaultTitleBlockProperties(const TitleBlockProperties &titl
 				collection = QETApp::commonTitleBlockTemplatesCollection();
 				break;
 			case QET::Company :
-			//	collection = QETApp::companyTitleBlockTemplatesCollection();
+				collection = QETApp::companyTitleBlockTemplatesCollection();
 				break;
 			case QET::Custom :
 				collection = QETApp::customTitleBlockTemplatesCollection();

--- a/sources/ui/configpage/configpages.cpp
+++ b/sources/ui/configpage/configpages.cpp
@@ -57,6 +57,7 @@ NewDiagramPage::NewDiagramPage(QETProject *project,
 	// default titleblock properties
 	QList <TitleBlockTemplatesCollection *> c;
 	c << QETApp::commonTitleBlockTemplatesCollection()
+	  << QETApp::companyTitleBlockTemplatesCollection()
 	  << QETApp::customTitleBlockTemplatesCollection();
 	if (m_project) c << m_project->embeddedTitleBlockTemplatesCollection();
 	ipw = new TitleBlockPropertiesWidget(


### PR DESCRIPTION
Fixed bug found by LievenC: 
[https://qelectrotech.org/forum/viewtopic.php?id=2856](url)