### PR TITLE
Sort names in element-file by language-code

### DIFF
--- a/sources/NameList/nameslist.cpp
+++ b/sources/NameList/nameslist.cpp
@@ -46,7 +46,7 @@ NamesList::~NamesList()
 void NamesList::addName(const QString &lang, const QString &name) {
 	if ((lang.length() != 2) && (lang.length() != 5)) return;
 	if ((lang.length() == 5) && (lang[2] != '_')) return;
-	hash_names.insert(lang, name);
+	map_names.insert(lang, name);
 }
 
 /**
@@ -54,7 +54,7 @@ void NamesList::addName(const QString &lang, const QString &name) {
 	@param lang la langue pour laquelle il faut supprimer le nom
 */
 void NamesList::removeName(const QString &lang) {
-	hash_names.remove(lang);
+	map_names.remove(lang);
 }
 
 /**
@@ -62,7 +62,7 @@ void NamesList::removeName(const QString &lang) {
 */
 void NamesList::clearNames()
 {
-	hash_names.clear();
+	map_names.clear();
 }
 
 /**
@@ -70,7 +70,7 @@ void NamesList::clearNames()
 */
 QList<QString> NamesList::langs() const
 {
-	return(hash_names.keys());
+	return(map_names.keys());
 }
 
 /**
@@ -78,7 +78,7 @@ QList<QString> NamesList::langs() const
 */
 bool NamesList::isEmpty() const
 {
-	return(hash_names.isEmpty());
+	return(map_names.isEmpty());
 }
 
 /**
@@ -86,7 +86,7 @@ bool NamesList::isEmpty() const
 */
 int NamesList::count() const
 {
-	return(hash_names.count());
+	return(map_names.count());
 }
 
 /**
@@ -95,7 +95,7 @@ int NamesList::count() const
 	defini
 */
 QString &NamesList::operator[](const QString &lang) {
-	return(hash_names[lang]);
+	return(map_names[lang]);
 }
 
 /**
@@ -105,7 +105,7 @@ QString &NamesList::operator[](const QString &lang) {
 */
 const QString NamesList::operator[](const QString &lang) const
 {
-	return(hash_names.value(lang));
+	return(map_names.value(lang));
 }
 
 
@@ -184,18 +184,19 @@ QDomElement NamesList::toXml(QDomDocument &xml_document, const QHash<QString, QS
 {
 	QHash<QString, QString> xml_opt = getXmlOptions(xml_options);
 	QDomElement names_elmt = xml_document.createElement(xml_opt["ParentTagName"]);
-	if (hash_names.isEmpty()) {
+	if (map_names.isEmpty()) {
+		qInfo() << " NamesList of element is empty - add default: [" << "en" << "] = " << "NoName" << "";
 		QDomElement name_elmt = xml_document.createElement(xml_opt["TagName"]);
 		name_elmt.setAttribute(xml_opt["LanguageAttribute"], "en");
 		name_elmt.appendChild(xml_document.createTextNode("NoName"));
 		names_elmt.appendChild(name_elmt);
 	}
-	QHashIterator<QString, QString> names_iterator(hash_names);
+	QMapIterator<QString, QString> names_iterator(map_names);
 	while (names_iterator.hasNext()) {
 		names_iterator.next();
 		QDomElement name_elmt = xml_document.createElement(xml_opt["TagName"]);
 		name_elmt.setAttribute(xml_opt["LanguageAttribute"], names_iterator.key());
-		name_elmt.appendChild(xml_document.createTextNode(names_iterator.value()));
+		name_elmt.appendChild(xml_document.createTextNode(names_iterator.value().trimmed()));
 		names_elmt.appendChild(name_elmt);
 	}
 	return(names_elmt);
@@ -229,7 +230,7 @@ QHash<QString, QString> NamesList::getXmlOptions(const QHash<QString, QString> &
 */
 bool NamesList::operator!=(const NamesList &nl) const
 {
-	return(hash_names != nl.hash_names);
+	return(map_names != nl.map_names);
 }
 
 /**
@@ -238,7 +239,7 @@ bool NamesList::operator!=(const NamesList &nl) const
 */
 bool NamesList::operator==(const NamesList &nl) const
 {
-	return(hash_names == nl.hash_names);
+	return(map_names == nl.map_names);
 }
 
 /**
@@ -257,10 +258,10 @@ bool NamesList::operator==(const NamesList &nl) const
 QString NamesList::name(const QString &fallback_name) const
 {
 	QString system_language = QETApp::langFromSetting();
-	if (! hash_names[system_language].isEmpty())
-		return (hash_names[system_language]);
-	if (! hash_names["en"].isEmpty()) return (hash_names["en"]);
+	if (! map_names[system_language].isEmpty())
+		return (map_names[system_language]);
+	if (! map_names["en"].isEmpty()) return (map_names["en"]);
 	if (! fallback_name.isEmpty()) return (fallback_name);
-	if (hash_names.count()) return (hash_names.begin().value());
+	if (map_names.count()) return (map_names.begin().value());
 	return (QString(""));
 }

--- a/sources/NameList/nameslist.cpp
+++ b/sources/NameList/nameslist.cpp
@@ -168,8 +168,13 @@ void NamesList::fromXml(const pugi::xml_node &xml_element, const QHash<QString, 
 }
 
 /**
+	Exports the list of names to an XML element.
+	Make sure that the list of names is not empty before exporting.
+	If list is empty, set name to "en" / "NoName"
+	French:
 	Exporte la liste des noms vers un element XML. Veillez a verifier que la
 	liste de noms n'est pas vide avant de l'exporter.
+	Si la liste est vide, le nom sera "en" / "NoName".
 	@param xml_document Le document XML dans lequel l'element XML sera insere
 	@param xml_options A set of options related to XML parsing.
 	@return L'element XML correspondant a la section "names"
@@ -179,6 +184,12 @@ QDomElement NamesList::toXml(QDomDocument &xml_document, const QHash<QString, QS
 {
 	QHash<QString, QString> xml_opt = getXmlOptions(xml_options);
 	QDomElement names_elmt = xml_document.createElement(xml_opt["ParentTagName"]);
+	if (hash_names.isEmpty()) {
+		QDomElement name_elmt = xml_document.createElement(xml_opt["TagName"]);
+		name_elmt.setAttribute(xml_opt["LanguageAttribute"], "en");
+		name_elmt.appendChild(xml_document.createTextNode("NoName"));
+		names_elmt.appendChild(name_elmt);
+	}
 	QHashIterator<QString, QString> names_iterator(hash_names);
 	while (names_iterator.hasNext()) {
 		names_iterator.next();

--- a/sources/NameList/nameslist.h
+++ b/sources/NameList/nameslist.h
@@ -21,6 +21,12 @@
 
 #include <QtXml>
 /**
+	This class represents a list of names, used by elements and categories
+	to embed the same name in several languages.
+	Languages are represented by two or five letters (typically the first
+	two of the system locale); examples: en for English, fr for French,
+	pt_BR for Brazilian Portuguese.
+	French:
 	Cette classe represente une liste de noms, utilisee
 	par les elements et categories pour embarquer un meme nom en plusieurs
 	langues.
@@ -36,7 +42,7 @@ class NamesList {
 	
 	// attributes
 	private:
-	QHash<QString, QString> hash_names;
+	QMap<QString, QString> map_names;
 	
 	public:
 	static int MetaTypeId;


### PR DESCRIPTION
NamesList: Use ‘Qmap’ instead of ‘Qhash’
to automatically sort the names of an element by
language code before saving the element-file.
If no name is set, set default: "en" / "NoName"
Sometimes I like it tidy...  ;)
adjusted comments
Added English part to comment in header-file.
