### PR TITLE
unify calls to "setRotation" for element-primitives again

### DIFF
--- a/sources/diagramevent/diagrameventaddelement.cpp
+++ b/sources/diagramevent/diagrameventaddelement.cpp
@@ -248,9 +248,9 @@ void DiagramEventAddElement::addElement()
 	QUndoCommand *undo_object = new QUndoCommand(tr("Ajouter %1").arg(element->name()));
 	new AddGraphicsObjectCommand(element, m_diagram, m_element -> pos(), undo_object);
 
-		//When we search for free aligned terminal we
-		//temporally  remove m_element to avoid any interaction with the function Element::AlignedFreeTerminals
-		//this is useful when an element who have two (or more) terminals opposite,
+		//When we search for free aligned terminal we temporally remove m_element to
+		//avoid any interaction with the function Element::AlignedFreeTerminals
+		//This is useful when an element has two (or more) terminals on opposite sides,
 		//because m_element is exactly at the same pos of the new element
 		//added to the scene so new conductor are created between terminal of the new element
 		//and the opposite terminal of m_element.

--- a/sources/editor/editorcommands.cpp
+++ b/sources/editor/editorcommands.cpp
@@ -541,19 +541,19 @@ void RotateElementsCommand::undo()
 		}
 		else if (item->type() == PartLine::Type) {
 			PartLine* line = qgraphicsitem_cast<PartLine*>(item);
-			line->setRotation(-90);
+			line->setRotation(line->rotation()-90);
 		}
 		else if (item->type() == PartPolygon::Type) {
 			PartPolygon* poly = qgraphicsitem_cast<PartPolygon*>(item);
-			poly->setRotation(-90);
+			poly->setRotation(poly->rotation()-90);
 		}
 		else if (item->type() == PartText::Type) {
 			PartText* text = qgraphicsitem_cast<PartText*>(item);
-			text->setRotation(-90);
+			text->setRotation(text->rotation()-90);
 		}
 		else if (item->type() == PartDynamicTextField::Type) {
 			PartDynamicTextField* dyntext = qgraphicsitem_cast<PartDynamicTextField*>(item);
-			dyntext->setRotation(-90);
+			dyntext->setRotation(dyntext->rotation()-90);
 		}
 		else {
 			item->setRotation(item->rotation()-90);
@@ -586,19 +586,19 @@ void RotateElementsCommand::redo()
 		}
 		else if (item->type() == PartLine::Type) {
 			PartLine* line = qgraphicsitem_cast<PartLine*>(item);
-			line->setRotation(+90);
+			line->setRotation(line->rotation()+90);
 		}
 		else if (item->type() == PartPolygon::Type) {
 			PartPolygon* poly = qgraphicsitem_cast<PartPolygon*>(item);
-			poly->setRotation(+90);
+			poly->setRotation(poly->rotation()+90);
 		}
 		else if (item->type() == PartText::Type) {
 			PartText* text = qgraphicsitem_cast<PartText*>(item);
-			text->setRotation(+90);
+			text->setRotation(text->rotation()+90);
 		}
 		else if (item->type() == PartDynamicTextField::Type) {
 			PartDynamicTextField* dyntext = qgraphicsitem_cast<PartDynamicTextField*>(item);
-			dyntext->setRotation(+90);
+			dyntext->setRotation(dyntext->rotation()+90);
 		}
 		else {
 			item->setRotation(item->rotation()+90);
@@ -622,22 +622,22 @@ void RotateFineElementsCommand::undo()
 	{
 		if (item->type() == PartLine::Type) {
 			PartLine* line = qgraphicsitem_cast<PartLine*>(item);
-			line->setRotation(-5);
+			line->setRotation(line->rotation()-5);
 		}
 		else if (item->type() == PartPolygon::Type) {
 			PartPolygon* poly = qgraphicsitem_cast<PartPolygon*>(item);
-			poly->setRotation(-5);
+			poly->setRotation(poly->rotation()-5);
 		}
 		else if (item->type() == PartText::Type) {
 			PartText* text = qgraphicsitem_cast<PartText*>(item);
-			text->setRotation(-5);
+			text->setRotation(text->rotation()-5);
 		}
 		else if (item->type() == PartDynamicTextField::Type) {
 			PartDynamicTextField* dyntext = qgraphicsitem_cast<PartDynamicTextField*>(item);
-			dyntext->setRotation(-5);
+			dyntext->setRotation(dyntext->rotation()-5);
 		}
 		else {
-			//item->setRotation(-5);
+			//item->setRotation(item->rotation()-5);
 		}
 	}
 }
@@ -651,22 +651,22 @@ void RotateFineElementsCommand::redo()
 	{
 		if (item->type() == PartLine::Type) {
 			PartLine* line = qgraphicsitem_cast<PartLine*>(item);
-			line->setRotation(+5);
+			line->setRotation(line->rotation()+5);
 		}
 		else if (item->type() == PartPolygon::Type) {
 			PartPolygon* poly = qgraphicsitem_cast<PartPolygon*>(item);
-			poly->setRotation(+5);
+			poly->setRotation(poly->rotation()+5);
 		}
 		else if (item->type() == PartText::Type) {
 			PartText* text = qgraphicsitem_cast<PartText*>(item);
-			text->setRotation(+5);
+			text->setRotation(text->rotation()+5);
 		}
 		else if (item->type() == PartDynamicTextField::Type) {
 			PartDynamicTextField* dyntext = qgraphicsitem_cast<PartDynamicTextField*>(item);
-			dyntext->setRotation(+5);
+			dyntext->setRotation(dyntext->rotation()+5);
 		}
 		else {
-			//item->setRotation(+5);
+			//item->setRotation(item->rotation()+5);
 		}
 	}
 }

--- a/sources/editor/graphicspart/partarc.cpp
+++ b/sources/editor/graphicspart/partarc.cpp
@@ -172,8 +172,10 @@ QPainterPath PartArc::shadowShape() const
 
 
 void PartArc::setRotation(qreal angle) {
+	qreal diffAngle = qRound((angle - rotation()) * 100.0) / 100.0;
+	m_rot = QET::correctAngle(angle, true);
 // idea taken from QET_ElementScaler:
-if (angle > 0) {
+	if (diffAngle > 0) {
 	m_start_angle += 270.0 * 16;
 	while (m_start_angle < 0) { m_start_angle += (360*16); }
 	while (m_start_angle >= (360*16)) { m_start_angle -= (360*16); }

--- a/sources/editor/graphicspart/partdynamictextfield.cpp
+++ b/sources/editor/graphicspart/partdynamictextfield.cpp
@@ -67,8 +67,9 @@ QString PartDynamicTextField::xmlName() const
 	@param angle
 */
 void PartDynamicTextField::setRotation(qreal angle) {
-	QGraphicsObject::setRotation(QET::correctAngle(rotation()+angle, true));
-	setPos(QTransform().rotate(angle).map(pos()));
+	qreal diffAngle = qRound((angle - rotation()) * 100.0) / 100.0;
+	QGraphicsObject::setRotation(QET::correctAngle(angle, true));
+	setPos(QTransform().rotate(diffAngle).map(pos()));
 }
 
 void PartDynamicTextField::mirror() {

--- a/sources/editor/graphicspart/partellipse.cpp
+++ b/sources/editor/graphicspart/partellipse.cpp
@@ -238,8 +238,10 @@ bool PartEllipse::sceneEventFilter(QGraphicsItem *watched, QEvent *event)
 
 
 void PartEllipse::setRotation(qreal angle) {
+	qreal diffAngle = qRound((angle - rotation()) * 100.0) / 100.0;
+	m_rot = QET::correctAngle(angle, true);
 // idea taken from QET_ElementScaler:
-	if (angle > 0) {
+	if (diffAngle > 0) {
 		qreal width  = m_rect.height();
 		qreal height = m_rect.width();
 		qreal x = (m_rect.y() + m_rect.height()) * (-1);

--- a/sources/editor/graphicspart/partline.cpp
+++ b/sources/editor/graphicspart/partline.cpp
@@ -579,9 +579,10 @@ void PartLine::setSecondEndLength(const qreal &l)
 }
 
 void PartLine::setRotation(qreal angle) {
-	m_rot += angle;
-	m_line.setP1(QTransform().rotate(angle).map(m_line.p1()));
-	m_line.setP2(QTransform().rotate(angle).map(m_line.p2()));
+	qreal diffAngle = qRound((angle - rotation()) * 100.0) / 100.0;
+	m_rot = QET::correctAngle(angle, true);
+	m_line.setP1(QTransform().rotate(diffAngle).map(m_line.p1()));
+	m_line.setP2(QTransform().rotate(diffAngle).map(m_line.p2()));
 	prepareGeometryChange();
 	setLine(m_line);
 	adjustHandlerPos();

--- a/sources/editor/graphicspart/partpolygon.cpp
+++ b/sources/editor/graphicspart/partpolygon.cpp
@@ -297,8 +297,9 @@ void PartPolygon::resetAllHandlerColor()
 
 
 void PartPolygon::setRotation(qreal angle) {
-	QTransform rotation = QTransform().rotate(angle);
-	m_rot += angle;
+	qreal diffAngle = qRound((angle - rotation()) * 100.0) / 100.0;
+	m_rot = QET::correctAngle(angle, true);
+	QTransform rotation = QTransform().rotate(diffAngle);
 	setPolygon(rotation.map(m_polygon));
 	prepareGeometryChange();
 	adjustHandlerPos();

--- a/sources/editor/graphicspart/partrectangle.cpp
+++ b/sources/editor/graphicspart/partrectangle.cpp
@@ -168,12 +168,14 @@ void PartRectangle::setYRadius(qreal Y)
 }
 
 void PartRectangle::setRotation(qreal angle) {
+	qreal diffAngle = qRound((angle - rotation()) * 100.0) / 100.0;
+	m_rot = QET::correctAngle(angle, true);
 	// for whatever reason: with "rect" we need to use scene-positions...
 	auto pos = mapToScene(m_rect.x(),m_rect.y());
 	qreal width  = m_rect.height();
 	qreal height = m_rect.width();
 	qreal x; qreal y;
-	if (angle > 0) {
+	if (diffAngle > 0) {
 		x = (pos.y() + m_rect.height()) * (-1);
 		y = pos.x();
 	} else {

--- a/sources/editor/graphicspart/partterminal.cpp
+++ b/sources/editor/graphicspart/partterminal.cpp
@@ -42,8 +42,9 @@ PartTerminal::~PartTerminal()
 }
 
 /**
+	Import terminal properties from an XML element
 	Importe les proprietes d'une borne depuis un element XML
-	@param xml_elmt Element XML a lire
+	@param xml_elmt Element XML a lire / XML element to read
 */
 void PartTerminal::fromXml(const QDomElement &xml_elmt) {
 	d -> fromXml(xml_elmt);
@@ -166,8 +167,9 @@ void PartTerminal::setRotation(qreal angle) {
 	else if (180 <= angle_mod && angle_mod < 270) new_ori = Qet::South;
 	else new_ori = Qet::West;
 
+	qreal diffAngle = qRound((angle - rotation()) * 100.0) / 100.0;
 	double tmp, y, x;
-	if (angle > 0) {
+	if (diffAngle > 0) {
 		tmp = d->m_pos.y();
 		y   = d->m_pos.x();
 		x   = (-1) * tmp;

--- a/sources/editor/graphicspart/parttext.cpp
+++ b/sources/editor/graphicspart/parttext.cpp
@@ -68,8 +68,9 @@ PartText::~PartText()
 	@param angle
 */
 void PartText::setRotation(qreal angle) {
-	QGraphicsObject::setRotation(QET::correctAngle(rotation()+angle, true));
-	setPos(QTransform().rotate(angle).map(pos()));
+	qreal diffAngle = qRound((angle - rotation()) * 100.0) / 100.0;
+	QGraphicsObject::setRotation(QET::correctAngle(angle, true));
+	setPos(QTransform().rotate(diffAngle).map(pos()));
 }
 
 void PartText::mirror() {

--- a/sources/qetgraphicsitem/terminal.cpp
+++ b/sources/qetgraphicsitem/terminal.cpp
@@ -695,11 +695,15 @@ bool Terminal::valideXml(QDomElement &terminal)
 
 /**
 	@brief Terminal::fromXml
+	Enables you to find out whether an XML element represents this terminal.
+	Warning, the XML element is not checked
 	Permet de savoir si un element XML represente cette borne. Attention,
 	l'element XML n'est pas verifie
-	@param terminal Le QDomElement a analyser
+	@param terminal Le QDomElement a analyser / QDomElement to check
 	@return true si la borne "se reconnait"
 	(memes coordonnes, meme orientation), false sinon
+	true, if the terminal ‘recognises’ itself (same coordinates,
+	same orientation), false otherwise
 */
 bool Terminal::fromXml(QDomElement &terminal)
 {


### PR DESCRIPTION
the function-calls worked, but for future use it's better to have them unified.