### PR TITLE
Fix typo widht to width

### DIFF
--- a/sources/qetgraphicsitem/dynamicelementtextitem.cpp
+++ b/sources/qetgraphicsitem/dynamicelementtextitem.cpp
@@ -46,7 +46,7 @@ DynamicElementTextItem::DynamicElementTextItem(Element *parent_element) :
 	QSettings settings;
 	setRotation(settings.value("dynamic_text_rotation", 0).toInt());
 	setKeepVisualRotation(true);
-	setTextWidth(settings.value("dynamic_text_widht", -1).toInt());
+	setTextWidth(settings.value("dynamic_text_width", -1).toInt());
 	connect(this, &DynamicElementTextItem::textEdited, [this](const QString &old_str, const QString &new_str)
 	{
 		if(this->m_parent_element && this->m_parent_element->diagram())

--- a/sources/ui/elementpropertieswidget.cpp
+++ b/sources/ui/elementpropertieswidget.cpp
@@ -403,10 +403,10 @@ QWidget *ElementPropertiesWidget::generalWidget()
 		//Set the maximum size of the pixmap to the minimum size of the layout
 	QPixmap pixmap = m_element->pixmap();
 	int margin = vlayout_->contentsMargins().left() + vlayout_->contentsMargins().right();
-	int widht_ = vlayout_->minimumSize().width()-margin;
+	int width_ = vlayout_->minimumSize().width()-margin;
 
-	if (pixmap.size().width() > widht_ || pixmap.size().height() > widht_) {
-		pix->setPixmap(m_element->pixmap().scaled (widht_, widht_, Qt::KeepAspectRatio, Qt::SmoothTransformation));
+	if (pixmap.size().width() > width_ || pixmap.size().height() > width_) {
+		pix->setPixmap(m_element->pixmap().scaled (width_, width_, Qt::KeepAspectRatio, Qt::SmoothTransformation));
 	}
 	else {
 		pix->setPixmap(pixmap);


### PR DESCRIPTION
While searching for something different i saw that there is a settings key not written in a consistent way. So in some places it was already spelled `dynamic_text_width` but within evaluation it was written `dynamic_text_widht` which is only a typo i think.

I fixed this and found another place where it was spelled wrong as well

I did not do testing on this cause i do not really know what is meant here.