### PR TITLE
unify some more code for Qt5 & Qt6 (and more)

### DIFF
--- a/sources/ElementsCollection/xmlelementcollection.cpp
+++ b/sources/ElementsCollection/xmlelementcollection.cpp
@@ -46,125 +46,64 @@ XmlElementCollection::XmlElementCollection(QETProject *project) :
 	collection.appendChild(import);
 
 	NamesList names;
-#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0) // ### Qt 6: remove
-
-	const QChar russian_data[24] = {
-		0x0418, 0x043C, 0x043F, 0x043E, 0x0440, 0x0442, 0x0438, 0x0440,
-		0x043E, 0x0432, 0x0430, 0x043D, 0x043D, 0x044B, 0x0435, 0x0020,
-		0x044D, 0x043B, 0x0435, 0x043C, 0x0435, 0x043D, 0x0442, 0x044B};
+	const QChar chinese_data[4] ={
+		QChar(0x5BFC), QChar(0x5165), QChar(0x5143), QChar(0x4EF6)};
 	const QChar greek_data[18] = {
-		0x0395,
-		0x03b9,
-		0x03c3,
-		0x03b7,
-		0x03b3,
-		0x03bc,
-		0x03ad,
-		0x03bd,
-		0x03b1,
-		0x0020,
-		0x03c3,
-		0x03c4,
-		0x03bf,
-		0x03b9,
-		0x03c7,
-		0x03b5,
-		0x03af,
-		0x03b1};
-	const QChar turkish_data[12] = {
-		0x0130,
-		0x0074,
-		0x0068,
-		0x0061,
-		0x006C,
-		0x0020,
-		0x00F6,
-		0x011F,
-		0x0065,
-		0x006C,
-		0x0065,
-		0x0072};
-	const QChar ukrainian_data[20] = {
-		0x0406,
-		0x043c,
-		0x043f,
-		0x043e,
-		0x0440,
-		0x0442,
-		0x043e,
-		0x0432,
-		0x0430,
-		0x043d,
-		0x0456,
-		0x0020,
-		0x0435,
-		0x043b,
-		0x0435,
-		0x043c,
-		0x0435,
-		0x043d,
-		0x0442,
-		0x0438};
+		QChar(0x0395), QChar(0x03b9), QChar(0x03c3), QChar(0x03b7),
+		QChar(0x03b3), QChar(0x03bc), QChar(0x03ad), QChar(0x03bd),
+		QChar(0x03b1), QChar(0x0020), QChar(0x03c3), QChar(0x03c4),
+		QChar(0x03bf), QChar(0x03b9), QChar(0x03c7), QChar(0x03b5),
+		QChar(0x03af), QChar(0x03b1)};
 	const QChar japanese_data[10] = {
-		0x30A4,
-		0x30F3,
-		0x30D0,
-		0x30FC,
-		0x30C8,
-		0x3055,
-		0x308C,
-		0x305F,
-		0x8981,
-		0x7D20};
-
+		QChar(0x30A4), QChar(0x30F3), QChar(0x30D0), QChar(0x30FC),
+		QChar(0x30C8), QChar(0x3055), QChar(0x308C), QChar(0x305F),
+		QChar(0x8981), QChar(0x7D20)};
+	const QChar russian_data[24] = {
+		QChar(0x0418), QChar(0x043C), QChar(0x043F), QChar(0x043E),
+		QChar(0x0440), QChar(0x0442), QChar(0x0438), QChar(0x0440),
+		QChar(0x043E), QChar(0x0432), QChar(0x0430), QChar(0x043D),
+		QChar(0x043D), QChar(0x044B), QChar(0x0435), QChar(0x0020),
+		QChar(0x044D), QChar(0x043B), QChar(0x0435), QChar(0x043C),
+		QChar(0x0435), QChar(0x043D), QChar(0x0442), QChar(0x044B)};
+	const QChar turkish_data[12] = {
+		QChar(0x0130), QChar(0x0074), QChar(0x0068), QChar(0x0061),
+		QChar(0x006C), QChar(0x0020), QChar(0x00F6), QChar(0x011F),
+		QChar(0x0065), QChar(0x006C), QChar(0x0065), QChar(0x0072)};
+	const QChar ukrainian_data[20] = {
+		QChar(0x0406), QChar(0x043c), QChar(0x043f), QChar(0x043e),
+		QChar(0x0440), QChar(0x0442), QChar(0x043e), QChar(0x0432),
+		QChar(0x0430), QChar(0x043d), QChar(0x0456), QChar(0x0020),
+		QChar(0x0435), QChar(0x043b), QChar(0x0435), QChar(0x043c),
+		QChar(0x0435), QChar(0x043d), QChar(0x0442), QChar(0x0438)};
 	names.addName("ca",    "Elements importats");
 	names.addName("cs",    "Zavedené prvky");
 	names.addName("da",    "Importerede elementer");
-	names.addName("de",    "Importierte elemente");
+	names.addName("de",    "Importierte Elemente");
 	names.addName("el",    QString(greek_data, 18));
+	//names.addName("el",    "Εισηγμένα στοιχεία);
 	names.addName("en",    "Imported elements");
 	names.addName("es",    "Elementos importados");
 	names.addName("fr",    "Éléments importés");
 	names.addName("hr",    "Uvezeni elementi");
 	names.addName("it",    "Elementi importati");
 	names.addName("ja",    QString(japanese_data, 10));
-	names.addName("nl_BE", "Elementen geïmporteerd");
+	//names.addName("ja",    "インバートされた要素");
 	names.addName("nl",    "Elementen geïmporteerd");
+	names.addName("nl_BE", "Elementen geïmporteerd");
 	names.addName("pl",    "Elementy importowane");
-	names.addName("pt_BR", "elementos importados");
-	names.addName("pt",    "elementos importados");
+	names.addName("pt",    "Elementos importados");
+	names.addName("pt_BR", "Elementos importados");
 	names.addName("ro",    "Elemente importate");
 	names.addName("ru",    QString(russian_data, 24));
+	//names.addName("ru",    "Импортированные элементы");
 	names.addName("sl",    "Uvoženi elementi");
+	names.addName("sv",    "Importerade element");
 	names.addName("tr",    QString(turkish_data, 12));
+	//names.addName("tr",    "İthal öğeler");
 	names.addName("uk",    QString(ukrainian_data, 20));
-#else
-#	if TODO_LIST
-#		pragma message("@TODO remove code for QT 6 or later")
-#	endif
-	qDebug() << "Help code for QT 6 or later";
-	names.addName("ca",    "Elements importats");
-	names.addName("cs",    "Zavedené prvky");
-	names.addName("da",    "Importerede elementer");
-	names.addName("de",    "Importierte elemente");
-	names.addName("el",    "Εισηγμένα στοιχεία");
-	names.addName("en",    "Imported elements");
-	names.addName("es",    "Elementos importados");
-	names.addName("fr",    "Éléments importés");
-	names.addName("hr",    "Uvezeni elementi");
-	names.addName("it",    "Elementi importati");
-	names.addName("ja",    "インバートされた要素");
-	names.addName("nl_BE", "Elementen geïmporteerd");
-	names.addName("nl",    "Elementen geïmporteerd");
-	names.addName("pl",    "Elementy importowane");
-	names.addName("pt_BR", "elementos importados");
-	names.addName("pt",    "elementos importados");
-	names.addName("ro",    "Elemente importate");
-	names.addName("ru",    "Импортированные элементы");
-	names.addName("sl",    "Uvoženi elementi");
-	names.addName("tr",    "İthal öğeler");
-	names.addName("uk",    "Імпортовані елементи");
-#endif
+	//names.addName("uk",    "Імпортовані елементи");
+	names.addName("zh",    QString(chinese_data, 4));
+	//names.addName("zh",    "导入元件");
 
 	import.appendChild(names.toXml(m_dom_document));
 }

--- a/sources/editor/UndoCommand/openelmtcommand.cpp
+++ b/sources/editor/UndoCommand/openelmtcommand.cpp
@@ -63,9 +63,9 @@ void OpenElmtCommand::redo()
 		m_scene->addItems(m_graphics_item.toVector());
 	}
 
-#pragma message("@TODO uncommante slot_select when fixed, see itemChange function for each primitive")
-		//Commented because take a lot of time
-		//when a lot of primitive are loaded
-		//need work
+#pragma message("@TODO uncomment slot_select when fixed, see itemChange function for each primitive")
+		//Commented because it takes a lot of time
+		//when a lot of primitives are loaded!
+		//needs work
 	//m_scene->slot_select(m_graphics_item);
 }

--- a/sources/editor/graphicspart/partpolygon.cpp
+++ b/sources/editor/graphicspart/partpolygon.cpp
@@ -66,14 +66,7 @@ void PartPolygon::paint(QPainter *painter, const QStyleOptionGraphicsItem *optio
 	applyStylesToQPainter(*painter);
 
 	QPen t = painter -> pen();
-#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)	// ### Qt 6: remove
-	t.setCosmetic(options && options -> levelOfDetail < 1.0);
-#else
-#if TODO_LIST
-#pragma message("@TODO remove code for QT 6 or later")
-#endif
 	t.setCosmetic(options && options -> levelOfDetailFromTransform(painter->worldTransform()) < 1.0);
-#endif
 	if (isSelected()) t.setColor(Qt::red);
 	painter -> setPen(t);
 

--- a/sources/qetapp.cpp
+++ b/sources/qetapp.cpp
@@ -1260,7 +1260,7 @@ QFont QETApp::diagramTextsFont(qreal size)
 }
 /**
 	@brief QETApp::diagramTextsItemFont
-	the font for to use in independent text item
+	the font to use in independent text items
 	@param size of font
 	@return
 */

--- a/sources/qetapp.cpp
+++ b/sources/qetapp.cpp
@@ -1275,7 +1275,7 @@ QFont QETApp::diagramTextsItemFont(qreal size)
 							   9.0).toDouble();
 	auto diagram_texts_item_weight =
 			static_cast<QFont::Weight>(
-				settings.value("diagramitemweight").toInt());
+				settings.value("diagramitemweight", QFont::Normal).toInt());
 	QString diagram_texts_item_style  = settings.value("diagramitemstyle",
 							   "normal").toString();
 

--- a/sources/qetgraphicsitem/ViewItem/qetgraphicstableitem.cpp
+++ b/sources/qetgraphicsitem/ViewItem/qetgraphicstableitem.cpp
@@ -991,21 +991,14 @@ void QetGraphicsTableItem::adjustColumnsWidth()
 	int sum_=0;
 	for(auto i= 0 ; i<m_model->columnCount() ; ++i)
 	{
-#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)	// ### Qt 6: remove
-		auto at_a = std::min(m_minimum_column_width.size()-1, i);               //In case of the I is higher than m_minimum_column_width or
-		auto at_b = std::min(m_header_item->minimumSectionWidth().size()-1, i); //m_header_item->minimumSectionWidth().size()
+		auto at_a = std::min((int)m_minimum_column_width.size()-1, i);               //In case of the I is higher than m_minimum_column_width or
+		auto at_b = std::min((int)m_header_item->minimumSectionWidth().size()-1, i); //m_header_item->minimumSectionWidth().size()
 		m_header_item->resizeSection(
 					i,
 					std::max(
 						m_minimum_column_width.at(at_a),
 						m_header_item->minimumSectionWidth().at(at_b))+b);
 		sum_+= m_header_item->sectionSize(i);
-#else
-#if TODO_LIST
-#pragma message("@TODO remove code for QT 6 or later")
-#endif
-		qDebug()<<"Help code for QT 6 or later";
-#endif
 	}
 
 

--- a/sources/qetgraphicsitem/element.cpp
+++ b/sources/qetgraphicsitem/element.cpp
@@ -758,15 +758,10 @@ bool Element::fromXml(QDomElement &e,
 	QList <QDomElement> uuid_list = QET::findInDomElement(e,
 														  QStringLiteral("links_uuids"),
 														  QStringLiteral("link_uuid"));
-	foreach (QDomElement qdo, uuid_list)
-#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)	// ### Qt 6: remove
-		tmp_uuids_link << qdo.attribute(QStringLiteral("uuid"));
-#else
-#if TODO_LIST
-#pragma message("@TODO remove code for QT 6 or later")
-#endif
-		qDebug()<<"Help code for QT 6 or later";
-#endif
+	foreach (QDomElement qdo, uuid_list) {
+		tmp_uuids_link << QUuid(qdo.attribute(QStringLiteral("uuid")));
+	}
+
 	//uuid of this element
 	m_uuid = QUuid(e.attribute(QStringLiteral("uuid"), QUuid::createUuid().toString()));
 

--- a/sources/qetproject.cpp
+++ b/sources/qetproject.cpp
@@ -1778,134 +1778,6 @@ void QETProject::addDiagram(Diagram *diagram, int pos)
 }
 
 /**
-	@return La liste des noms a utiliser pour la categorie dediee aux elements
-	integres automatiquement dans le projet.
-*/
-NamesList QETProject::namesListForIntegrationCategory()
-{
-#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0) // ### Qt 6: remove
-	NamesList	names;
-	const QChar russian_data[24] = {
-		0x0418, 0x043C, 0x043F, 0x043E, 0x0440, 0x0442, 0x0438, 0x0440,
-		0x043E, 0x0432, 0x0430, 0x043D, 0x043D, 0x044B, 0x0435, 0x0020,
-		0x044D, 0x043B, 0x0435, 0x043C, 0x0435, 0x043D, 0x0442, 0x044B};
-	const QChar greek_data[18] = {
-		0x0395,
-		0x03b9,
-		0x03c3,
-		0x03b7,
-		0x03b3,
-		0x03bc,
-		0x03ad,
-		0x03bd,
-		0x03b1,
-		0x0020,
-		0x03c3,
-		0x03c4,
-		0x03bf,
-		0x03b9,
-		0x03c7,
-		0x03b5,
-		0x03af,
-		0x03b1};
-	const QChar turkish_data[12] = {
-		0x0130,
-		0x0074,
-		0x0068,
-		0x0061,
-		0x006C,
-		0x0020,
-		0x00F6,
-		0x011F,
-		0x0065,
-		0x006C,
-		0x0065,
-		0x0072};
-	const QChar ukrainian_data[20] = {
-		0x0406,
-		0x043c,
-		0x043f,
-		0x043e,
-		0x0440,
-		0x0442,
-		0x043e,
-		0x0432,
-		0x0430,
-		0x043d,
-		0x0456,
-		0x0020,
-		0x0435,
-		0x043b,
-		0x0435,
-		0x043c,
-		0x0435,
-		0x043d,
-		0x0442,
-		0x0438};
-	const QChar japanese_data[10] = {
-		0x30A4,
-		0x30F3,
-		0x30D0,
-		0x30FC,
-		0x30C8,
-		0x3055,
-		0x308C,
-		0x305F,
-		0x8981,
-		0x7D20};
-	const QChar chinese_data[4] ={
-		0x5BFC,
-		0x5165,
-		0x5143,
-		0x4EF6};
-	names.addName("fr", "Éléments importés");
-	names.addName("en", "Imported elements");
-	names.addName("de", "Importierte elemente");
-	names.addName("es", "Elementos importados");
-	names.addName("ru", QString(russian_data, 24));
-	names.addName("cs", "Zavedené prvky");
-	names.addName("pl", "Elementy importowane");
-	names.addName("pt", "elementos importados");
-	names.addName("it", "Elementi importati");
-	names.addName("el", QString(greek_data, 18));
-	names.addName("nl", "Elementen geïmporteerd");
-	names.addName("hr", "Uvezeni elementi");
-	names.addName("ca", "Elements importats");
-	names.addName("ro", "Elemente importate");
-	names.addName("tr", QString(turkish_data, 12));
-	names.addName("da", "Importerede elementer");
-	names.addName("sl", "Uvoženi elementi");
-	names.addName("sv", "Importerade element");
-	names.addName("ja", QString(japanese_data, 10));
-	names.addName("uk", QString(ukrainian_data, 20));
-	names.addName("zh", QString(chinese_data, 4));
-	return (names);
-#else
-#	if TODO_LIST
-#		pragma message("@TODO remove code for QT 6 or later")
-#	endif
-	qDebug() << "Help code for QT 6 or later";
-	NamesList names;
-	names.addName("fr", "Éléments importés");
-	names.addName("en", "Imported elements");
-	names.addName("de", "Importierte elemente");
-	names.addName("es", "Elementos importados");
-	names.addName("cs", "Zavedené prvky");
-	names.addName("pl", "Elementy importowane");
-	names.addName("pt", "elementos importados");
-	names.addName("it", "Elementi importati");
-	names.addName("nl", "Elementen geïmporteerd");
-	names.addName("hr", "Uvezeni elementi");
-	names.addName("ca", "Elements importats");
-	names.addName("ro", "Elemente importate");
-	names.addName("da", "Importerede elementer");
-	names.addName("sl", "Uvoženi elementi");
-	names.addName("uk", "Імпортовані елементи");
-	return (names);
-#endif
-}
-
-/**
 	@brief QETProject::writeBackup
 	Write a backup file of this project, in the case that QET crash
 */
@@ -2110,7 +1982,7 @@ void QETProject::removeDiagramsTitleBlockTemplate(TitleBlockTemplatesCollection 
 }
 
 /**
-	Handles the fact a digram changed the title block template it used
+	Handles the fact that a diagram changed the title block template it uses
 	@param template_name Name of the template
 */
 void QETProject::usedTitleBlockTemplateChanged(const QString &template_name) {

--- a/sources/qetproject.h
+++ b/sources/qetproject.h
@@ -234,7 +234,6 @@ class QETProject : public QObject
 		void writeProjectPropertiesXml(QDomElement &);
 		void writeDefaultPropertiesXml(QDomElement &);
 		void addDiagram(Diagram *diagram, int pos = -1);
-		NamesList namesListForIntegrationCategory();
 		void writeBackup();
 		void init();
 		ProjectState openFile(QFile *file);

--- a/sources/undocommand/deleteqgraphicsitemcommand.cpp
+++ b/sources/undocommand/deleteqgraphicsitemcommand.cpp
@@ -179,7 +179,7 @@ void DeleteQGraphicsItemCommand::setPotentialsOfRemovedElements()
 					//If a conductor was already created between these two terminals
 					//in this undo command, from another removed element, we do nothing
 				bool exist_ = false;
-				for (QPair<Terminal *, Terminal *> pair : m_connected_terminals)
+				for (std::pair<Terminal *, Terminal *> pair : m_connected_terminals)
 				{
 					if  (pair.first == hub_terminal && pair.second == t) {
 						exist_ = true;
@@ -192,14 +192,8 @@ void DeleteQGraphicsItemCommand::setPotentialsOfRemovedElements()
 
 				if (exist_ == false)
 				{
-#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)	// ### Qt 6: remove
-					m_connected_terminals.append(qMakePair<Terminal *, Terminal *>(hub_terminal, t));
-#else
-#if TODO_LIST
-#pragma message("@TODO remove code for QT 6 or later")
-#endif
-					qDebug()<<"Help code for QT 6 or later";
-#endif
+					m_connected_terminals.append(std::make_pair<Terminal *, Terminal *>((Terminal *)hub_terminal, (Terminal *)t));
+					qInfo() << "m_connected_terminals" << m_connected_terminals;
 					Conductor *new_cond = new Conductor(hub_terminal, t);
 					new_cond->setProperties(properties);
 					new AddGraphicsObjectCommand(new_cond, t->diagram(), QPointF(), this);

--- a/sources/undocommand/deleteqgraphicsitemcommand.h
+++ b/sources/undocommand/deleteqgraphicsitemcommand.h
@@ -52,7 +52,7 @@ class DeleteQGraphicsItemCommand : public QUndoCommand
 		QHash <Element *, QList<Element *> > m_link_hash; /// keep linked element for each removed element linked to other element.
 		QHash <DynamicElementTextItem *, Element *> m_elmt_text_hash; /// Keep the parent element of each deleted dynamic element text item
 		QHash <DynamicElementTextItem *, ElementTextItemGroup *> m_grp_texts_hash; ///Keep the parent group of each deleted element text item
-		QList <QPair<Terminal *, Terminal *>> m_connected_terminals;
+		QList <std::pair<Terminal *, Terminal *>> m_connected_terminals;
 		QHash <QetGraphicsTableItem *, QPointer<QGraphicsScene>> m_table_scene_hash;
 		bool m_remove_linked_table = false;
 };


### PR DESCRIPTION
- set default-value for QFont::Weight to prevent warning at runtime
- remove unused NamesList from qetproject.cpp / qetproject.h
- unify NamesList "imported elements" to be used with Qt5 & Qt6
  we still need to decide whether to use list of QChars or written text in utf-8; kept both variants for now
- corrected comment
- use same code for Qt5 & Qt6 for XRef-list
  Until now the code was just added for Qt6, but it can be used by Qt5 as well.