### PR TITLE
corrected a few places where QETApp::documentDir() should also be used

### DIFF
--- a/sources/editor/ui/qetelementeditor.cpp
+++ b/sources/editor/ui/qetelementeditor.cpp
@@ -1282,24 +1282,6 @@ void QETElementEditor::on_m_open_from_file_action_triggered()
 	openElement(user_filename);
 }
 
-void QETElementEditor::on_m_open_scaled_element_action_triggered()
-{
-#ifdef TODO_LIST
-#	pragma message("@TODO Merge 'Element-Scaling' code into QET")
-#	pragma message("https://github.com/plc-user/QET_ElementScaler")
-#endif
-#if defined(Q_OS_WIN32) || defined(Q_OS_WIN64)
-	QString program = (QDir::homePath() + "/Application Data/qet/QET_ElementScaler.exe");
-#elif defined(Q_OS_MAC)
-	QString program = (QDir::homePath() + "/.qet/QET_ElementScaler.app");
-#else
-	QString program = (QDir::homePath() + "/.qet/QET_ElementScaler");
-#endif
-	QStringList arguments;
-	QProcess *ES = new QProcess(qApp);
-	ES -> start(program,arguments);
-}
-
 bool QETElementEditor::on_m_save_as_file_action_triggered()
 {
 	// Check element before writing

--- a/sources/editor/ui/qetelementeditor.cpp
+++ b/sources/editor/ui/qetelementeditor.cpp
@@ -1472,7 +1472,7 @@ void QETElementEditor::on_m_import_dxf_triggered()
 	{
 		QString file_path{QFileDialog::getOpenFileName(this,
 													   QObject::tr("Importer un fichier dxf"),
-													   QDir::homePath(),
+													   QETApp::documentDir(),
 													   "DXF (*.dxf)")};
 		if (file_path.isEmpty()) {
 			return;
@@ -1498,7 +1498,7 @@ void QETElementEditor::on_m_import_scaled_element_triggered()
 	{
 		QString file_path{QFileDialog::getOpenFileName(this,
 													   tr("Importer un élément à redimensionner"),
-													   QDir::homePath(),
+													   QETApp::documentDir(),
 													   tr("Éléments QElectroTech (*.elmt)"))};
 		if (file_path.isEmpty()) {
 			return;

--- a/sources/editor/ui/qetelementeditor.h
+++ b/sources/editor/ui/qetelementeditor.h
@@ -86,7 +86,6 @@ class QETElementEditor : public QMainWindow
 		void on_m_new_action_triggered();
 		void on_m_open_action_triggered();
 		void on_m_open_from_file_action_triggered();
-		void on_m_open_scaled_element_action_triggered();
 		bool on_m_save_as_file_action_triggered();
 		void on_m_reload_action_triggered();
 		void on_m_quit_action_triggered();

--- a/sources/ui/configpage/generalconfigurationpage.cpp
+++ b/sources/ui/configpage/generalconfigurationpage.cpp
@@ -436,7 +436,7 @@ void GeneralConfigurationPage::on_m_common_elmt_path_cb_currentIndexChanged(int 
 {
 	if (index == 1)
 	{
-		QString path = QFileDialog::getExistingDirectory(this, tr("Chemin de la collection commune"), QDir::homePath());
+		QString path = QFileDialog::getExistingDirectory(this, tr("Chemin de la collection commune"), QETApp::documentDir());
 		if (!path.isEmpty()) {
 			ui->m_common_elmt_path_cb->setItemData(1, path, Qt::DisplayRole);
 		}
@@ -450,7 +450,7 @@ void GeneralConfigurationPage::on_m_company_elmt_path_cb_currentIndexChanged(int
 {
 	if (index == 1)
 	{
-		QString path = QFileDialog::getExistingDirectory(this, tr("Chemin de la collection company"), QDir::homePath());
+		QString path = QFileDialog::getExistingDirectory(this, tr("Chemin de la collection company"), QETApp::documentDir());
 		if (!path.isEmpty()) {
 			ui->m_company_elmt_path_cb->setItemData(1, path, Qt::DisplayRole);
 		}
@@ -464,7 +464,7 @@ void GeneralConfigurationPage::on_m_custom_elmt_path_cb_currentIndexChanged(int 
 {
 	if (index == 1)
 	{
-		QString path = QFileDialog::getExistingDirectory(this, tr("Chemin de la collection utilisateur"), QDir::homePath());
+		QString path = QFileDialog::getExistingDirectory(this, tr("Chemin de la collection utilisateur"), QETApp::documentDir());
 		if (!path.isEmpty()) {
 			ui->m_custom_elmt_path_cb->setItemData(1, path, Qt::DisplayRole);
 		}
@@ -478,7 +478,7 @@ void GeneralConfigurationPage::on_m_company_tbt_path_cb_currentIndexChanged(int 
 {
 	if (index == 1)
 	{
-		QString path = QFileDialog::getExistingDirectory(this, tr("Chemin des cartouches company"), QDir::homePath());
+		QString path = QFileDialog::getExistingDirectory(this, tr("Chemin des cartouches company"), QETApp::documentDir());
 		if (!path.isEmpty()) {
 			ui->m_company_tbt_path_cb->setItemData(1, path, Qt::DisplayRole);
 		}
@@ -492,7 +492,7 @@ void GeneralConfigurationPage::on_m_custom_tbt_path_cb_currentIndexChanged(int i
 {
 	if (index == 1)
 	{
-		QString path = QFileDialog::getExistingDirectory(this, tr("Chemin des cartouches utilisateur"), QDir::homePath());
+		QString path = QFileDialog::getExistingDirectory(this, tr("Chemin des cartouches utilisateur"), QETApp::documentDir());
 		if (!path.isEmpty()) {
 			ui->m_custom_tbt_path_cb->setItemData(1, path, Qt::DisplayRole);
 		}


### PR DESCRIPTION
Additionally:
Source-code compiles and binary runs perfectly without the removed function to call ElementScaler!