### PR TITLE
Set default-location for projects to documents-dir.

### DIFF
--- a/sources/conductornumexport.cpp
+++ b/sources/conductornumexport.cpp
@@ -17,6 +17,7 @@
 */
 #include "conductornumexport.h"
 
+#include "qetapp.h"
 #include "diagram.h"
 #include "diagramcontent.h"
 #include "qetgraphicsitem/conductor.h"
@@ -45,7 +46,10 @@ ConductorNumExport::ConductorNumExport(QETProject *project, QWidget *parent) :
 */
 bool ConductorNumExport::toCsv()
 {
-	QString name = QObject::tr("numero_de_fileries_") + m_project->title() + ".csv";
+		//save in csv file in same directory as project by default
+	QString dir = m_project->currentDir();
+	if (dir.isEmpty()) dir = QETApp::documentDir();
+	QString name = dir + "/" + QObject::tr("numero_de_fileries_") + m_project->title() + ".csv";
 	//    if(!name.endsWith(".csv")) {
 	//        name += ".csv";
 	//    }

--- a/sources/dataBase/projectdatabase.cpp
+++ b/sources/dataBase/projectdatabase.cpp
@@ -670,8 +670,7 @@ void projectDataBase::exportDb(projectDataBase *db,
 	if(dir_.isEmpty()) {
 		dir_ = db->project()->filePath();
 		if (dir_.isEmpty()) {
-			dir_ = QStandardPaths::standardLocations(QStandardPaths::DocumentsLocation).first();
-			dir_ += QString("/") += tr("sans_nom") += ".sqlite";
+			dir_ = QETApp::documentDir() + "/" + tr("sans_nom") + ".sqlite";
 		} else {
 			dir_.remove(".qet");
 			dir_.append(".sqlite");

--- a/sources/diagramevent/diagrameventaddimage.cpp
+++ b/sources/diagramevent/diagrameventaddimage.cpp
@@ -18,6 +18,7 @@
 
 #include "diagrameventaddimage.h"
 
+#include "../qetapp.h"
 #include "../diagram.h"
 #include "../undocommand/addgraphicsobjectcommand.h"
 #include "../qetgraphicsitem/diagramimageitem.h"
@@ -155,7 +156,7 @@ void DiagramEventAddImage::openDialog()
 	if (m_diagram -> isReadOnly()) return;
 	
 	//Open dialog to select image
-	QString pathPictures = QStandardPaths::writableLocation(QStandardPaths::PicturesLocation);
+	QString pathPictures = QETApp::pictureDir();
 	QString fileName = QFileDialog::getOpenFileName(m_diagram->views().isEmpty()? nullptr : m_diagram->views().first(), QObject::tr("Selectionner une image..."), pathPictures, QObject::tr("Image Files (*.png *.jpg  *.jpeg *.bmp *.svg)"));
 	
 	if (fileName.isEmpty()) return;

--- a/sources/exportproperties.cpp
+++ b/sources/exportproperties.cpp
@@ -16,8 +16,7 @@
 	along with QElectroTech.  If not, see <http://www.gnu.org/licenses/>.
 */
 #include "exportproperties.h"
-
-#include <QStandardPaths>
+#include "qetapp.h"
 
 /**
 	Constructeur par defaut :
@@ -28,9 +27,7 @@
 	  * la zone exportee est le schema avec son cadre et son cartouche
 */
 ExportProperties::ExportProperties() :
-	destination_directory(
-		QStandardPaths::writableLocation(
-			QStandardPaths::DesktopLocation)),
+	destination_directory(QETApp::documentDir()),
 	format("PNG"),
 	draw_grid(false),
 	draw_border(true),
@@ -85,14 +82,13 @@ void ExportProperties::toSettings(QSettings &settings,
 */
 void ExportProperties::fromSettings(QSettings &settings,
 				    const QString &prefix) {
-	QString desktop_path = QStandardPaths::writableLocation(
-				QStandardPaths::DesktopLocation);
+	QString export_path = QETApp::documentDir();
 	destination_directory.setPath(
 				settings.value(
 					prefix + "path",
-					desktop_path).toString());
+					export_path).toString());
 	if (!destination_directory.exists())
-		destination_directory.setPath(desktop_path);
+		destination_directory.setPath(export_path);
 
 	format = settings.value(prefix + "format").toString();
 

--- a/sources/exportproperties.cpp
+++ b/sources/exportproperties.cpp
@@ -20,7 +20,7 @@
 
 /**
 	Constructeur par defaut :
-	  * le repertoire de destination est le Bureau de l'utilisateur
+	  * le repertoire de destination est l'emplacement des documents de l'utilisateur
 	  * le format d'export est PNG
 	  * la grille et les bornes ne doivent pas etre dessinees
 	  * la bordure et le cartouche doivent etre dessines

--- a/sources/qetapp.cpp
+++ b/sources/qetapp.cpp
@@ -870,6 +870,44 @@ QString QETApp::dataDir()
 }
 
 /**
+	@brief QETApp::documentDir
+	Return the standard-folder where to save users documents
+	This directory is generally
+	C:/Users/<USER>/Documents
+	on Windows and
+	~/Documents
+	under UNIX-like systems.
+	\~ @return The path of users document-folder
+*/
+QString QETApp::documentDir()
+{
+	QString docdir = QStandardPaths::writableLocation(QStandardPaths::DocumentsLocation);
+	if (docdir.endsWith('/')) {
+		docdir.remove(docdir.length()-1, 1);
+	}
+	return docdir;
+}
+
+/**
+	@brief QETApp::pictureDir
+	Returns the standard-folder of users pictures
+	This directory is generally
+	C:/Users/<USER>/Pictures
+	on Windows and
+	~/Pictures
+	under UNIX-like systems.
+	\~ @return The path of users picture-folder
+*/
+QString QETApp::pictureDir()
+{
+	QString picturedir = QStandardPaths::writableLocation(QStandardPaths::PicturesLocation);
+	if (picturedir.endsWith('/')) {
+		picturedir.remove(picturedir.length()-1, 1);
+	}
+	return picturedir;
+}
+
+/**
 	@brief QETApp::realPath
 	Allows you to know the absolute path of the * .elmt file
 	corresponding to a symbolic path

--- a/sources/qetapp.h
+++ b/sources/qetapp.h
@@ -98,6 +98,8 @@ class QETApp : public QObject
 		static int projectId(const QETProject *);
 		static QString configDir();
 		static QString dataDir();
+		static QString documentDir();
+		static QString pictureDir();
 		static QString languagesPath();
 		static QString realPath(const QString &);
 		static QString symbolicPath(const QString &);

--- a/sources/qetdiagrameditor.cpp
+++ b/sources/qetdiagrameditor.cpp
@@ -65,7 +65,7 @@ QETDiagramEditor::QETDiagramEditor(const QStringList &files, QWidget *parent) :
 	m_zoom_actions_group       (this),
 	m_select_actions_group     (this),
 	m_file_actions_group       (this),
-	open_dialog_dir            (QStandardPaths::writableLocation(QStandardPaths::DesktopLocation))
+	open_dialog_dir            (QETApp::documentDir())
 {
 		//Trivial property use to set the graphics handler size
 	setProperty("graphics_handler_size", 10);

--- a/sources/qetproject.cpp
+++ b/sources/qetproject.cpp
@@ -360,9 +360,11 @@ void QETProject::setFilePath(const QString &filepath)
 }
 
 /**
-	@return le dossier contenant le fichier projet si celui-ci a ete
-	enregistre ; dans le cas contraire, cette methode retourne l'emplacement
-	du bureau de l'utilisateur.
+	@return the folder containing the project file if it has been saved;
+	otherwise, this method returns the location of the user's documents.
+	en français:
+	@return le dossier contenant le fichier du projet s'il a été enregistré ;
+	sinon, cette méthode renvoie l'emplacement des documents de l'utilisateur.
 */
 QString QETProject::currentDir() const
 {

--- a/sources/qetproject.cpp
+++ b/sources/qetproject.cpp
@@ -36,7 +36,6 @@
 #include "qetversion.h"
 
 #include <QHash>
-#include <QStandardPaths>
 #include <QTimer>
 #include <QtConcurrent>
 #include <QtDebug>
@@ -369,7 +368,7 @@ QString QETProject::currentDir() const
 {
 	QString current_directory;
 	if (m_file_path.isEmpty()) {
-		current_directory = QStandardPaths::writableLocation(QStandardPaths::DesktopLocation);
+		current_directory = QETApp::documentDir();
 	} else {
 		current_directory = QFileInfo(m_file_path).absoluteDir().absolutePath();
 	}

--- a/sources/titleblock/templatelogomanager.cpp
+++ b/sources/titleblock/templatelogomanager.cpp
@@ -17,10 +17,9 @@
 */
 #include "templatelogomanager.h"
 
+#include "../qetapp.h"
 #include "../qeticons.h"
 #include "../titleblocktemplate.h"
-
-#include <QStandardPaths>
 
 /**
 	Constructor
@@ -78,7 +77,7 @@ void TitleBlockTemplateLogoManager::emitLogosChangedSignal()
 */
 void TitleBlockTemplateLogoManager::initWidgets()
 {
-	open_dialog_dir_.setPath(QStandardPaths::writableLocation(QStandardPaths::DesktopLocation));
+	open_dialog_dir_.setPath(QETApp::documentDir());
 
 	setWindowTitle(tr("Gestionnaire de logos"));
 	setWindowIcon(QET::Icons::InsertImage);

--- a/sources/ui/bomexportdialog.cpp
+++ b/sources/ui/bomexportdialog.cpp
@@ -62,8 +62,10 @@ int BOMExportDialog::exec()
 	auto r = QDialog::exec();
 	if (r == QDialog::Accepted)
 	{
-			//save in csv file
-		QString file_name = tr("nomenclature_") + QString(m_project ->title() + ".csv");
+			//save in csv file in same directory as project by default
+		QString dir = m_project->currentDir();
+		if (dir.isEmpty()) dir = QETApp::documentDir();
+		QString file_name = dir + "/" + tr("nomenclature_") + QString(m_project ->title() + ".csv");
 		QString file_path = QFileDialog::getSaveFileName(this, tr("Enregister sous... "), file_name, tr("Fichiers csv (*.csv)"));
 		QFile file(file_path);
 		if (!file_path.isEmpty())


### PR DESCRIPTION
All export files that are derived from the project (BOM, nomenclature, etc.) are saved in the same directory by default. 
In this context, the standard directories have been grouped together in qetapp.cpp / qetapp.h so that only one place needs to be searched for in case of any adjustments.