### PR TITLE
build-aux/snap/snapcraft.yaml:  python3.8 -> 3.10

### DIFF
--- a/build-aux/snap/snapcraft.yaml
+++ b/build-aux/snap/snapcraft.yaml
@@ -33,7 +33,7 @@ apps:
     environment: &env
       TCL_LIBRARY: $SNAP/usr/share/tcltk/tcl8.6
       HOME: $SNAP_USER_COMMON
-      PYTHONPATH: $SNAP:$SNAP/lib/python3.8/site-packages:$SNAP/usr/lib/python3.8:$SNAP/usr/lib/python3.8/lib-dynload
+      PYTHONPATH: $SNAP:$SNAP/lib/python3.10/site-packages:$SNAP/usr/lib/python3.10:$SNAP/usr/lib/python3.10/lib-dynload
 
   qet-tb-generator:
     command: bin/qet_tb_generator


### PR DESCRIPTION
Fix traceback when selecting "Project" menu "Launch the terminal block creation plugin" item:

    Traceback (most recent call last):
      File "/snap/qelectrotech/1973/bin/qet_tb_generator", line 33, in <module>
        sys.exit(load_entry_point('qet-tb-generator==1.3.1', 'console_scripts', 'qet_tb_generator')())
      File "/snap/qelectrotech/1973/bin/qet_tb_generator", line 25, in importlib_load_entry_point
        return next(matches).load()
      File "/usr/lib/python3.10/importlib/metadata/__init__.py", line 171, in load
        module = import_module(match.group('module'))
      File "/usr/lib/python3.10/importlib/__init__.py", line 126, in import_module
        return _bootstrap._gcd_import(name[level:], package, level)
      File "<frozen importlib._bootstrap>", line 1050, in _gcd_import
      File "<frozen importlib._bootstrap>", line 1027, in _find_and_load
      File "<frozen importlib._bootstrap>", line 1006, in _find_and_load_unlocked
      File "<frozen importlib._bootstrap>", line 688, in _load_unlocked
      File "<frozen importlib._bootstrap_external>", line 883, in exec_module
      File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
      File "/snap/qelectrotech/1973/lib/python3.10/site-packages/src/main.py", line 98, in <module>
        import src.PySimpleGUI as sg
      File "/snap/qelectrotech/1973/lib/python3.10/site-packages/src/PySimpleGUI.py", line 95, in <module>
        import tkinter as tk
    ModuleNotFoundError: No module named 'tkinter'