### PR TITLE
simplify and use the same code for Qt5 & Qt6

### DIFF
--- a/sources/editor/graphicspart/partarc.cpp
+++ b/sources/editor/graphicspart/partarc.cpp
@@ -61,14 +61,7 @@ void PartArc::paint(QPainter *painter, const QStyleOptionGraphicsItem *options, 
 		//Always remove the brush
 	painter -> setBrush(Qt::NoBrush);
 	QPen t = painter -> pen();
-#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)	// ### Qt 6: remove
-	t.setCosmetic(options && options -> levelOfDetail < 1.0);
-#else
-#if TODO_LIST
-#pragma message("@TODO remove code for QT 6 or later")
-#endif
 	t.setCosmetic(options && options -> levelOfDetailFromTransform(painter->worldTransform()) < 1.0);
-#endif
 	painter -> setPen(t);
 
 	if (isSelected())

--- a/sources/editor/graphicspart/partellipse.cpp
+++ b/sources/editor/graphicspart/partellipse.cpp
@@ -57,14 +57,7 @@ void PartEllipse::paint(QPainter *painter, const QStyleOptionGraphicsItem *optio
 
 	QPen t = painter -> pen();
 
-#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)	// ### Qt 6: remove
-	t.setCosmetic(options && options -> levelOfDetail < 1.0);
-#else
-#if TODO_LIST
-#pragma message("@TODO remove code for QT 6 or later")
-#endif
 	t.setCosmetic(options && options -> levelOfDetailFromTransform(painter->worldTransform()) < 1.0);
-#endif
 	if (isSelected())
 		t.setColor(Qt::red);
 

--- a/sources/editor/graphicspart/partline.cpp
+++ b/sources/editor/graphicspart/partline.cpp
@@ -81,14 +81,7 @@ void PartLine::paint(QPainter *painter, const QStyleOptionGraphicsItem *options,
 	QPen t = painter -> pen();
 	t.setJoinStyle(Qt::MiterJoin);
 
-#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)	// ### Qt 6: remove
-	t.setCosmetic(options && options -> levelOfDetail < 1.0);
-#else
-#if TODO_LIST
-#pragma message("@TODO remove code for QT 6 or later")
-#endif
 	t.setCosmetic(options && options -> levelOfDetailFromTransform(painter->worldTransform()) < 1.0);
-#endif
 	if (isSelected()) t.setColor(Qt::red);
 
 	painter -> setPen(t);

--- a/sources/editor/graphicspart/partrectangle.cpp
+++ b/sources/editor/graphicspart/partrectangle.cpp
@@ -54,14 +54,7 @@ void PartRectangle::paint(QPainter *painter, const QStyleOptionGraphicsItem *opt
 	Q_UNUSED(widget);
 	applyStylesToQPainter(*painter);
 	QPen t = painter -> pen();
-#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)	// ### Qt 6: remove
-	t.setCosmetic(options && options -> levelOfDetail < 1.0);
-#else
-#if TODO_LIST
-#pragma message("@TODO remove code for QT 6 or later")
-#endif
 	t.setCosmetic(options && options -> levelOfDetailFromTransform(painter->worldTransform()) < 1.0);
-#endif
 	if (isSelected())
 		t.setColor(Qt::red);
 

--- a/sources/editor/graphicspart/partterminal.cpp
+++ b/sources/editor/graphicspart/partterminal.cpp
@@ -84,18 +84,8 @@ void PartTerminal::paint(
 	QPen t;
 	t.setWidthF(1.0);
 
-#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)	// ### Qt 6: remove
-	t.setCosmetic(options && options -> levelOfDetail < 1.0);
-#else
-#if TODO_LIST
-#pragma message("@TODO remove code for QT 6 or later")
-#endif
-	t.setCosmetic(
-				options
-				&& options->levelOfDetailFromTransform(
-					painter->worldTransform())
-				< 1.0);
-#endif
+	t.setCosmetic(options && options -> levelOfDetailFromTransform(painter->worldTransform()) < 1.0);
+
 	// dessin de la borne en rouge
 	t.setColor(isSelected() ? Terminal::neutralColor : Qt::red);
 	painter -> setPen(t);

--- a/sources/qetgraphicsitem/terminal.cpp
+++ b/sources/qetgraphicsitem/terminal.cpp
@@ -163,15 +163,8 @@ void Terminal::paint(
 		QWidget *)
 {
 	// en dessous d'un certain zoom, les bornes ne sont plus dessinees
-#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)	// ### Qt 6: remove
-	if (options && options -> levelOfDetail < 0.5) return;
-#else
-#if TODO_LIST
-#pragma message("@TODO remove code for QT 6 or later")
-#endif
 	if (options && options->levelOfDetailFromTransform(painter->worldTransform()) < 0.5)
 		return;
-#endif
 	painter -> save();
 
 	//annulation des renderhints
@@ -186,14 +179,7 @@ void Terminal::paint(
 	QPen t;
 	t.setWidthF(1.0);
 
-#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)	// ### Qt 6: remove
-	if (options && options -> levelOfDetail < 1.0)
-#else
-#if TODO_LIST
-#pragma message("@TODO remove code for QT 6 or later")
-#endif
 	if (options && options->levelOfDetailFromTransform(painter->worldTransform()) < 1.0)
-#endif
 	{
 		t.setCosmetic(true);
 	}


### PR DESCRIPTION
When reading and comparing [Qt5-docs](https://qthub.com/static/doc/qt5/qtwidgets/qstyleoptiongraphicsitem.html#levelOfDetailFromTransform) and [Qt6-docs](https://doc.qt.io/qt-6/qstyleoptiongraphicsitem.html#levelOfDetailFromTransform), I read, that there are no differences in the functions!
So it is not necessary to have the differentiation between the Qt-Versions.
Code compiles without errors or warnings for Qt5 and Qt6 and there are no visible differences in elements.
But check yourself, before merging...
