### PR TITLE
FIX copy-and-paste in element-editor: set paste-position to meaningful values

### DIFF
--- a/sources/editor/elementscene.cpp
+++ b/sources/editor/elementscene.cpp
@@ -517,11 +517,11 @@ QRectF ElementScene::boundingRectFromXml(const QDomDocument &xml_document)
 	ElementContent loaded_content = loadContent(xml_document);
 	if (loaded_content.isEmpty()) return(QRectF());
 
-	// calcule the boundingRect
+	// calculate the boundingRect
 	// calcule le boundingRect
 	QRectF bounding_rect = elementContentBoundingRect(loaded_content);
 
-	// destroy charged parties
+	// destroy loaded parts
 	// detruit les parties chargees
 	qDeleteAll(loaded_content);
 

--- a/sources/editor/elementview.cpp
+++ b/sources/editor/elementview.cpp
@@ -321,10 +321,12 @@ ElementContent ElementView::paste(const QDomDocument &xml_document, const QPoint
 }
 
 /**
+	Paste the XML document "xml_document" at position pos
 	Colle le document XML xml_document a la position pos
 	@param xml_document Document XML a coller
 */
 ElementContent ElementView::pasteWithOffset(const QDomDocument &xml_document) {
+	// object to retrieve content added to the scheme by pasting
 	// objet pour recuperer le contenu ajoute au schema par le coller
 	ElementContent content_pasted;
 
@@ -358,6 +360,7 @@ ElementContent ElementView::pasteWithOffset(const QDomDocument &xml_document) {
 	start_top_left_corner_ = final_pasted_content_bounding_rect.topLeft();
 	m_scene -> fromXml(xml_document, start_top_left_corner_, false, &content_pasted);
 
+	// if something has actually been added to the scheme, a cancel object is created
 	// si quelque chose a effectivement ete ajoute au schema, on cree un objet d'annulation
 	if (content_pasted.count()) {
 		m_scene -> clearSelection();

--- a/sources/editor/elementview.cpp
+++ b/sources/editor/elementview.cpp
@@ -307,10 +307,12 @@ ElementContent ElementView::pasteAreaDefined(const QRectF &target_rect) {
 	@param pos Coin superieur gauche du rectangle cible
 */
 ElementContent ElementView::paste(const QDomDocument &xml_document, const QPointF &pos) {
+	// object to retrieve content added to the scheme by pasting
 	// objet pour recuperer le contenu ajoute au schema par le coller
 	ElementContent content_pasted;
 	m_scene -> fromXml(xml_document, pos, false, &content_pasted);
 
+	// if something has actually been added to the scheme, an undo object is created
 	// si quelque chose a effectivement ete ajoute au schema, on cree un objet d'annulation
 	if (content_pasted.count()) {
 		m_scene -> clearSelection();
@@ -334,6 +336,7 @@ ElementContent ElementView::pasteWithOffset(const QDomDocument &xml_document) {
 	QRectF pasted_content_bounding_rect = m_scene -> boundingRectFromXml(xml_document);
 	if (pasted_content_bounding_rect.isEmpty()) return(content_pasted);
 
+	// paste copied parts with offset
 	// copier/coller avec decalage
 	QRectF final_pasted_content_bounding_rect;
 	++ offset_paste_count_;
@@ -594,10 +597,12 @@ void ElementView::drawBackground(QPainter *p, const QRectF &r) {
 	@return
 */
 QRectF ElementView::applyMovement(const QRectF &start, const QPointF &offset) {
+	// calculates the offset to be applied from the offset
 	// calcule le decalage a appliquer a partir de l'offset
 	QPointF final_offset;
 	final_offset.rx() =  start.width() + offset.x();
 
+	// applies the calculated offset
 	// applique le decalage ainsi calcule
 	return(start.translated(final_offset));
 }

--- a/sources/editor/elementview.cpp
+++ b/sources/editor/elementview.cpp
@@ -336,29 +336,20 @@ ElementContent ElementView::pasteWithOffset(const QDomDocument &xml_document) {
 	QRectF pasted_content_bounding_rect = m_scene -> boundingRectFromXml(xml_document);
 	if (pasted_content_bounding_rect.isEmpty()) return(content_pasted);
 
+	// ok ... there is something to do for us!
+	int initialOffsetX = 10 + (qRound((pasted_content_bounding_rect.width())/10) * 10);
+
 	// paste copied parts with offset
 	// copier/coller avec decalage
-	QRectF final_pasted_content_bounding_rect;
-	++ offset_paste_count_;
-	if (!offset_paste_count_) {
-		// the pasted content was cut
-		start_top_left_corner_ = pasted_content_bounding_rect.topLeft();
-		final_pasted_content_bounding_rect = pasted_content_bounding_rect;
-	}
-	else {
-		// the pasted content was copied
-		if (offset_paste_count_ == 1) {
-			start_top_left_corner_ = pasted_content_bounding_rect.topLeft();
-		} else {
-			pasted_content_bounding_rect.moveTopLeft(start_top_left_corner_);
-		}
+	QRectF  final_pasted_content_bounding_rect;
+	QPointF offset(initialOffsetX, 0);
+	++ offset_paste_count_;  // == 0 when selection was cut to clipboard
+	// place pasted parts right from copied selection or already pasted parts
+	offset.setX(initialOffsetX * offset_paste_count_);
+	offset.setY(0);
+	final_pasted_content_bounding_rect = pasted_content_bounding_rect.translated(offset);
 
-		// on applique le decalage qui convient
-		final_pasted_content_bounding_rect = applyMovement(
-			pasted_content_bounding_rect,
-			QETElementEditor::pasteOffset()
-		);
-	}
+	start_top_left_corner_ = pasted_content_bounding_rect.topLeft();
 	QPointF old_start_top_left_corner = start_top_left_corner_;
 	start_top_left_corner_ = final_pasted_content_bounding_rect.topLeft();
 	m_scene -> fromXml(xml_document, start_top_left_corner_, false, &content_pasted);

--- a/sources/qetgraphicsitem/ViewItem/qetgraphicstableitem.cpp
+++ b/sources/qetgraphicsitem/ViewItem/qetgraphicstableitem.cpp
@@ -274,7 +274,7 @@ void QetGraphicsTableItem::paint(
 		offset += m_header_item->sectionSize(i);
 	}
 
-		//Calcule the number of rows to display.
+		//calculate the number of rows to display.
 	auto row_count = m_model->rowCount();
 
 	if (m_previous_table) //Remove the number of row already displayed by previous tables
@@ -516,7 +516,7 @@ int QetGraphicsTableItem::displayedRowCount() const
 		return 0;
 	}
 
-		//Calcule the number of rows to display.
+		//calculate the number of rows to display.
 	auto row_count = m_model->rowCount();
 
 	if (m_previous_table) //Remove the number of row already displayed by previous tables
@@ -858,7 +858,7 @@ void QetGraphicsTableItem::modelReseted()
 
 /**
 	@brief QetGraphicsTableItem::setUpColumnAndRowMinimumSize
-	Calcule the minimum row height and the minimum column width for each columns
+	Calculate the minimum row height and the minimum column width for each columns
 	this function doesn't change the geometry of the table.
 */
 void QetGraphicsTableItem::setUpColumnAndRowMinimumSize()


### PR DESCRIPTION
"_Why keep it simple when you can make it complicated?_"
Really???
I prefer:
**Keep it small and simple!**

The paste position is equal to the copied position plus an integer offset in x-direction right of the copied selection or the last pasted parts.
If the copied selection contains decimal places for the position, they are of course also retained in the copy! We don't want falsified copies ...!


Note:
This fix does not mean that we should revert the limitation of decimal places: These are two separate issues!