### PR TITLE
A few small improvements

### DIFF
--- a/sources/autoNum/assignvariables.cpp
+++ b/sources/autoNum/assignvariables.cpp
@@ -221,11 +221,12 @@ namespace autonum
 		str.replace("%{designation}", dc.value("designation").toString());
 		str.replace("%{manufacturer}", dc.value("manufacturer").toString());
 		str.replace("%{manufacturer_reference}",
-			    dc.value("manufacturer_reference").toString());
+				dc.value("manufacturer_reference").toString());
 		str.replace("%{supplier}", dc.value("supplier").toString());
 		str.replace("%{quantity}", dc.value("quantity").toString());
 		str.replace("%{unity}", dc.value("unity").toString());
-				str.replace("%{auxiliary1}", dc.value("auxiliary1").toString());
+
+		str.replace("%{auxiliary1}", dc.value("auxiliary1").toString());
 		str.replace("%{description_auxiliary1}", dc.value("description_auxiliary1").toString());
 		str.replace("%{designation_auxiliary1}", dc.value("designation_auxiliary1").toString());
 		str.replace("%{manufacturer_auxiliary1}", dc.value("manufacturer_auxiliary1").toString());
@@ -264,10 +265,14 @@ namespace autonum
 		str.replace("%{unity_auxiliary4}", dc.value("unity_auxiliary4").toString());
 		
 		
-		str.replace("%{machine_manufacturer_reference}",
-			    dc.value("machine_manufacturer_reference").toString());
+		str.replace("%{machine_manufacturer_reference}", dc.value("machine_manufacturer_reference").toString());
+
 		str.replace("%{location}", dc.value("location").toString());
 		str.replace("%{function}", dc.value("function").toString());
+		str.replace("%{tension_protocol}", dc.value("tension_protocol").toString());
+		str.replace("%{conductor_section}", dc.value("conductor_section").toString());
+		str.replace("%{conductor_color}", dc.value("conductor_color").toString());
+
 		str.replace("%{void}", QString());
 
 		return str;

--- a/sources/diagram.cpp
+++ b/sources/diagram.cpp
@@ -1438,33 +1438,6 @@ bool Diagram::fromXml(QDomElement &document,
 		added_shapes << dii;
 	}
 
-		// Load conductor
-	QList<Conductor *> added_conductors;
-	for (auto f : QET::findInDomElement(root,
-										QStringLiteral("conductors"),
-										QStringLiteral("conductor")))
-	{
-		if (!Conductor::valideXml(f)) continue;
-
-		//Check if terminal that conductor must be linked is know
-
-		Terminal* p1 = findTerminal(1, f, table_adr_id, added_elements);
-		Terminal* p2 = findTerminal(2, f, table_adr_id, added_elements);
-
-		if (p1 && p2 && p1 != p2)
-		{
-			Conductor *c = new Conductor(p1, p2);
-			if (c->isValid())
-			{
-				addItem(c);
-				c -> fromXml(f);
-				added_conductors << c;
-			}
-			else
-				delete c;
-		}
-	}
-
 		//Load tables
 	QVector<QetGraphicsTableItem *> added_tables;
 	for (const auto &dom_table : QETXML::subChild(root,
@@ -1485,7 +1458,6 @@ bool Diagram::fromXml(QDomElement &document,
 	{
 		QVector <QGraphicsItem *> added_items;
 		for (auto element : qAsConst(added_elements   )) added_items << element;
-		for (auto cond    : qAsConst(added_conductors )) added_items << cond;
 		for (auto shape   : qAsConst(added_shapes     )) added_items << shape;
 		for (auto text    : qAsConst(added_texts      )) added_items << text;
 		for (auto image   : qAsConst(added_images     )) added_items << image;
@@ -1508,6 +1480,33 @@ bool Diagram::fromXml(QDomElement &document,
 			//Translate all added items
 		for (auto qgi : added_items)
 			qgi->setPos(qgi->pos() += pos_);
+	}
+
+	  // Load conductor
+	QList<Conductor *> added_conductors;
+	for (auto f : QET::findInDomElement(root,
+										QStringLiteral("conductors"),
+										QStringLiteral("conductor")))
+	{
+		if (!Conductor::valideXml(f)) continue;
+
+			   //Check if terminal that conductor must be linked is know
+
+		Terminal* p1 = findTerminal(1, f, table_adr_id, added_elements);
+		Terminal* p2 = findTerminal(2, f, table_adr_id, added_elements);
+
+		if (p1 && p2 && p1 != p2)
+		{
+			Conductor *c = new Conductor(p1, p2);
+			if (c->isValid())
+			{
+				addItem(c);
+				c -> fromXml(f);
+				added_conductors << c;
+			}
+			else
+				delete c;
+		}
 	}
 
 		//Filling of falculatory lists

--- a/sources/diagram.cpp
+++ b/sources/diagram.cpp
@@ -762,10 +762,12 @@ QList < QSet <Conductor *> > Diagram::potentials()
 	represent the entire schema or only the selected content
 	\~French Booleen (a vrai par defaut) indiquant si le XML genere doit
 	representer l'integralite du schema ou seulement le contenu selectionne
+	\~ @param is_copy_command:
+	Boolean (false by default) indicating if function is called by an copy command
 	\~ @return An XML Document (QDomDocument)
 	\~French Un Document XML (QDomDocument)
 */
-QDomDocument Diagram::toXml(bool whole_content) {
+QDomDocument Diagram::toXml(bool whole_content, bool is_copy_command) {
 	// document
 	QDomDocument document;
 
@@ -912,8 +914,13 @@ QDomDocument Diagram::toXml(bool whole_content) {
 		{
 			case Element::Type: {
 				auto elmt = static_cast<Element *>(qgi);
-				if (whole_content || elmt->isSelected())
+				if (whole_content || elmt->isSelected()){
+					//  For a copy/paste command, the text positions must be recalculated for
+					//  correct text alignment, before it is saved to the clipboard
+					if(is_copy_command && (elmt->linkType() == Element::Slave || elmt->linkType()&Element::AllReport))
+						correctTextPos(elmt);
 					list_elements << elmt;
+				}
 				break;
 			}
 			case Conductor::Type: {
@@ -973,6 +980,9 @@ QDomDocument Diagram::toXml(bool whole_content) {
 		for (auto elmt : list_elements) {
 			dom_elements.appendChild(elmt->toXml(document,
 								 table_adr_id));
+			// If copy is active we have to undo the changes we have made during creating(filling) 'list_elements'
+			if(is_copy_command && (elmt->linkType() == Element::Slave || elmt->linkType()&Element::AllReport))
+				restoreText(elmt);
 		}
 		dom_root.appendChild(dom_elements);
 	}
@@ -2471,4 +2481,81 @@ bool Diagram::canRotateSelection() const
 	}
 
 	return false;
+}
+/*
+ * 	To copy elements with right-aligned or centered elementtext, the text position
+	of dynamicElementTextItems in report- and slave elements must be reset
+	to the original insert position bevor writing to clipboard.
+	It is only necessary for right-aligned and centered texts,
+	but we do it for all, because it has no influence on other texts.
+*/
+/**
+	@brief Diagram::correctTextPos
+	set insertion position to the original insertion position of the element texts before copying
+	@param Element
+*/
+void Diagram::correctTextPos(Element* elmt)
+{
+	for (auto deti : elmt->dynamicTextItems()){
+		if( deti->textFrom() == DynamicElementTextItem::ElementInfo ||
+			deti->textFrom() == DynamicElementTextItem::CompositeText) {
+
+			if (deti->text().isEmpty()){
+				deti->setText(deti->toPlainText());
+			}
+			// block alignment calculation
+			deti->m_block_alignment = true;
+			deti->setPlainText(deti->text());
+			// release the alignment calculation
+			deti->m_block_alignment = false;
+			// writing an empty string sets the insertion point
+			// to the original insertion point
+			deti->setPlainText("");
+		}
+	}
+	  // same for textgroups
+	for (auto group : elmt->textGroups()){
+		for(DynamicElementTextItem *deti : group->texts()){
+			if( deti->textFrom() == DynamicElementTextItem::ElementInfo ||
+				deti->textFrom() == DynamicElementTextItem::CompositeText) {
+				if (deti->text().isEmpty()){
+					deti->setText(deti->toPlainText());
+				}
+				deti->m_block_alignment = true;
+				deti->setPlainText(deti->text());
+				deti->m_block_alignment = false;
+				deti->setPlainText("");
+			}
+		}
+	}
+}
+
+/*
+ * After changing the element texts for copying, the element texts has to be restored.
+ */
+/**
+	@brief Diagram::restoreText
+	After correcting the elementtext position during copying
+	the Text has to be restored
+	@param Element
+*/
+void Diagram::restoreText(Element* elmt)
+{
+	for (auto deti : elmt->dynamicTextItems()){
+		if( deti->textFrom() == DynamicElementTextItem::ElementInfo ||
+			deti->textFrom() == DynamicElementTextItem::CompositeText)
+		{
+			deti->setPlainText(deti->text());
+		}
+	}
+
+	for (auto group : elmt->textGroups()){
+		for(DynamicElementTextItem *deti : group->texts()){
+			if( deti->textFrom() == DynamicElementTextItem::ElementInfo ||
+				deti->textFrom() == DynamicElementTextItem::CompositeText)
+			{
+				deti->setPlainText(deti->text());
+			}
+		}
+	}
 }

--- a/sources/diagram.h
+++ b/sources/diagram.h
@@ -142,6 +142,8 @@ class Diagram : public QGraphicsScene
 		void wheelEvent (QGraphicsSceneWheelEvent *event) override;
 		void keyPressEvent (QKeyEvent *event) override;
 		void keyReleaseEvent (QKeyEvent *) override;
+		void correctTextPos(Element* elmt);
+		void restoreText(Element* elmt);
 	
 	public:
 		QUuid uuid();
@@ -167,7 +169,7 @@ class Diagram : public QGraphicsScene
 		QList < QSet <Conductor *> > potentials();
 	
 		// methods related to XML import/export
-		QDomDocument toXml(bool = true);
+		QDomDocument toXml(bool wholeContent = true, bool is_copy_command = false);
 		bool initFromXml(QDomElement &,
 				 QPointF = QPointF(),
 				 bool = true,

--- a/sources/diagramview.cpp
+++ b/sources/diagramview.cpp
@@ -391,7 +391,7 @@ void DiagramView::cut()
 void DiagramView::copy()
 {
 	QClipboard *presse_papier = QApplication::clipboard();
-	QString contenu_presse_papier = m_diagram -> toXml(false).toString(4);
+	QString contenu_presse_papier = m_diagram -> toXml(false, true).toString(4);
 	if (presse_papier -> supportsSelection()) presse_papier -> setText(contenu_presse_papier, QClipboard::Selection);
 	presse_papier -> setText(contenu_presse_papier);
 }

--- a/sources/qetgraphicsitem/dynamicelementtextitem.cpp
+++ b/sources/qetgraphicsitem/dynamicelementtextitem.cpp
@@ -1212,6 +1212,12 @@ QString DynamicElementTextItem::reportReplacedCompositeText() const
 			label = autonum::AssignVariables::formulaToLabel(label, elmt->rSequenceStruct(), elmt->diagram(), elmt);
 			string.replace("%{label}", label);
 		}
+			// if element is not linked, replace an empty string
+		else
+		{
+			string.replace("%{label}", "");
+		}
+
 		if (m_watched_conductor)
 		{
 			if(string.contains("%{function}"))
@@ -1222,6 +1228,18 @@ QString DynamicElementTextItem::reportReplacedCompositeText() const
 				string.replace("%{conductor_color}", m_watched_conductor.data()->properties().m_wire_color);
 			if(string.contains("%{conductor_section}"))
 				string.replace("%{conductor_section}", m_watched_conductor.data()->properties().m_wire_section);
+		}
+			// if no conductor is connected, replace an empty String
+		else
+		{
+			if(string.contains("%{function}"))
+				string.replace("%{function}", "");
+			if(string.contains("%{tension_protocol}"))
+				string.replace("%{tension_protocol}", "");
+			if(string.contains("%{conductor_color}"))
+				string.replace("%{conductor_color}", "");
+			if(string.contains("%{conductor_section}"))
+				string.replace("%{conductor_section}", "");
 		}
 	}
 	


### PR DESCRIPTION
with translator:
commit: correcting the visibility of Variables in CompositeText

When a report element with composite text from the collection is inserted into the diagram, the variable name is displayed, e.g. %{function} . The element works perfectly, but of course, it doesn't look good. This is corrected here. 


commit: Correcting dynamicElementTextItem alignment on copying

We have the problem that after copying elements with right-aligned text (and centered text), the text gets an offset to the left by the text width. The cause is the text insertion point, which is not constant for right-aligned text, but changes according to the text width. When copying, the insertion point of the labeled text is copied to the clipboard and then used as the insertion point for empty text when pasting it into the diagram. This means that when labeling the copied text, the insertion point moves further to the left, which then leads to the offset. As a solution to the problem, the insertion point is reset to its original value before writing to the clipboard.


Commit: Better handling of conductors when creating from XML 

The position of a conductor is determined by the two terminals the conductor connects. Therefore, it makes no sense to set the position with 'setPos()'. At this point in the code, it is better to first load all elements (but not the conductors), position them if necessary, and only then load the conductors and assign them to the elements (terminals). 
Sometimes there is the problem that a free space appears above and to the left of the diagram. That space cannot be removed. It has already been suspected that copying plays a role. And indeed, at this point in the code, very large negative x and y coordinates could arise for the conductors when copying, which then led to a shift in the scene. In my opinion, this problem should no longer occur.

Original:
commit: correcting the visibility of Variables in CompositeText

Wenn ein report element mit composite Text aus der Sammlung in das diagram eingefügt wird, wird der variablenname angezeigt, zB. %{function} . Das Element funktioniert einwandfrei, aber es sieht natürlich nicht guht aus . Das wird hiermit korrigiert


commit: Correcting dynamicElementTextItem alignment on copying

Wir haben ja das Problem das nach kopieren von Elementen mit rechtsbündigen Text (und centered text) die Texte einen Versatz um Textbreite nach links haben. Ursache ist der Einfügepunkt des Textes, der ist bei rechtsbündigen Text nicht konstant, sondern der ändert sich entsprechend der Textbreite. Beim kopieren wird der Einfügepunkt des beschrifteten Textes in die Zwischenablage kopiert und wird dann beim Einfügen ins Diagram als Einfügepunkt für einen leeren Text benutzt. Das bedeutet: beim beschriften des kopierten Textes wandert der Einfügepunkt weiter nach links, was dann zu dem Versatz führt.
Als Lösung für das Problem wird der Einfügepunkt vor dem schreiben in die Zwischenablage auf seinen originalen Wert zurückgesetzt.


Commit: Better handling of conductors when creating from XML

Die Position eines conductors wird von den beiden Terminals  bestimmt, die der conductor verbindet. Deshalb macht es keinen Sinn die Position mit 'setPos()' festzulegen.
An der stelle im Code ist es besser erst alle Elemente (aber nicht die conductoren)zu laden,
falls nötig sie zu positionieren und erst dann die conductoren zu laden und den Elementen(Terminals) zuzuordnen.
Manchmal gibt es das Problem das oberhalb und links vom Diagramm  ein Freiraum entsteht. Den Freiraum kann man nicht entfernen kann. Es wurde ja schon vermutet das kopieren eine Rolle spielt.
Und tatsächlich konnten an dieser stelle im Code, beim Kopieren, sehr hohe negative x- und y-Koordinaten bei den conductoren entstehen die dann zu einer Verschiebung in der Scene geführt haben. Dieses Problem dürfte meiner Meinung nach jetzt nicht mehr auftreten.