### PR TITLE
machine_info: fix element-count and make static text a bit shorter

### DIFF
--- a/sources/machine_info.cpp
+++ b/sources/machine_info.cpp
@@ -166,11 +166,11 @@ void MachineInfo::send_info_to_debug()
 #if defined(Q_OS_WIN32) || defined(Q_OS_WIN64)
 	qInfo()<< " App Config Location: see Regedit: HKEY_CURRENT_USER/Software/QElectroTech/";
 #else
-	qInfo()<< " App Config Location:"<< QStandardPaths::writableLocation(QStandardPaths::AppConfigLocation) +".conf/";
+	qInfo()<< " App Config Location:"<< QETApp::configDir();
 #endif
 
 	qInfo()<< " For data-files (user-/company-collections, titleblocks, etc.):";
-	qInfo()<< " App Data Location:"<< QStandardPaths::writableLocation(QStandardPaths::AppDataLocation);
+	qInfo()<< " App Data Location:"<< QETApp::dataDir();
 	qInfo()<< " Directory for project stalefiles:";
 	qInfo()<< " Generic Data Location:"<< QStandardPaths::writableLocation(QStandardPaths::GenericDataLocation) + "/stalefiles/QElectroTech/";
 	// qInfo()<< " App Local DataLocation:"<< QStandardPaths::writableLocation(QStandardPaths::ApplicationsLocation);

--- a/sources/machine_info.cpp
+++ b/sources/machine_info.cpp
@@ -180,7 +180,7 @@ void MachineInfo::send_info_to_debug()
 	qInfo()<< "";
 
 
-	qInfo()<< " Count the *.elmt files you have in your collections (Official-common-collection, user-/company-collections, user-/custom-collections, etc.):";
+	qInfo()<< " Count the elements in your collections (Official-common-collection, company-collections, custom-collections):";
 	QStringList nameFilters;
 	nameFilters << "*.elmt";
 	
@@ -252,7 +252,7 @@ void MachineInfo::send_info_to_debug()
 			qInfo()  << "FileSystemType:" << storage.fileSystemType();
 			qInfo()  << "SizeTotal:" << storage.bytesTotal()/1000000000  <<  "GB";
 			qInfo()  << "AvailableSize:" << storage.bytesAvailable()/1000000000 <<  "GB";
-			qInfo()<< "Count All Elements in collections ="<< commomElementsDir + customElementsDir + customElementsDir << "Elements";
+			qInfo()<< "Count All Elements in collections ="<< commomElementsDir + customElementsDir + companyElementsDir << "Elements";
 		
 }
 


### PR DESCRIPTION
The custom elements were counted twice instead of adding company-elements... 