### PR TITLE
Lock text to element

### DIFF
--- a/sources/editor/graphicspart/partdynamictextfield.cpp
+++ b/sources/editor/graphicspart/partdynamictextfield.cpp
@@ -209,6 +209,7 @@ void PartDynamicTextField::fromXml(const QDomElement &dom_elmt) {
 	setZValue(dom_elmt.attribute("z", QString::number(zValue())).toDouble());
 	QGraphicsObject::setRotation(QET::correctAngle(dom_elmt.attribute("rotation", QString::number(0)).toDouble()));
 	setKeepVisualRotation(dom_elmt.attribute("keep_visual_rotation", "true") == "true"? true : false);
+	setLockToElement(dom_elmt.attribute("lock_to_element", "false") == "true"? true : false);
 
 	if (dom_elmt.hasAttribute("font")) {
 		QFont font_;
@@ -487,6 +488,20 @@ void PartDynamicTextField::setKeepVisualRotation(const bool &keep)
 
 bool PartDynamicTextField::keepVisualRotation() const {
 	return m_keep_visual_rotation;
+}
+
+void PartDynamicTextField::setLockToElement(const bool &set)
+{
+	if (set == this->m_lock_to_element) {
+		return;
+	}
+
+	m_lock_to_element = set;
+	emit keepVisualRotationChanged(set);
+}
+
+bool PartDynamicTextField::lockToElement() const {
+	return m_lock_to_element;
 }
 
 /**

--- a/sources/editor/graphicspart/partdynamictextfield.h
+++ b/sources/editor/graphicspart/partdynamictextfield.h
@@ -44,6 +44,7 @@ class PartDynamicTextField : public QGraphicsTextItem, public CustomElementPart
 	Q_PROPERTY(Qt::Alignment alignment READ alignment WRITE setAlignment NOTIFY alignmentChanged)
 	Q_PROPERTY(QFont font READ font WRITE setFont NOTIFY fontChanged)
 	Q_PROPERTY(bool keepVisualRotation READ keepVisualRotation WRITE setKeepVisualRotation NOTIFY keepVisualRotationChanged)
+	Q_PROPERTY(bool lockToElement READ lockToElement WRITE setLockToElement NOTIFY keepLockToElementChanged)
 
 	public:
 			///PROPERTY
@@ -62,6 +63,7 @@ class PartDynamicTextField : public QGraphicsTextItem, public CustomElementPart
 		void alignmentChanged(Qt::Alignment alignment);
 		void fontChanged(QFont font);
 		void keepVisualRotationChanged(bool keep);
+		void keepLockToElementChanged(bool lock);
 
 	public:
 		PartDynamicTextField(QETElementEditor *editor, QGraphicsItem *parent = nullptr);
@@ -100,6 +102,8 @@ class PartDynamicTextField : public QGraphicsTextItem, public CustomElementPart
 		void setFont(const QFont &font);
 		void setKeepVisualRotation(const bool &keep);
 		bool keepVisualRotation() const;
+		void setLockToElement(const bool &set);
+		bool lockToElement() const;
 
 		void setRotation(qreal angle);
 		void mirror();
@@ -129,7 +133,8 @@ class PartDynamicTextField : public QGraphicsTextItem, public CustomElementPart
 		bool m_frame = false,
 			 m_first_add = true,
 			 m_block_alignment = false,
-			 m_keep_visual_rotation = false;
+			 m_keep_visual_rotation = false,
+			 m_lock_to_element = false;
 		qreal m_text_width = -1;
 		Qt::Alignment m_alignment = Qt::AlignTop|Qt::AlignLeft;
 		QRectF m_alignment_rect;

--- a/sources/editor/ui/dynamictextfieldeditor.cpp
+++ b/sources/editor/ui/dynamictextfieldeditor.cpp
@@ -140,6 +140,7 @@ void DynamicTextFieldEditor::updateForm()
 		ui -> m_user_text_le -> setText(m_text_field.data() -> text());
 		ui -> m_size_sb -> setValue(m_text_field.data() -> font().pointSize());
 		ui->m_keep_visual_rotation_cb->setChecked(m_text_field.data()->keepVisualRotation());
+		ui->m_lock_to_element_cb->setChecked(m_text_field.data()->lockToElement());
 #ifdef BUILD_WITHOUT_KF5
 #else
 		m_color_kpb -> setColor(m_text_field.data() -> color());
@@ -197,6 +198,7 @@ void DynamicTextFieldEditor::setUpConnections()
 	m_connection_list << connect(m_text_field.data(), &PartDynamicTextField::textWidthChanged, this, [=](){this -> updateForm();});
 	m_connection_list << connect(m_text_field.data(), &PartDynamicTextField::compositeTextChanged,this, [=](){this -> updateForm();});
 	m_connection_list << connect(m_text_field.data(), &PartDynamicTextField::keepVisualRotationChanged, this, [=](){this -> updateForm();});
+	m_connection_list << connect(m_text_field.data(), &PartDynamicTextField::keepLockToElementChanged, this, [=](){this -> updateForm();});
 }
 
 void DynamicTextFieldEditor::disconnectConnections()
@@ -436,6 +438,19 @@ void DynamicTextFieldEditor::on_m_keep_visual_rotation_cb_clicked()
 		if(keep != m_parts[i] -> keepVisualRotation()) {
 			QPropertyUndoCommand *undo = new QPropertyUndoCommand(m_parts[i], "keepVisualRotation", m_parts[i] -> frame(), keep);
 			undo -> setText(tr("Modifier la conservation de l'angle"));
+			undoStack().push(undo);
+		}
+	}
+}
+
+void DynamicTextFieldEditor::on_m_lock_to_element_cb_clicked()
+{
+	bool lock = ui -> m_lock_to_element_cb -> isChecked();
+
+	for (int i = 0; i < m_parts.length(); i++) {
+		if(lock != m_parts[i] -> lockToElement()) {
+			QPropertyUndoCommand *undo = new QPropertyUndoCommand(m_parts[i], "lockToElement", m_parts[i] -> frame(), lock);
+			undo -> setText(tr("Lock text position to element position"));
 			undoStack().push(undo);
 		}
 	}

--- a/sources/editor/ui/dynamictextfieldeditor.h
+++ b/sources/editor/ui/dynamictextfieldeditor.h
@@ -70,6 +70,7 @@ class DynamicTextFieldEditor : public ElementItemEditor {
 		void on_m_color_kpb_changed(const QColor &newColor);
 
 		void on_m_keep_visual_rotation_cb_clicked();
+		void on_m_lock_to_element_cb_clicked();
 
 	private:
 		Ui::DynamicTextFieldEditor *ui;

--- a/sources/editor/ui/dynamictextfieldeditor.ui
+++ b/sources/editor/ui/dynamictextfieldeditor.ui
@@ -6,48 +6,81 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>354</width>
-    <height>391</height>
+    <width>403</width>
+    <height>431</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>Form</string>
   </property>
   <layout class="QGridLayout" name="m_main_grid_layout">
-   <item row="6" column="0">
-    <widget class="QLabel" name="label_3">
+   <item row="12" column="1" colspan="2">
+    <widget class="QLineEdit" name="m_user_text_le"/>
+   </item>
+   <item row="4" column="0">
+    <widget class="QLabel" name="label_7">
      <property name="text">
-      <string>Couleur</string>
+      <string>Rotation</string>
      </property>
      <property name="alignment">
       <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
      </property>
     </widget>
    </item>
-   <item row="13" column="1">
-    <spacer name="verticalSpacer">
+   <item row="4" column="2">
+    <widget class="QCheckBox" name="m_keep_visual_rotation_cb">
+     <property name="text">
+      <string>Conserver la rotation visuel</string>
+     </property>
+    </widget>
+   </item>
+   <item row="5" column="1">
+    <widget class="QSpinBox" name="m_width_sb">
+     <property name="minimum">
+      <number>-1</number>
+     </property>
+     <property name="maximum">
+      <number>500</number>
+     </property>
+    </widget>
+   </item>
+   <item row="5" column="2">
+    <widget class="QPushButton" name="m_alignment_pb">
+     <property name="text">
+      <string>Alignement</string>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="1" colspan="2">
+    <widget class="QDoubleSpinBox" name="m_x_sb">
+     <property name="minimum">
+      <double>-5000.000000000000000</double>
+     </property>
+     <property name="maximum">
+      <double>5000.000000000000000</double>
+     </property>
+    </widget>
+   </item>
+   <item row="13" column="1" colspan="2">
+    <widget class="QComboBox" name="m_elmt_info_cb"/>
+   </item>
+   <item row="6" column="1">
+    <spacer name="verticalSpacer_2">
      <property name="orientation">
       <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeType">
+      <enum>QSizePolicy::Fixed</enum>
      </property>
      <property name="sizeHint" stdset="0">
       <size>
        <width>20</width>
-       <height>40</height>
+       <height>18</height>
       </size>
      </property>
     </spacer>
    </item>
-   <item row="3" column="0">
-    <widget class="QLabel" name="label_2">
-     <property name="text">
-      <string>Largeur</string>
-     </property>
-     <property name="alignment">
-      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-     </property>
-    </widget>
-   </item>
-   <item row="9" column="1" colspan="2">
+   <item row="11" column="1" colspan="2">
     <widget class="QComboBox" name="m_text_from_cb">
      <item>
       <property name="text">
@@ -66,18 +99,48 @@
      </item>
     </widget>
    </item>
-   <item row="2" column="2">
-    <widget class="QCheckBox" name="m_keep_visual_rotation_cb">
-     <property name="text">
-      <string>Conserver la rotation visuel</string>
+   <item row="15" column="1">
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item row="4" column="1">
+    <widget class="QSpinBox" name="m_rotation_sb">
+     <property name="maximum">
+      <number>359</number>
      </property>
     </widget>
    </item>
-   <item row="11" column="1" colspan="2">
-    <widget class="QComboBox" name="m_elmt_info_cb"/>
+   <item row="8" column="0">
+    <widget class="QLabel" name="label_3">
+     <property name="text">
+      <string>Couleur</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+     </property>
+    </widget>
    </item>
-   <item row="4" column="1">
-    <spacer name="verticalSpacer_2">
+   <item row="5" column="0">
+    <widget class="QLabel" name="label_2">
+     <property name="text">
+      <string>Largeur</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+     </property>
+    </widget>
+   </item>
+   <item row="10" column="1">
+    <spacer name="verticalSpacer_3">
      <property name="orientation">
       <enum>Qt::Vertical</enum>
      </property>
@@ -92,34 +155,7 @@
      </property>
     </spacer>
    </item>
-   <item row="3" column="1">
-    <widget class="QSpinBox" name="m_width_sb">
-     <property name="minimum">
-      <number>-1</number>
-     </property>
-     <property name="maximum">
-      <number>500</number>
-     </property>
-    </widget>
-   </item>
-   <item row="2" column="1">
-    <widget class="QSpinBox" name="m_rotation_sb">
-     <property name="maximum">
-      <number>359</number>
-     </property>
-    </widget>
-   </item>
-   <item row="1" column="0">
-    <widget class="QLabel" name="label_6">
-     <property name="text">
-      <string>Y</string>
-     </property>
-     <property name="alignment">
-      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-     </property>
-    </widget>
-   </item>
-   <item row="9" column="0">
+   <item row="11" column="0">
     <widget class="QLabel" name="label_4">
      <property name="text">
       <string>Source du texte</string>
@@ -129,41 +165,44 @@
      </property>
     </widget>
    </item>
-   <item row="10" column="1" colspan="2">
-    <widget class="QLineEdit" name="m_user_text_le"/>
-   </item>
-   <item row="2" column="0">
-    <widget class="QLabel" name="label_7">
-     <property name="text">
-      <string>Rotation</string>
-     </property>
-     <property name="alignment">
-      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-     </property>
-    </widget>
-   </item>
-   <item row="12" column="1" colspan="2">
+   <item row="14" column="1" colspan="2">
     <widget class="QPushButton" name="m_composite_text_pb">
      <property name="text">
       <string>Texte composé</string>
      </property>
     </widget>
    </item>
-   <item row="3" column="2">
-    <widget class="QPushButton" name="m_alignment_pb">
+   <item row="7" column="1">
+    <widget class="QSpinBox" name="m_size_sb"/>
+   </item>
+   <item row="7" column="0">
+    <widget class="QLabel" name="label">
      <property name="text">
-      <string>Alignement</string>
+      <string>Police</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
      </property>
     </widget>
    </item>
-   <item row="7" column="1" colspan="2">
+   <item row="0" column="0">
+    <widget class="QLabel" name="label_5">
+     <property name="text">
+      <string>X</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+     </property>
+    </widget>
+   </item>
+   <item row="9" column="1" colspan="2">
     <widget class="QCheckBox" name="m_frame_cb">
      <property name="text">
       <string>Encadrer le texte</string>
      </property>
     </widget>
    </item>
-   <item row="5" column="2">
+   <item row="7" column="2">
     <widget class="QPushButton" name="m_font_pb">
      <property name="text">
       <string/>
@@ -180,60 +219,32 @@
      </property>
     </widget>
    </item>
-   <item row="0" column="1" colspan="2">
-    <widget class="QDoubleSpinBox" name="m_x_sb">
-     <property name="minimum">
-      <double>-5000.000000000000000</double>
-     </property>
-     <property name="maximum">
-      <double>5000.000000000000000</double>
-     </property>
-    </widget>
-   </item>
-   <item row="5" column="1">
-    <widget class="QSpinBox" name="m_size_sb"/>
-   </item>
-   <item row="0" column="0">
-    <widget class="QLabel" name="label_5">
+   <item row="1" column="0">
+    <widget class="QLabel" name="label_6">
      <property name="text">
-      <string>X</string>
+      <string>Y</string>
      </property>
      <property name="alignment">
       <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
      </property>
     </widget>
    </item>
-   <item row="5" column="0">
-    <widget class="QLabel" name="label">
-     <property name="text">
-      <string>Police</string>
+   <item row="2" column="1" colspan="2">
+    <widget class="QCheckBox" name="m_lock_to_element_cb">
+     <property name="toolTip">
+      <string>Lock the position of the text to the position of the element so that the text can not be moved accidentally.</string>
      </property>
-     <property name="alignment">
-      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+     <property name="text">
+      <string>Lock position to element</string>
      </property>
     </widget>
-   </item>
-   <item row="8" column="1">
-    <spacer name="verticalSpacer_3">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
-     </property>
-     <property name="sizeType">
-      <enum>QSizePolicy::Fixed</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>20</width>
-       <height>18</height>
-      </size>
-     </property>
-    </spacer>
    </item>
   </layout>
  </widget>
  <tabstops>
   <tabstop>m_x_sb</tabstop>
   <tabstop>m_y_sb</tabstop>
+  <tabstop>m_lock_to_element_cb</tabstop>
   <tabstop>m_rotation_sb</tabstop>
   <tabstop>m_keep_visual_rotation_cb</tabstop>
   <tabstop>m_width_sb</tabstop>

--- a/sources/qetgraphicsitem/diagramtextitem.cpp
+++ b/sources/qetgraphicsitem/diagramtextitem.cpp
@@ -327,7 +327,12 @@ void DiagramTextItem::mouseDoubleClickEvent(QGraphicsSceneMouseEvent *event) {
 */
 void DiagramTextItem::mousePressEvent (QGraphicsSceneMouseEvent *event)
 {
-	if (event->button() == Qt::LeftButton)
+	if (m_no_moveable)
+	{
+		event->ignore();
+		return;
+	}
+	else if (event->button() == Qt::LeftButton)
 	{
 		m_first_move = true;
 			//Save the pos of item at the beggining of the movement

--- a/sources/qetgraphicsitem/diagramtextitem.h
+++ b/sources/qetgraphicsitem/diagramtextitem.h
@@ -110,6 +110,7 @@ class DiagramTextItem : public QGraphicsTextItem
 		m_mouse_hover = false,
 		m_first_move = true,
 		m_no_editable,
+		m_no_moveable,
 		m_is_html = false;
 
 		QString

--- a/sources/qetgraphicsitem/dynamicelementtextitem.cpp
+++ b/sources/qetgraphicsitem/dynamicelementtextitem.cpp
@@ -98,7 +98,8 @@ QDomElement DynamicElementTextItem::toXml(QDomDocument &dom_doc) const
 	root_element.setAttribute("text_width", QString::number(m_text_width));
 	root_element.setAttribute("font", font().toString());
 	root_element.setAttribute("keep_visual_rotation", m_keep_visual_rotation ? "true" : "false");
-	
+	root_element.setAttribute("lock_to_element", m_lock_to_element ? "true" : "false");
+
 	QMetaEnum me = textFromMetaEnum();
 	root_element.setAttribute("text_from", me.valueToKey(m_text_from));
 	
@@ -220,6 +221,8 @@ void DynamicElementTextItem::fromXml(const QDomElement &dom_elmt)
 	
 	QGraphicsTextItem::setPos(dom_elmt.attribute("x", QString::number(0)).toDouble(),
 							  dom_elmt.attribute("y", QString::number(0)).toDouble());
+
+	setLockToElement(dom_elmt.attribute("lock_to_element", "false") == "true"? true : false);
 }
 
 /**
@@ -554,7 +557,7 @@ void DynamicElementTextItem::mousePressEvent(QGraphicsSceneMouseEvent *event)
 	@param event
 */
 void DynamicElementTextItem::mouseMoveEvent(QGraphicsSceneMouseEvent *event)
-{	
+{
 	if((event->buttons() & Qt::LeftButton) && (flags() & ItemIsMovable))
 	{
 		if(diagram() && m_first_move)
@@ -1472,5 +1475,16 @@ void DynamicElementTextItem::setKeepVisualRotation(bool set)
 
 bool DynamicElementTextItem::keepVisualRotation() const {
 	return m_keep_visual_rotation;
+}
+
+void DynamicElementTextItem::setLockToElement(bool set)
+{
+	this->m_lock_to_element = set;
+	this->m_no_moveable = set;
+	emit lockToElementChanged(set);
+}
+
+bool DynamicElementTextItem::lockToElement() const {
+	return m_lock_to_element;
 }
 

--- a/sources/qetgraphicsitem/dynamicelementtextitem.h
+++ b/sources/qetgraphicsitem/dynamicelementtextitem.h
@@ -51,6 +51,7 @@ class DynamicElementTextItem : public DiagramTextItem
 	Q_PROPERTY(bool frame READ frame WRITE setFrame NOTIFY frameChanged)
 	Q_PROPERTY(qreal textWidth READ textWidth WRITE setTextWidth NOTIFY textWidthChanged)
 	Q_PROPERTY(bool keepVisualRotation READ keepVisualRotation WRITE setKeepVisualRotation NOTIFY keepVisualRotationChanged)
+	Q_PROPERTY(bool lockToElement READ lockToElement WRITE setLockToElement NOTIFY lockToElementChanged)
 
 	public:
 
@@ -72,6 +73,7 @@ class DynamicElementTextItem : public DiagramTextItem
 		void plainTextChanged();
 		void textWidthChanged(qreal width);
 		void keepVisualRotationChanged(bool keep);
+		void lockToElementChanged(bool lock);
 
 	public:
 		DynamicElementTextItem(Element *parent_element);
@@ -109,6 +111,8 @@ class DynamicElementTextItem : public DiagramTextItem
 
 		void setKeepVisualRotation(bool set);
 		bool keepVisualRotation() const;
+		void setLockToElement(bool set);
+		bool lockToElement() const;
 
 	protected:
 		void mousePressEvent(QGraphicsSceneMouseEvent *event) override;
@@ -169,6 +173,7 @@ class DynamicElementTextItem : public DiagramTextItem
 		qreal m_text_width = -1;
 		QPointF m_initial_position;
 		bool m_keep_visual_rotation = true;
+		bool m_lock_to_element = false;
 		qreal m_visual_rotation_ref = 0;
 };
 

--- a/sources/ui/dynamicelementtextmodel.cpp
+++ b/sources/ui/dynamicelementtextmodel.cpp
@@ -51,7 +51,8 @@ static int x_txt_row     = 9;
 static int y_txt_row     = 10;
 static int rot_txt_row   = 11;
 static int keep_rot_row  = 12;
-static int align_txt_row = 13;
+static int lock_elem_row = 13;
+static int align_txt_row = 14;
 
 static int align_grp_row          = 0;
 static int x_grp_row              = 1;
@@ -355,6 +356,20 @@ QList<QStandardItem *> DynamicElementTextModel::itemsForText(
 		qsi_list << keep_rotation << keep_rotation_a;
 		qsi->appendRow(qsi_list);
 
+		//lock to element
+		auto lock_to_element = new QStandardItem(tr("Lock position to element"));
+		lock_to_element->setFlags(Qt::ItemIsSelectable | Qt::ItemIsEnabled);
+
+		auto lock_to_element_a = new QStandardItem;
+		lock_to_element_a->setCheckable(true);
+		lock_to_element_a->setCheckState(deti->lockToElement() ? Qt::Checked : Qt::Unchecked);
+		lock_to_element_a->setData(DynamicElementTextModel::lockToElement, Qt::UserRole+1);
+		lock_to_element_a->setFlags(Qt::ItemIsSelectable | Qt::ItemIsEnabled | Qt::ItemIsUserCheckable);
+
+		qsi_list.clear();
+		qsi_list << lock_to_element << lock_to_element_a;
+		qsi->appendRow(qsi_list);
+
 			//Alignment
 		QStandardItem *alignment = new QStandardItem(tr("Alignement"));
 		alignment->setFlags(Qt::ItemIsSelectable | Qt::ItemIsEnabled);
@@ -626,7 +641,17 @@ QUndoCommand *DynamicElementTextModel::undoForEditedText(
 			qpuc->setText(tr("Modifier le maintient de la rotation d'un texte d'élément"));
 		}
 	}
-		
+
+	if (text_qsi->child(lock_elem_row,1))
+	{
+		bool lock_elem = text_qsi->child(lock_elem_row, 1)->checkState() == Qt::Checked? true : false;
+		if (lock_elem != deti->lockToElement())
+		{
+			auto qpuc = new QPropertyUndoCommand(deti, "lockToElement", QVariant(deti->lockToElement()), QVariant(lock_elem), undo);
+			qpuc->setText(tr("Changed setting text position locked to element"));
+		}
+	}
+
 		//When text is in a groupe, they're isn't item for alignment of the text
 	if(text_qsi->child(align_txt_row, 1))
 	{

--- a/sources/ui/dynamicelementtextmodel.h
+++ b/sources/ui/dynamicelementtextmodel.h
@@ -52,6 +52,7 @@ class DynamicElementTextModel : public QStandardItemModel
 		frame,
 		rotation,
 		keepVisualRotation,
+		lockToElement,
 		textWidth,
 		grpAlignment,
 		grpPos,


### PR DESCRIPTION
I often ran into the situation that in needed to move elements that were overlapping with text or i wanted to change some text and accidentally moved the text instead of changing the content only.

With this PR i added an option to the text properties that will allow to lock the current text position to the element. The whole element will then be moved instead of the text if some drag and drop is applied.

This is not fully functional at the moment (e.g. the property in the element editor is not saved and used when imported to a schematic). But comments are appreciated.

Here is a screenshot of the schematic editor:
![grafik](https://github.com/user-attachments/assets/850ad57f-405c-40e6-9454-2a5f89293a53)

This is the view inside the symbol editor:
![grafik](https://github.com/user-attachments/assets/0c4853cb-f49b-4d55-922f-5ca44bb13c53)
