### PR TITLE
rewrite code for executing “qet_tb_generator” plugin

### DIFF
--- a/sources/qetdiagrameditor.cpp
+++ b/sources/qetdiagrameditor.cpp
@@ -2360,50 +2360,31 @@ void QETDiagramEditor::generateTerminalBlock()
 		//connect(process, SIGNAL(errorOcurred(int error)), this, SLOT(slot_generateTerminalBlock_error()));
 		//process->start("qet_tb_generator");
 
-#if defined(Q_OS_WIN32) || defined(Q_OS_WIN64)
 	if (openedProjects().count()) {
 		QList<QString> exeList;
+#if defined(Q_OS_WIN32) || defined(Q_OS_WIN64)
 		exeList << QStandardPaths::findExecutable("qet_tb_generator.exe")
 				<< "qet_tb_generator"
 				<< (QDir::homePath() + "/Application Data/qet/qet_tb_generator.exe")
 				<< (QETApp::dataDir() + "/binary/qet_tb_generator.exe");
-		foreach(QString exe, exeList) {
-			qInfo() << " success so far: " << success << "  - now searching for " << exe;
-			if ((success == false) && exe.length() && QFile::exists(exe)) {
-				success = process->startDetached(exe, {(QETDiagramEditor::currentProjectView()->project()->filePath())});
-			}
-		}
-	}
 #elif  defined(Q_OS_MACOS)
-	if (openedProjects().count()) {
-		QList<QString> exeList;
 		exeList << QStandardPaths::findExecutable("qet_tb_generator")
 				<< "/Library/Frameworks/Python.framework/Versions/3.11/bin/qet_tb_generator"
 				<< (QDir::homePath() + "/.qet/qet_tb_generator.app")
 				<< (QETApp::dataDir() + "/binary/qet_tb_generator");
-		foreach(QString exe, exeList) {
-			qInfo() << " success so far: " << success << "  - now searching for " << exe;
-			if ((success == false) && exe.length() && QFile::exists(exe)) {
-				success = process->startDetached(exe, {(QETDiagramEditor::currentProjectView()->project()->filePath())});
-			}
-		}
-	}
 #else
-	if (openedProjects().count()) {
-		QList<QString> exeList;
 		exeList << QStandardPaths::findExecutable("qet_tb_generator")
 				<< (QETApp::dataDir() + "/binary/qet_tb_generator")
 				<< (QDir::homePath() + "/.qet/qet_tb_generator")
 				<< "qet_tb_generator";
+#endif
 		foreach(QString exe, exeList) {
 			qInfo() << " success so far: " << success << "  - now searching for " << exe;
 			if ((success == false) && exe.length() && QFile::exists(exe)) {
 				success = process->startDetached(exe, {(QETDiagramEditor::currentProjectView()->project()->filePath())});
 			}
 		}
-	}
-#endif
-	else {
+	} else {
 		qInfo() << "No project loaded - no need to start \"qet_tb_generator\"";
 	}
 	process->close();

--- a/sources/qetdiagrameditor.cpp
+++ b/sources/qetdiagrameditor.cpp
@@ -2404,9 +2404,9 @@ void QETDiagramEditor::generateTerminalBlock()
 	}
 #endif
 	else {
-		process->close();
 		qInfo() << "No project loaded - no need to start \"qet_tb_generator\"";
 	}
+	process->close();
 
 #if defined(Q_OS_WIN32) || defined(Q_OS_WIN64)
 	QString message=QObject::tr(

--- a/sources/qetdiagrameditor.cpp
+++ b/sources/qetdiagrameditor.cpp
@@ -2353,7 +2353,7 @@ void QETDiagramEditor::generateTerminalBlock()
 #	pragma message("https://github.com/qelectrotech/qet_tb_generator")
 #endif
 
-	bool success;
+	bool success = false;
 	QProcess *process = new QProcess(qApp);
 
 		// If launched under control:
@@ -2361,47 +2361,52 @@ void QETDiagramEditor::generateTerminalBlock()
 		//process->start("qet_tb_generator");
 
 #if defined(Q_OS_WIN32) || defined(Q_OS_WIN64)
-	if (openedProjects().count()){
-		success = process->startDetached("qet_tb_generator", {(QETDiagramEditor::currentProjectView()->project()->filePath())});
+	if (openedProjects().count()) {
+		QList<QString> exeList;
+		exeList << QStandardPaths::findExecutable("qet_tb_generator.exe")
+				<< "qet_tb_generator"
+				<< (QDir::homePath() + "/Application Data/qet/qet_tb_generator.exe")
+				<< (QETApp::dataDir() + "/binary/qet_tb_generator.exe");
+		foreach(QString exe, exeList) {
+			qInfo() << " success so far: " << success << "  - now searching for " << exe;
+			if ((success == false) && exe.length() && QFile::exists(exe)) {
+				success = process->startDetached(exe, {(QETDiagramEditor::currentProjectView()->project()->filePath())});
+			}
+		}
 	}
-	else  {
-		success = process->startDetached("qet_tb_generator", {("")});
-	}
-	if (openedProjects().count()){
-		success = process->startDetached(QDir::homePath() + "/Application Data/qet/qet_tb_generator.exe", {(QETDiagramEditor::currentProjectView()->project()->filePath())});
-	}
-	else  {
-		success = process->startDetached(QDir::homePath() + "/Application Data/qet/qet_tb_generator.exe", {("")});
-	}
-	if (openedProjects().count()){
-		success = process->startDetached(QDir::homePath() + "/qet_tb_generator.exe", {(QETDiagramEditor::currentProjectView()->project()->filePath())});
-	}
-	else  {
-		success = process->startDetached(QDir::homePath() + "/qet_tb_generator.exe", {("")});
-	}
-
-	
-
 #elif  defined(Q_OS_MACOS)
-	if (openedProjects().count()){
-		success = process->startDetached("/Library/Frameworks/Python.framework/Versions/3.11/bin/qet_tb_generator", {(QETDiagramEditor::currentProjectView()->project()->filePath())});
+	if (openedProjects().count()) {
+		QList<QString> exeList;
+		exeList << QStandardPaths::findExecutable("qet_tb_generator")
+				<< "/Library/Frameworks/Python.framework/Versions/3.11/bin/qet_tb_generator"
+				<< (QDir::homePath() + "/.qet/qet_tb_generator.app")
+				<< (QETApp::dataDir() + "/binary/qet_tb_generator");
+		foreach(QString exe, exeList) {
+			qInfo() << " success so far: " << success << "  - now searching for " << exe;
+			if ((success == false) && exe.length() && QFile::exists(exe)) {
+				success = process->startDetached(exe, {(QETDiagramEditor::currentProjectView()->project()->filePath())});
+			}
+		}
 	}
-	else  {
-		success = process->startDetached(QDir::homePath() + "/.qet/qet_tb_generator.app", {(QETDiagramEditor::currentProjectView()->project()->filePath())});
-	}
-	
-
 #else
-	if (openedProjects().count()){
-		success = process->startDetached("qet_tb_generator", {(QETDiagramEditor::currentProjectView()->project()->filePath())});
+	if (openedProjects().count()) {
+		QList<QString> exeList;
+		exeList << QStandardPaths::findExecutable("qet_tb_generator")
+				<< (QETApp::dataDir() + "/binary/qet_tb_generator")
+				<< (QDir::homePath() + "/.qet/qet_tb_generator")
+				<< "qet_tb_generator";
+		foreach(QString exe, exeList) {
+			qInfo() << " success so far: " << success << "  - now searching for " << exe;
+			if ((success == false) && exe.length() && QFile::exists(exe)) {
+				success = process->startDetached(exe, {(QETDiagramEditor::currentProjectView()->project()->filePath())});
+			}
+		}
+	} else {
+		process->close();
+		qInfo() << "Did not find binary of \"qet_tb_generator\"";
 	}
-	
-	else  {
-		success = process->startDetached(QDir::homePath() + "/.qet/qet_tb_generator", {(QETDiagramEditor::currentProjectView()->project()->filePath())});
-	}
-	
-
 #endif
+
 #if defined(Q_OS_WIN32) || defined(Q_OS_WIN64)
 	QString message=QObject::tr(
 		"To install the plugin qet_tb_generator"

--- a/sources/qetdiagrameditor.cpp
+++ b/sources/qetdiagrameditor.cpp
@@ -2401,11 +2401,12 @@ void QETDiagramEditor::generateTerminalBlock()
 				success = process->startDetached(exe, {(QETDiagramEditor::currentProjectView()->project()->filePath())});
 			}
 		}
-	} else {
-		process->close();
-		qInfo() << "Did not find binary of \"qet_tb_generator\"";
 	}
 #endif
+	else {
+		process->close();
+		qInfo() << "No project loaded - no need to start \"qet_tb_generator\"";
+	}
 
 #if defined(Q_OS_WIN32) || defined(Q_OS_WIN64)
 	QString message=QObject::tr(

--- a/sources/qetdiagrameditor.cpp
+++ b/sources/qetdiagrameditor.cpp
@@ -2354,30 +2354,34 @@ void QETDiagramEditor::generateTerminalBlock()
 #endif
 
 	bool success = false;
+	QList<QString> exeList;
 	QProcess *process = new QProcess(qApp);
+
+#if defined(Q_OS_WIN32) || defined(Q_OS_WIN64)
+	exeList << QStandardPaths::findExecutable("qet_tb_generator.exe")
+			<< "qet_tb_generator"
+			<< (QDir::homePath() + "/Application Data/qet/qet_tb_generator.exe")
+			<< (QETApp::dataDir() + "/binary/qet_tb_generator.exe");
+#elif  defined(Q_OS_MACOS)
+	exeList << QStandardPaths::findExecutable("qet_tb_generator")
+			<< "/Library/Frameworks/Python.framework/Versions/3.11/bin/qet_tb_generator"
+			<< (QDir::homePath() + "/.qet/qet_tb_generator.app")
+			<< (QETApp::dataDir() + "/binary/qet_tb_generator");
+#else
+	exeList << QStandardPaths::findExecutable("qet_tb_generator")
+			<< (QETApp::dataDir() + "/binary/qet_tb_generator")
+			<< (QDir::homePath() + "/.qet/qet_tb_generator")
+			<< "qet_tb_generator";
+#endif
 
 		// If launched under control:
 		//connect(process, SIGNAL(errorOcurred(int error)), this, SLOT(slot_generateTerminalBlock_error()));
 		//process->start("qet_tb_generator");
 
+	qInfo() << " project to use for qet_tb_generator: "
+			<< (QETDiagramEditor::currentProjectView()->project()->filePath());
+
 	if (openedProjects().count()) {
-		QList<QString> exeList;
-#if defined(Q_OS_WIN32) || defined(Q_OS_WIN64)
-		exeList << QStandardPaths::findExecutable("qet_tb_generator.exe")
-				<< "qet_tb_generator"
-				<< (QDir::homePath() + "/Application Data/qet/qet_tb_generator.exe")
-				<< (QETApp::dataDir() + "/binary/qet_tb_generator.exe");
-#elif  defined(Q_OS_MACOS)
-		exeList << QStandardPaths::findExecutable("qet_tb_generator")
-				<< "/Library/Frameworks/Python.framework/Versions/3.11/bin/qet_tb_generator"
-				<< (QDir::homePath() + "/.qet/qet_tb_generator.app")
-				<< (QETApp::dataDir() + "/binary/qet_tb_generator");
-#else
-		exeList << QStandardPaths::findExecutable("qet_tb_generator")
-				<< (QETApp::dataDir() + "/binary/qet_tb_generator")
-				<< (QDir::homePath() + "/.qet/qet_tb_generator")
-				<< "qet_tb_generator";
-#endif
 		foreach(QString exe, exeList) {
 			qInfo() << " success so far: " << success << "  - now searching for " << exe;
 			if ((success == false) && exe.length() && QFile::exists(exe)) {

--- a/sources/qetdiagrameditor.cpp
+++ b/sources/qetdiagrameditor.cpp
@@ -2358,19 +2358,23 @@ void QETDiagramEditor::generateTerminalBlock()
 	QProcess *process = new QProcess(qApp);
 
 #if defined(Q_OS_WIN32) || defined(Q_OS_WIN64)
-	exeList << QStandardPaths::findExecutable("qet_tb_generator.exe")
-			<< "qet_tb_generator"
+	exeList << (QETApp::dataDir() + "/binary/qet_tb_generator.exe")
+			<< (QDir::currentPath() + "/qet_tb_generator.exe")
+			<< QStandardPaths::findExecutable("qet_tb_generator.exe")
 			<< (QDir::homePath() + "/Application Data/qet/qet_tb_generator.exe")
-			<< (QETApp::dataDir() + "/binary/qet_tb_generator.exe");
+			<< "qet_tb_generator.exe"
+			<< "qet_tb_generator";    // from original code: missing ".exe" ???
 #elif  defined(Q_OS_MACOS)
-	exeList << QStandardPaths::findExecutable("qet_tb_generator")
-			<< "/Library/Frameworks/Python.framework/Versions/3.11/bin/qet_tb_generator"
+	exeList << (QETApp::dataDir() + "/binary/qet_tb_generator")
+			<< (QDir::currentPath() + "/qet_tb_generator")
+			<< QStandardPaths::findExecutable("qet_tb_generator")
 			<< (QDir::homePath() + "/.qet/qet_tb_generator.app")
-			<< (QETApp::dataDir() + "/binary/qet_tb_generator");
+			<< "/Library/Frameworks/Python.framework/Versions/3.11/bin/qet_tb_generator";
 #else
-	exeList << QStandardPaths::findExecutable("qet_tb_generator")
-			<< (QETApp::dataDir() + "/binary/qet_tb_generator")
+	exeList << (QETApp::dataDir() + "/binary/qet_tb_generator")
+			<< (QDir::currentPath() + "/qet_tb_generator")
 			<< (QDir::homePath() + "/.qet/qet_tb_generator")
+			<< QStandardPaths::findExecutable("qet_tb_generator")
 			<< "qet_tb_generator";
 #endif
 


### PR DESCRIPTION
Now it's better readable and maintainable up to the moment we have our own internal Terminal-Manager for productive use. Additionally added the storage location “dataDir()/binary”, so that the new structure for the separation of
configuration and data can be properly kept.
We can remove the inserted qInfo() - lines later, when we know that everything is o.k. with this part of code. On my Debian stable and unstable the code works perfectly!