### PR TITLE
New variables for conductor text formulas

### DIFF
--- a/sources/autoNum/assignvariables.cpp
+++ b/sources/autoNum/assignvariables.cpp
@@ -20,6 +20,7 @@
 #include "../diagram.h"
 #include "../diagramposition.h"
 #include "../qetapp.h"
+#include "../qetgraphicsitem/conductor.h"
 #include "../qetgraphicsitem/element.h"
 #include "../qetxml.h"
 
@@ -189,12 +190,14 @@ namespace autonum
 	QString AssignVariables::formulaToLabel(QString formula,
 						sequentialNumbers &seqStruct,
 						Diagram *diagram,
-						const Element *elmt)
+						const Element *elmt,
+						const Conductor *cndr)
 	{
 		AssignVariables av(std::move(formula),
 				   seqStruct,
 				   diagram,
-				   elmt);
+				   elmt,
+				   cndr);
 		seqStruct = av.m_seq_struct;
 		return av.m_assigned_label;
 	}
@@ -301,13 +304,14 @@ namespace autonum
 	AssignVariables::AssignVariables(const QString& formula,
 					 const sequentialNumbers& seqStruct,
 					 Diagram *diagram,
-					 const Element *elmt):
+					 const Element *elmt,
+					 const Conductor *cndr):
 	m_diagram(diagram),
 	m_arg_formula(formula),
 	m_assigned_label(formula),
 	m_seq_struct(seqStruct),
-	m_element(elmt)
-	
+	m_element(elmt),
+	m_conductor(cndr)
 	{
 		if (m_diagram)
 		{
@@ -347,6 +351,14 @@ namespace autonum
 				}
 				m_assigned_label.replace("%l", m_diagram->convertPosition(m_element->scenePos()).letter());
 				m_assigned_label.replace("%prefix", m_element->getPrefix());
+			}
+
+			if (m_conductor)
+			{
+				m_assigned_label.replace("%wf", cndr->properties().m_function);
+				m_assigned_label.replace("%wv", cndr->properties().m_tension_protocol);
+				m_assigned_label.replace("%wc", cndr->properties().m_wire_color);
+				m_assigned_label.replace("%ws", cndr->properties().m_wire_section);
 			}
 
 			assignTitleBlockVar();

--- a/sources/autoNum/assignvariables.h
+++ b/sources/autoNum/assignvariables.h
@@ -24,6 +24,7 @@
 #include <QString>
 #include <QStringList>
 
+class Conductor;
 class Diagram;
 class Element;
 class ElementsLocation;
@@ -61,12 +62,12 @@ namespace autonum
 	class AssignVariables
 	{
 		public:
-			static QString formulaToLabel (QString formula, sequentialNumbers &seqStruct, Diagram *diagram, const Element *elmt = nullptr);
+			static QString formulaToLabel (QString formula, sequentialNumbers &seqStruct, Diagram *diagram, const Element *elmt = nullptr, const Conductor *cndr = nullptr);
 			static QString replaceVariable (const QString &formula, const DiagramContext &dc);
 			static QString genericXref (const Element *element);
 
 		private:
-			AssignVariables(const QString& formula, const sequentialNumbers& seqStruct , Diagram *diagram, const Element *elmt = nullptr);
+			AssignVariables(const QString& formula, const sequentialNumbers& seqStruct , Diagram *diagram, const Element *elmt = nullptr, const Conductor *cndr = nullptr);
 			void assignTitleBlockVar();
 			void assignProjectVar();
 			void assignSequence();
@@ -76,6 +77,7 @@ namespace autonum
 			QString m_assigned_label;
 			sequentialNumbers m_seq_struct;
 			const Element *m_element = nullptr;
+			const Conductor *m_conductor = nullptr;
 	};
 
 	void setSequentialToList(QStringList &list, NumerotationContext &nc, const QString& type);

--- a/sources/qetgraphicsitem/conductor.cpp
+++ b/sources/qetgraphicsitem/conductor.cpp
@@ -1505,7 +1505,7 @@ void Conductor::refreshText()
 		{
 			if (diagram())
 			{
-				QString text = autonum::AssignVariables::formulaToLabel(m_properties.m_formula, m_autoNum_seq, diagram());
+				QString text = autonum::AssignVariables::formulaToLabel(m_properties.m_formula, m_autoNum_seq, diagram(), nullptr, this);
 				m_properties.text = text;
 				m_text_item->setPlainText(text);
 			}
@@ -1590,7 +1590,7 @@ void Conductor::setProperties(const ConductorProperties &property)
 	{
 		if (diagram())
 		{
-			QString text = autonum::AssignVariables::formulaToLabel(m_properties.m_formula, m_autoNum_seq, diagram());
+			QString text = autonum::AssignVariables::formulaToLabel(m_properties.m_formula, m_autoNum_seq, diagram(), nullptr, this);
 			m_properties.text = text;
 		}
 		else if (m_properties.text.isEmpty())


### PR DESCRIPTION
In label: New variables for conductor text formulas
"%wf" = conductor = function
"%wv" = conductor = tension_protocol
"%wc" = conductor = wire_color);
"%ws"= conductor = wire_section