### PR TITLE
Mouse hover text for dynamic text items

### DIFF
--- a/sources/qetgraphicsitem/diagramtextitem.cpp
+++ b/sources/qetgraphicsitem/diagramtextitem.cpp
@@ -483,7 +483,13 @@ void DiagramTextItem::hoverEnterEvent(QGraphicsSceneHoverEvent *e) {
 
 	m_mouse_hover = true;
 	QString str_ToolTip = toPlainText();
-	setToolTip( str_ToolTip );
+	
+	// Add movement instruction for DynamicElementTextItem
+	if (inherits("DynamicElementTextItem")) {
+		str_ToolTip += tr("\n<Shift> to move");
+	}
+	
+	setToolTip(str_ToolTip);
 	update();
 }
 


### PR DESCRIPTION
  - Added text for dynamic text item to indicate that shift needs to be held down to move the text.