### PR TITLE
some clean-up for element-file and in code

### DIFF
--- a/sources/ElementsCollection/elementslocation.cpp
+++ b/sources/ElementsCollection/elementslocation.cpp
@@ -870,7 +870,7 @@ QIcon ElementsLocation::icon() const
 
 /**
 	@brief ElementLocation::name
-	@return The name of the represented element in the current local
+	@return The name of the represented element in the current locale
 */
 QString ElementsLocation::name() const
 {

--- a/sources/NameList/nameslist.cpp
+++ b/sources/NameList/nameslist.cpp
@@ -111,11 +111,15 @@ const QString NamesList::operator[](const QString &lang) const
 
 
 /**
+	Loads the list of names from an XML element. This element is assumed to be
+	the parent of a ‘names’ element, which itself contains the ‘names’. The
+	names previously contained in the list are not deleted, but can be overwritten.
+	French:
 	Charge la liste de noms depuis un element XML. Cet element est sense etre
 	le parent d'un element "names", qui contient lui meme les "name".
 	Les noms precedemment contenus dans la liste ne sont pas effaces mais
 	peuvent etre ecrases.
-	@param xml_element L'element XML a analyser
+	@param xml_element L'element XML a analyser / The XML element to be parsed
 	@param xml_options A set of options related to XML parsing.
 	@see getXmlOptions()
 */
@@ -190,14 +194,15 @@ QDomElement NamesList::toXml(QDomDocument &xml_document, const QHash<QString, QS
 		name_elmt.setAttribute(xml_opt["LanguageAttribute"], "en");
 		name_elmt.appendChild(xml_document.createTextNode("NoName"));
 		names_elmt.appendChild(name_elmt);
-	}
-	QMapIterator<QString, QString> names_iterator(map_names);
-	while (names_iterator.hasNext()) {
-		names_iterator.next();
-		QDomElement name_elmt = xml_document.createElement(xml_opt["TagName"]);
-		name_elmt.setAttribute(xml_opt["LanguageAttribute"], names_iterator.key());
-		name_elmt.appendChild(xml_document.createTextNode(names_iterator.value().trimmed()));
-		names_elmt.appendChild(name_elmt);
+	} else {
+		QMapIterator<QString, QString> names_iterator(map_names);
+		while (names_iterator.hasNext()) {
+			names_iterator.next();
+			QDomElement name_elmt = xml_document.createElement(xml_opt["TagName"]);
+			name_elmt.setAttribute(xml_opt["LanguageAttribute"], names_iterator.key());
+			name_elmt.appendChild(xml_document.createTextNode(names_iterator.value().trimmed()));
+			names_elmt.appendChild(name_elmt);
+		}
 	}
 	return(names_elmt);
 }

--- a/sources/diagramcontext.cpp
+++ b/sources/diagramcontext.cpp
@@ -151,10 +151,14 @@ bool DiagramContext::operator!=(const DiagramContext &dc) const
 void DiagramContext::toXml(QDomElement &e, const QString &tag_name) const
 {
 	foreach (QString key, keys()) {
+		if (m_content[key].toString().trimmed().isEmpty()) { continue; }
 		QDomElement property = e.ownerDocument().createElement(tag_name);
+		// try to sort attributes by removing and re-adding
+		property.removeAttribute("show");
+		property.removeAttribute("name");
+		property.setAttribute("show", m_content_show[key]);
 		property.setAttribute("name", key);
-		property.setAttribute("show",m_content_show[key]);
-		QDomText value = e.ownerDocument().createTextNode(m_content[key].toString());
+		QDomText value = e.ownerDocument().createTextNode(m_content[key].toString().trimmed());
 		property.appendChild(value);
 		e.appendChild(property);
 	}

--- a/sources/diagramcontext.h
+++ b/sources/diagramcontext.h
@@ -99,7 +99,7 @@ class DiagramContext
 	
 		void add(DiagramContext other);
 		void remove(const QString &key);
-		QList<QString> keys(KeyOrder = None) const;
+		QList<QString> keys(KeyOrder = Alphabetical) const;
 		bool contains(const QString &) const;
 		const QVariant operator[](const QString &) const;
 		bool addValue(const QString &, const QVariant &, bool show = true);


### PR DESCRIPTION
- for some time now and for whatever reason, element-editor
  sometimes adds element-information without content –> do not
  save info-lines without any content
- sort element-information alphabetically by name in element-file
- use trimmed strings for element-information to remove leading
  and trailing whitespace
- fix typo
- NamesList: move while-loop into "else"-clause, to be more precise 
- added English text to comments