### PR TITLE
Potential Isolation option for terminals

### DIFF
--- a/lang/qet_de.ts
+++ b/lang/qet_de.ts
@@ -5,51 +5,61 @@
     <name>AboutQETDialog</name>
     <message>
         <location filename="../sources/ui/aboutqetdialog.ui" line="20"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_aboutqetdialog.h" line="373"/>
         <source>À propos de QElectrotech</source>
         <translation>Über QElectroTech</translation>
     </message>
     <message>
         <location filename="../sources/ui/aboutqetdialog.ui" line="30"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_aboutqetdialog.h" line="375"/>
         <source>À propos</source>
         <translation>Über</translation>
     </message>
     <message>
         <location filename="../sources/ui/aboutqetdialog.ui" line="53"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_aboutqetdialog.h" line="377"/>
         <source>Auteurs</source>
         <translation>Autoren</translation>
     </message>
     <message>
         <location filename="../sources/ui/aboutqetdialog.ui" line="133"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_aboutqetdialog.h" line="379"/>
         <source>Traducteurs</source>
         <translation>Übersetzer</translation>
     </message>
     <message>
         <location filename="../sources/ui/aboutqetdialog.ui" line="216"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_aboutqetdialog.h" line="381"/>
         <source>Contributeurs</source>
         <translation>Mitwirkende</translation>
     </message>
     <message>
         <location filename="../sources/ui/aboutqetdialog.ui" line="296"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_aboutqetdialog.h" line="383"/>
         <source>Version</source>
         <translation>Version</translation>
     </message>
     <message>
         <location filename="../sources/ui/aboutqetdialog.ui" line="348"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_aboutqetdialog.h" line="385"/>
         <source>Projet annexe</source>
         <translation>Nebenprojekte</translation>
     </message>
     <message>
         <location filename="../sources/ui/aboutqetdialog.ui" line="428"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_aboutqetdialog.h" line="387"/>
         <source>Bibliothèques</source>
         <translation>Bibliotheken</translation>
     </message>
     <message>
         <location filename="../sources/ui/aboutqetdialog.ui" line="508"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_aboutqetdialog.h" line="388"/>
         <source>Licenses</source>
         <translation>Lizenzen</translation>
     </message>
     <message>
         <location filename="../sources/ui/aboutqetdialog.ui" line="532"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_aboutqetdialog.h" line="389"/>
         <source>log</source>
         <translation>Log</translation>
     </message>
@@ -329,18 +339,21 @@
     <name>AddLinkDialog</name>
     <message>
         <location filename="../sources/richtext/addlinkdialog.ui" line="5"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_addlinkdialog.h" line="100"/>
         <location filename="../sources/richtext/ui_addlinkdialog.h" line="104"/>
         <source>Insert Link</source>
         <translation>Link einfügen</translation>
     </message>
     <message>
         <location filename="../sources/richtext/addlinkdialog.ui" line="19"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_addlinkdialog.h" line="101"/>
         <location filename="../sources/richtext/ui_addlinkdialog.h" line="105"/>
         <source>Title:</source>
         <translation>Titel:</translation>
     </message>
     <message>
         <location filename="../sources/richtext/addlinkdialog.ui" line="36"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_addlinkdialog.h" line="102"/>
         <location filename="../sources/richtext/ui_addlinkdialog.h" line="106"/>
         <source>URL:</source>
         <translation>URL:</translation>
@@ -350,83 +363,105 @@
     <name>AddTableDialog</name>
     <message>
         <location filename="../sources/factory/ui/addtabledialog.ui" line="14"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_addtabledialog.h" line="224"/>
         <source>Ajouter un tableau</source>
         <translation>Tabelle einfügen</translation>
     </message>
     <message>
         <location filename="../sources/factory/ui/addtabledialog.ui" line="24"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_addtabledialog.h" line="250"/>
         <source>Affichage</source>
         <translation>Anzeige</translation>
     </message>
     <message>
         <location filename="../sources/factory/ui/addtabledialog.ui" line="33"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_addtabledialog.h" line="225"/>
         <source>Ajuster la taille du tableau au folio</source>
         <translation>Tabellegröße an Folie anpassen</translation>
     </message>
     <message>
         <location filename="../sources/factory/ui/addtabledialog.ui" line="46"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_addtabledialog.h" line="226"/>
         <source>Ajouter de nouveau folio et tableau si nécessaire.</source>
         <translation>Folie und Tabelle hinzufügen, wenn erforderlich.</translation>
     </message>
     <message>
         <location filename="../sources/factory/ui/addtabledialog.ui" line="66"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_addtabledialog.h" line="228"/>
         <source>Nom du tableau</source>
         <translation>Name der Tabelle</translation>
     </message>
     <message>
         <location filename="../sources/factory/ui/addtabledialog.ui" line="73"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_addtabledialog.h" line="229"/>
         <source>Texte des en-têtes</source>
         <translation>Tabellenkopf</translation>
     </message>
     <message>
         <location filename="../sources/factory/ui/addtabledialog.ui" line="80"/>
         <location filename="../sources/factory/ui/addtabledialog.ui" line="164"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_addtabledialog.h" line="230"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_addtabledialog.h" line="243"/>
         <source>Gauche</source>
         <translation>Linksbündig</translation>
     </message>
     <message>
         <location filename="../sources/factory/ui/addtabledialog.ui" line="85"/>
         <location filename="../sources/factory/ui/addtabledialog.ui" line="169"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_addtabledialog.h" line="231"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_addtabledialog.h" line="244"/>
         <source>Centre</source>
         <translation>Zentriert</translation>
     </message>
     <message>
         <location filename="../sources/factory/ui/addtabledialog.ui" line="90"/>
         <location filename="../sources/factory/ui/addtabledialog.ui" line="174"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_addtabledialog.h" line="232"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_addtabledialog.h" line="245"/>
         <source>Droite</source>
         <translation>Rechtsbündig</translation>
     </message>
     <message>
         <location filename="../sources/factory/ui/addtabledialog.ui" line="98"/>
         <location filename="../sources/factory/ui/addtabledialog.ui" line="182"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_addtabledialog.h" line="234"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_addtabledialog.h" line="247"/>
         <source>Police :</source>
         <translation>Schriftart:</translation>
     </message>
     <message>
         <location filename="../sources/factory/ui/addtabledialog.ui" line="105"/>
         <location filename="../sources/factory/ui/addtabledialog.ui" line="149"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_addtabledialog.h" line="235"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_addtabledialog.h" line="241"/>
         <source>Éditer</source>
         <translation>Bearbeiten</translation>
     </message>
     <message>
         <location filename="../sources/factory/ui/addtabledialog.ui" line="119"/>
         <location filename="../sources/factory/ui/addtabledialog.ui" line="142"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_addtabledialog.h" line="237"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_addtabledialog.h" line="240"/>
         <source>Marges :</source>
         <translation>Ränder:</translation>
     </message>
     <message>
         <location filename="../sources/factory/ui/addtabledialog.ui" line="126"/>
         <location filename="../sources/factory/ui/addtabledialog.ui" line="156"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_addtabledialog.h" line="238"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_addtabledialog.h" line="242"/>
         <source>Alignement :</source>
         <translation>Ausrichtung:</translation>
     </message>
     <message>
         <location filename="../sources/factory/ui/addtabledialog.ui" line="136"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_addtabledialog.h" line="239"/>
         <source>Texte du tableau</source>
         <translation>Tabelleninhalt</translation>
     </message>
     <message>
         <location filename="../sources/factory/ui/addtabledialog.ui" line="202"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_addtabledialog.h" line="249"/>
         <source>Configuration</source>
         <translation>Konfiguration</translation>
     </message>
@@ -450,11 +485,13 @@
     <name>AddTerminalStripItemDialog</name>
     <message>
         <location filename="../sources/TerminalStrip/ui/addterminalstripitemdialog.ui" line="14"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_addterminalstripitemdialog.h" line="70"/>
         <source>Dialog</source>
         <translation>Dialog</translation>
     </message>
     <message>
         <location filename="../sources/TerminalStrip/ui/addterminalstripitemdialog.ui" line="20"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_addterminalstripitemdialog.h" line="71"/>
         <source>Ajouter le plan de bornes suivant :</source>
         <translation>Folgenden Klemmenplan hinzufügen:</translation>
     </message>
@@ -463,6 +500,7 @@
     <name>AlignmentTextDialog</name>
     <message>
         <location filename="../sources/ui/alignmenttextdialog.ui" line="26"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_alignmenttextdialog.h" line="135"/>
         <source>Alignement du texte</source>
         <translation>Ausrichtung</translation>
     </message>
@@ -506,31 +544,37 @@
     <name>AutoNumberingDockWidget</name>
     <message>
         <location filename="../sources/autoNum/ui/autonumberingdockwidget.ui" line="14"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_autonumberingdockwidget.h" line="99"/>
         <source>Sélection numérotation auto</source>
         <translation>Auswahl Nummerierungsregeln</translation>
     </message>
     <message>
         <location filename="../sources/autoNum/ui/autonumberingdockwidget.ui" line="34"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_autonumberingdockwidget.h" line="101"/>
         <source>Element</source>
         <translation>Bauteil</translation>
     </message>
     <message>
         <location filename="../sources/autoNum/ui/autonumberingdockwidget.ui" line="41"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_autonumberingdockwidget.h" line="102"/>
         <source>Conducteur</source>
         <translation>Leiter</translation>
     </message>
     <message>
         <location filename="../sources/autoNum/ui/autonumberingdockwidget.ui" line="64"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_autonumberingdockwidget.h" line="104"/>
         <source>Configurer les règles d&apos;auto numérotation</source>
         <translation>Nummerierungsregel konfigurieren</translation>
     </message>
     <message>
         <location filename="../sources/autoNum/ui/autonumberingdockwidget.ui" line="67"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_autonumberingdockwidget.h" line="106"/>
         <source>Configurer</source>
         <translation>Konfigurieren</translation>
     </message>
     <message>
         <location filename="../sources/autoNum/ui/autonumberingdockwidget.ui" line="24"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_autonumberingdockwidget.h" line="100"/>
         <source>Folio</source>
         <translation>Folie</translation>
     </message>
@@ -539,51 +583,61 @@
     <name>AutoNumberingManagementW</name>
     <message>
         <location filename="../sources/autoNum/ui/autonumberingmanagementw.ui" line="26"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_autonumberingmanagementw.h" line="352"/>
         <source>Form</source>
         <translation>Form</translation>
     </message>
     <message>
         <location filename="../sources/autoNum/ui/autonumberingmanagementw.ui" line="149"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_autonumberingmanagementw.h" line="360"/>
         <source>Project Status:</source>
         <translation>Stand des Projekts:</translation>
     </message>
     <message>
         <location filename="../sources/autoNum/ui/autonumberingmanagementw.ui" line="32"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_autonumberingmanagementw.h" line="353"/>
         <source>Range</source>
         <translation>Bereich</translation>
     </message>
     <message>
         <location filename="../sources/autoNum/ui/autonumberingmanagementw.ui" line="45"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_autonumberingmanagementw.h" line="355"/>
         <source>Apply to Selected Locations</source>
         <translation>Auf ausgewählte Orte anwenden</translation>
     </message>
     <message>
         <location filename="../sources/autoNum/ui/autonumberingmanagementw.ui" line="52"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_autonumberingmanagementw.h" line="356"/>
         <source>Apply to Selected Folios</source>
         <translation>Auf ausgewählte Folien anwenden</translation>
     </message>
     <message>
         <location filename="../sources/autoNum/ui/autonumberingmanagementw.ui" line="59"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_autonumberingmanagementw.h" line="357"/>
         <source>Apply to Entire Project</source>
         <translation>Auf ganzes Projekt anwenden</translation>
     </message>
     <message>
         <location filename="../sources/autoNum/ui/autonumberingmanagementw.ui" line="78"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_autonumberingmanagementw.h" line="358"/>
         <source>From</source>
         <translation>von</translation>
     </message>
     <message>
         <location filename="../sources/autoNum/ui/autonumberingmanagementw.ui" line="101"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_autonumberingmanagementw.h" line="359"/>
         <source>To</source>
         <translation>bis</translation>
     </message>
     <message>
         <location filename="../sources/autoNum/ui/autonumberingmanagementw.ui" line="156"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_autonumberingmanagementw.h" line="361"/>
         <source>Update Policy</source>
         <translation>Richtlinie zur Aktualisierung</translation>
     </message>
     <message>
         <location filename="../sources/autoNum/ui/autonumberingmanagementw.ui" line="171"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_autonumberingmanagementw.h" line="362"/>
         <source>Conductor</source>
         <translation>Leiter</translation>
     </message>
@@ -591,6 +645,9 @@
         <location filename="../sources/autoNum/ui/autonumberingmanagementw.ui" line="188"/>
         <location filename="../sources/autoNum/ui/autonumberingmanagementw.ui" line="275"/>
         <location filename="../sources/autoNum/ui/autonumberingmanagementw.ui" line="353"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_autonumberingmanagementw.h" line="364"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_autonumberingmanagementw.h" line="369"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_autonumberingmanagementw.h" line="373"/>
         <source>Only New</source>
         <translation>nur Neue</translation>
     </message>
@@ -598,6 +655,9 @@
         <location filename="../sources/autoNum/ui/autonumberingmanagementw.ui" line="178"/>
         <location filename="../sources/autoNum/ui/autonumberingmanagementw.ui" line="259"/>
         <location filename="../sources/autoNum/ui/autonumberingmanagementw.ui" line="373"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_autonumberingmanagementw.h" line="363"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_autonumberingmanagementw.h" line="368"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_autonumberingmanagementw.h" line="375"/>
         <source>Both</source>
         <translation>Beide</translation>
     </message>
@@ -605,27 +665,35 @@
         <location filename="../sources/autoNum/ui/autonumberingmanagementw.ui" line="208"/>
         <location filename="../sources/autoNum/ui/autonumberingmanagementw.ui" line="307"/>
         <location filename="../sources/autoNum/ui/autonumberingmanagementw.ui" line="383"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_autonumberingmanagementw.h" line="366"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_autonumberingmanagementw.h" line="371"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_autonumberingmanagementw.h" line="376"/>
         <source>Disable</source>
         <translation>nicht aktualisieren</translation>
     </message>
     <message>
         <location filename="../sources/autoNum/ui/autonumberingmanagementw.ui" line="246"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_autonumberingmanagementw.h" line="367"/>
         <source>Element</source>
         <translation>Bauteile</translation>
     </message>
     <message>
         <location filename="../sources/autoNum/ui/autonumberingmanagementw.ui" line="198"/>
         <location filename="../sources/autoNum/ui/autonumberingmanagementw.ui" line="291"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_autonumberingmanagementw.h" line="365"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_autonumberingmanagementw.h" line="370"/>
         <source>Only Existent</source>
         <translation>nur Vorhandene</translation>
     </message>
     <message>
         <location filename="../sources/autoNum/ui/autonumberingmanagementw.ui" line="346"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_autonumberingmanagementw.h" line="372"/>
         <source>Folio</source>
         <translation>Folie</translation>
     </message>
     <message>
         <location filename="../sources/autoNum/ui/autonumberingmanagementw.ui" line="363"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_autonumberingmanagementw.h" line="374"/>
         <source>Existent</source>
         <translation>Vorhandene</translation>
     </message>
@@ -671,21 +739,25 @@ Bemerkung: diese Optionen verhindern NICHT das automatische Nummerieren.</transl
     <name>BOMExportDialog</name>
     <message>
         <location filename="../sources/ui/bomexportdialog.ui" line="14"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_bomexportdialog.h" line="81"/>
         <source>Dialog</source>
         <translation>Dialog</translation>
     </message>
     <message>
         <location filename="../sources/ui/bomexportdialog.ui" line="20"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_bomexportdialog.h" line="82"/>
         <source>Mise en page</source>
         <translation>Seitenlayout</translation>
     </message>
     <message>
         <location filename="../sources/ui/bomexportdialog.ui" line="26"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_bomexportdialog.h" line="83"/>
         <source>inclure les en-têtes</source>
         <translation>Überschriften einschließen</translation>
     </message>
     <message>
         <location filename="../sources/ui/bomexportdialog.ui" line="36"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_bomexportdialog.h" line="84"/>
         <source>Formater en tant que liste de materiel</source>
         <translation>Layout als Stückliste</translation>
     </message>
@@ -739,12 +811,15 @@ Bemerkung: diese Optionen verhindern NICHT das automatische Nummerieren.</transl
     <name>BorderPropertiesWidget</name>
     <message>
         <location filename="../sources/ui/borderpropertieswidget.ui" line="14"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_borderpropertieswidget.h" line="114"/>
         <source>Form</source>
         <translation>Folieneigenschaften</translation>
     </message>
     <message>
         <location filename="../sources/ui/borderpropertieswidget.ui" line="26"/>
         <location filename="../sources/ui/borderpropertieswidget.ui" line="42"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_borderpropertieswidget.h" line="116"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_borderpropertieswidget.h" line="118"/>
         <source>px</source>
         <comment>pixel</comment>
         <extracomment>pixel</extracomment>
@@ -753,40 +828,135 @@ Bemerkung: diese Optionen verhindern NICHT das automatische Nummerieren.</transl
     <message>
         <location filename="../sources/ui/borderpropertieswidget.ui" line="29"/>
         <location filename="../sources/ui/borderpropertieswidget.ui" line="45"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_borderpropertieswidget.h" line="117"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_borderpropertieswidget.h" line="119"/>
         <source>x</source>
         <translation>x</translation>
     </message>
     <message>
         <location filename="../sources/ui/borderpropertieswidget.ui" line="72"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_borderpropertieswidget.h" line="122"/>
         <source>Colonnes :</source>
         <translation>Spalten:</translation>
     </message>
     <message>
         <location filename="../sources/ui/borderpropertieswidget.ui" line="62"/>
         <location filename="../sources/ui/borderpropertieswidget.ui" line="79"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_borderpropertieswidget.h" line="121"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_borderpropertieswidget.h" line="123"/>
         <source>Afficher les en-têtes</source>
         <translation>Kopfzeilen anzeigen</translation>
     </message>
     <message>
         <location filename="../sources/ui/borderpropertieswidget.ui" line="55"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_borderpropertieswidget.h" line="120"/>
         <source>Lignes :</source>
         <translation>Zeilen:</translation>
     </message>
     <message>
         <location filename="../sources/ui/borderpropertieswidget.ui" line="20"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_borderpropertieswidget.h" line="115"/>
         <source>Dimensions du folio</source>
         <translation>Folienmaße</translation>
+    </message>
+</context>
+<context>
+    <name>ColumnResizerTestWidget</name>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/tests/kcolumnresizertestapp.ui" line="14"/>
+        <source>ColumnResizer Test</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/tests/kcolumnresizertestapp.ui" line="20"/>
+        <source>GridLayout</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/tests/kcolumnresizertestapp.ui" line="26"/>
+        <source>A line edit:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/tests/kcolumnresizertestapp.ui" line="42"/>
+        <source>Spin me:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/tests/kcolumnresizertestapp.ui" line="52"/>
+        <source>A check box</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/tests/kcolumnresizertestapp.ui" line="62"/>
+        <source>FormLayout</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/tests/kcolumnresizertestapp.ui" line="71"/>
+        <source>One line:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/tests/kcolumnresizertestapp.ui" line="81"/>
+        <source>A much bigger text area:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/tests/kcolumnresizertestapp.ui" line="94"/>
+        <source>FormLayout2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/tests/kcolumnresizertestapp.ui" line="103"/>
+        <source>Time:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/tests/kcolumnresizertestapp.ui" line="110"/>
+        <source>Show seconds</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/tests/kcolumnresizertestapp.ui" line="117"/>
+        <source>Details:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/tests/kcolumnresizertestapp.ui" line="124"/>
+        <source>Option &amp;1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/tests/kcolumnresizertestapp.ui" line="134"/>
+        <source>Option &amp;2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/tests/kcolumnresizertestapp.ui" line="144"/>
+        <source>Crazy QGridLayout</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/tests/kcolumnresizertestapp.ui" line="150"/>
+        <location filename="../build/_deps/kwidgetsaddons-src/tests/kcolumnresizertestapp.ui" line="157"/>
+        <location filename="../build/_deps/kwidgetsaddons-src/tests/kcolumnresizertestapp.ui" line="164"/>
+        <location filename="../build/_deps/kwidgetsaddons-src/tests/kcolumnresizertestapp.ui" line="177"/>
+        <source>PushButton</source>
+        <translation type="unfinished">Taste</translation>
     </message>
 </context>
 <context>
     <name>CompositeTextEditDialog</name>
     <message>
         <location filename="../sources/ui/compositetexteditdialog.ui" line="14"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_compositetexteditdialog.h" line="71"/>
         <source>Texte composé</source>
         <translation>Zusammengesetzter Text</translation>
     </message>
     <message>
         <location filename="../sources/ui/compositetexteditdialog.ui" line="23"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_compositetexteditdialog.h" line="72"/>
         <source>Ajouter une variable :</source>
         <translation>Variable einfügen:</translation>
     </message>
@@ -816,11 +986,13 @@ Bemerkung: diese Optionen verhindern NICHT das automatische Nummerieren.</transl
     <name>ConductorPropertiesDialog</name>
     <message>
         <location filename="../sources/ui/conductorpropertiesdialog.ui" line="14"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_conductorpropertiesdialog.h" line="58"/>
         <source>Éditer les propriétés d&apos;un conducteur</source>
         <translation>Leitereigenschaften bearbeiten</translation>
     </message>
     <message>
         <location filename="../sources/ui/conductorpropertiesdialog.ui" line="20"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_conductorpropertiesdialog.h" line="59"/>
         <source>Appliquer les propriétés à l&apos;ensemble des conducteurs de ce potentiel</source>
         <translation>Eigenschaften auf alle Verbindungen dieses Potenzials übertragen</translation>
     </message>
@@ -841,227 +1013,277 @@ Bemerkung: diese Optionen verhindern NICHT das automatische Nummerieren.</transl
     <name>ConductorPropertiesWidget</name>
     <message>
         <location filename="../sources/ui/conductorpropertieswidget.ui" line="14"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_conductorpropertieswidget.h" line="526"/>
         <source>Form</source>
         <translation>Leitereigenschaften</translation>
     </message>
     <message>
         <location filename="../sources/ui/conductorpropertieswidget.ui" line="223"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_conductorpropertieswidget.h" line="557"/>
         <source>Taille du texte :</source>
         <translation>Textgröße:</translation>
     </message>
     <message>
         <location filename="../sources/ui/conductorpropertieswidget.ui" line="213"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_conductorpropertieswidget.h" line="556"/>
         <source>Texte :</source>
         <translation>Text:</translation>
     </message>
     <message>
         <location filename="../sources/ui/conductorpropertieswidget.ui" line="75"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_conductorpropertieswidget.h" line="531"/>
         <source>Texte</source>
         <translation>Text</translation>
     </message>
     <message>
         <location filename="../sources/ui/conductorpropertieswidget.ui" line="154"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_conductorpropertieswidget.h" line="547"/>
         <source>Afficher un texte de potentiel par folio. </source>
         <translation>Nur eine Potenzialbeschriftung je Folie anzeigen. </translation>
     </message>
     <message>
         <location filename="../sources/ui/conductorpropertieswidget.ui" line="301"/>
         <location filename="../sources/ui/conductorpropertieswidget.ui" line="313"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_conductorpropertieswidget.h" line="566"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_conductorpropertieswidget.h" line="591"/>
         <source>Unifilaire</source>
         <translation>Einpolig</translation>
     </message>
     <message>
         <location filename="../sources/ui/conductorpropertieswidget.ui" line="377"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_conductorpropertieswidget.h" line="579"/>
         <source>terre</source>
         <translation>Erde</translation>
     </message>
     <message>
         <location filename="../sources/ui/conductorpropertieswidget.ui" line="363"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_conductorpropertieswidget.h" line="575"/>
         <source>neutre</source>
         <translation>Neutralleiter</translation>
     </message>
     <message>
         <location filename="../sources/ui/conductorpropertieswidget.ui" line="102"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_conductorpropertieswidget.h" line="536"/>
         <source>Taille du texte</source>
         <translation>Textgröße</translation>
     </message>
     <message>
         <location filename="../sources/ui/conductorpropertieswidget.ui" line="85"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_conductorpropertieswidget.h" line="533"/>
         <source>Tension / Protocole :</source>
         <translation>Spannung / Protokoll:</translation>
     </message>
     <message>
         <location filename="../sources/ui/conductorpropertieswidget.ui" line="161"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_conductorpropertieswidget.h" line="548"/>
         <source>Fonction :</source>
         <translation>Funktion:</translation>
     </message>
     <message>
         <location filename="../sources/ui/conductorpropertieswidget.ui" line="138"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_conductorpropertieswidget.h" line="541"/>
         <source>Texte visible</source>
         <translation>Sichtbarer Text</translation>
     </message>
     <message>
         <location filename="../sources/ui/conductorpropertieswidget.ui" line="254"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_conductorpropertieswidget.h" line="562"/>
         <source>Formule du texte :</source>
         <translation>Textformel:</translation>
     </message>
     <message>
         <location filename="../sources/ui/conductorpropertieswidget.ui" line="151"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_conductorpropertieswidget.h" line="545"/>
         <source>activer l&apos;option un texte par potentiel</source>
         <translation>Option &quot;ein Text je Potenzial&quot; aktivieren</translation>
     </message>
     <message>
         <location filename="../sources/ui/conductorpropertieswidget.ui" line="34"/>
         <location filename="../sources/ui/conductorpropertieswidget.ui" line="46"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_conductorpropertieswidget.h" line="527"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_conductorpropertieswidget.h" line="565"/>
         <source>&amp;Multifilaire</source>
         <translation>&amp;Mehrpolig</translation>
     </message>
     <message>
         <location filename="../sources/ui/conductorpropertieswidget.ui" line="92"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_conductorpropertieswidget.h" line="534"/>
         <source>Autonumérotation</source>
         <translation>Automatische Nummerierung:</translation>
     </message>
     <message>
         <location filename="../sources/ui/conductorpropertieswidget.ui" line="230"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_conductorpropertieswidget.h" line="559"/>
         <source>éditer les numérotations</source>
         <translation>Nummerierung bearbeiten</translation>
     </message>
     <message>
         <location filename="../sources/ui/conductorpropertieswidget.ui" line="131"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_conductorpropertieswidget.h" line="539"/>
         <source>Section du conducteur</source>
         <translation>Leiterquerschnitt:</translation>
     </message>
     <message>
         <location filename="../sources/ui/conductorpropertieswidget.ui" line="264"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_conductorpropertieswidget.h" line="563"/>
         <source>cable</source>
         <translation>Kabel:</translation>
     </message>
     <message>
         <location filename="../sources/ui/conductorpropertieswidget.ui" line="274"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_conductorpropertieswidget.h" line="564"/>
         <source>bus</source>
         <translation>Bus:</translation>
     </message>
     <message>
         <location filename="../sources/ui/conductorpropertieswidget.ui" line="330"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_conductorpropertieswidget.h" line="567"/>
         <source>TextLabel</source>
         <translation>TextLabel</translation>
     </message>
     <message>
         <location filename="../sources/ui/conductorpropertieswidget.ui" line="340"/>
         <location filename="../sources/ui/conductorpropertieswidget.ui" line="408"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_conductorpropertieswidget.h" line="569"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_conductorpropertieswidget.h" line="585"/>
         <source>Nombre de phase</source>
         <translation>Phasenanzahl</translation>
     </message>
     <message>
         <location filename="../sources/ui/conductorpropertieswidget.ui" line="360"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_conductorpropertieswidget.h" line="573"/>
         <source>Neutre</source>
         <translation>Neutralleiter</translation>
     </message>
     <message>
         <location filename="../sources/ui/conductorpropertieswidget.ui" line="388"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_conductorpropertieswidget.h" line="581"/>
         <source>Phase</source>
         <translation>Phase</translation>
     </message>
     <message>
         <location filename="../sources/ui/conductorpropertieswidget.ui" line="391"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_conductorpropertieswidget.h" line="583"/>
         <source>phase</source>
         <translation>Phase</translation>
     </message>
     <message>
         <location filename="../sources/ui/conductorpropertieswidget.ui" line="424"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_conductorpropertieswidget.h" line="588"/>
         <source>Protective Earth Neutral</source>
         <translation>PEN-Leiter (protective earth neutral)</translation>
     </message>
     <message>
         <location filename="../sources/ui/conductorpropertieswidget.ui" line="427"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_conductorpropertieswidget.h" line="590"/>
         <source>PEN</source>
         <translation>PEN</translation>
     </message>
     <message>
         <location filename="../sources/ui/conductorpropertieswidget.ui" line="374"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_conductorpropertieswidget.h" line="577"/>
         <source>Terre</source>
         <translation>Erde</translation>
     </message>
     <message>
         <location filename="../sources/ui/conductorpropertieswidget.ui" line="466"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_conductorpropertieswidget.h" line="593"/>
         <source>Taille :</source>
         <translation>Größe:</translation>
     </message>
     <message>
         <location filename="../sources/ui/conductorpropertieswidget.ui" line="486"/>
         <location filename="../sources/ui/conductorpropertieswidget.ui" line="557"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_conductorpropertieswidget.h" line="595"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_conductorpropertieswidget.h" line="603"/>
         <source>Style du conducteur</source>
         <translation>Leiterstil</translation>
     </message>
     <message>
         <location filename="../sources/ui/conductorpropertieswidget.ui" line="195"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_conductorpropertieswidget.h" line="553"/>
         <source>Horizontal en haut</source>
         <translation>Waagerecht oben</translation>
     </message>
     <message>
         <location filename="../sources/ui/conductorpropertieswidget.ui" line="200"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_conductorpropertieswidget.h" line="554"/>
         <source>Horizontal en bas</source>
         <translation>Waagerecht unten</translation>
     </message>
     <message>
         <location filename="../sources/ui/conductorpropertieswidget.ui" line="171"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_conductorpropertieswidget.h" line="549"/>
         <source>Vertical à gauche</source>
         <translation>Vertikal links</translation>
     </message>
     <message>
         <location filename="../sources/ui/conductorpropertieswidget.ui" line="58"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_conductorpropertieswidget.h" line="528"/>
         <source>Couleur du texte:</source>
         <translation>Textfarbe:</translation>
     </message>
     <message>
         <location filename="../sources/ui/conductorpropertieswidget.ui" line="176"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_conductorpropertieswidget.h" line="550"/>
         <source>Vertical à droite</source>
         <translation>Vertikal rechts</translation>
     </message>
     <message>
         <location filename="../sources/ui/conductorpropertieswidget.ui" line="184"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_conductorpropertieswidget.h" line="552"/>
         <source>Position et rotation du texte de conducteur :</source>
         <translation>Position und Ausrichtung der Leiterbeschriftung:</translation>
     </message>
     <message>
         <location filename="../sources/ui/conductorpropertieswidget.ui" line="496"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_conductorpropertieswidget.h" line="598"/>
         <source>Couleur secondaire :</source>
         <translation>Zweite Farbe:</translation>
     </message>
     <message>
         <location filename="../sources/ui/conductorpropertieswidget.ui" line="518"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_conductorpropertieswidget.h" line="600"/>
         <source>px</source>
         <translation>px</translation>
     </message>
     <message>
         <location filename="../sources/ui/conductorpropertieswidget.ui" line="511"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_conductorpropertieswidget.h" line="599"/>
         <source>Taille de trait :</source>
         <translation>Linienstärke:</translation>
     </message>
     <message>
         <location filename="../sources/ui/conductorpropertieswidget.ui" line="65"/>
         <location filename="../sources/ui/conductorpropertieswidget.ui" line="564"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_conductorpropertieswidget.h" line="529"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_conductorpropertieswidget.h" line="606"/>
         <source>Couleur du conducteur</source>
         <translation>Leiterfarbe:</translation>
     </message>
     <message>
         <location filename="../sources/ui/conductorpropertieswidget.ui" line="24"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_conductorpropertieswidget.h" line="592"/>
         <source>Type</source>
         <translation>Typ</translation>
     </message>
     <message>
         <location filename="../sources/ui/conductorpropertieswidget.ui" line="457"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_conductorpropertieswidget.h" line="609"/>
         <source>Apparence</source>
         <translation>Darstellung</translation>
     </message>
     <message>
         <location filename="../sources/ui/conductorpropertieswidget.ui" line="528"/>
         <location filename="../sources/ui/conductorpropertieswidget.ui" line="567"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_conductorpropertieswidget.h" line="601"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_conductorpropertieswidget.h" line="608"/>
         <source>Couleur :</source>
         <translation>Farbe:</translation>
     </message>
     <message>
         <location filename="../sources/ui/conductorpropertieswidget.ui" line="489"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_conductorpropertieswidget.h" line="597"/>
         <source>Style :</source>
         <translation>Stil:</translation>
     </message>
@@ -1088,11 +1310,13 @@ Bemerkung: diese Optionen verhindern NICHT das automatische Nummerieren.</transl
     <name>ConfigSaveLoaderWidget</name>
     <message>
         <location filename="../sources/ui/configsaveloaderwidget.ui" line="14"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_configsaveloaderwidget.h" line="76"/>
         <source>GroupBox</source>
         <translation>Gruppierung</translation>
     </message>
     <message>
         <location filename="../sources/ui/configsaveloaderwidget.ui" line="17"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_configsaveloaderwidget.h" line="77"/>
         <source>Configuration</source>
         <translation>Einstellungen</translation>
     </message>
@@ -1117,22 +1341,26 @@ Bemerkung: diese Optionen verhindern NICHT das automatische Nummerieren.</transl
     <name>DiagramContextWidget</name>
     <message>
         <location filename="../sources/ui/diagramcontextwidget.ui" line="14"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_diagramcontextwidget.h" line="69"/>
         <source>Form</source>
         <translation>Form</translation>
     </message>
     <message>
         <location filename="../sources/ui/diagramcontextwidget.ui" line="20"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_diagramcontextwidget.h" line="70"/>
         <location filename="../sources/ui/diagramcontextwidget.cpp" line="155"/>
         <source>Les noms ne peuvent contenir que des lettres minuscules, des chiffres et des tirets.</source>
         <translation>Namen dürfen ausschließlich Kleinbuchstaben, Zahlen und Minuszeichen enthalten.</translation>
     </message>
     <message>
         <location filename="../sources/ui/diagramcontextwidget.ui" line="50"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_diagramcontextwidget.h" line="72"/>
         <source>Nom</source>
         <translation>Name</translation>
     </message>
     <message>
         <location filename="../sources/ui/diagramcontextwidget.ui" line="55"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_diagramcontextwidget.h" line="74"/>
         <source>Valeur</source>
         <translation>Wert</translation>
     </message>
@@ -1141,26 +1369,31 @@ Bemerkung: diese Optionen verhindern NICHT das automatische Nummerieren.</transl
     <name>DiagramEditorHandlerSizeWidget</name>
     <message>
         <location filename="../sources/ui/diagrameditorhandlersizewidget.ui" line="14"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_diagrameditorhandlersizewidget.h" line="56"/>
         <source>Form</source>
         <translation>Form</translation>
     </message>
     <message>
         <location filename="../sources/ui/diagrameditorhandlersizewidget.ui" line="20"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_diagrameditorhandlersizewidget.h" line="57"/>
         <source>Poignées :</source>
         <translation>Anfasser:</translation>
     </message>
     <message>
         <location filename="../sources/ui/diagrameditorhandlersizewidget.ui" line="28"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_diagrameditorhandlersizewidget.h" line="58"/>
         <source>x 1</source>
         <translation>x 1</translation>
     </message>
     <message>
         <location filename="../sources/ui/diagrameditorhandlersizewidget.ui" line="33"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_diagrameditorhandlersizewidget.h" line="59"/>
         <source>x 2</source>
         <translation>x 2</translation>
     </message>
     <message>
         <location filename="../sources/ui/diagrameditorhandlersizewidget.ui" line="38"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_diagrameditorhandlersizewidget.h" line="60"/>
         <source>x 3</source>
         <translation>x 3</translation>
     </message>
@@ -1284,16 +1517,19 @@ Bemerkung: diese Optionen verhindern NICHT das automatische Nummerieren.</transl
     <name>DialogWaiting</name>
     <message>
         <location filename="../sources/ui/dialogwaiting.ui" line="14"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_dialogwaiting.h" line="96"/>
         <source>Merci de patienter</source>
         <translation>Bitte warten</translation>
     </message>
     <message>
         <location filename="../sources/ui/dialogwaiting.ui" line="26"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_dialogwaiting.h" line="97"/>
         <source>Titre</source>
         <translation>Titel</translation>
     </message>
     <message>
         <location filename="../sources/ui/dialogwaiting.ui" line="88"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_dialogwaiting.h" line="99"/>
         <source>TextLabel</source>
         <translation>TextLabel</translation>
     </message>
@@ -1315,11 +1551,13 @@ Bemerkung: diese Optionen verhindern NICHT das automatische Nummerieren.</transl
     <name>DynamicElementTextItemEditor</name>
     <message>
         <location filename="../sources/ui/dynamicelementtextitemeditor.ui" line="14"/>
+        <location filename="../build/qelectrotech_autogen/ui_dynamicelementtextitemeditor.h" line="118"/>
         <source>Form</source>
         <translation>Form</translation>
     </message>
     <message>
         <location filename="../sources/ui/dynamicelementtextitemeditor.ui" line="22"/>
+        <location filename="../build/qelectrotech_autogen/ui_dynamicelementtextitemeditor.h" line="120"/>
         <source>Exporter l&apos;actuelle configuration des textes</source>
         <translation>Aktuelle Texteinstellungen exportieren</translation>
     </message>
@@ -1329,26 +1567,35 @@ Bemerkung: diese Optionen verhindern NICHT das automatische Nummerieren.</transl
         <location filename="../sources/ui/dynamicelementtextitemeditor.ui" line="66"/>
         <location filename="../sources/ui/dynamicelementtextitemeditor.ui" line="80"/>
         <location filename="../sources/ui/dynamicelementtextitemeditor.ui" line="94"/>
+        <location filename="../build/qelectrotech_autogen/ui_dynamicelementtextitemeditor.h" line="122"/>
+        <location filename="../build/qelectrotech_autogen/ui_dynamicelementtextitemeditor.h" line="126"/>
+        <location filename="../build/qelectrotech_autogen/ui_dynamicelementtextitemeditor.h" line="130"/>
+        <location filename="../build/qelectrotech_autogen/ui_dynamicelementtextitemeditor.h" line="134"/>
+        <location filename="../build/qelectrotech_autogen/ui_dynamicelementtextitemeditor.h" line="138"/>
         <source>...</source>
         <translation>...</translation>
     </message>
     <message>
         <location filename="../sources/ui/dynamicelementtextitemeditor.ui" line="36"/>
+        <location filename="../build/qelectrotech_autogen/ui_dynamicelementtextitemeditor.h" line="124"/>
         <source>Importer une configuration de texte</source>
         <translation>Texteinstellungen importieren</translation>
     </message>
     <message>
         <location filename="../sources/ui/dynamicelementtextitemeditor.ui" line="63"/>
+        <location filename="../build/qelectrotech_autogen/ui_dynamicelementtextitemeditor.h" line="128"/>
         <source>Ajouter un texte</source>
         <translation>Text einfügen</translation>
     </message>
     <message>
         <location filename="../sources/ui/dynamicelementtextitemeditor.ui" line="77"/>
+        <location filename="../build/qelectrotech_autogen/ui_dynamicelementtextitemeditor.h" line="132"/>
         <source>Ajouter un groupe de textes</source>
         <translation>Textgruppe einfügen</translation>
     </message>
     <message>
         <location filename="../sources/ui/dynamicelementtextitemeditor.ui" line="91"/>
+        <location filename="../build/qelectrotech_autogen/ui_dynamicelementtextitemeditor.h" line="136"/>
         <source>Supprimer la sélection</source>
         <translation>Auswahl löschen</translation>
     </message>
@@ -1598,72 +1845,87 @@ Bemerkung: diese Optionen verhindern NICHT das automatische Nummerieren.</transl
     <name>DynamicTextFieldEditor</name>
     <message>
         <location filename="../sources/editor/ui/dynamictextfieldeditor.ui" line="14"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_dynamictextfieldeditor.h" line="211"/>
         <source>Form</source>
         <translation>Form</translation>
     </message>
     <message>
         <location filename="../sources/editor/ui/dynamictextfieldeditor.ui" line="125"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_dynamictextfieldeditor.h" line="220"/>
         <source>Source du texte</source>
         <translation>Textquelle</translation>
     </message>
     <message>
         <location filename="../sources/editor/ui/dynamictextfieldeditor.ui" line="20"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_dynamictextfieldeditor.h" line="212"/>
         <source>Couleur</source>
         <translation>Farbe</translation>
     </message>
     <message>
         <location filename="../sources/editor/ui/dynamictextfieldeditor.ui" line="72"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_dynamictextfieldeditor.h" line="218"/>
         <source>Conserver la rotation visuel</source>
         <translation>Leserichtung beim Drehen beibehalten</translation>
     </message>
     <message>
         <location filename="../sources/editor/ui/dynamictextfieldeditor.ui" line="54"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_dynamictextfieldeditor.h" line="214"/>
         <source>Texte utilisateur</source>
         <translation>Benutzertext</translation>
     </message>
     <message>
         <location filename="../sources/editor/ui/dynamictextfieldeditor.ui" line="59"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_dynamictextfieldeditor.h" line="215"/>
         <source>Information de l&apos;élément</source>
         <translation>Bauteilinformation</translation>
     </message>
     <message>
         <location filename="../sources/editor/ui/dynamictextfieldeditor.ui" line="162"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_dynamictextfieldeditor.h" line="224"/>
         <source>Encadrer le texte</source>
         <translation>Text einrahmen</translation>
     </message>
     <message>
         <location filename="../sources/editor/ui/dynamictextfieldeditor.ui" line="64"/>
         <location filename="../sources/editor/ui/dynamictextfieldeditor.ui" line="148"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_dynamictextfieldeditor.h" line="216"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_dynamictextfieldeditor.h" line="222"/>
         <source>Texte composé</source>
         <translation>Zusammengesetzter Text</translation>
     </message>
     <message>
         <location filename="../sources/editor/ui/dynamictextfieldeditor.ui" line="209"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_dynamictextfieldeditor.h" line="227"/>
         <source>Police</source>
         <translation>Schriftart</translation>
     </message>
     <message>
         <location filename="../sources/editor/ui/dynamictextfieldeditor.ui" line="199"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_dynamictextfieldeditor.h" line="226"/>
         <source>X</source>
         <translation>X</translation>
     </message>
     <message>
         <location filename="../sources/editor/ui/dynamictextfieldeditor.ui" line="43"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_dynamictextfieldeditor.h" line="213"/>
         <source>Largeur</source>
         <translation>Breite</translation>
     </message>
     <message>
         <location filename="../sources/editor/ui/dynamictextfieldeditor.ui" line="115"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_dynamictextfieldeditor.h" line="219"/>
         <source>Y</source>
         <translation>Y</translation>
     </message>
     <message>
         <location filename="../sources/editor/ui/dynamictextfieldeditor.ui" line="155"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_dynamictextfieldeditor.h" line="223"/>
         <source>Alignement</source>
         <translation>Ausrichtung</translation>
     </message>
     <message>
         <location filename="../sources/editor/ui/dynamictextfieldeditor.ui" line="138"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_dynamictextfieldeditor.h" line="221"/>
         <source>Rotation</source>
         <translation>Drehung</translation>
     </message>
@@ -1900,16 +2162,19 @@ Bemerkung: diese Optionen verhindern NICHT das automatische Nummerieren.</transl
     <name>ElementInfoPartWidget</name>
     <message>
         <location filename="../sources/ui/elementinfopartwidget.ui" line="20"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_elementinfopartwidget.h" line="66"/>
         <source>Form</source>
         <translation>Form</translation>
     </message>
     <message>
         <location filename="../sources/ui/elementinfopartwidget.ui" line="54"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_elementinfopartwidget.h" line="67"/>
         <source>TextLabel</source>
         <translation>TextLabel</translation>
     </message>
     <message>
         <location filename="../sources/ui/elementinfopartwidget.ui" line="61"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_elementinfopartwidget.h" line="69"/>
         <source>Supprimer ce texte</source>
         <translation>Diesen Text löschen</translation>
     </message>
@@ -1918,95 +2183,118 @@ Bemerkung: diese Optionen verhindern NICHT das automatische Nummerieren.</transl
     <name>ElementInfoWidget</name>
     <message>
         <location filename="../sources/ui/elementinfowidget.ui" line="26"/>
+        <location filename="../build/qelectrotech_autogen/ui_elementinfowidget.h" line="77"/>
         <source>Form</source>
         <translation>Form</translation>
     </message>
     <message>
         <location filename="../sources/ui/elementinfowidget.ui" line="35"/>
+        <location filename="../build/qelectrotech_autogen/ui_elementinfowidget.h" line="78"/>
         <source>Exclure de la numérotation auto</source>
         <translation>Sperre der automatischen Nummerierung</translation>
     </message>
     <message>
-        <location filename="../sources/ui/elementinfowidget.h" line="51"/>
+        <location filename="../sources/ui/elementinfowidget.h" line="52"/>
         <source>Informations</source>
         <translation>Informationen</translation>
+    </message>
+    <message>
+        <location filename="../sources/ui/elementinfowidget.cpp" line="207"/>
+        <source>Séparation de potentiel</source>
+        <translation>Potentialtrennung</translation>
     </message>
 </context>
 <context>
     <name>ElementPropertiesEditorWidget</name>
     <message>
         <location filename="../sources/editor/ui/elementpropertieseditorwidget.ui" line="14"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_elementpropertieseditorwidget.h" line="236"/>
         <source>Propriété de l&apos;élément</source>
         <translation>Bauteileigenschaften</translation>
     </message>
     <message>
         <location filename="../sources/editor/ui/elementpropertieseditorwidget.ui" line="27"/>
         <location filename="../sources/editor/ui/elementpropertieseditorwidget.ui" line="136"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_elementpropertieseditorwidget.h" line="246"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_elementpropertieseditorwidget.h" line="248"/>
         <source>Type</source>
         <translation>Typ</translation>
     </message>
     <message>
         <location filename="../sources/editor/ui/elementpropertieseditorwidget.ui" line="35"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_elementpropertieseditorwidget.h" line="237"/>
         <source>Type de base :</source>
         <translation>Grundtyp:</translation>
     </message>
     <message>
         <location filename="../sources/editor/ui/elementpropertieseditorwidget.ui" line="47"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_elementpropertieseditorwidget.h" line="238"/>
         <source>Élément esclave</source>
         <translation>Slave-Bauteil</translation>
     </message>
     <message>
         <location filename="../sources/editor/ui/elementpropertieseditorwidget.ui" line="62"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_elementpropertieseditorwidget.h" line="239"/>
         <source>Nombre de contact représenté</source>
         <translation>Anzahl der dargestellten Kontakte</translation>
     </message>
     <message>
         <location filename="../sources/editor/ui/elementpropertieseditorwidget.ui" line="69"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_elementpropertieseditorwidget.h" line="240"/>
         <source>Type de contact</source>
         <translation>Kontakttyp</translation>
     </message>
     <message>
         <location filename="../sources/editor/ui/elementpropertieseditorwidget.ui" line="76"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_elementpropertieseditorwidget.h" line="241"/>
         <source>État du contact</source>
         <translation>Kontaktzustand</translation>
     </message>
     <message>
         <location filename="../sources/editor/ui/elementpropertieseditorwidget.ui" line="94"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_elementpropertieseditorwidget.h" line="242"/>
         <source>Élément maître</source>
         <translation>Master-Bauteil</translation>
     </message>
     <message>
         <location filename="../sources/editor/ui/elementpropertieseditorwidget.ui" line="100"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_elementpropertieseditorwidget.h" line="243"/>
         <source>Type concret</source>
         <translation>Typ</translation>
     </message>
     <message>
         <location filename="../sources/editor/ui/elementpropertieseditorwidget.ui" line="110"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_elementpropertieseditorwidget.h" line="244"/>
         <source>Définir le nombre maximal d&apos;esclaves</source>
         <translation>max. Slave-Anzahl definieren</translation>
     </message>
     <message>
         <location filename="../sources/editor/ui/elementpropertieseditorwidget.ui" line="130"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_elementpropertieseditorwidget.h" line="245"/>
         <source>Élément bornier</source>
         <translation>Klemmblockelement</translation>
     </message>
     <message>
         <location filename="../sources/editor/ui/elementpropertieseditorwidget.ui" line="143"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_elementpropertieseditorwidget.h" line="247"/>
         <source>Fonction</source>
         <translation>Funktion</translation>
     </message>
     <message>
         <location filename="../sources/editor/ui/elementpropertieseditorwidget.ui" line="173"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_elementpropertieseditorwidget.h" line="252"/>
         <source>Informations</source>
         <translation>Informationen</translation>
     </message>
     <message>
         <location filename="../sources/editor/ui/elementpropertieseditorwidget.ui" line="183"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_elementpropertieseditorwidget.h" line="251"/>
         <source>Nom</source>
         <translation>Name</translation>
     </message>
     <message>
         <location filename="../sources/editor/ui/elementpropertieseditorwidget.ui" line="188"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_elementpropertieseditorwidget.h" line="250"/>
         <source>Valeurs</source>
         <translation>Wert</translation>
     </message>
@@ -2249,141 +2537,169 @@ Bemerkung: diese Optionen verhindern NICHT das automatische Nummerieren.</transl
     <name>ElementQueryWidget</name>
     <message>
         <location filename="../sources/dataBase/ui/elementquerywidget.ui" line="35"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_elementquerywidget.h" line="339"/>
         <source>Informations disponibles</source>
         <translation>Verfügbare Informationen</translation>
     </message>
     <message>
         <location filename="../sources/dataBase/ui/elementquerywidget.ui" line="45"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_elementquerywidget.h" line="340"/>
         <source>Informations à exporter</source>
         <translation>Zu exportierende Informationen</translation>
     </message>
     <message>
         <location filename="../sources/dataBase/ui/elementquerywidget.ui" line="85"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_elementquerywidget.h" line="342"/>
         <source>Monter la sélection</source>
         <translation>Auswahl nach oben verschieben</translation>
     </message>
     <message>
         <location filename="../sources/dataBase/ui/elementquerywidget.ui" line="102"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_elementquerywidget.h" line="346"/>
         <source>Ajouter la sélection</source>
         <translation>Auswahl einfügen</translation>
     </message>
     <message>
         <location filename="../sources/dataBase/ui/elementquerywidget.ui" line="116"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_elementquerywidget.h" line="350"/>
         <source>Supprimer la sélection</source>
         <translation>Auswahl löschen</translation>
     </message>
     <message>
         <location filename="../sources/dataBase/ui/elementquerywidget.ui" line="130"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_elementquerywidget.h" line="354"/>
         <source>Descendre la sélection</source>
         <translation>Auswahl nach unten verschieben</translation>
     </message>
     <message>
         <location filename="../sources/dataBase/ui/elementquerywidget.ui" line="173"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_elementquerywidget.h" line="357"/>
         <source>Pas de filtre</source>
         <translation>Kein Filter</translation>
     </message>
     <message>
         <location filename="../sources/dataBase/ui/elementquerywidget.ui" line="178"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_elementquerywidget.h" line="358"/>
         <source>N&apos;est pas vide</source>
         <translation>Ist nicht leer</translation>
     </message>
     <message>
         <location filename="../sources/dataBase/ui/elementquerywidget.ui" line="183"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_elementquerywidget.h" line="359"/>
         <source>Est vide</source>
         <translation>Ist leer</translation>
     </message>
     <message>
         <location filename="../sources/dataBase/ui/elementquerywidget.ui" line="188"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_elementquerywidget.h" line="360"/>
         <source>Contient</source>
         <translation>Enthält</translation>
     </message>
     <message>
         <location filename="../sources/dataBase/ui/elementquerywidget.ui" line="193"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_elementquerywidget.h" line="361"/>
         <source>Ne contient pas</source>
         <translation>Enthält nicht</translation>
     </message>
     <message>
         <location filename="../sources/dataBase/ui/elementquerywidget.ui" line="198"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_elementquerywidget.h" line="362"/>
         <source>Est égal à</source>
         <translation>Ist gleich</translation>
     </message>
     <message>
         <location filename="../sources/dataBase/ui/elementquerywidget.ui" line="203"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_elementquerywidget.h" line="363"/>
         <source>N&apos;est pas égale à</source>
         <translation>Ungleich</translation>
     </message>
     <message>
         <location filename="../sources/dataBase/ui/elementquerywidget.ui" line="214"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_elementquerywidget.h" line="365"/>
         <source>Filtre :</source>
         <translation>Filter:</translation>
     </message>
     <message>
         <location filename="../sources/dataBase/ui/elementquerywidget.ui" line="239"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_elementquerywidget.h" line="366"/>
         <source>Type d&apos;éléments</source>
         <translation>Bauteiltypen</translation>
     </message>
     <message>
         <location filename="../sources/dataBase/ui/elementquerywidget.ui" line="248"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_elementquerywidget.h" line="367"/>
         <source>Simples</source>
         <translation>Einzelbauteile</translation>
     </message>
     <message>
         <location filename="../sources/dataBase/ui/elementquerywidget.ui" line="268"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_elementquerywidget.h" line="369"/>
         <source>Tous</source>
         <translation>Alle</translation>
     </message>
     <message>
         <location filename="../sources/dataBase/ui/elementquerywidget.ui" line="298"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_elementquerywidget.h" line="372"/>
         <source>Vignettes</source>
         <translation>(Miniatur-)Ansichten</translation>
     </message>
     <message>
         <location filename="../sources/dataBase/ui/elementquerywidget.ui" line="308"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_elementquerywidget.h" line="373"/>
         <source>Contacteurs et relais</source>
         <translation>Schütze und Relais</translation>
     </message>
     <message>
         <location filename="../sources/dataBase/ui/elementquerywidget.ui" line="278"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_elementquerywidget.h" line="370"/>
         <source>Boutons et commutateurs</source>
         <translation>Tasten und Schalter</translation>
     </message>
     <message>
         <location filename="../sources/dataBase/ui/elementquerywidget.ui" line="288"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_elementquerywidget.h" line="371"/>
         <source>Borniers</source>
         <translation>Klemmleisten</translation>
     </message>
     <message>
         <location filename="../sources/dataBase/ui/elementquerywidget.ui" line="258"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_elementquerywidget.h" line="368"/>
         <source>Organes de protection</source>
         <translation>Schutzeinrichtungen</translation>
     </message>
     <message>
         <location filename="../sources/dataBase/ui/elementquerywidget.ui" line="14"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_elementquerywidget.h" line="338"/>
         <source>Form</source>
         <translation>Exportieren</translation>
     </message>
     <message>
         <location filename="../sources/dataBase/ui/elementquerywidget.ui" line="331"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_elementquerywidget.h" line="374"/>
         <source>Configuration</source>
         <translation>Konfiguration</translation>
     </message>
     <message>
         <location filename="../sources/dataBase/ui/elementquerywidget.ui" line="340"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_elementquerywidget.h" line="376"/>
         <source>Ouvrir la configuration sélectionné</source>
         <translation>Ausgewählte Konfiguration öffnen</translation>
     </message>
     <message>
         <location filename="../sources/dataBase/ui/elementquerywidget.ui" line="367"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_elementquerywidget.h" line="380"/>
         <source>Sauvegarder la configuration actuelle</source>
         <translation>Aktuelle Konfiguration speichern</translation>
     </message>
     <message>
         <location filename="../sources/dataBase/ui/elementquerywidget.ui" line="399"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_elementquerywidget.h" line="384"/>
         <source>Requête SQL personnalisée</source>
         <translation>Benutzerdefinierte SQL-Abfrage</translation>
     </message>
     <message>
         <location filename="../sources/dataBase/ui/elementquerywidget.ui" line="409"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_elementquerywidget.h" line="387"/>
         <source>Requête SQL :</source>
         <translation>SQL-Abfrage:</translation>
     </message>
@@ -2866,36 +3182,43 @@ Alle Bauteile und Unterordner von diesem Ordner werden ebenso gelöscht.</transl
     <name>EllipseEditor</name>
     <message>
         <location filename="../sources/editor/ui/ellipseeditor.ui" line="14"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_ellipseeditor.h" line="129"/>
         <source>Form</source>
         <translation>Eigenschaften der Ellipse</translation>
     </message>
     <message>
         <location filename="../sources/editor/ui/ellipseeditor.ui" line="23"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_ellipseeditor.h" line="130"/>
         <source>Centre :</source>
         <translation>Mitte:</translation>
     </message>
     <message>
         <location filename="../sources/editor/ui/ellipseeditor.ui" line="30"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_ellipseeditor.h" line="131"/>
         <source>Y</source>
         <translation>Y</translation>
     </message>
     <message>
         <location filename="../sources/editor/ui/ellipseeditor.ui" line="60"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_ellipseeditor.h" line="132"/>
         <source>X</source>
         <translation>X</translation>
     </message>
     <message>
         <location filename="../sources/editor/ui/ellipseeditor.ui" line="70"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_ellipseeditor.h" line="133"/>
         <source>Vertical :</source>
         <translation>Vertikal:</translation>
     </message>
     <message>
         <location filename="../sources/editor/ui/ellipseeditor.ui" line="90"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_ellipseeditor.h" line="134"/>
         <source>Horizontal :</source>
         <translation>Horizontal:</translation>
     </message>
     <message>
         <location filename="../sources/editor/ui/ellipseeditor.ui" line="110"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_ellipseeditor.h" line="135"/>
         <source>Diamètres :</source>
         <translation>Durchmesser:</translation>
     </message>
@@ -3099,46 +3422,55 @@ Alle Bauteile und Unterordner von diesem Ordner werden ebenso gelöscht.</transl
     <name>FolioAutonumberingW</name>
     <message>
         <location filename="../sources/autoNum/ui/folioautonumbering.ui" line="26"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_folioautonumbering.h" line="190"/>
         <source>Form</source>
         <translation>Form</translation>
     </message>
     <message>
         <location filename="../sources/autoNum/ui/folioautonumbering.ui" line="107"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_folioautonumbering.h" line="195"/>
         <source> Options de numérotation</source>
         <translation> Nummerierungsoptionen</translation>
     </message>
     <message>
         <location filename="../sources/autoNum/ui/folioautonumbering.ui" line="78"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_folioautonumbering.h" line="193"/>
         <source>C&amp;réer de nouveaux folios</source>
         <translation>Neue Folien e&amp;rstellen</translation>
     </message>
     <message>
         <location filename="../sources/autoNum/ui/folioautonumbering.ui" line="91"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_folioautonumbering.h" line="194"/>
         <source>Numérotation automatique des folios sélectionnés</source>
         <translation>Ausgewählte Folien automatisch nummerieren</translation>
     </message>
     <message>
         <location filename="../sources/autoNum/ui/folioautonumbering.ui" line="132"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_folioautonumbering.h" line="196"/>
         <source>Nouveaux folios</source>
         <translation>Neue Folien</translation>
     </message>
     <message>
         <location filename="../sources/autoNum/ui/folioautonumbering.ui" line="174"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_folioautonumbering.h" line="197"/>
         <source>À</source>
         <translation>bis</translation>
     </message>
     <message>
         <location filename="../sources/autoNum/ui/folioautonumbering.ui" line="187"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_folioautonumbering.h" line="198"/>
         <source>De</source>
         <translation>von</translation>
     </message>
     <message>
         <location filename="../sources/autoNum/ui/folioautonumbering.ui" line="66"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_folioautonumbering.h" line="192"/>
         <source>Sélection:</source>
         <translation>Aktion auswählen:</translation>
     </message>
     <message>
         <location filename="../sources/autoNum/ui/folioautonumbering.ui" line="40"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_folioautonumbering.h" line="191"/>
         <source>Numérotation automatique de Folio :</source>
         <translation>Regel für die Foliennummerierung:</translation>
     </message>
@@ -3178,19 +3510,58 @@ In diesem Fall wird das Feld &quot;Inkrementierung&quot; ignoriert.
     </message>
 </context>
 <context>
+    <name>FontHelpers</name>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/fonthelpers.cpp" line="16"/>
+        <source>Sans Serif</source>
+        <comment>@item Font name</comment>
+        <extracomment>Generic sans serif font presented in font choosers. When selected, the system will choose a real font, mandated by distro settings.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/fonthelpers.cpp" line="19"/>
+        <source>Serif</source>
+        <comment>@item Font name</comment>
+        <extracomment>Generic serif font presented in font choosers. When selected, the system will choose a real font, mandated by distro settings.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/fonthelpers.cpp" line="22"/>
+        <source>Monospace</source>
+        <comment>@item Font name</comment>
+        <extracomment>Generic monospace font presented in font choosers. When selected, the system will choose a real font, mandated by distro settings.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/fonthelpers.cpp" line="65"/>
+        <source>%1</source>
+        <comment>@item Font name</comment>
+        <translation type="unfinished">%1% {1?}</translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/fonthelpers.cpp" line="69"/>
+        <source>%1 [%2]</source>
+        <comment>@item Font name [foundry]</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>FormulaAssistantDialog</name>
     <message>
         <location filename="../sources/ui/formulaassistantdialog.ui" line="14"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_formulaassistantdialog.h" line="70"/>
         <source>Assistant de formule</source>
         <translation>Assistent für Formel</translation>
     </message>
     <message>
         <location filename="../sources/ui/formulaassistantdialog.ui" line="20"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_formulaassistantdialog.h" line="71"/>
         <source>TextLabel</source>
         <translation>TextLabel</translation>
     </message>
     <message>
         <location filename="../sources/ui/formulaassistantdialog.ui" line="27"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_formulaassistantdialog.h" line="72"/>
         <source>Formule</source>
         <translation>Formel</translation>
     </message>
@@ -3199,26 +3570,31 @@ In diesem Fall wird das Feld &quot;Inkrementierung&quot; ignoriert.
     <name>FormulaAutonumberingW</name>
     <message>
         <location filename="../sources/autoNum/ui/formulaautonumberingw.ui" line="26"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_formulaautonumberingw.h" line="105"/>
         <source>Form</source>
         <translation>Form</translation>
     </message>
     <message>
         <location filename="../sources/autoNum/ui/formulaautonumberingw.ui" line="41"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_formulaautonumberingw.h" line="106"/>
         <source>Dénomination automatique :</source>
         <translation>Automatische Kennzeichnung:</translation>
     </message>
     <message>
         <location filename="../sources/autoNum/ui/formulaautonumberingw.ui" line="53"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_formulaautonumberingw.h" line="107"/>
         <source>Formule</source>
         <translation>Formel</translation>
     </message>
     <message>
         <location filename="../sources/autoNum/ui/formulaautonumberingw.ui" line="72"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_formulaautonumberingw.h" line="108"/>
         <source>Insert Formula Here e.g.: %prefix%l%c</source>
         <translation>Formel hier aufschreiben, z.B.: %prefix%l%c</translation>
     </message>
     <message>
         <location filename="../sources/autoNum/ui/formulaautonumberingw.ui" line="101"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_formulaautonumberingw.h" line="109"/>
         <source>You can use the following variables to your formula:
  -%prefix: Default Element Prefix
  -%l: Element Line
@@ -3245,77 +3621,93 @@ Texte und Zahlen sind ebenso erlaubt.</translation>
     <name>FreeTerminalEditor</name>
     <message>
         <location filename="../sources/TerminalStrip/ui/freeterminaleditor.ui" line="14"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_freeterminaleditor.h" line="140"/>
         <source>Form</source>
         <translation>Klemmen-Editor</translation>
     </message>
     <message>
         <location filename="../sources/TerminalStrip/ui/freeterminaleditor.ui" line="20"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_freeterminaleditor.h" line="141"/>
         <source>Déplacer dans :</source>
         <translation>Verschieben nach:</translation>
     </message>
     <message>
         <location filename="../sources/TerminalStrip/ui/freeterminaleditor.ui" line="60"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_freeterminaleditor.h" line="142"/>
         <source>Type :</source>
         <translation>Typ:</translation>
     </message>
     <message>
         <location filename="../sources/TerminalStrip/ui/freeterminaleditor.ui" line="67"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_freeterminaleditor.h" line="143"/>
         <source>Fonction :</source>
         <translation>Funktion:</translation>
     </message>
     <message>
         <location filename="../sources/TerminalStrip/ui/freeterminaleditor.ui" line="74"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_freeterminaleditor.h" line="144"/>
         <source>LED :</source>
         <translation>LED:</translation>
     </message>
     <message>
         <location filename="../sources/TerminalStrip/ui/freeterminaleditor.ui" line="81"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_freeterminaleditor.h" line="146"/>
         <source>Appliquer le déplacement</source>
         <translation>Verschieben anwenden</translation>
     </message>
     <message>
         <location filename="../sources/TerminalStrip/ui/freeterminaleditor.ui" line="103"/>
         <location filename="../sources/TerminalStrip/ui/freeterminaleditor.ui" line="132"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_freeterminaleditor.h" line="149"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_freeterminaleditor.h" line="155"/>
         <source>Générique</source>
         <translation>Generisch</translation>
     </message>
     <message>
         <location filename="../sources/TerminalStrip/ui/freeterminaleditor.ui" line="108"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_freeterminaleditor.h" line="150"/>
         <source>Fusible</source>
         <translation>mit Sicherung</translation>
     </message>
     <message>
         <location filename="../sources/TerminalStrip/ui/freeterminaleditor.ui" line="113"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_freeterminaleditor.h" line="151"/>
         <source>Sectionnable</source>
         <translation>Trennklemme</translation>
     </message>
     <message>
         <location filename="../sources/TerminalStrip/ui/freeterminaleditor.ui" line="118"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_freeterminaleditor.h" line="152"/>
         <source>Diode</source>
         <translation>Diode</translation>
     </message>
     <message>
         <location filename="../sources/TerminalStrip/ui/freeterminaleditor.ui" line="123"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_freeterminaleditor.h" line="153"/>
         <source>Terre</source>
         <translation>Erde</translation>
     </message>
     <message>
         <location filename="../sources/TerminalStrip/ui/freeterminaleditor.ui" line="137"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_freeterminaleditor.h" line="156"/>
         <source>Phase</source>
         <translation>Aussenleiter</translation>
     </message>
     <message>
         <location filename="../sources/TerminalStrip/ui/freeterminaleditor.ui" line="142"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_freeterminaleditor.h" line="157"/>
         <source>Neutre</source>
         <translation>Neutralleiter</translation>
     </message>
     <message>
         <location filename="../sources/TerminalStrip/ui/freeterminaleditor.ui" line="151"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_freeterminaleditor.h" line="159"/>
         <source>Sans</source>
         <translation>ohne</translation>
     </message>
     <message>
         <location filename="../sources/TerminalStrip/ui/freeterminaleditor.ui" line="156"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_freeterminaleditor.h" line="160"/>
         <source>Avec</source>
         <translation>mit</translation>
     </message>
@@ -3357,11 +3749,13 @@ Texte und Zahlen sind ebenso erlaubt.</translation>
     <name>GeneralConfigurationPage</name>
     <message>
         <location filename="../sources/ui/configpage/generalconfigurationpage.ui" line="24"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_generalconfigurationpage.h" line="843"/>
         <source>Apparence</source>
         <translation>Darstellung</translation>
     </message>
     <message>
         <location filename="../sources/ui/configpage/generalconfigurationpage.ui" line="30"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_generalconfigurationpage.h" line="836"/>
         <source>Utiliser les couleurs du système</source>
         <translation>Farben vom Betriebssystem verwenden</translation>
     </message>
@@ -3387,6 +3781,12 @@ Texte und Zahlen sind ebenso erlaubt.</translation>
         <location filename="../sources/ui/configpage/generalconfigurationpage.ui" line="314"/>
         <location filename="../sources/ui/configpage/generalconfigurationpage.ui" line="335"/>
         <location filename="../sources/ui/configpage/generalconfigurationpage.ui" line="363"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_generalconfigurationpage.h" line="853"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_generalconfigurationpage.h" line="857"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_generalconfigurationpage.h" line="861"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_generalconfigurationpage.h" line="865"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_generalconfigurationpage.h" line="869"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_generalconfigurationpage.h" line="874"/>
         <source>Par defaut</source>
         <translation>Standard</translation>
     </message>
@@ -3397,53 +3797,68 @@ Texte und Zahlen sind ebenso erlaubt.</translation>
         <location filename="../sources/ui/configpage/generalconfigurationpage.ui" line="319"/>
         <location filename="../sources/ui/configpage/generalconfigurationpage.ui" line="340"/>
         <location filename="../sources/ui/configpage/generalconfigurationpage.ui" line="368"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_generalconfigurationpage.h" line="854"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_generalconfigurationpage.h" line="858"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_generalconfigurationpage.h" line="862"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_generalconfigurationpage.h" line="866"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_generalconfigurationpage.h" line="870"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_generalconfigurationpage.h" line="875"/>
         <source>Parcourir...</source>
         <translation>Auswählen...</translation>
     </message>
     <message>
         <location filename="../sources/ui/configpage/generalconfigurationpage.ui" line="348"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_generalconfigurationpage.h" line="872"/>
         <source>(Recharger les collections d&apos;éléments pour appliquer les changements)</source>
         <translation>(Bauteilsammlungen neu laden, um die Änderungen zu übernehmen)</translation>
     </message>
     <message>
         <location filename="../sources/ui/configpage/generalconfigurationpage.ui" line="142"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_generalconfigurationpage.h" line="850"/>
         <source>Projets</source>
         <translation>Projekte</translation>
     </message>
     <message>
         <location filename="../sources/ui/configpage/generalconfigurationpage.ui" line="44"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_generalconfigurationpage.h" line="837"/>
         <source>Utiliser les gestes du pavé tactile</source>
         <translation>Gesten vom Touchpad aktivieren</translation>
     </message>
     <message>
         <location filename="../sources/ui/configpage/generalconfigurationpage.ui" line="148"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_generalconfigurationpage.h" line="844"/>
         <source>Utiliser les numéros de folio à la place de leur position dans le projet</source>
         <translation>Foliennummern anstelle von Seitennummern für Projektanzeigen verwenden</translation>
     </message>
     <message>
         <location filename="../sources/ui/configpage/generalconfigurationpage.ui" line="217"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_generalconfigurationpage.h" line="849"/>
         <source>Numéroter les colonnes de cartouche à partir de 0 (1 sinon)</source>
         <extracomment>Choix de l&apos;increment de depart 1 ou 0</extracomment>
         <translation>Spalten vom Schriftfeld ab 0 nummerieren (sonst ab 1)</translation>
     </message>
     <message>
         <location filename="../sources/ui/configpage/generalconfigurationpage.ui" line="165"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_generalconfigurationpage.h" line="846"/>
         <source>Désactivé</source>
         <translation>Deaktiviert</translation>
     </message>
     <message>
         <location filename="../sources/ui/configpage/generalconfigurationpage.ui" line="171"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_generalconfigurationpage.h" line="847"/>
         <source> min</source>
         <comment>minute</comment>
         <translation> min</translation>
     </message>
     <message>
         <location filename="../sources/ui/configpage/generalconfigurationpage.ui" line="388"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_generalconfigurationpage.h" line="878"/>
         <source>Mettre en valeur dans le panel les éléments fraîchement intégrés</source>
         <translation>Neu zum Projekt hinzugefügte Bauteile in der Sammlung hervorheben</translation>
     </message>
     <message>
         <location filename="../sources/ui/configpage/generalconfigurationpage.ui" line="395"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_generalconfigurationpage.h" line="879"/>
         <source>Chaque élément embarque des informations sur ses auteurs, sa licence, ou tout autre renseignement que vous jugerez utile dans un champ libre.
 Vous pouvez spécifier ici la valeur par défaut de ce champ pour les éléments que vous créerez :</source>
         <translation>Jedes Bauteil enthält Informationen über den Autor, die Lizenz und weiteren nützlichen Hinweise in einem frei definierbaren Textfeld.
@@ -3451,116 +3866,139 @@ Hier unten kann der Standardwert dieses Textfeldes für Ihre eigenen Bauteile de
     </message>
     <message>
         <location filename="../sources/ui/configpage/generalconfigurationpage.ui" line="432"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_generalconfigurationpage.h" line="882"/>
         <source>Appliqué au prochain lancement de QElectroTech</source>
         <translation>Wirksam nach einem Neustart von QElectroTech</translation>
     </message>
     <message>
         <location filename="../sources/ui/configpage/generalconfigurationpage.ui" line="14"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_generalconfigurationpage.h" line="835"/>
         <source>Form</source>
         <translation>Form</translation>
     </message>
     <message>
         <location filename="../sources/ui/configpage/generalconfigurationpage.ui" line="155"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_generalconfigurationpage.h" line="845"/>
         <source>Sauvegarde automatique des projets (appliqué au prochain lancement de QElectroTech)</source>
         <translation>Automatisches Abspeichern der Projekte (wirksam nach einem Neustart von QElectroTech)</translation>
     </message>
     <message>
         <location filename="../sources/ui/configpage/generalconfigurationpage.ui" line="225"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_generalconfigurationpage.h" line="881"/>
         <source>Collections</source>
         <translation>Sammlungen</translation>
     </message>
     <message>
         <location filename="../sources/ui/configpage/generalconfigurationpage.ui" line="231"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_generalconfigurationpage.h" line="851"/>
         <source>Accès aux collections</source>
         <translation>Zugriff auf Sammlungen</translation>
     </message>
     <message>
         <location filename="../sources/ui/configpage/generalconfigurationpage.ui" line="243"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_generalconfigurationpage.h" line="852"/>
         <source>Répertoire de la collection commune</source>
         <translation>Pfad zur gemeinsamen Bauteilsammlung</translation>
     </message>
     <message>
         <location filename="../sources/ui/configpage/generalconfigurationpage.ui" line="306"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_generalconfigurationpage.h" line="864"/>
         <source>Répertoire de la collection utilisateur</source>
         <translation>Pfad zur Benutzer-Bauteilsammlung</translation>
     </message>
     <message>
         <location filename="../sources/ui/configpage/generalconfigurationpage.ui" line="327"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_generalconfigurationpage.h" line="868"/>
         <source>Répertoire des cartouches utilisateur</source>
         <translation>Pfad zu den Benutzer-Schriftfeldern</translation>
     </message>
     <message>
         <location filename="../sources/ui/configpage/generalconfigurationpage.ui" line="379"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_generalconfigurationpage.h" line="877"/>
         <source>Gestion des éléments</source>
         <translation>Bauteilverwaltung</translation>
     </message>
     <message>
         <location filename="../sources/ui/configpage/generalconfigurationpage.ui" line="472"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_generalconfigurationpage.h" line="884"/>
         <source>Vous pouvez définir ici l&apos;apparence par defaut des differents textes de QElectroTech</source>
         <translation>Einstellungen für die Standarddarstellung der verschiedenen Texte</translation>
     </message>
     <message>
         <location filename="../sources/ui/configpage/generalconfigurationpage.ui" line="655"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_generalconfigurationpage.h" line="916"/>
         <source>Grille + Clavier</source>
         <translation>Raster &amp; Tastatur</translation>
     </message>
     <message>
         <location filename="../sources/ui/configpage/generalconfigurationpage.ui" line="661"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_generalconfigurationpage.h" line="899"/>
         <source>Grille : 1 - 30</source>
         <translation>Raster: 1 - 30</translation>
     </message>
     <message>
         <location filename="../sources/ui/configpage/generalconfigurationpage.ui" line="728"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_generalconfigurationpage.h" line="902"/>
         <source>DiagramEditor xGrid</source>
         <translation>Schaltplaneditor, Schrittweite x</translation>
     </message>
     <message>
         <location filename="../sources/ui/configpage/generalconfigurationpage.ui" line="695"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_generalconfigurationpage.h" line="900"/>
         <source>DiagramEditor yGrid</source>
         <translation>Schaltplaneditor, Schrittweite y</translation>
     </message>
     <message>
         <location filename="../sources/ui/configpage/generalconfigurationpage.ui" line="65"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_generalconfigurationpage.h" line="839"/>
         <source>Utiliser des fen&amp;êtres (appliqué au prochain lancement de QElectroTech)</source>
         <translation>Projekte in Fenstern anz&amp;eigen (wirksam nach einem Neustart von QElectroTech)</translation>
     </message>
     <message>
         <location filename="../sources/ui/configpage/generalconfigurationpage.ui" line="72"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_generalconfigurationpage.h" line="840"/>
         <source>Utiliser des onglets (appliqué au prochain lance&amp;ment de QElectroTech)</source>
         <translation>Projekte in Reitern anzeigen (wirksa&amp;m nach einem Neustart von QElectroTech)</translation>
     </message>
     <message>
         <location filename="../sources/ui/configpage/generalconfigurationpage.ui" line="111"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_generalconfigurationpage.h" line="842"/>
         <source>Méthode de mise à l&apos;echelle des écrans à haute densité de pixels (hdpi) (appliqué au prochain lancement de QElectroTech) :</source>
         <translation>Methode zur Skalierung bei hochauflösenden Bildschirmen (hdpi) (wirksam nach einem Neustart von QElectroTech):</translation>
     </message>
     <message>
         <location filename="../sources/ui/configpage/generalconfigurationpage.ui" line="264"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_generalconfigurationpage.h" line="856"/>
         <source>Répertoire de la collection company</source>
         <translation>Pfad zur Firmen-Bauteilsammlung</translation>
     </message>
     <message>
         <location filename="../sources/ui/configpage/generalconfigurationpage.ui" line="285"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_generalconfigurationpage.h" line="860"/>
         <source>Répertoire des cartouches company</source>
         <translation>Pfad zu Firmen-Schriftfeldern</translation>
     </message>
     <message>
         <location filename="../sources/ui/configpage/generalconfigurationpage.ui" line="355"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_generalconfigurationpage.h" line="873"/>
         <source>Répertoire des Macros utilisateur</source>
         <translation>Pfad zu Benutzer-Vorlagen</translation>
     </message>
     <message>
         <location filename="../sources/ui/configpage/generalconfigurationpage.ui" line="423"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_generalconfigurationpage.h" line="883"/>
         <source>Langues</source>
         <translation>Sprachen</translation>
     </message>
     <message>
         <location filename="../sources/ui/configpage/generalconfigurationpage.ui" line="466"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_generalconfigurationpage.h" line="898"/>
         <source>Textes</source>
         <translation>Texte</translation>
     </message>
     <message>
         <location filename="../sources/ui/configpage/generalconfigurationpage.ui" line="486"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_generalconfigurationpage.h" line="885"/>
         <source>Textes d&apos;éléments</source>
         <translation>Bauteiltexte</translation>
     </message>
@@ -3568,115 +4006,143 @@ Hier unten kann der Standardwert dieses Textfeldes für Ihre eigenen Bauteile de
         <location filename="../sources/ui/configpage/generalconfigurationpage.ui" line="499"/>
         <location filename="../sources/ui/configpage/generalconfigurationpage.ui" line="565"/>
         <location filename="../sources/ui/configpage/generalconfigurationpage.ui" line="611"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_generalconfigurationpage.h" line="886"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_generalconfigurationpage.h" line="892"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_generalconfigurationpage.h" line="896"/>
         <source>Police :</source>
         <translation>Schriftart:</translation>
     </message>
     <message>
         <location filename="../sources/ui/configpage/generalconfigurationpage.ui" line="509"/>
         <location filename="../sources/ui/configpage/generalconfigurationpage.ui" line="572"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_generalconfigurationpage.h" line="887"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_generalconfigurationpage.h" line="893"/>
         <source>°</source>
         <translation>°</translation>
     </message>
     <message>
         <location filename="../sources/ui/configpage/generalconfigurationpage.ui" line="519"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_generalconfigurationpage.h" line="888"/>
         <source>Longueur :</source>
         <translation>Länge:</translation>
     </message>
     <message>
         <location filename="../sources/ui/configpage/generalconfigurationpage.ui" line="529"/>
         <location filename="../sources/ui/configpage/generalconfigurationpage.ui" line="558"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_generalconfigurationpage.h" line="889"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_generalconfigurationpage.h" line="891"/>
         <source>Rotation :</source>
         <translation>Drehung:</translation>
     </message>
     <message>
         <location filename="../sources/ui/configpage/generalconfigurationpage.ui" line="552"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_generalconfigurationpage.h" line="890"/>
         <source>Textes indépendants</source>
         <translation>Unabhängige Textfelder</translation>
     </message>
     <message>
         <location filename="../sources/ui/configpage/generalconfigurationpage.ui" line="605"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_generalconfigurationpage.h" line="895"/>
         <source>Autres textes</source>
         <translation>Sonstige Texte</translation>
     </message>
     <message>
         <location filename="../sources/ui/configpage/generalconfigurationpage.ui" line="702"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_generalconfigurationpage.h" line="901"/>
         <source>La Grille doite etre active pour pouvoir voir les modifications.</source>
         <translation>Änderungen sind nur sichtbar, wenn das Raster aktiviert ist.</translation>
     </message>
     <message>
         <location filename="../sources/ui/configpage/generalconfigurationpage.ui" line="751"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_generalconfigurationpage.h" line="903"/>
         <source>Déplacement au clavier : 1 - 30</source>
         <translation>Bewegung mittels Tastatur: 1 - 30</translation>
     </message>
     <message>
         <location filename="../sources/ui/configpage/generalconfigurationpage.ui" line="801"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_generalconfigurationpage.h" line="904"/>
         <source>DiagramEditor (touche :   gauche / droite)  xGrid</source>
         <translation>Schaltplaneditor (rechts/links Tasten), Schrittweite x</translation>
     </message>
     <message>
         <location filename="../sources/ui/configpage/generalconfigurationpage.ui" line="808"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_generalconfigurationpage.h" line="905"/>
         <source>DiagramEditor (touche :   haut / bas)  yGrid</source>
         <translation>Schaltplaneditor (hoch/runter Tasten), Schrittweite y</translation>
     </message>
     <message>
         <location filename="../sources/ui/configpage/generalconfigurationpage.ui" line="831"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_generalconfigurationpage.h" line="906"/>
         <source>Déplacement au clavier avec la touche ALT : 1 - 9</source>
         <translation>Bewegung mittels Tastatur und ALT Taste: 1 - 9</translation>
     </message>
     <message>
         <location filename="../sources/ui/configpage/generalconfigurationpage.ui" line="837"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_generalconfigurationpage.h" line="907"/>
         <source>DiagramEditor (touche :   gauche / droite ) xGrid</source>
         <translation>Schaltplaneditor (rechts/links Tasten), Schrittweite x</translation>
     </message>
     <message>
         <location filename="../sources/ui/configpage/generalconfigurationpage.ui" line="866"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_generalconfigurationpage.h" line="908"/>
         <source>DiagramEditor (touche :  haut / bas)  yGrid</source>
         <translation>Schaltplaneditor (hoch/runter Tasten), Schrittweite y</translation>
     </message>
     <message>
         <location filename="../sources/ui/configpage/generalconfigurationpage.ui" line="911"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_generalconfigurationpage.h" line="909"/>
         <source>Affichage Grille</source>
         <translation>Anzeige Raster</translation>
     </message>
     <message>
         <location filename="../sources/ui/configpage/generalconfigurationpage.ui" line="930"/>
         <location filename="../sources/ui/configpage/generalconfigurationpage.ui" line="1006"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_generalconfigurationpage.h" line="910"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_generalconfigurationpage.h" line="914"/>
         <source>max:</source>
         <translation></translation>
     </message>
     <message>
         <location filename="../sources/ui/configpage/generalconfigurationpage.ui" line="937"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_generalconfigurationpage.h" line="911"/>
         <source>Taille des points de la grille de Diagram-Editor : 1 - 5</source>
         <translation>Punktgröße im Schaltplaneditor: 1 - 5</translation>
     </message>
     <message>
         <location filename="../sources/ui/configpage/generalconfigurationpage.ui" line="960"/>
         <location filename="../sources/ui/configpage/generalconfigurationpage.ui" line="1029"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_generalconfigurationpage.h" line="912"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_generalconfigurationpage.h" line="915"/>
         <source>min:</source>
         <translation></translation>
     </message>
     <message>
         <location filename="../sources/ui/configpage/generalconfigurationpage.ui" line="983"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_generalconfigurationpage.h" line="913"/>
         <source>Taille des points de la grille de l&apos;éditeur d&apos;éléments : 1 - 5</source>
         <translation>Punktgröße im Element-Editor: 1 - 5</translation>
     </message>
     <message>
         <location filename="../sources/ui/configpage/generalconfigurationpage.ui" line="1053"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_generalconfigurationpage.h" line="918"/>
         <source>Editor</source>
         <translation>Editor</translation>
     </message>
     <message>
         <location filename="../sources/ui/configpage/generalconfigurationpage.ui" line="1061"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_generalconfigurationpage.h" line="917"/>
         <source>Max. parts in Element Editor List</source>
         <translation>Max. Anzahl in der Element Editor Liste</translation>
     </message>
     <message>
         <location filename="../sources/ui/configpage/generalconfigurationpage.ui" line="184"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_generalconfigurationpage.h" line="848"/>
         <source>Ne pas conserver les labels des éléments lors des copier coller</source>
         <translation>Betriebsmittelkennzeichen von Bauteilen beim Kopieren/Einfügen nicht beibehalten</translation>
     </message>
     <message>
         <location filename="../sources/ui/configpage/generalconfigurationpage.ui" line="51"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_generalconfigurationpage.h" line="838"/>
         <source>Autoriser le dézoom au delà du folio</source>
         <translation>Ansicht verkleinern über die Folie hinaus erlauben</translation>
     </message>
@@ -3951,132 +4417,162 @@ Alle Einstellungen außer „Keine Rundung“ können je nach folgenden Faktoren
     <name>GraphicsTablePropertiesEditor</name>
     <message>
         <location filename="../sources/qetgraphicsitem/ViewItem/ui/graphicstablepropertieseditor.ui" line="24"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_graphicstablepropertieseditor.h" line="482"/>
         <source>Affichage</source>
         <translation>Darstellung</translation>
     </message>
     <message>
         <location filename="../sources/qetgraphicsitem/ViewItem/ui/graphicstablepropertieseditor.ui" line="33"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_graphicstablepropertieseditor.h" line="440"/>
         <source>Nom du tableau</source>
         <translation>Name der Tabelle</translation>
     </message>
     <message>
         <location filename="../sources/qetgraphicsitem/ViewItem/ui/graphicstablepropertieseditor.ui" line="80"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_graphicstablepropertieseditor.h" line="447"/>
         <location filename="../sources/qetgraphicsitem/ViewItem/ui/graphicstablepropertieseditor.cpp" line="327"/>
         <source>Aucun</source>
         <translation>Keine</translation>
     </message>
     <message>
         <location filename="../sources/qetgraphicsitem/ViewItem/ui/graphicstablepropertieseditor.ui" line="46"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_graphicstablepropertieseditor.h" line="442"/>
         <source>Toutes</source>
         <translation>Alles</translation>
     </message>
     <message>
         <location filename="../sources/qetgraphicsitem/ViewItem/ui/graphicstablepropertieseditor.ui" line="224"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_graphicstablepropertieseditor.h" line="464"/>
         <source>Lignes à afficher :</source>
         <translation>Anzuzeigende Zeilen:</translation>
     </message>
     <message>
         <location filename="../sources/qetgraphicsitem/ViewItem/ui/graphicstablepropertieseditor.ui" line="128"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_graphicstablepropertieseditor.h" line="453"/>
         <source>Y :</source>
         <translation>y:</translation>
     </message>
     <message>
         <location filename="../sources/qetgraphicsitem/ViewItem/ui/graphicstablepropertieseditor.ui" line="59"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_graphicstablepropertieseditor.h" line="444"/>
         <source>Tableau suivant</source>
         <translation>Nächste Tabelle</translation>
     </message>
     <message>
         <location filename="../sources/qetgraphicsitem/ViewItem/ui/graphicstablepropertieseditor.ui" line="138"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_graphicstablepropertieseditor.h" line="454"/>
         <source>X :</source>
         <translation>x:</translation>
     </message>
     <message>
         <location filename="../sources/qetgraphicsitem/ViewItem/ui/graphicstablepropertieseditor.ui" line="176"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_graphicstablepropertieseditor.h" line="456"/>
         <source>Tableau précédent</source>
         <translation>Vorherige Tabelle</translation>
     </message>
     <message>
         <location filename="../sources/qetgraphicsitem/ViewItem/ui/graphicstablepropertieseditor.ui" line="214"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_graphicstablepropertieseditor.h" line="463"/>
         <source>Tableau précédent :</source>
         <translation>Vorherige Tabelle:</translation>
     </message>
     <message>
         <location filename="../sources/qetgraphicsitem/ViewItem/ui/graphicstablepropertieseditor.ui" line="40"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_graphicstablepropertieseditor.h" line="441"/>
         <source>Géometrie et lignes</source>
         <translation>Geometrie und Linien</translation>
     </message>
     <message>
         <location filename="../sources/qetgraphicsitem/ViewItem/ui/graphicstablepropertieseditor.ui" line="200"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_graphicstablepropertieseditor.h" line="460"/>
         <source>Appliquer la géometrie à tous les tableaux liée à celui-ci</source>
         <translation>Geometrie auf alle hiermit verknüpften Tabellen anwenden</translation>
     </message>
     <message>
         <location filename="../sources/qetgraphicsitem/ViewItem/ui/graphicstablepropertieseditor.ui" line="101"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_graphicstablepropertieseditor.h" line="450"/>
         <source>Ajuster le tableau au folio</source>
         <translation>Tabelle an Foliengröße anpassen</translation>
     </message>
     <message>
         <location filename="../sources/qetgraphicsitem/ViewItem/ui/graphicstablepropertieseditor.ui" line="14"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_graphicstablepropertieseditor.h" line="438"/>
         <source>Form</source>
         <translation>Eigenschaften Tabelle</translation>
     </message>
     <message>
         <location filename="../sources/qetgraphicsitem/ViewItem/ui/graphicstablepropertieseditor.ui" line="234"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_graphicstablepropertieseditor.h" line="465"/>
         <source>TextLabel</source>
         <translation>TextLabel</translation>
     </message>
     <message>
         <location filename="../sources/qetgraphicsitem/ViewItem/ui/graphicstablepropertieseditor.ui" line="250"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_graphicstablepropertieseditor.h" line="466"/>
         <source>En tête</source>
         <translation>Kopfzeile</translation>
     </message>
     <message>
         <location filename="../sources/qetgraphicsitem/ViewItem/ui/graphicstablepropertieseditor.ui" line="274"/>
         <location filename="../sources/qetgraphicsitem/ViewItem/ui/graphicstablepropertieseditor.ui" line="433"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_graphicstablepropertieseditor.h" line="467"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_graphicstablepropertieseditor.h" line="476"/>
         <source>Marge</source>
         <translation>Rand</translation>
     </message>
     <message>
         <location filename="../sources/qetgraphicsitem/ViewItem/ui/graphicstablepropertieseditor.ui" line="343"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_graphicstablepropertieseditor.h" line="470"/>
         <source>Aligement :</source>
         <translation>Ausrichtung:</translation>
     </message>
     <message>
         <location filename="../sources/qetgraphicsitem/ViewItem/ui/graphicstablepropertieseditor.ui" line="350"/>
         <location filename="../sources/qetgraphicsitem/ViewItem/ui/graphicstablepropertieseditor.ui" line="493"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_graphicstablepropertieseditor.h" line="471"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_graphicstablepropertieseditor.h" line="478"/>
         <source>Gauche</source>
         <translation>Linksbündig</translation>
     </message>
     <message>
         <location filename="../sources/qetgraphicsitem/ViewItem/ui/graphicstablepropertieseditor.ui" line="357"/>
         <location filename="../sources/qetgraphicsitem/ViewItem/ui/graphicstablepropertieseditor.ui" line="500"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_graphicstablepropertieseditor.h" line="472"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_graphicstablepropertieseditor.h" line="479"/>
         <source>Centré</source>
         <translation>Zentriert</translation>
     </message>
     <message>
         <location filename="../sources/qetgraphicsitem/ViewItem/ui/graphicstablepropertieseditor.ui" line="364"/>
         <location filename="../sources/qetgraphicsitem/ViewItem/ui/graphicstablepropertieseditor.ui" line="507"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_graphicstablepropertieseditor.h" line="473"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_graphicstablepropertieseditor.h" line="480"/>
         <source>Droite</source>
         <translation>Rechtsbündig</translation>
     </message>
     <message>
         <location filename="../sources/qetgraphicsitem/ViewItem/ui/graphicstablepropertieseditor.ui" line="387"/>
         <location filename="../sources/qetgraphicsitem/ViewItem/ui/graphicstablepropertieseditor.ui" line="530"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_graphicstablepropertieseditor.h" line="474"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_graphicstablepropertieseditor.h" line="481"/>
         <source>Police</source>
         <translation>Schriftart</translation>
     </message>
     <message>
         <location filename="../sources/qetgraphicsitem/ViewItem/ui/graphicstablepropertieseditor.ui" line="400"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_graphicstablepropertieseditor.h" line="475"/>
         <source>Tableau</source>
         <translation>Tabelleninhalt</translation>
     </message>
     <message>
         <location filename="../sources/qetgraphicsitem/ViewItem/ui/graphicstablepropertieseditor.ui" line="486"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_graphicstablepropertieseditor.h" line="477"/>
         <source>Alignement :</source>
         <translation>Ausrichtung:</translation>
     </message>
     <message>
         <location filename="../sources/qetgraphicsitem/ViewItem/ui/graphicstablepropertieseditor.ui" line="557"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_graphicstablepropertieseditor.h" line="483"/>
         <source>Contenu</source>
         <translation>Inhalt</translation>
     </message>
@@ -4139,21 +4635,25 @@ Alle Einstellungen außer „Keine Rundung“ können je nach folgenden Faktoren
     <name>ImagePropertiesWidget</name>
     <message>
         <location filename="../sources/ui/imagepropertieswidget.ui" line="14"/>
+        <location filename="../build/qelectrotech_autogen/ui_imagepropertieswidget.h" line="81"/>
         <source>Form</source>
         <translation>Form</translation>
     </message>
     <message>
         <location filename="../sources/ui/imagepropertieswidget.ui" line="23"/>
+        <location filename="../build/qelectrotech_autogen/ui_imagepropertieswidget.h" line="82"/>
         <source>Verrouiller la position</source>
         <translation>Position sperren</translation>
     </message>
     <message>
         <location filename="../sources/ui/imagepropertieswidget.ui" line="30"/>
+        <location filename="../build/qelectrotech_autogen/ui_imagepropertieswidget.h" line="83"/>
         <source>Dimension de l&apos;image</source>
         <translation>Bildgröße</translation>
     </message>
     <message>
         <location filename="../sources/ui/imagepropertieswidget.ui" line="50"/>
+        <location filename="../build/qelectrotech_autogen/ui_imagepropertieswidget.h" line="84"/>
         <source>%</source>
         <translation>%</translation>
     </message>
@@ -4167,31 +4667,37 @@ Alle Einstellungen außer „Keine Rundung“ können je nach folgenden Faktoren
     <name>ImportElementDialog</name>
     <message>
         <location filename="../sources/ui/importelementdialog.ui" line="14"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_importelementdialog.h" line="94"/>
         <source>Intégration d&apos;un élément</source>
         <translation>Bauteil einbetten</translation>
     </message>
     <message>
         <location filename="../sources/ui/importelementdialog.ui" line="20"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_importelementdialog.h" line="95"/>
         <source>L&apos;élément a déjà été intégré dans le projet. Toutefois, la version que vous tentez de poser semble différente. Que souhaitez-vous faire ?</source>
         <translation>Das Bauteil wurde bereits in das Projekt eingebettet. Es gibt aber vermutlich Versionsunterschiede. Wie möchten Sie vorgehen?</translation>
     </message>
     <message>
         <location filename="../sources/ui/importelementdialog.ui" line="27"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_importelementdialog.h" line="96"/>
         <source>Utiliser l&apos;élément déjà integré</source>
         <translation>Bereits eingebettetes Bauteil verwenden</translation>
     </message>
     <message>
         <location filename="../sources/ui/importelementdialog.ui" line="34"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_importelementdialog.h" line="97"/>
         <source>Intégrer l&apos;élément déposé</source>
         <translation>Das neu angelegte Bauteil einbetten</translation>
     </message>
     <message>
         <location filename="../sources/ui/importelementdialog.ui" line="52"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_importelementdialog.h" line="98"/>
         <source>Écraser l&apos;élément déjà intégé</source>
         <translation>Das bereits eingebettete Bauteil überschreiben</translation>
     </message>
     <message>
         <location filename="../sources/ui/importelementdialog.ui" line="59"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_importelementdialog.h" line="99"/>
         <source>Faire cohabiter les deux éléments</source>
         <translation>Beide Bauteile beibehalten</translation>
     </message>
@@ -4200,16 +4706,19 @@ Alle Einstellungen außer „Keine Rundung“ können je nach folgenden Faktoren
     <name>ImportElementTextPatternDialog</name>
     <message>
         <location filename="../sources/ui/importelementtextpatterndialog.ui" line="14"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_importelementtextpatterndialog.h" line="71"/>
         <source>Dialog</source>
         <translation>Dialog</translation>
     </message>
     <message>
         <location filename="../sources/ui/importelementtextpatterndialog.ui" line="20"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_importelementtextpatterndialog.h" line="72"/>
         <source>TextLabel</source>
         <translation>TextLabel</translation>
     </message>
     <message>
         <location filename="../sources/ui/importelementtextpatterndialog.ui" line="30"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_importelementtextpatterndialog.h" line="73"/>
         <source>Écraser les textes existants</source>
         <translation>Bestehende Texte überschreiben</translation>
     </message>
@@ -4218,58 +4727,70 @@ Alle Einstellungen außer „Keine Rundung“ können je nach folgenden Faktoren
     <name>IndiTextPropertiesWidget</name>
     <message>
         <location filename="../sources/ui/inditextpropertieswidget.ui" line="14"/>
+        <location filename="../build/qelectrotech_autogen/ui_inditextpropertieswidget.h" line="150"/>
         <source>Form</source>
         <translation>Form</translation>
     </message>
     <message>
         <location filename="../sources/ui/inditextpropertieswidget.ui" line="20"/>
+        <location filename="../build/qelectrotech_autogen/ui_inditextpropertieswidget.h" line="151"/>
         <source>X :</source>
         <translation>x:</translation>
     </message>
     <message>
         <location filename="../sources/ui/inditextpropertieswidget.ui" line="30"/>
+        <location filename="../build/qelectrotech_autogen/ui_inditextpropertieswidget.h" line="152"/>
         <source>Éditeur avancé</source>
         <translation>Fortgeschrittener Editor</translation>
     </message>
     <message>
         <location filename="../sources/ui/inditextpropertieswidget.ui" line="37"/>
+        <location filename="../build/qelectrotech_autogen/ui_inditextpropertieswidget.h" line="153"/>
         <source>Taille :</source>
         <translation>Größe:</translation>
     </message>
     <message>
         <location filename="../sources/ui/inditextpropertieswidget.ui" line="47"/>
+        <location filename="../build/qelectrotech_autogen/ui_inditextpropertieswidget.h" line="154"/>
         <source>Angle :</source>
         <translation>Winkel:</translation>
     </message>
     <message>
         <location filename="../sources/ui/inditextpropertieswidget.ui" line="57"/>
         <location filename="../sources/ui/inditextpropertieswidget.ui" line="93"/>
+        <location filename="../build/qelectrotech_autogen/ui_inditextpropertieswidget.h" line="155"/>
+        <location filename="../build/qelectrotech_autogen/ui_inditextpropertieswidget.h" line="156"/>
         <source>px</source>
         <translation>px</translation>
     </message>
     <message>
         <location filename="../sources/ui/inditextpropertieswidget.ui" line="109"/>
+        <location filename="../build/qelectrotech_autogen/ui_inditextpropertieswidget.h" line="157"/>
         <source>°</source>
         <translation>°</translation>
     </message>
     <message>
         <location filename="../sources/ui/inditextpropertieswidget.ui" line="122"/>
+        <location filename="../build/qelectrotech_autogen/ui_inditextpropertieswidget.h" line="158"/>
         <source>Y :</source>
         <translation>y:</translation>
     </message>
     <message>
         <location filename="../sources/ui/inditextpropertieswidget.ui" line="132"/>
+        <location filename="../build/qelectrotech_autogen/ui_inditextpropertieswidget.h" line="159"/>
         <source>Le contenu, la taille et la police du texte ne peuvent être modifié car formaté en html.
 Veuillez utiliser l&apos;éditeur avancé pour cela.</source>
         <translation>Inhalt, Größe und Schriftart vom Text können nur im fortgeschrittenen Editor geändert werden (wegen html Formatierung).</translation>
     </message>
     <message>
         <location filename="../sources/ui/inditextpropertieswidget.ui" line="153"/>
+        <location filename="../build/qelectrotech_autogen/ui_inditextpropertieswidget.h" line="162"/>
         <source>Texte</source>
         <translation>Text</translation>
     </message>
     <message>
         <location filename="../sources/ui/inditextpropertieswidget.ui" line="160"/>
+        <location filename="../build/qelectrotech_autogen/ui_inditextpropertieswidget.h" line="163"/>
         <location filename="../sources/ui/inditextpropertieswidget.cpp" line="380"/>
         <location filename="../sources/ui/inditextpropertieswidget.cpp" line="412"/>
         <location filename="../sources/ui/inditextpropertieswidget.cpp" line="460"/>
@@ -4278,6 +4799,7 @@ Veuillez utiliser l&apos;éditeur avancé pour cela.</source>
     </message>
     <message>
         <location filename="../sources/ui/inditextpropertieswidget.ui" line="146"/>
+        <location filename="../build/qelectrotech_autogen/ui_inditextpropertieswidget.h" line="161"/>
         <source>Cliquez ici pour annuler le formatage html</source>
         <translation>html Formatierung entfernen</translation>
     </message>
@@ -4385,6 +4907,3560 @@ Veuillez utiliser l&apos;éditeur avancé pour cela.</source>
     </message>
 </context>
 <context>
+    <name>KAboutData</name>
+    <message>
+        <location filename="../build/_deps/kcoreaddons-src/src/lib/kaboutdata.cpp" line="936"/>
+        <source>&lt;p&gt;KDE is translated into many languages thanks to the work of the translation teams all over the world.&lt;/p&gt;&lt;p&gt;For more information on KDE internationalization visit &lt;a href=&quot;https://l10n.kde.org&quot;&gt;https://l10n.kde.org&lt;/a&gt;&lt;/p&gt;</source>
+        <comment>replace this with information about your translation team</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>KAboutData CLI</name>
+    <message>
+        <location filename="../build/_deps/kcoreaddons-src/src/lib/kaboutdata.cpp" line="1181"/>
+        <source>Show author information.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kcoreaddons-src/src/lib/kaboutdata.cpp" line="1182"/>
+        <source>Show license information.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kcoreaddons-src/src/lib/kaboutdata.cpp" line="1184"/>
+        <source>The base file name of the desktop entry for this application.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kcoreaddons-src/src/lib/kaboutdata.cpp" line="1185"/>
+        <source>file name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kcoreaddons-src/src/lib/kaboutdata.cpp" line="1194"/>
+        <source>This application was written by somebody who wants to remain anonymous.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kcoreaddons-src/src/lib/kaboutdata.cpp" line="1196"/>
+        <source>%1 was written by:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kcoreaddons-src/src/lib/kaboutdata.cpp" line="1207"/>
+        <source>Please use https://bugs.kde.org to report bugs.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kcoreaddons-src/src/lib/kaboutdata.cpp" line="1209"/>
+        <source>Please report bugs to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>KAboutLicense</name>
+    <message>
+        <location filename="../build/_deps/kcoreaddons-src/src/lib/kaboutdata.cpp" line="283"/>
+        <source>No licensing terms for this program have been specified.
+Please check the documentation or the source for any
+licensing terms.
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kcoreaddons-src/src/lib/kaboutdata.cpp" line="293"/>
+        <source>This program is distributed under the terms of the %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kcoreaddons-src/src/lib/kaboutdata.cpp" line="339"/>
+        <source>GPL v2</source>
+        <comment>@item license (short name)</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kcoreaddons-src/src/lib/kaboutdata.cpp" line="340"/>
+        <source>GNU General Public License Version 2</source>
+        <comment>@item license</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kcoreaddons-src/src/lib/kaboutdata.cpp" line="343"/>
+        <source>LGPL v2</source>
+        <comment>@item license (short name)</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kcoreaddons-src/src/lib/kaboutdata.cpp" line="344"/>
+        <source>GNU Lesser General Public License Version 2</source>
+        <comment>@item license</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kcoreaddons-src/src/lib/kaboutdata.cpp" line="347"/>
+        <source>BSD License</source>
+        <comment>@item license (short name)</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kcoreaddons-src/src/lib/kaboutdata.cpp" line="348"/>
+        <source>BSD License</source>
+        <comment>@item license</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kcoreaddons-src/src/lib/kaboutdata.cpp" line="351"/>
+        <source>Artistic License</source>
+        <comment>@item license (short name)</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kcoreaddons-src/src/lib/kaboutdata.cpp" line="352"/>
+        <source>Artistic License</source>
+        <comment>@item license</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kcoreaddons-src/src/lib/kaboutdata.cpp" line="355"/>
+        <source>QPL v1.0</source>
+        <comment>@item license (short name)</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kcoreaddons-src/src/lib/kaboutdata.cpp" line="356"/>
+        <source>Q Public License</source>
+        <comment>@item license</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kcoreaddons-src/src/lib/kaboutdata.cpp" line="359"/>
+        <source>GPL v3</source>
+        <comment>@item license (short name)</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kcoreaddons-src/src/lib/kaboutdata.cpp" line="360"/>
+        <source>GNU General Public License Version 3</source>
+        <comment>@item license</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kcoreaddons-src/src/lib/kaboutdata.cpp" line="363"/>
+        <source>LGPL v3</source>
+        <comment>@item license (short name)</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kcoreaddons-src/src/lib/kaboutdata.cpp" line="364"/>
+        <source>GNU Lesser General Public License Version 3</source>
+        <comment>@item license</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kcoreaddons-src/src/lib/kaboutdata.cpp" line="367"/>
+        <source>LGPL v2.1</source>
+        <comment>@item license (short name)</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kcoreaddons-src/src/lib/kaboutdata.cpp" line="368"/>
+        <source>GNU Lesser General Public License Version 2.1</source>
+        <comment>@item license</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kcoreaddons-src/src/lib/kaboutdata.cpp" line="372"/>
+        <source>Custom</source>
+        <comment>@item license</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kcoreaddons-src/src/lib/kaboutdata.cpp" line="375"/>
+        <source>Not specified</source>
+        <comment>@item license</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>KActionSelector</name>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kactionselector.cpp" line="95"/>
+        <source>&amp;Available:</source>
+        <comment>@label:listbox</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kactionselector.cpp" line="112"/>
+        <source>&amp;Selected:</source>
+        <comment>@label:listbox</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>KAssistantDialog</name>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kassistantdialog.cpp" line="94"/>
+        <source>&amp;Back</source>
+        <comment>@action:button go back</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kassistantdialog.cpp" line="96"/>
+        <source>Go back one step</source>
+        <comment>@info:tooltip</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kassistantdialog.cpp" line="101"/>
+        <source>Next</source>
+        <comment>@action:button Opposite to Back</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kassistantdialog.cpp" line="108"/>
+        <source>Finish</source>
+        <comment>@action:button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>KCharSelect</name>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselect.cpp" line="387"/>
+        <source>Enter a search term or character...</source>
+        <comment>@info:placeholder</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselect.cpp" line="389"/>
+        <source>Enter a search term or character here</source>
+        <comment>@info:tooltip</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselect.cpp" line="394"/>
+        <source>&amp;Find...</source>
+        <comment>@action</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselect.cpp" line="414"/>
+        <source>Previous in History</source>
+        <comment>@action:button Goes to previous character</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselect.cpp" line="416"/>
+        <source>Go to previous character in history</source>
+        <comment>@info:tooltip</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselect.cpp" line="421"/>
+        <source>Next in History</source>
+        <comment>@action:button Goes to next character</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselect.cpp" line="423"/>
+        <source>Go to next character in history</source>
+        <comment>info:tooltip</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselect.cpp" line="428"/>
+        <source>&amp;Back</source>
+        <comment>@action go back</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselect.cpp" line="435"/>
+        <source>&amp;Forward</source>
+        <comment>@action go forward</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselect.cpp" line="450"/>
+        <source>Select a category</source>
+        <comment>@info:tooltip</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselect.cpp" line="454"/>
+        <source>Select a block to be displayed</source>
+        <comment>@info:tooltip</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselect.cpp" line="467"/>
+        <source>Set font</source>
+        <comment>@info:tooltip</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselect.cpp" line="474"/>
+        <source>Set font size</source>
+        <comment>@info:tooltip</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselect.cpp" line="766"/>
+        <source>Character:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselect.cpp" line="772"/>
+        <source>Name: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselect.cpp" line="781"/>
+        <source>Annotations and Cross References</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselect.cpp" line="785"/>
+        <source>Alias names:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselect.cpp" line="793"/>
+        <source>Notes:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselect.cpp" line="801"/>
+        <source>See also:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselect.cpp" line="816"/>
+        <source>Equivalents:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselect.cpp" line="824"/>
+        <source>Approximate equivalents:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselect.cpp" line="832"/>
+        <source>Decomposition:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselect.cpp" line="844"/>
+        <source>CJK Ideograph Information</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselect.cpp" line="847"/>
+        <source>Definition in English: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselect.cpp" line="854"/>
+        <source>Mandarin Pronunciation: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselect.cpp" line="861"/>
+        <source>Cantonese Pronunciation: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselect.cpp" line="868"/>
+        <source>Japanese On Pronunciation: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselect.cpp" line="875"/>
+        <source>Japanese Kun Pronunciation: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselect.cpp" line="882"/>
+        <source>Tang Pronunciation: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselect.cpp" line="889"/>
+        <source>Korean Pronunciation: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselect.cpp" line="895"/>
+        <source>General Character Properties</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselect.cpp" line="896"/>
+        <source>Block: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselect.cpp" line="897"/>
+        <source>Unicode category: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselect.cpp" line="901"/>
+        <source>Various Useful Representations</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselect.cpp" line="902"/>
+        <source>UTF-8:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselect.cpp" line="906"/>
+        <source>UTF-16: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselect.cpp" line="913"/>
+        <source>C octal escaped UTF-8: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselect.cpp" line="917"/>
+        <source>XML decimal entity:</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>KCharSelectData</name>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselect-translation.cpp" line="11"/>
+        <source>European Scripts</source>
+        <comment>KCharSelect section name</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselect-translation.cpp" line="12"/>
+        <source>African Scripts</source>
+        <comment>KCharSelect section name</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselect-translation.cpp" line="13"/>
+        <source>Middle Eastern Scripts</source>
+        <comment>KCharSelect section name</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselect-translation.cpp" line="14"/>
+        <source>Central Asian Scripts</source>
+        <comment>KCharSelect section name</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselect-translation.cpp" line="15"/>
+        <source>South Asian Scripts</source>
+        <comment>KCharSelect section name</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselect-translation.cpp" line="16"/>
+        <source>Southeast Asian Scripts</source>
+        <comment>KCharSelect section name</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselect-translation.cpp" line="17"/>
+        <source>Indonesia and Oceania Scripts</source>
+        <comment>KCharSelect section name</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselect-translation.cpp" line="18"/>
+        <source>East Asian Scripts</source>
+        <comment>KCharSelect section name</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselect-translation.cpp" line="19"/>
+        <source>American Scripts</source>
+        <comment>KCharSelect section name</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselect-translation.cpp" line="20"/>
+        <source>Symbols</source>
+        <comment>KCharSelect section name</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselect-translation.cpp" line="21"/>
+        <source>Mathematical Symbols</source>
+        <comment>KCharSelect section name</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselect-translation.cpp" line="22"/>
+        <source>Phonetic Symbols</source>
+        <comment>KCharSelect section name</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselect-translation.cpp" line="23"/>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselectdata.cpp" line="737"/>
+        <source>Combining Diacritics</source>
+        <comment>KCharSelect section name</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselect-translation.cpp" line="24"/>
+        <source>Other</source>
+        <comment>KCharSelect section name</comment>
+        <translation type="unfinished">Andere</translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselect-translation.cpp" line="25"/>
+        <source>Basic Latin</source>
+        <comment>KCharselect unicode block name</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselect-translation.cpp" line="26"/>
+        <source>Latin-1 Supplement</source>
+        <comment>KCharselect unicode block name</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselect-translation.cpp" line="27"/>
+        <source>Latin Extended-A</source>
+        <comment>KCharselect unicode block name</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselect-translation.cpp" line="28"/>
+        <source>Latin Extended-B</source>
+        <comment>KCharselect unicode block name</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselect-translation.cpp" line="29"/>
+        <source>IPA Extensions</source>
+        <comment>KCharselect unicode block name</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselect-translation.cpp" line="30"/>
+        <source>Spacing Modifier Letters</source>
+        <comment>KCharselect unicode block name</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselect-translation.cpp" line="31"/>
+        <source>Combining Diacritical Marks</source>
+        <comment>KCharselect unicode block name</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselect-translation.cpp" line="32"/>
+        <source>Greek and Coptic</source>
+        <comment>KCharselect unicode block name</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselect-translation.cpp" line="33"/>
+        <source>Cyrillic</source>
+        <comment>KCharselect unicode block name</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselect-translation.cpp" line="34"/>
+        <source>Cyrillic Supplement</source>
+        <comment>KCharselect unicode block name</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselect-translation.cpp" line="35"/>
+        <source>Armenian</source>
+        <comment>KCharselect unicode block name</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselect-translation.cpp" line="36"/>
+        <source>Hebrew</source>
+        <comment>KCharselect unicode block name</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselect-translation.cpp" line="37"/>
+        <source>Arabic</source>
+        <comment>KCharselect unicode block name</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselect-translation.cpp" line="38"/>
+        <source>Syriac</source>
+        <comment>KCharselect unicode block name</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselect-translation.cpp" line="39"/>
+        <source>Arabic Supplement</source>
+        <comment>KCharselect unicode block name</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselect-translation.cpp" line="40"/>
+        <source>Thaana</source>
+        <comment>KCharselect unicode block name</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselect-translation.cpp" line="41"/>
+        <source>NKo</source>
+        <comment>KCharselect unicode block name</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselect-translation.cpp" line="42"/>
+        <source>Samaritan</source>
+        <comment>KCharselect unicode block name</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselect-translation.cpp" line="43"/>
+        <source>Mandaic</source>
+        <comment>KCharselect unicode block name</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselect-translation.cpp" line="44"/>
+        <source>Syriac Supplement</source>
+        <comment>KCharselect unicode block name</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselect-translation.cpp" line="45"/>
+        <source>Arabic Extended-A</source>
+        <comment>KCharselect unicode block name</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselect-translation.cpp" line="46"/>
+        <source>Devanagari</source>
+        <comment>KCharselect unicode block name</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselect-translation.cpp" line="47"/>
+        <source>Bengali</source>
+        <comment>KCharselect unicode block name</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselect-translation.cpp" line="48"/>
+        <source>Gurmukhi</source>
+        <comment>KCharselect unicode block name</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselect-translation.cpp" line="49"/>
+        <source>Gujarati</source>
+        <comment>KCharselect unicode block name</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselect-translation.cpp" line="50"/>
+        <source>Oriya</source>
+        <comment>KCharselect unicode block name</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselect-translation.cpp" line="51"/>
+        <source>Tamil</source>
+        <comment>KCharselect unicode block name</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselect-translation.cpp" line="52"/>
+        <source>Telugu</source>
+        <comment>KCharselect unicode block name</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselect-translation.cpp" line="53"/>
+        <source>Kannada</source>
+        <comment>KCharselect unicode block name</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselect-translation.cpp" line="54"/>
+        <source>Malayalam</source>
+        <comment>KCharselect unicode block name</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselect-translation.cpp" line="55"/>
+        <source>Sinhala</source>
+        <comment>KCharselect unicode block name</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselect-translation.cpp" line="56"/>
+        <source>Thai</source>
+        <comment>KCharselect unicode block name</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselect-translation.cpp" line="57"/>
+        <source>Lao</source>
+        <comment>KCharselect unicode block name</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselect-translation.cpp" line="58"/>
+        <source>Tibetan</source>
+        <comment>KCharselect unicode block name</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselect-translation.cpp" line="59"/>
+        <source>Myanmar</source>
+        <comment>KCharselect unicode block name</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselect-translation.cpp" line="60"/>
+        <source>Georgian</source>
+        <comment>KCharselect unicode block name</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselect-translation.cpp" line="61"/>
+        <source>Hangul Jamo</source>
+        <comment>KCharselect unicode block name</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselect-translation.cpp" line="62"/>
+        <source>Ethiopic</source>
+        <comment>KCharselect unicode block name</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselect-translation.cpp" line="63"/>
+        <source>Ethiopic Supplement</source>
+        <comment>KCharselect unicode block name</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselect-translation.cpp" line="64"/>
+        <source>Cherokee</source>
+        <comment>KCharselect unicode block name</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselect-translation.cpp" line="65"/>
+        <source>Unified Canadian Aboriginal Syllabics</source>
+        <comment>KCharselect unicode block name</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselect-translation.cpp" line="66"/>
+        <source>Ogham</source>
+        <comment>KCharselect unicode block name</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselect-translation.cpp" line="67"/>
+        <source>Runic</source>
+        <comment>KCharselect unicode block name</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselect-translation.cpp" line="68"/>
+        <source>Tagalog</source>
+        <comment>KCharselect unicode block name</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselect-translation.cpp" line="69"/>
+        <source>Hanunoo</source>
+        <comment>KCharselect unicode block name</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselect-translation.cpp" line="70"/>
+        <source>Buhid</source>
+        <comment>KCharselect unicode block name</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselect-translation.cpp" line="71"/>
+        <source>Tagbanwa</source>
+        <comment>KCharselect unicode block name</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselect-translation.cpp" line="72"/>
+        <source>Khmer</source>
+        <comment>KCharselect unicode block name</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselect-translation.cpp" line="73"/>
+        <source>Mongolian</source>
+        <comment>KCharselect unicode block name</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselect-translation.cpp" line="74"/>
+        <source>Unified Canadian Aboriginal Syllabics Extended</source>
+        <comment>KCharselect unicode block name</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselect-translation.cpp" line="75"/>
+        <source>Limbu</source>
+        <comment>KCharselect unicode block name</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselect-translation.cpp" line="76"/>
+        <source>Tai Le</source>
+        <comment>KCharselect unicode block name</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselect-translation.cpp" line="77"/>
+        <source>New Tai Lue</source>
+        <comment>KCharselect unicode block name</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselect-translation.cpp" line="78"/>
+        <source>Khmer Symbols</source>
+        <comment>KCharselect unicode block name</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselect-translation.cpp" line="79"/>
+        <source>Buginese</source>
+        <comment>KCharselect unicode block name</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselect-translation.cpp" line="80"/>
+        <source>Tai Tham</source>
+        <comment>KCharselect unicode block name</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselect-translation.cpp" line="81"/>
+        <source>Combining Diacritical Marks Extended</source>
+        <comment>KCharselect unicode block name</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselect-translation.cpp" line="82"/>
+        <source>Balinese</source>
+        <comment>KCharselect unicode block name</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselect-translation.cpp" line="83"/>
+        <source>Sundanese</source>
+        <comment>KCharselect unicode block name</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselect-translation.cpp" line="84"/>
+        <source>Batak</source>
+        <comment>KCharselect unicode block name</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselect-translation.cpp" line="85"/>
+        <source>Lepcha</source>
+        <comment>KCharselect unicode block name</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselect-translation.cpp" line="86"/>
+        <source>Ol Chiki</source>
+        <comment>KCharselect unicode block name</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselect-translation.cpp" line="87"/>
+        <source>Cyrillic Extended-C</source>
+        <comment>KCharselect unicode block name</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselect-translation.cpp" line="88"/>
+        <source>Georgian Extended</source>
+        <comment>KCharselect unicode block name</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselect-translation.cpp" line="89"/>
+        <source>Sundanese Supplement</source>
+        <comment>KCharselect unicode block name</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselect-translation.cpp" line="90"/>
+        <source>Vedic Extensions</source>
+        <comment>KCharselect unicode block name</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselect-translation.cpp" line="91"/>
+        <source>Phonetic Extensions</source>
+        <comment>KCharselect unicode block name</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselect-translation.cpp" line="92"/>
+        <source>Phonetic Extensions Supplement</source>
+        <comment>KCharselect unicode block name</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselect-translation.cpp" line="93"/>
+        <source>Combining Diacritical Marks Supplement</source>
+        <comment>KCharselect unicode block name</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselect-translation.cpp" line="94"/>
+        <source>Latin Extended Additional</source>
+        <comment>KCharselect unicode block name</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselect-translation.cpp" line="95"/>
+        <source>Greek Extended</source>
+        <comment>KCharselect unicode block name</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselect-translation.cpp" line="96"/>
+        <source>General Punctuation</source>
+        <comment>KCharselect unicode block name</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselect-translation.cpp" line="97"/>
+        <source>Superscripts and Subscripts</source>
+        <comment>KCharselect unicode block name</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselect-translation.cpp" line="98"/>
+        <source>Currency Symbols</source>
+        <comment>KCharselect unicode block name</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselect-translation.cpp" line="99"/>
+        <source>Combining Diacritical Marks for Symbols</source>
+        <comment>KCharselect unicode block name</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselect-translation.cpp" line="100"/>
+        <source>Letterlike Symbols</source>
+        <comment>KCharselect unicode block name</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselect-translation.cpp" line="101"/>
+        <source>Number Forms</source>
+        <comment>KCharselect unicode block name</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselect-translation.cpp" line="102"/>
+        <source>Arrows</source>
+        <comment>KCharselect unicode block name</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselect-translation.cpp" line="103"/>
+        <source>Mathematical Operators</source>
+        <comment>KCharselect unicode block name</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselect-translation.cpp" line="104"/>
+        <source>Miscellaneous Technical</source>
+        <comment>KCharselect unicode block name</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselect-translation.cpp" line="105"/>
+        <source>Control Pictures</source>
+        <comment>KCharselect unicode block name</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselect-translation.cpp" line="106"/>
+        <source>Optical Character Recognition</source>
+        <comment>KCharselect unicode block name</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselect-translation.cpp" line="107"/>
+        <source>Enclosed Alphanumerics</source>
+        <comment>KCharselect unicode block name</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselect-translation.cpp" line="108"/>
+        <source>Box Drawing</source>
+        <comment>KCharselect unicode block name</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselect-translation.cpp" line="109"/>
+        <source>Block Elements</source>
+        <comment>KCharselect unicode block name</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselect-translation.cpp" line="110"/>
+        <source>Geometric Shapes</source>
+        <comment>KCharselect unicode block name</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselect-translation.cpp" line="111"/>
+        <source>Miscellaneous Symbols</source>
+        <comment>KCharselect unicode block name</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselect-translation.cpp" line="112"/>
+        <source>Dingbats</source>
+        <comment>KCharselect unicode block name</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselect-translation.cpp" line="113"/>
+        <source>Miscellaneous Mathematical Symbols-A</source>
+        <comment>KCharselect unicode block name</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselect-translation.cpp" line="114"/>
+        <source>Supplemental Arrows-A</source>
+        <comment>KCharselect unicode block name</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselect-translation.cpp" line="115"/>
+        <source>Braille Patterns</source>
+        <comment>KCharselect unicode block name</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselect-translation.cpp" line="116"/>
+        <source>Supplemental Arrows-B</source>
+        <comment>KCharselect unicode block name</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselect-translation.cpp" line="117"/>
+        <source>Miscellaneous Mathematical Symbols-B</source>
+        <comment>KCharselect unicode block name</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselect-translation.cpp" line="118"/>
+        <source>Supplemental Mathematical Operators</source>
+        <comment>KCharselect unicode block name</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselect-translation.cpp" line="119"/>
+        <source>Miscellaneous Symbols and Arrows</source>
+        <comment>KCharselect unicode block name</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselect-translation.cpp" line="120"/>
+        <source>Glagolitic</source>
+        <comment>KCharselect unicode block name</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselect-translation.cpp" line="121"/>
+        <source>Latin Extended-C</source>
+        <comment>KCharselect unicode block name</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselect-translation.cpp" line="122"/>
+        <source>Coptic</source>
+        <comment>KCharselect unicode block name</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselect-translation.cpp" line="123"/>
+        <source>Georgian Supplement</source>
+        <comment>KCharselect unicode block name</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselect-translation.cpp" line="124"/>
+        <source>Tifinagh</source>
+        <comment>KCharselect unicode block name</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselect-translation.cpp" line="125"/>
+        <source>Ethiopic Extended</source>
+        <comment>KCharselect unicode block name</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselect-translation.cpp" line="126"/>
+        <source>Cyrillic Extended-A</source>
+        <comment>KCharselect unicode block name</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselect-translation.cpp" line="127"/>
+        <source>Supplemental Punctuation</source>
+        <comment>KCharselect unicode block name</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselect-translation.cpp" line="128"/>
+        <source>CJK Radicals Supplement</source>
+        <comment>KCharselect unicode block name</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselect-translation.cpp" line="129"/>
+        <source>Kangxi Radicals</source>
+        <comment>KCharselect unicode block name</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselect-translation.cpp" line="130"/>
+        <source>Ideographic Description Characters</source>
+        <comment>KCharselect unicode block name</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselect-translation.cpp" line="131"/>
+        <source>CJK Symbols and Punctuation</source>
+        <comment>KCharselect unicode block name</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselect-translation.cpp" line="132"/>
+        <source>Hiragana</source>
+        <comment>KCharselect unicode block name</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselect-translation.cpp" line="133"/>
+        <source>Katakana</source>
+        <comment>KCharselect unicode block name</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselect-translation.cpp" line="134"/>
+        <source>Bopomofo</source>
+        <comment>KCharselect unicode block name</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselect-translation.cpp" line="135"/>
+        <source>Hangul Compatibility Jamo</source>
+        <comment>KCharselect unicode block name</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselect-translation.cpp" line="136"/>
+        <source>Kanbun</source>
+        <comment>KCharselect unicode block name</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselect-translation.cpp" line="137"/>
+        <source>Bopomofo Extended</source>
+        <comment>KCharselect unicode block name</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselect-translation.cpp" line="138"/>
+        <source>CJK Strokes</source>
+        <comment>KCharselect unicode block name</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselect-translation.cpp" line="139"/>
+        <source>Katakana Phonetic Extensions</source>
+        <comment>KCharselect unicode block name</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselect-translation.cpp" line="140"/>
+        <source>Enclosed CJK Letters and Months</source>
+        <comment>KCharselect unicode block name</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselect-translation.cpp" line="141"/>
+        <source>CJK Compatibility</source>
+        <comment>KCharselect unicode block name</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselect-translation.cpp" line="142"/>
+        <source>CJK Unified Ideographs Extension A</source>
+        <comment>KCharselect unicode block name</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselect-translation.cpp" line="143"/>
+        <source>Yijing Hexagram Symbols</source>
+        <comment>KCharselect unicode block name</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselect-translation.cpp" line="144"/>
+        <source>CJK Unified Ideographs</source>
+        <comment>KCharselect unicode block name</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselect-translation.cpp" line="145"/>
+        <source>Yi Syllables</source>
+        <comment>KCharselect unicode block name</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselect-translation.cpp" line="146"/>
+        <source>Yi Radicals</source>
+        <comment>KCharselect unicode block name</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselect-translation.cpp" line="147"/>
+        <source>Lisu</source>
+        <comment>KCharselect unicode block name</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselect-translation.cpp" line="148"/>
+        <source>Vai</source>
+        <comment>KCharselect unicode block name</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselect-translation.cpp" line="149"/>
+        <source>Cyrillic Extended-B</source>
+        <comment>KCharselect unicode block name</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselect-translation.cpp" line="150"/>
+        <source>Bamum</source>
+        <comment>KCharselect unicode block name</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselect-translation.cpp" line="151"/>
+        <source>Modifier Tone Letters</source>
+        <comment>KCharselect unicode block name</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselect-translation.cpp" line="152"/>
+        <source>Latin Extended-D</source>
+        <comment>KCharselect unicode block name</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselect-translation.cpp" line="153"/>
+        <source>Syloti Nagri</source>
+        <comment>KCharselect unicode block name</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselect-translation.cpp" line="154"/>
+        <source>Common Indic Number Forms</source>
+        <comment>KCharselect unicode block name</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselect-translation.cpp" line="155"/>
+        <source>Phags-pa</source>
+        <comment>KCharselect unicode block name</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselect-translation.cpp" line="156"/>
+        <source>Saurashtra</source>
+        <comment>KCharselect unicode block name</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselect-translation.cpp" line="157"/>
+        <source>Devanagari Extended</source>
+        <comment>KCharselect unicode block name</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselect-translation.cpp" line="158"/>
+        <source>Kayah Li</source>
+        <comment>KCharselect unicode block name</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselect-translation.cpp" line="159"/>
+        <source>Rejang</source>
+        <comment>KCharselect unicode block name</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselect-translation.cpp" line="160"/>
+        <source>Hangul Jamo Extended-A</source>
+        <comment>KCharselect unicode block name</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselect-translation.cpp" line="161"/>
+        <source>Javanese</source>
+        <comment>KCharselect unicode block name</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselect-translation.cpp" line="162"/>
+        <source>Myanmar Extended-B</source>
+        <comment>KCharselect unicode block name</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselect-translation.cpp" line="163"/>
+        <source>Cham</source>
+        <comment>KCharselect unicode block name</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselect-translation.cpp" line="164"/>
+        <source>Myanmar Extended-A</source>
+        <comment>KCharselect unicode block name</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselect-translation.cpp" line="165"/>
+        <source>Tai Viet</source>
+        <comment>KCharselect unicode block name</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselect-translation.cpp" line="166"/>
+        <source>Meetei Mayek Extensions</source>
+        <comment>KCharselect unicode block name</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselect-translation.cpp" line="167"/>
+        <source>Ethiopic Extended-A</source>
+        <comment>KCharselect unicode block name</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselect-translation.cpp" line="168"/>
+        <source>Latin Extended-E</source>
+        <comment>KCharselect unicode block name</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselect-translation.cpp" line="169"/>
+        <source>Cherokee Supplement</source>
+        <comment>KCharselect unicode block name</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselect-translation.cpp" line="170"/>
+        <source>Meetei Mayek</source>
+        <comment>KCharselect unicode block name</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselect-translation.cpp" line="171"/>
+        <source>Hangul Syllables</source>
+        <comment>KCharselect unicode block name</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselect-translation.cpp" line="172"/>
+        <source>Hangul Jamo Extended-B</source>
+        <comment>KCharselect unicode block name</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselect-translation.cpp" line="173"/>
+        <source>High Surrogates</source>
+        <comment>KCharselect unicode block name</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselect-translation.cpp" line="174"/>
+        <source>High Private Use Surrogates</source>
+        <comment>KCharselect unicode block name</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselect-translation.cpp" line="175"/>
+        <source>Low Surrogates</source>
+        <comment>KCharselect unicode block name</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselect-translation.cpp" line="176"/>
+        <source>Private Use Area</source>
+        <comment>KCharselect unicode block name</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselect-translation.cpp" line="177"/>
+        <source>CJK Compatibility Ideographs</source>
+        <comment>KCharselect unicode block name</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselect-translation.cpp" line="178"/>
+        <source>Alphabetic Presentation Forms</source>
+        <comment>KCharselect unicode block name</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselect-translation.cpp" line="179"/>
+        <source>Arabic Presentation Forms-A</source>
+        <comment>KCharselect unicode block name</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselect-translation.cpp" line="180"/>
+        <source>Variation Selectors</source>
+        <comment>KCharselect unicode block name</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselect-translation.cpp" line="181"/>
+        <source>Vertical Forms</source>
+        <comment>KCharselect unicode block name</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselect-translation.cpp" line="182"/>
+        <source>Combining Half Marks</source>
+        <comment>KCharselect unicode block name</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselect-translation.cpp" line="183"/>
+        <source>CJK Compatibility Forms</source>
+        <comment>KCharselect unicode block name</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselect-translation.cpp" line="184"/>
+        <source>Small Form Variants</source>
+        <comment>KCharselect unicode block name</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselect-translation.cpp" line="185"/>
+        <source>Arabic Presentation Forms-B</source>
+        <comment>KCharselect unicode block name</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselect-translation.cpp" line="186"/>
+        <source>Halfwidth and Fullwidth Forms</source>
+        <comment>KCharselect unicode block name</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselect-translation.cpp" line="187"/>
+        <source>Specials</source>
+        <comment>KCharselect unicode block name</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselect-translation.cpp" line="189"/>
+        <source>Mahjong Tiles</source>
+        <comment>KCharselect unicode block name</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselect-translation.cpp" line="190"/>
+        <source>Domino Tiles</source>
+        <comment>KCharselect unicode block name</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselect-translation.cpp" line="191"/>
+        <source>Playing Cards</source>
+        <comment>KCharselect unicode block name</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselect-translation.cpp" line="192"/>
+        <source>Enclosed Alphanumeric Supplement</source>
+        <comment>KCharselect unicode block name</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselect-translation.cpp" line="193"/>
+        <source>Enclosed Ideographic Supplement</source>
+        <comment>KCharselect unicode block name</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselect-translation.cpp" line="194"/>
+        <source>Miscellaneous Symbols and Pictographs</source>
+        <comment>KCharselect unicode block name</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselect-translation.cpp" line="195"/>
+        <source>Emoticons</source>
+        <comment>KCharselect unicode block name</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselect-translation.cpp" line="196"/>
+        <source>Ornamental Dingbats</source>
+        <comment>KCharselect unicode block name</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselect-translation.cpp" line="197"/>
+        <source>Transport and Map Symbols</source>
+        <comment>KCharselect unicode block name</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselect-translation.cpp" line="198"/>
+        <source>Alchemical Symbols</source>
+        <comment>KCharselect unicode block name</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselect-translation.cpp" line="199"/>
+        <source>Geometric Shapes Extended</source>
+        <comment>KCharselect unicode block name</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselect-translation.cpp" line="200"/>
+        <source>Supplemental Arrows-C</source>
+        <comment>KCharselect unicode block name</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselect-translation.cpp" line="201"/>
+        <source>Supplemental Symbols and Pictographs</source>
+        <comment>KCharselect unicode block name</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselect-translation.cpp" line="202"/>
+        <source>Chess Symbols</source>
+        <comment>KCharselect unicode block name</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselect-translation.cpp" line="203"/>
+        <source>Symbols and Pictographs Extended-A</source>
+        <comment>KCharselect unicode block name</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselect-translation.cpp" line="204"/>
+        <source>Symbols for Legacy Computing</source>
+        <comment>KCharselect unicode block name</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselectdata.cpp" line="305"/>
+        <source>&lt;noncharacter&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselectdata.cpp" line="326"/>
+        <source>&lt;Non Private Use High Surrogate&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselectdata.cpp" line="328"/>
+        <source>&lt;Private Use High Surrogate&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselectdata.cpp" line="330"/>
+        <source>&lt;Low Surrogate&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselectdata.cpp" line="332"/>
+        <source>&lt;Private Use&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselectdata.cpp" line="364"/>
+        <source>&lt;not assigned&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselectdata.cpp" line="746"/>
+        <source>Non-printable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselectdata.cpp" line="779"/>
+        <source>Other, Control</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselectdata.cpp" line="780"/>
+        <source>Other, Format</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselectdata.cpp" line="781"/>
+        <source>Other, Not Assigned</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselectdata.cpp" line="782"/>
+        <source>Other, Private Use</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselectdata.cpp" line="783"/>
+        <source>Other, Surrogate</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselectdata.cpp" line="784"/>
+        <source>Letter, Lowercase</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselectdata.cpp" line="785"/>
+        <source>Letter, Modifier</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselectdata.cpp" line="786"/>
+        <source>Letter, Other</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselectdata.cpp" line="787"/>
+        <source>Letter, Titlecase</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselectdata.cpp" line="788"/>
+        <source>Letter, Uppercase</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselectdata.cpp" line="789"/>
+        <source>Mark, Spacing Combining</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselectdata.cpp" line="790"/>
+        <source>Mark, Enclosing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselectdata.cpp" line="791"/>
+        <source>Mark, Non-Spacing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselectdata.cpp" line="792"/>
+        <source>Number, Decimal Digit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselectdata.cpp" line="793"/>
+        <source>Number, Letter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselectdata.cpp" line="794"/>
+        <source>Number, Other</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselectdata.cpp" line="795"/>
+        <source>Punctuation, Connector</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselectdata.cpp" line="796"/>
+        <source>Punctuation, Dash</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselectdata.cpp" line="797"/>
+        <source>Punctuation, Close</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselectdata.cpp" line="798"/>
+        <source>Punctuation, Final Quote</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselectdata.cpp" line="799"/>
+        <source>Punctuation, Initial Quote</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselectdata.cpp" line="800"/>
+        <source>Punctuation, Other</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselectdata.cpp" line="801"/>
+        <source>Punctuation, Open</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselectdata.cpp" line="802"/>
+        <source>Symbol, Currency</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselectdata.cpp" line="803"/>
+        <source>Symbol, Modifier</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselectdata.cpp" line="804"/>
+        <source>Symbol, Math</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselectdata.cpp" line="805"/>
+        <source>Symbol, Other</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselectdata.cpp" line="806"/>
+        <source>Separator, Line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselectdata.cpp" line="807"/>
+        <source>Separator, Paragraph</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselectdata.cpp" line="808"/>
+        <source>Separator, Space</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselectdata.cpp" line="809"/>
+        <source>Unknown</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>KCharSelectItemModel</name>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselect.cpp" line="1062"/>
+        <source>Unicode code point:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcharselect.cpp" line="1063"/>
+        <source>In decimal</source>
+        <comment>Character</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>KColorCombo</name>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kcolorcombo.cpp" line="329"/>
+        <source>Custom...</source>
+        <comment>@item:inlistbox Custom color</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>KColumnResizerTestForms</name>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/autotests/kcolumnresizertest-forms.ui" line="14"/>
+        <source>Form</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/autotests/kcolumnresizertest-forms.ui" line="20"/>
+        <location filename="../build/_deps/kwidgetsaddons-src/autotests/kcolumnresizertest-forms.ui" line="39"/>
+        <source>GroupBox</source>
+        <translation type="unfinished">Gruppierung</translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/autotests/kcolumnresizertest-forms.ui" line="26"/>
+        <source>Short:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/autotests/kcolumnresizertest-forms.ui" line="45"/>
+        <source>Some long label:</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>KColumnResizerTestGridAndForms</name>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/autotests/kcolumnresizertest-grid-and-form.ui" line="14"/>
+        <source>Form</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/autotests/kcolumnresizertest-grid-and-form.ui" line="20"/>
+        <location filename="../build/_deps/kwidgetsaddons-src/autotests/kcolumnresizertest-grid-and-form.ui" line="53"/>
+        <source>GroupBox</source>
+        <translation type="unfinished">Gruppierung</translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/autotests/kcolumnresizertest-grid-and-form.ui" line="29"/>
+        <source>Short:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/autotests/kcolumnresizertest-grid-and-form.ui" line="36"/>
+        <source>CheckBox</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/autotests/kcolumnresizertest-grid-and-form.ui" line="43"/>
+        <source>PushButton</source>
+        <translation type="unfinished">Taste</translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/autotests/kcolumnresizertest-grid-and-form.ui" line="59"/>
+        <source>Some long label:</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>KColumnResizerTestGrids</name>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/autotests/kcolumnresizertest-grids.ui" line="14"/>
+        <source>Form</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/autotests/kcolumnresizertest-grids.ui" line="20"/>
+        <location filename="../build/_deps/kwidgetsaddons-src/autotests/kcolumnresizertest-grids.ui" line="39"/>
+        <source>GroupBox</source>
+        <translation type="unfinished">Gruppierung</translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/autotests/kcolumnresizertest-grids.ui" line="26"/>
+        <source>Short:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/autotests/kcolumnresizertest-grids.ui" line="45"/>
+        <source>Some long label:</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>KDateComboBox</name>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/autotests/kdatetimeedittest.cpp" line="242"/>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kdatecombobox.cpp" line="159"/>
+        <source>Next Month</source>
+        <comment>@option next month</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kdatecombobox.cpp" line="158"/>
+        <source>Next Year</source>
+        <comment>@option next year</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kdatecombobox.cpp" line="160"/>
+        <source>Next Week</source>
+        <comment>@option next week</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kdatecombobox.cpp" line="161"/>
+        <source>Tomorrow</source>
+        <comment>@option tomorrow</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kdatecombobox.cpp" line="162"/>
+        <source>Today</source>
+        <comment>@option today</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kdatecombobox.cpp" line="163"/>
+        <source>Yesterday</source>
+        <comment>@option yesterday</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kdatecombobox.cpp" line="164"/>
+        <source>Last Week</source>
+        <comment>@option last week</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kdatecombobox.cpp" line="165"/>
+        <source>Last Month</source>
+        <comment>@option last month</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kdatecombobox.cpp" line="166"/>
+        <source>Last Year</source>
+        <comment>@option last year</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kdatecombobox.cpp" line="168"/>
+        <source>No Date</source>
+        <comment>@option do not specify a date</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kdatecombobox.cpp" line="299"/>
+        <source>The date you entered is invalid</source>
+        <comment>@info</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kdatecombobox.cpp" line="302"/>
+        <source>Date cannot be earlier than %1</source>
+        <comment>@info</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kdatecombobox.cpp" line="309"/>
+        <source>Date cannot be later than %1</source>
+        <comment>@info</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>KDatePicker</name>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kdatepicker.cpp" line="180"/>
+        <source>Week %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kdatepicker.cpp" line="285"/>
+        <source>Next year</source>
+        <comment>@info:tooltip</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kdatepicker.cpp" line="286"/>
+        <source>Previous year</source>
+        <comment>@info:tooltip</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kdatepicker.cpp" line="287"/>
+        <source>Next month</source>
+        <comment>@info:tooltip</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kdatepicker.cpp" line="288"/>
+        <source>Previous month</source>
+        <comment>@info:tooltip</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kdatepicker.cpp" line="289"/>
+        <source>Select a week</source>
+        <comment>@info:tooltip</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kdatepicker.cpp" line="290"/>
+        <source>Select a month</source>
+        <comment>@info:tooltip</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kdatepicker.cpp" line="291"/>
+        <source>Select a year</source>
+        <comment>@info:tooltip</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kdatepicker.cpp" line="292"/>
+        <source>Select the current day</source>
+        <comment>@info:tooltip</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kdatepicker.cpp" line="632"/>
+        <source>Close</source>
+        <comment>@action:button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>KDateTimeEdit</name>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kdatetimeedit.cpp" line="173"/>
+        <source>UTC</source>
+        <comment>@item:inlistbox UTC time zone</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kdatetimeedit.cpp" line="174"/>
+        <source>Floating</source>
+        <comment>@item:inlistbox No specific time zone</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kdatetimeedit.cpp" line="214"/>
+        <source>The entered date and time is before the minimum allowed date and time.</source>
+        <comment>@info</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kdatetimeedit.cpp" line="224"/>
+        <source>The entered date and time is after the maximum allowed date and time.</source>
+        <comment>@info</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>KEditListWidget</name>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/keditlistwidget.cpp" line="292"/>
+        <source>&amp;Add</source>
+        <comment>@action:button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/keditlistwidget.cpp" line="304"/>
+        <source>&amp;Remove</source>
+        <comment>@action:button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/keditlistwidget.cpp" line="316"/>
+        <source>Move &amp;Up</source>
+        <comment>@action:button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/keditlistwidget.cpp" line="321"/>
+        <source>Move &amp;Down</source>
+        <comment>@action:button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>KFontChooser</name>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kfontchooser.cpp" line="177"/>
+        <source>Requested Font</source>
+        <comment>@title:group</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kfontchooser.cpp" line="191"/>
+        <source>Font</source>
+        <comment>@option:check</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kfontchooser.cpp" line="196"/>
+        <source>Font:</source>
+        <comment>@label</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kfontchooser.cpp" line="229"/>
+        <source>Font style</source>
+        <comment>@option:check</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kfontchooser.cpp" line="234"/>
+        <source>Font style:</source>
+        <comment>@label</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kfontchooser.cpp" line="247"/>
+        <source>Normal</source>
+        <comment>@item font</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kfontchooser.cpp" line="248"/>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kfontchooser.cpp" line="576"/>
+        <source>Italic</source>
+        <comment>@item font</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kfontchooser.cpp" line="249"/>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kfontchooser.cpp" line="577"/>
+        <source>Oblique</source>
+        <comment>@item font</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kfontchooser.cpp" line="250"/>
+        <source>Bold</source>
+        <comment>@item font</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kfontchooser.cpp" line="251"/>
+        <source>Bold Italic</source>
+        <comment>@item font</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kfontchooser.cpp" line="268"/>
+        <source>Size</source>
+        <comment>@option:check</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kfontchooser.cpp" line="273"/>
+        <source>Size:</source>
+        <comment>@label:listbox Font size</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kfontchooser.cpp" line="291"/>
+        <source>Relative</source>
+        <comment>@item font size</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kfontchooser.cpp" line="293"/>
+        <source>Font size&lt;br /&gt;&lt;i&gt;fixed&lt;/i&gt; or &lt;i&gt;relative&lt;/i&gt;&lt;br /&gt;to environment</source>
+        <comment>@info:tooltip</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kfontchooser.cpp" line="295"/>
+        <source>Here you can switch between fixed font size and font size to be calculated dynamically and adjusted to changing environment (e.g. widget dimensions, paper size).</source>
+        <comment>@info:whatsthis</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kfontchooser.cpp" line="349"/>
+        <source>The Quick Brown Fox Jumps Over The Lazy Dog</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kfontchooser.cpp" line="352"/>
+        <source>This sample text illustrates the current settings. You may edit it to test special characters.</source>
+        <comment>@info:whatsthis</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kfontchooser.cpp" line="365"/>
+        <source>Show only monospaced fonts</source>
+        <comment>@option:check</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kfontchooser.cpp" line="561"/>
+        <source>%1</source>
+        <comment>@item Font style</comment>
+        <translation type="unfinished">%1% {1?}</translation>
+    </message>
+</context>
+<context>
+    <name>KFontChooserDialog</name>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kfontchooserdialog.cpp" line="38"/>
+        <source>Select Font</source>
+        <comment>@title:window</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>KFontRequester</name>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kfontrequester.cpp" line="150"/>
+        <source>Choose font...</source>
+        <comment>@info:tooltip</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kfontrequester.cpp" line="156"/>
+        <source>Preview of the selected font</source>
+        <comment>@info:tooltip</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kfontrequester.cpp" line="157"/>
+        <source>This is a preview of the selected font. You can change it by clicking the &quot;Choose Font...&quot; button.</source>
+        <comment>@info:whatsthis</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kfontrequester.cpp" line="160"/>
+        <source>Preview of the &quot;%1&quot; font</source>
+        <comment>@info:tooltip</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kfontrequester.cpp" line="161"/>
+        <source>This is a preview of the &quot;%1&quot; font. You can change it by clicking the &quot;Choose Font...&quot; button.</source>
+        <comment>@info:whatsthis</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>KFormat</name>
+    <message>
+        <location filename="../build/_deps/kcoreaddons-src/src/lib/util/kformatprivate.cpp" line="104"/>
+        <source>y</source>
+        <comment>SI prefix for 10^⁻24</comment>
+        <translation type="unfinished">y</translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kcoreaddons-src/src/lib/util/kformatprivate.cpp" line="105"/>
+        <source>z</source>
+        <comment>SI prefix for 10^⁻21</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kcoreaddons-src/src/lib/util/kformatprivate.cpp" line="106"/>
+        <source>a</source>
+        <comment>SI prefix for 10^⁻18</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kcoreaddons-src/src/lib/util/kformatprivate.cpp" line="107"/>
+        <source>f</source>
+        <comment>SI prefix for 10^⁻15</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kcoreaddons-src/src/lib/util/kformatprivate.cpp" line="108"/>
+        <source>p</source>
+        <comment>SI prefix for 10^⁻12</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kcoreaddons-src/src/lib/util/kformatprivate.cpp" line="109"/>
+        <source>n</source>
+        <comment>SI prefix for 10^⁻9</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kcoreaddons-src/src/lib/util/kformatprivate.cpp" line="110"/>
+        <source>µ</source>
+        <comment>SI prefix for 10^⁻6</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kcoreaddons-src/src/lib/util/kformatprivate.cpp" line="111"/>
+        <source>m</source>
+        <comment>SI prefix for 10^⁻3</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kcoreaddons-src/src/lib/util/kformatprivate.cpp" line="113"/>
+        <source>k</source>
+        <comment>SI prefix for 10^3</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kcoreaddons-src/src/lib/util/kformatprivate.cpp" line="113"/>
+        <source>Ki</source>
+        <comment>IEC binary prefix for 2^10</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kcoreaddons-src/src/lib/util/kformatprivate.cpp" line="114"/>
+        <source>M</source>
+        <comment>SI prefix for 10^6</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kcoreaddons-src/src/lib/util/kformatprivate.cpp" line="114"/>
+        <source>Mi</source>
+        <comment>IEC binary prefix for 2^20</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kcoreaddons-src/src/lib/util/kformatprivate.cpp" line="115"/>
+        <source>G</source>
+        <comment>SI prefix for 10^9</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kcoreaddons-src/src/lib/util/kformatprivate.cpp" line="115"/>
+        <source>Gi</source>
+        <comment>IEC binary prefix for 2^30</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kcoreaddons-src/src/lib/util/kformatprivate.cpp" line="116"/>
+        <source>T</source>
+        <comment>SI prefix for 10^12</comment>
+        <translation type="unfinished">T</translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kcoreaddons-src/src/lib/util/kformatprivate.cpp" line="116"/>
+        <source>Ti</source>
+        <comment>IEC binary prefix for 2^40</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kcoreaddons-src/src/lib/util/kformatprivate.cpp" line="117"/>
+        <source>P</source>
+        <comment>SI prefix for 10^15</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kcoreaddons-src/src/lib/util/kformatprivate.cpp" line="117"/>
+        <source>Pi</source>
+        <comment>IEC binary prefix for 2^50</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kcoreaddons-src/src/lib/util/kformatprivate.cpp" line="118"/>
+        <source>E</source>
+        <comment>SI prefix for 10^18</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kcoreaddons-src/src/lib/util/kformatprivate.cpp" line="118"/>
+        <source>Ei</source>
+        <comment>IEC binary prefix for 2^60</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kcoreaddons-src/src/lib/util/kformatprivate.cpp" line="119"/>
+        <source>Z</source>
+        <comment>SI prefix for 10^21</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kcoreaddons-src/src/lib/util/kformatprivate.cpp" line="119"/>
+        <source>Zi</source>
+        <comment>IEC binary prefix for 2^70</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kcoreaddons-src/src/lib/util/kformatprivate.cpp" line="120"/>
+        <source>Y</source>
+        <comment>SI prefix for 10^24</comment>
+        <translation type="unfinished">Y</translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kcoreaddons-src/src/lib/util/kformatprivate.cpp" line="120"/>
+        <source>Yi</source>
+        <comment>IEC binary prefix for 2^80</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kcoreaddons-src/src/lib/util/kformatprivate.cpp" line="128"/>
+        <source>bit</source>
+        <comment>Symbol of binary digit</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kcoreaddons-src/src/lib/util/kformatprivate.cpp" line="131"/>
+        <source>B</source>
+        <comment>Symbol of byte</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kcoreaddons-src/src/lib/util/kformatprivate.cpp" line="134"/>
+        <source>m</source>
+        <comment>Symbol of meter</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kcoreaddons-src/src/lib/util/kformatprivate.cpp" line="137"/>
+        <source>Hz</source>
+        <comment>Symbol of hertz</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kcoreaddons-src/src/lib/util/kformatprivate.cpp" line="146"/>
+        <source>%1 %2</source>
+        <comment>no Prefix</comment>
+        <extracomment>value without prefix, format &quot;&lt;val&gt; &lt;unit&gt;&quot;</extracomment>
+        <translation type="unfinished">%1 %2</translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kcoreaddons-src/src/lib/util/kformatprivate.cpp" line="165"/>
+        <source>%1 %2%3</source>
+        <comment>MetricBinaryDialect</comment>
+        <extracomment>value with prefix, format &quot;&lt;val&gt; &lt;prefix&gt;&lt;unit&gt;&quot;</extracomment>
+        <translation type="unfinished">%1% {1 %2%3?}</translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kcoreaddons-src/src/lib/util/kformatprivate.cpp" line="216"/>
+        <source>%1 B</source>
+        <comment>MetricBinaryDialect</comment>
+        <extracomment>MetricBinaryDialect size in bytes</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kcoreaddons-src/src/lib/util/kformatprivate.cpp" line="219"/>
+        <source>%1 kB</source>
+        <comment>MetricBinaryDialect</comment>
+        <extracomment>MetricBinaryDialect size in 1000 bytes</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kcoreaddons-src/src/lib/util/kformatprivate.cpp" line="222"/>
+        <source>%1 MB</source>
+        <comment>MetricBinaryDialect</comment>
+        <extracomment>MetricBinaryDialect size in 10^6 bytes</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kcoreaddons-src/src/lib/util/kformatprivate.cpp" line="225"/>
+        <source>%1 GB</source>
+        <comment>MetricBinaryDialect</comment>
+        <extracomment>MetricBinaryDialect size in 10^9 bytes</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kcoreaddons-src/src/lib/util/kformatprivate.cpp" line="228"/>
+        <source>%1 TB</source>
+        <comment>MetricBinaryDialect</comment>
+        <extracomment>MetricBinaryDialect size in 10^12 bytes</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kcoreaddons-src/src/lib/util/kformatprivate.cpp" line="231"/>
+        <source>%1 PB</source>
+        <comment>MetricBinaryDialect</comment>
+        <extracomment>MetricBinaryDialect size in 10^15 bytes</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kcoreaddons-src/src/lib/util/kformatprivate.cpp" line="234"/>
+        <source>%1 EB</source>
+        <comment>MetricBinaryDialect</comment>
+        <extracomment>MetricBinaryDialect size in 10^18 byte</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kcoreaddons-src/src/lib/util/kformatprivate.cpp" line="237"/>
+        <source>%1 ZB</source>
+        <comment>MetricBinaryDialect</comment>
+        <extracomment>MetricBinaryDialect size in 10^21 bytes</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kcoreaddons-src/src/lib/util/kformatprivate.cpp" line="240"/>
+        <source>%1 YB</source>
+        <comment>MetricBinaryDialect</comment>
+        <extracomment>MetricBinaryDialect size in 10^24 bytes</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kcoreaddons-src/src/lib/util/kformatprivate.cpp" line="246"/>
+        <source>%1 B</source>
+        <comment>JEDECBinaryDialect</comment>
+        <extracomment>JEDECBinaryDialect memory size in bytes</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kcoreaddons-src/src/lib/util/kformatprivate.cpp" line="249"/>
+        <source>%1 KB</source>
+        <comment>JEDECBinaryDialect</comment>
+        <extracomment>JEDECBinaryDialect memory size in 1024 bytes</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kcoreaddons-src/src/lib/util/kformatprivate.cpp" line="252"/>
+        <source>%1 MB</source>
+        <comment>JEDECBinaryDialect</comment>
+        <extracomment>JEDECBinaryDialect memory size in 10^20 bytes</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kcoreaddons-src/src/lib/util/kformatprivate.cpp" line="255"/>
+        <source>%1 GB</source>
+        <comment>JEDECBinaryDialect</comment>
+        <extracomment>JEDECBinaryDialect memory size in 10^30 bytes</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kcoreaddons-src/src/lib/util/kformatprivate.cpp" line="258"/>
+        <source>%1 TB</source>
+        <comment>JEDECBinaryDialect</comment>
+        <extracomment>JEDECBinaryDialect memory size in 10^40 bytes</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kcoreaddons-src/src/lib/util/kformatprivate.cpp" line="261"/>
+        <source>%1 PB</source>
+        <comment>JEDECBinaryDialect</comment>
+        <extracomment>JEDECBinaryDialect memory size in 10^50 bytes</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kcoreaddons-src/src/lib/util/kformatprivate.cpp" line="264"/>
+        <source>%1 EB</source>
+        <comment>JEDECBinaryDialect</comment>
+        <extracomment>JEDECBinaryDialect memory size in 10^60 bytes</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kcoreaddons-src/src/lib/util/kformatprivate.cpp" line="267"/>
+        <source>%1 ZB</source>
+        <comment>JEDECBinaryDialect</comment>
+        <extracomment>JEDECBinaryDialect memory size in 10^70 bytes</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kcoreaddons-src/src/lib/util/kformatprivate.cpp" line="270"/>
+        <source>%1 YB</source>
+        <comment>JEDECBinaryDialect</comment>
+        <extracomment>JEDECBinaryDialect memory size in 10^80 bytes</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kcoreaddons-src/src/lib/util/kformatprivate.cpp" line="276"/>
+        <source>%1 B</source>
+        <comment>IECBinaryDialect</comment>
+        <extracomment>IECBinaryDialect size in bytes</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kcoreaddons-src/src/lib/util/kformatprivate.cpp" line="279"/>
+        <source>%1 KiB</source>
+        <comment>IECBinaryDialect</comment>
+        <extracomment>IECBinaryDialect size in 1024 bytes</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kcoreaddons-src/src/lib/util/kformatprivate.cpp" line="282"/>
+        <source>%1 MiB</source>
+        <comment>IECBinaryDialect</comment>
+        <extracomment>IECBinaryDialect size in 10^20 bytes</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kcoreaddons-src/src/lib/util/kformatprivate.cpp" line="285"/>
+        <source>%1 GiB</source>
+        <comment>IECBinaryDialect</comment>
+        <extracomment>IECBinaryDialect size in 10^30 bytes</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kcoreaddons-src/src/lib/util/kformatprivate.cpp" line="288"/>
+        <source>%1 TiB</source>
+        <comment>IECBinaryDialect</comment>
+        <extracomment>IECBinaryDialect size in 10^40 bytes</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kcoreaddons-src/src/lib/util/kformatprivate.cpp" line="291"/>
+        <source>%1 PiB</source>
+        <comment>IECBinaryDialect</comment>
+        <extracomment>IECBinaryDialect size in 10^50 bytes</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kcoreaddons-src/src/lib/util/kformatprivate.cpp" line="294"/>
+        <source>%1 EiB</source>
+        <comment>IECBinaryDialect</comment>
+        <extracomment>IECBinaryDialect size in 10^60 bytes</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kcoreaddons-src/src/lib/util/kformatprivate.cpp" line="297"/>
+        <source>%1 ZiB</source>
+        <comment>IECBinaryDialect</comment>
+        <extracomment>IECBinaryDialect size in 10^70 bytes</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kcoreaddons-src/src/lib/util/kformatprivate.cpp" line="300"/>
+        <source>%1 YiB</source>
+        <comment>IECBinaryDialect</comment>
+        <extracomment>IECBinaryDialect size in 10^80 bytes</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kcoreaddons-src/src/lib/util/kformatprivate.cpp" line="339"/>
+        <source>%1m%2.%3s</source>
+        <extracomment>@item:intext Duration format minutes, seconds and milliseconds</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kcoreaddons-src/src/lib/util/kformatprivate.cpp" line="344"/>
+        <source>%1m%2s</source>
+        <extracomment>@item:intext Duration format minutes and seconds</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kcoreaddons-src/src/lib/util/kformatprivate.cpp" line="348"/>
+        <source>%1h%2m</source>
+        <extracomment>@item:intext Duration format hours and minutes</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kcoreaddons-src/src/lib/util/kformatprivate.cpp" line="352"/>
+        <source>%1h%2m%3.%4s</source>
+        <extracomment>@item:intext Duration format hours, minutes, seconds, milliseconds</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kcoreaddons-src/src/lib/util/kformatprivate.cpp" line="358"/>
+        <source>%1h%2m%3s</source>
+        <extracomment>@item:intext Duration format hours, minutes, seconds</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kcoreaddons-src/src/lib/util/kformatprivate.cpp" line="368"/>
+        <source>%1:%2.%3</source>
+        <extracomment>@item:intext Duration format minutes, seconds and milliseconds</extracomment>
+        <translation type="unfinished">%1% {1:%2.%3?}</translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kcoreaddons-src/src/lib/util/kformatprivate.cpp" line="373"/>
+        <location filename="../build/_deps/kcoreaddons-src/src/lib/util/kformatprivate.cpp" line="377"/>
+        <source>%1:%2</source>
+        <extracomment>@item:intext Duration format minutes and seconds
+----------
+@item:intext Duration format hours and minutes</extracomment>
+        <translation type="unfinished">%1% {1:%2?}</translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kcoreaddons-src/src/lib/util/kformatprivate.cpp" line="381"/>
+        <source>%1:%2:%3.%4</source>
+        <extracomment>@item:intext Duration format hours, minutes, seconds, milliseconds</extracomment>
+        <translation type="unfinished">%1% {1:%2:%3.%4?}</translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kcoreaddons-src/src/lib/util/kformatprivate.cpp" line="387"/>
+        <source>%1:%2:%3</source>
+        <extracomment>@item:intext Duration format hours, minutes, seconds</extracomment>
+        <translation type="unfinished">%1% {1:%2:%3?}</translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kcoreaddons-src/src/lib/util/kformatprivate.cpp" line="402"/>
+        <source>%1 days</source>
+        <extracomment>@item:intext %1 is a real number, e.g. 1.23 days</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kcoreaddons-src/src/lib/util/kformatprivate.cpp" line="405"/>
+        <source>%1 hours</source>
+        <extracomment>@item:intext %1 is a real number, e.g. 1.23 hours</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kcoreaddons-src/src/lib/util/kformatprivate.cpp" line="408"/>
+        <source>%1 minutes</source>
+        <extracomment>@item:intext %1 is a real number, e.g. 1.23 minutes</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kcoreaddons-src/src/lib/util/kformatprivate.cpp" line="411"/>
+        <source>%1 seconds</source>
+        <extracomment>@item:intext %1 is a real number, e.g. 1.23 seconds</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../build/_deps/kcoreaddons-src/src/lib/util/kformatprivate.cpp" line="416"/>
+        <source>%n millisecond(s)</source>
+        <extracomment>@item:intext %1 is a whole number</extracomment>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+        <extra-plural>%n milliseconds</extra-plural>
+        <extra-singular>%n millisecond</extra-singular>
+    </message>
+    <message numerus="yes">
+        <location filename="../build/_deps/kcoreaddons-src/src/lib/util/kformatprivate.cpp" line="434"/>
+        <source>%n day(s)</source>
+        <extracomment>@item:intext %n is a whole number</extracomment>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+        <extra-plural>%n days</extra-plural>
+        <extra-singular>%n day</extra-singular>
+    </message>
+    <message numerus="yes">
+        <location filename="../build/_deps/kcoreaddons-src/src/lib/util/kformatprivate.cpp" line="439"/>
+        <source>%n hour(s)</source>
+        <extracomment>@item:intext %n is a whole number</extracomment>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+        <extra-plural>%n hours</extra-plural>
+        <extra-singular>%n hour</extra-singular>
+    </message>
+    <message numerus="yes">
+        <location filename="../build/_deps/kcoreaddons-src/src/lib/util/kformatprivate.cpp" line="444"/>
+        <source>%n minute(s)</source>
+        <extracomment>@item:intext %n is a whole number</extracomment>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+        <extra-plural>%n minutes</extra-plural>
+        <extra-singular>%n minute</extra-singular>
+    </message>
+    <message numerus="yes">
+        <location filename="../build/_deps/kcoreaddons-src/src/lib/util/kformatprivate.cpp" line="449"/>
+        <source>%n second(s)</source>
+        <extracomment>@item:intext %n is a whole number</extracomment>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+        <extra-plural>%n seconds</extra-plural>
+        <extra-singular>%n second</extra-singular>
+    </message>
+    <message>
+        <location filename="../build/_deps/kcoreaddons-src/src/lib/util/kformatprivate.cpp" line="474"/>
+        <location filename="../build/_deps/kcoreaddons-src/src/lib/util/kformatprivate.cpp" line="480"/>
+        <location filename="../build/_deps/kcoreaddons-src/src/lib/util/kformatprivate.cpp" line="486"/>
+        <source>%1 and %2</source>
+        <extracomment>@item:intext days and hours. This uses the previous item:intext messages. If this does not fit the grammar of your language please contact the i18n team to solve the problem
+----------
+@item:intext hours and minutes. This uses the previous item:intext messages. If this does not fit the grammar of your language please contact the i18n team to solve the problem
+----------
+@item:intext minutes and seconds. This uses the previous item:intext messages. If this does not fit the grammar of your language please contact the i18n team to solve the problem</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kcoreaddons-src/src/lib/util/kformatprivate.cpp" line="497"/>
+        <source>Invalid date</source>
+        <comment>used when a relative date string can&apos;t be generated because the date is invalid</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kcoreaddons-src/src/lib/util/kformatprivate.cpp" line="507"/>
+        <source>In two days</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kcoreaddons-src/src/lib/util/kformatprivate.cpp" line="509"/>
+        <source>Tomorrow</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kcoreaddons-src/src/lib/util/kformatprivate.cpp" line="511"/>
+        <source>Today</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kcoreaddons-src/src/lib/util/kformatprivate.cpp" line="513"/>
+        <source>Yesterday</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kcoreaddons-src/src/lib/util/kformatprivate.cpp" line="515"/>
+        <source>Two days ago</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kcoreaddons-src/src/lib/util/kformatprivate.cpp" line="532"/>
+        <source>Just now</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kcoreaddons-src/src/lib/util/kformatprivate.cpp" line="534"/>
+        <source>%1 minutes ago</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kcoreaddons-src/src/lib/util/kformatprivate.cpp" line="540"/>
+        <source>%1, %2</source>
+        <extracomment>relative datetime with %1 result of formatReleativeDate() and %2 the formatted time If this does not fit the grammar of your language please contact the i18n team to solve the problem</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>KLed</name>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kled.cpp" line="176"/>
+        <source>LED on</source>
+        <comment>Accessible name of a Led whose state is on</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kled.cpp" line="177"/>
+        <source>LED off</source>
+        <comment>Accessible name of a Led whose state is off</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>KMessageBox</name>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kmessagebox.cpp" line="63"/>
+        <source>.</source>
+        <comment>@action:button post-filter</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kmessagebox.cpp" line="302"/>
+        <source>Details</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kmessagebox.cpp" line="460"/>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kmessagebox.cpp" line="514"/>
+        <source>Question</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kmessagebox.cpp" line="472"/>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kmessagebox.cpp" line="528"/>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kmessagebox.cpp" line="599"/>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kmessagebox.cpp" line="663"/>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kmessagebox.cpp" line="746"/>
+        <source>Do not ask again</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kmessagebox.cpp" line="587"/>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kmessagebox.cpp" line="651"/>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kmessagebox.cpp" line="733"/>
+        <source>Warning</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kmessagebox.cpp" line="785"/>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kmessagebox.cpp" line="806"/>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kmessagebox.cpp" line="833"/>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kmessagebox.cpp" line="866"/>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kmessagebox.cpp" line="1133"/>
+        <source>Sorry</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kmessagebox.cpp" line="909"/>
+        <source>Information</source>
+        <translation type="unfinished">Information</translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kmessagebox.cpp" line="920"/>
+        <source>Do not show this message again</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>KMessageDialog</name>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kmessagedialog.cpp" line="133"/>
+        <source>Details</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kmessagedialog.cpp" line="198"/>
+        <source>Question</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kmessagedialog.cpp" line="203"/>
+        <source>Warning</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kmessagedialog.cpp" line="206"/>
+        <source>Information</source>
+        <translation type="unfinished">Information</translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kmessagedialog.cpp" line="209"/>
+        <source>Sorry</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kmessagedialog.cpp" line="212"/>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>KMessageWidget</name>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kmessagewidget.cpp" line="76"/>
+        <source>&amp;Close</source>
+        <comment>@action:button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kmessagewidget.cpp" line="77"/>
+        <source>Close message</source>
+        <comment>@info:tooltip</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>KMimeTypeChooser</name>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kmimetypechooser.cpp" line="88"/>
+        <source>Search for file type or filename pattern...</source>
+        <comment>@info:placeholder</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kmimetypechooser.cpp" line="89"/>
+        <source>&amp;Filter:</source>
+        <comment>@label:textbox</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kmimetypechooser.cpp" line="103"/>
+        <source>MIME Type</source>
+        <comment>@title:column</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kmimetypechooser.cpp" line="106"/>
+        <source>Comment</source>
+        <comment>@title:column</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kmimetypechooser.cpp" line="110"/>
+        <source>Patterns</source>
+        <comment>@title:column</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kmimetypechooser.cpp" line="126"/>
+        <source>&amp;Edit...</source>
+        <comment>@action:button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kmimetypechooser.cpp" line="136"/>
+        <source>Launch the MIME type editor</source>
+        <comment>@info:tooltip</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>KNewPasswordDialog</name>
+    <message numerus="yes">
+        <location filename="../build/_deps/kwidgetsaddons-src/src/knewpassworddialog.cpp" line="58"/>
+        <source>Password must be at least %n character(s) long.</source>
+        <comment>@info</comment>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+        <extra-plural>Password must be at least %n characters long</extra-plural>
+        <extra-singular>Password must be at least %n character long</extra-singular>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/knewpassworddialog.cpp" line="62"/>
+        <source>Password is empty.</source>
+        <comment>@info</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/knewpassworddialog.cpp" line="66"/>
+        <source>Passwords do not match.</source>
+        <comment>@info</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/knewpassworddialog.cpp" line="71"/>
+        <source>Passwords match.</source>
+        <comment>@info</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/knewpassworddialog.cpp" line="147"/>
+        <source>Low Password Strength</source>
+        <comment>@title:window</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/knewpassworddialog.cpp" line="148"/>
+        <source>The password you have entered has a low strength. To improve the strength of the password, try:
+ - using a longer password;
+ - using a mixture of upper- and lower-case letters;
+ - using numbers or symbols as well as letters.
+
+Would you like to use this password anyway?</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>KNewPasswordWidget</name>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/knewpasswordwidget.ui" line="19"/>
+        <location filename="../build/_deps/kwidgetsaddons-build/src/ui_knewpasswordwidget.h" line="107"/>
+        <source>Password:</source>
+        <comment>@label:textbox</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/knewpasswordwidget.ui" line="29"/>
+        <location filename="../build/_deps/kwidgetsaddons-build/src/ui_knewpasswordwidget.h" line="108"/>
+        <source>&amp;Verify:</source>
+        <comment>@label:textbox</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/knewpasswordwidget.ui" line="54"/>
+        <location filename="../build/_deps/kwidgetsaddons-build/src/ui_knewpasswordwidget.h" line="109"/>
+        <source>Password strength &amp;meter:</source>
+        <comment>@label</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/knewpasswordwidget.cpp" line="48"/>
+        <source>The password strength meter gives an indication of the security of the password you have entered. To improve the strength of the password, try:&lt;ul&gt;&lt;li&gt;using a longer password;&lt;/li&gt;&lt;li&gt;using a mixture of upper- and lower-case letters;&lt;/li&gt;&lt;li&gt;using numbers or symbols, such as #, as well as letters.&lt;/li&gt;&lt;/ul&gt;</source>
+        <comment>@info:whatsthis</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>KPasswordDialog</name>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kpassworddialog.ui" line="33"/>
+        <location filename="../build/_deps/kwidgetsaddons-build/src/ui_kpassworddialog.h" line="190"/>
+        <source>Supply a username and password below.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kpassworddialog.ui" line="70"/>
+        <location filename="../build/_deps/kwidgetsaddons-build/src/ui_kpassworddialog.h" line="191"/>
+        <source>No password, use anonymous (or &amp;guest) login</source>
+        <comment>@option:radio</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kpassworddialog.ui" line="77"/>
+        <location filename="../build/_deps/kwidgetsaddons-build/src/ui_kpassworddialog.h" line="192"/>
+        <source>Use this password:</source>
+        <comment>@option:radio</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kpassworddialog.ui" line="102"/>
+        <location filename="../build/_deps/kwidgetsaddons-build/src/ui_kpassworddialog.h" line="193"/>
+        <source>Username:</source>
+        <comment>@label:textbox</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kpassworddialog.ui" line="127"/>
+        <location filename="../build/_deps/kwidgetsaddons-build/src/ui_kpassworddialog.h" line="195"/>
+        <source>Domain:</source>
+        <comment>@label:textbox</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kpassworddialog.ui" line="141"/>
+        <location filename="../build/_deps/kwidgetsaddons-build/src/ui_kpassworddialog.h" line="196"/>
+        <source>Password:</source>
+        <comment>@label:textbox</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kpassworddialog.ui" line="155"/>
+        <location filename="../build/_deps/kwidgetsaddons-build/src/ui_kpassworddialog.h" line="197"/>
+        <source>Remember password</source>
+        <comment>@option:check</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kpassworddialog.cpp" line="51"/>
+        <source>Password</source>
+        <comment>@title:window</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kpassworddialog.cpp" line="82"/>
+        <source>Show Contextual Help</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kpassworddialog.cpp" line="103"/>
+        <source>Supply a password below.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>KPixmapRegionSelectorDialog</name>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kpixmapregionselectordialog.cpp" line="60"/>
+        <source>Select Region of Image</source>
+        <comment>@title:window</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kpixmapregionselectordialog.cpp" line="64"/>
+        <source>Please click and drag on the image to select the region of interest:</source>
+        <comment>@label:chooser</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>KPixmapRegionSelectorWidget</name>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kpixmapregionselectorwidget.cpp" line="174"/>
+        <source>Image Operations</source>
+        <comment>@title:menu</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kpixmapregionselectorwidget.cpp" line="176"/>
+        <source>&amp;Rotate Clockwise</source>
+        <comment>@action:inmenu</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kpixmapregionselectorwidget.cpp" line="178"/>
+        <source>Rotate &amp;Counterclockwise</source>
+        <comment>@action:inmenu</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>KPluginLoader</name>
+    <message>
+        <location filename="../build/_deps/kcoreaddons-src/src/lib/plugin/kpluginloader.cpp" line="109"/>
+        <source>The library %1 does not offer a KPluginFactory.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>KRecentFilesMenu</name>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/krecentfilesmenu.cpp" line="103"/>
+        <source>No Entries</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/krecentfilesmenu.cpp" line="106"/>
+        <source>Clear List</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/krecentfilesmenu.cpp" line="113"/>
+        <source>Recent Files</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>KSqueezedTextLabel</name>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/ksqueezedtextlabel.cpp" line="206"/>
+        <source>&amp;Copy Full Text</source>
+        <comment>@action:inmenu</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>KStandardGuiItem</name>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kstandardguiitem.cpp" line="96"/>
+        <source>&amp;OK</source>
+        <translation type="unfinished">&amp;OK</translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kstandardguiitem.cpp" line="101"/>
+        <source>&amp;Cancel</source>
+        <translation type="unfinished">Abbre&amp;chen</translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kstandardguiitem.cpp" line="106"/>
+        <source>&amp;Yes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kstandardguiitem.cpp" line="106"/>
+        <source>Yes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kstandardguiitem.cpp" line="111"/>
+        <source>&amp;No</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kstandardguiitem.cpp" line="111"/>
+        <source>No</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kstandardguiitem.cpp" line="116"/>
+        <source>&amp;Discard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kstandardguiitem.cpp" line="116"/>
+        <source>Discard changes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kstandardguiitem.cpp" line="117"/>
+        <source>Pressing this button will discard all recent changes made in this dialog.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kstandardguiitem.cpp" line="123"/>
+        <source>&amp;Save</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kstandardguiitem.cpp" line="123"/>
+        <source>Save data</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kstandardguiitem.cpp" line="128"/>
+        <source>&amp;Do Not Save</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kstandardguiitem.cpp" line="129"/>
+        <source>Do not save data</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kstandardguiitem.cpp" line="134"/>
+        <source>Save &amp;As...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kstandardguiitem.cpp" line="135"/>
+        <source>Save file with another name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kstandardguiitem.cpp" line="140"/>
+        <source>&amp;Apply</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kstandardguiitem.cpp" line="140"/>
+        <source>Apply changes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kstandardguiitem.cpp" line="141"/>
+        <source>When you click &lt;b&gt;Apply&lt;/b&gt;, the settings will be handed over to the program, but the dialog will not be closed.
+Use this to try different settings.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kstandardguiitem.cpp" line="149"/>
+        <source>Administrator &amp;Mode...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kstandardguiitem.cpp" line="149"/>
+        <source>Enter Administrator Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kstandardguiitem.cpp" line="150"/>
+        <source>When you click &lt;b&gt;Administrator Mode&lt;/b&gt; you will be prompted for the administrator (root) password in order to make changes which require root privileges.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kstandardguiitem.cpp" line="157"/>
+        <source>C&amp;lear</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kstandardguiitem.cpp" line="158"/>
+        <source>Clear input</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kstandardguiitem.cpp" line="159"/>
+        <source>Clear the input in the edit field</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kstandardguiitem.cpp" line="164"/>
+        <source>&amp;Help</source>
+        <comment>show help</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kstandardguiitem.cpp" line="165"/>
+        <source>Show help</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kstandardguiitem.cpp" line="170"/>
+        <source>&amp;Close</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kstandardguiitem.cpp" line="171"/>
+        <source>Close the current window or document</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kstandardguiitem.cpp" line="176"/>
+        <source>&amp;Close Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kstandardguiitem.cpp" line="177"/>
+        <source>Close the current window.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kstandardguiitem.cpp" line="182"/>
+        <source>&amp;Close Document</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kstandardguiitem.cpp" line="183"/>
+        <source>Close the current document.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kstandardguiitem.cpp" line="188"/>
+        <source>&amp;Defaults</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kstandardguiitem.cpp" line="189"/>
+        <source>Reset all items to their default values</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kstandardguiitem.cpp" line="196"/>
+        <source>&amp;Back</source>
+        <comment>go back</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kstandardguiitem.cpp" line="197"/>
+        <source>Go back one step</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kstandardguiitem.cpp" line="204"/>
+        <source>&amp;Forward</source>
+        <comment>go forward</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kstandardguiitem.cpp" line="205"/>
+        <source>Go forward one step</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kstandardguiitem.cpp" line="215"/>
+        <source>&amp;Print...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kstandardguiitem.cpp" line="216"/>
+        <source>Opens the print dialog to print the current document</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kstandardguiitem.cpp" line="222"/>
+        <source>C&amp;ontinue</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kstandardguiitem.cpp" line="223"/>
+        <source>Continue operation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kstandardguiitem.cpp" line="228"/>
+        <source>&amp;Delete</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kstandardguiitem.cpp" line="229"/>
+        <source>Delete item(s)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kstandardguiitem.cpp" line="234"/>
+        <source>&amp;Open...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kstandardguiitem.cpp" line="235"/>
+        <source>Open file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kstandardguiitem.cpp" line="240"/>
+        <source>&amp;Quit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kstandardguiitem.cpp" line="241"/>
+        <source>Quit application</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kstandardguiitem.cpp" line="246"/>
+        <source>&amp;Reset</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kstandardguiitem.cpp" line="247"/>
+        <source>Reset configuration</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kstandardguiitem.cpp" line="252"/>
+        <source>&amp;Insert</source>
+        <comment>Verb</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kstandardguiitem.cpp" line="257"/>
+        <source>Confi&amp;gure...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kstandardguiitem.cpp" line="262"/>
+        <source>&amp;Find</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kstandardguiitem.cpp" line="267"/>
+        <source>Stop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kstandardguiitem.cpp" line="272"/>
+        <source>Add</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kstandardguiitem.cpp" line="277"/>
+        <source>Remove</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kstandardguiitem.cpp" line="282"/>
+        <source>Test</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kstandardguiitem.cpp" line="287"/>
+        <source>Properties</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kstandardguiitem.cpp" line="292"/>
+        <source>&amp;Overwrite</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>KTimeComboBox</name>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/ktimecombobox.cpp" line="256"/>
+        <source>The time you entered is invalid</source>
+        <comment>@info</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/ktimecombobox.cpp" line="259"/>
+        <source>Time cannot be earlier than %1</source>
+        <comment>@info</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/ktimecombobox.cpp" line="266"/>
+        <source>Time cannot be later than %1</source>
+        <comment>@info</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>KToggleFullScreenAction</name>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/ktogglefullscreenaction.cpp" line="32"/>
+        <source>Exit F&amp;ull Screen Mode</source>
+        <comment>@action:inmenu</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/ktogglefullscreenaction.cpp" line="33"/>
+        <source>Exit Full Screen</source>
+        <comment>@action:intoolbar</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/ktogglefullscreenaction.cpp" line="34"/>
+        <source>Exit full screen mode</source>
+        <comment>@info:tooltip</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/ktogglefullscreenaction.cpp" line="37"/>
+        <source>F&amp;ull Screen Mode</source>
+        <comment>@action:inmenu</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/ktogglefullscreenaction.cpp" line="38"/>
+        <source>Full Screen</source>
+        <comment>@action:intoolbar</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/ktogglefullscreenaction.cpp" line="39"/>
+        <source>Display the window in full screen</source>
+        <comment>@info:tooltip</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>LineEditor</name>
     <message>
         <location filename="../sources/editor/ui/lineeditor.cpp" line="42"/>
@@ -4429,42 +8505,51 @@ Veuillez utiliser l&apos;éditeur avancé pour cela.</source>
     </message>
     <message>
         <location filename="../sources/editor/ui/lineeditor.ui" line="14"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_lineeditor.h" line="163"/>
         <source>Form</source>
         <translation>Linieneigenschaften</translation>
     </message>
     <message>
         <location filename="../sources/editor/ui/lineeditor.ui" line="52"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_lineeditor.h" line="164"/>
         <source>X1 :</source>
         <translation>X1:</translation>
     </message>
     <message>
         <location filename="../sources/editor/ui/lineeditor.ui" line="59"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_lineeditor.h" line="165"/>
         <source>Y1 :</source>
         <translation>Y1:</translation>
     </message>
     <message>
         <location filename="../sources/editor/ui/lineeditor.ui" line="66"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_lineeditor.h" line="166"/>
         <source>X2 :</source>
         <translation>X2:</translation>
     </message>
     <message>
         <location filename="../sources/editor/ui/lineeditor.ui" line="83"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_lineeditor.h" line="167"/>
         <source>Fin 1 :</source>
         <translation>Ende 1:</translation>
     </message>
     <message>
         <location filename="../sources/editor/ui/lineeditor.ui" line="90"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_lineeditor.h" line="168"/>
         <source>Y2 :</source>
         <translation>Y2:</translation>
     </message>
     <message>
         <location filename="../sources/editor/ui/lineeditor.ui" line="97"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_lineeditor.h" line="169"/>
         <source>Fin 2 :</source>
         <translation>Ende 2:</translation>
     </message>
     <message>
         <location filename="../sources/editor/ui/lineeditor.ui" line="110"/>
         <location filename="../sources/editor/ui/lineeditor.ui" line="117"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_lineeditor.h" line="170"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_lineeditor.h" line="171"/>
         <source>Longueur :</source>
         <translation>Länge:</translation>
     </message>
@@ -4473,21 +8558,25 @@ Veuillez utiliser l&apos;éditeur avancé pour cela.</source>
     <name>LinkSingleElementWidget</name>
     <message>
         <location filename="../sources/ui/linksingleelementwidget.ui" line="14"/>
+        <location filename="../build/qelectrotech_autogen/ui_linksingleelementwidget.h" line="95"/>
         <source>Form</source>
         <translation>Form</translation>
     </message>
     <message>
         <location filename="../sources/ui/linksingleelementwidget.ui" line="56"/>
+        <location filename="../build/qelectrotech_autogen/ui_linksingleelementwidget.h" line="99"/>
         <source>Cet élément est déjà lié</source>
         <translation>Das Bauteil ist bereits gebunden</translation>
     </message>
     <message>
         <location filename="../sources/ui/linksingleelementwidget.ui" line="63"/>
+        <location filename="../build/qelectrotech_autogen/ui_linksingleelementwidget.h" line="100"/>
         <source>Recherche</source>
         <translation>Suchen</translation>
     </message>
     <message>
         <location filename="../sources/ui/linksingleelementwidget.ui" line="71"/>
+        <location filename="../build/qelectrotech_autogen/ui_linksingleelementwidget.h" line="101"/>
         <source>Remarque : les éléments maîtres ayant atteint leur nombre maximal d&apos;esclaves sont masqués.</source>
         <translation>Hinweis: Master-Elemente, die ihre maximale Anzahl an Slaves erreicht haben, werden ausgeblendet.</translation>
     </message>
@@ -4563,11 +8652,13 @@ Veuillez utiliser l&apos;éditeur avancé pour cela.</source>
     </message>
     <message>
         <location filename="../sources/ui/linksingleelementwidget.ui" line="20"/>
+        <location filename="../build/qelectrotech_autogen/ui_linksingleelementwidget.h" line="96"/>
         <source>Voir cet élément</source>
         <translation>Bauteil zeigen</translation>
     </message>
     <message>
         <location filename="../sources/ui/linksingleelementwidget.ui" line="49"/>
+        <location filename="../build/qelectrotech_autogen/ui_linksingleelementwidget.h" line="98"/>
         <source>Voir l&apos;élément lié</source>
         <translation>gebundenes Bauteil zeigen</translation>
     </message>
@@ -4603,6 +8694,7 @@ Veuillez utiliser l&apos;éditeur avancé pour cela.</source>
     </message>
     <message>
         <location filename="../sources/ui/linksingleelementwidget.ui" line="42"/>
+        <location filename="../build/qelectrotech_autogen/ui_linksingleelementwidget.h" line="97"/>
         <source>Délier</source>
         <translation>Trennen</translation>
     </message>
@@ -4611,26 +8703,31 @@ Veuillez utiliser l&apos;éditeur avancé pour cela.</source>
     <name>MarginsEditDialog</name>
     <message>
         <location filename="../sources/ui/marginseditdialog.ui" line="14"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_marginseditdialog.h" line="109"/>
         <source>Editer les marges</source>
         <translation>Ränder ändern</translation>
     </message>
     <message>
         <location filename="../sources/ui/marginseditdialog.ui" line="71"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_marginseditdialog.h" line="114"/>
         <source>Haut :</source>
         <translation>Oben:</translation>
     </message>
     <message>
         <location filename="../sources/ui/marginseditdialog.ui" line="78"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_marginseditdialog.h" line="115"/>
         <source>Gauche :</source>
         <translation>Links:</translation>
     </message>
     <message>
         <location filename="../sources/ui/marginseditdialog.ui" line="85"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_marginseditdialog.h" line="116"/>
         <source>Droit :</source>
         <translation>Rechts:</translation>
     </message>
     <message>
         <location filename="../sources/ui/marginseditdialog.ui" line="92"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_marginseditdialog.h" line="117"/>
         <source>Bas :</source>
         <translation>Unten:</translation>
     </message>
@@ -4639,16 +8736,19 @@ Veuillez utiliser l&apos;éditeur avancé pour cela.</source>
     <name>MasterPropertiesWidget</name>
     <message>
         <location filename="../sources/ui/masterpropertieswidget.ui" line="20"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_masterpropertieswidget.h" line="116"/>
         <source>Form</source>
         <translation>Form</translation>
     </message>
     <message>
         <location filename="../sources/ui/masterpropertieswidget.ui" line="133"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_masterpropertieswidget.h" line="120"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Délier l&apos;élément sélectionné&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Ausgewähltes Bauteil trennen&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
         <location filename="../sources/ui/masterpropertieswidget.ui" line="147"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_masterpropertieswidget.h" line="124"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Lier l&apos;élément sélectionné&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Ausgewähltes Bauteil verbinden&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
@@ -4682,11 +8782,13 @@ Veuillez utiliser l&apos;éditeur avancé pour cela.</source>
     </message>
     <message>
         <location filename="../sources/ui/masterpropertieswidget.ui" line="123"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_masterpropertieswidget.h" line="118"/>
         <source>Éléments disponibles</source>
         <translation>Verfügbare Bauteile</translation>
     </message>
     <message>
         <location filename="../sources/ui/masterpropertieswidget.ui" line="32"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_masterpropertieswidget.h" line="117"/>
         <source>Éléments liés</source>
         <translation>Gebundene Bauteile</translation>
     </message>
@@ -4735,47 +8837,57 @@ Veuillez utiliser l&apos;éditeur avancé pour cela.</source>
     <name>MultiPasteDialog</name>
     <message>
         <location filename="../sources/ui/multipastedialog.ui" line="14"/>
+        <location filename="../build/qelectrotech_autogen/ui_multipastedialog.h" line="129"/>
         <source>Collage multiple</source>
         <translation>Mehrfach einfügen</translation>
     </message>
     <message>
         <location filename="../sources/ui/multipastedialog.ui" line="22"/>
+        <location filename="../build/qelectrotech_autogen/ui_multipastedialog.h" line="130"/>
         <source>Décalage</source>
         <translation>Versatz</translation>
     </message>
     <message>
         <location filename="../sources/ui/multipastedialog.ui" line="29"/>
         <location filename="../sources/ui/multipastedialog.ui" line="51"/>
+        <location filename="../build/qelectrotech_autogen/ui_multipastedialog.h" line="131"/>
+        <location filename="../build/qelectrotech_autogen/ui_multipastedialog.h" line="133"/>
         <source>px</source>
         <translation>px</translation>
     </message>
     <message>
         <location filename="../sources/ui/multipastedialog.ui" line="32"/>
+        <location filename="../build/qelectrotech_autogen/ui_multipastedialog.h" line="132"/>
         <source>x:  </source>
         <translation>x:  </translation>
     </message>
     <message>
         <location filename="../sources/ui/multipastedialog.ui" line="54"/>
+        <location filename="../build/qelectrotech_autogen/ui_multipastedialog.h" line="134"/>
         <source>y:  </source>
         <translation>y:  </translation>
     </message>
     <message>
         <location filename="../sources/ui/multipastedialog.ui" line="77"/>
+        <location filename="../build/qelectrotech_autogen/ui_multipastedialog.h" line="135"/>
         <source>Nombre de copie</source>
         <translation>Anzahl Kopien</translation>
     </message>
     <message>
         <location filename="../sources/ui/multipastedialog.ui" line="93"/>
+        <location filename="../build/qelectrotech_autogen/ui_multipastedialog.h" line="136"/>
         <source>Auto-connexion</source>
         <translation>Automatische Leiterverbindung</translation>
     </message>
     <message>
         <location filename="../sources/ui/multipastedialog.ui" line="100"/>
+        <location filename="../build/qelectrotech_autogen/ui_multipastedialog.h" line="137"/>
         <source>Auto-numérotation des éléments</source>
         <translation>Auto-Nummerierung der Bauteile</translation>
     </message>
     <message>
         <location filename="../sources/ui/multipastedialog.ui" line="107"/>
+        <location filename="../build/qelectrotech_autogen/ui_multipastedialog.h" line="138"/>
         <source>Auto-numérotation des conducteurs</source>
         <translation>Auto-Nummerierung der Leiter</translation>
     </message>
@@ -4789,6 +8901,7 @@ Veuillez utiliser l&apos;éditeur avancé pour cela.</source>
     <name>NameListDialog</name>
     <message>
         <location filename="../sources/NameList/ui/namelistdialog.ui" line="14"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_namelistdialog.h" line="59"/>
         <source>Dialog</source>
         <translation>Dialog</translation>
     </message>
@@ -4802,26 +8915,31 @@ Veuillez utiliser l&apos;éditeur avancé pour cela.</source>
     <name>NameListWidget</name>
     <message>
         <location filename="../sources/NameList/ui/namelistwidget.ui" line="14"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_namelistwidget.h" line="75"/>
         <source>Form</source>
         <translation>Form</translation>
     </message>
     <message>
         <location filename="../sources/NameList/ui/namelistwidget.ui" line="21"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_namelistwidget.h" line="78"/>
         <source>Langue</source>
         <translation>Sprache</translation>
     </message>
     <message>
         <location filename="../sources/NameList/ui/namelistwidget.ui" line="26"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_namelistwidget.h" line="77"/>
         <source>Texte</source>
         <translation>Text</translation>
     </message>
     <message>
         <location filename="../sources/NameList/ui/namelistwidget.ui" line="36"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_namelistwidget.h" line="79"/>
         <source>Ajouter une ligne</source>
         <translation>Zeile einfügen</translation>
     </message>
     <message>
         <location filename="../sources/NameList/ui/namelistwidget.ui" line="48"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_namelistwidget.h" line="80"/>
         <source>Copier dans le presse papier</source>
         <translation>In die Zwischenablage kopieren</translation>
     </message>
@@ -4956,6 +9074,7 @@ Veuillez utiliser l&apos;éditeur avancé pour cela.</source>
     <name>NumPartEditorW</name>
     <message>
         <location filename="../sources/autoNum/ui/numparteditorw.ui" line="14"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_numparteditorw.h" line="79"/>
         <source>Form</source>
         <translation>Formular</translation>
     </message>
@@ -5159,36 +9278,43 @@ Veuillez utiliser l&apos;éditeur avancé pour cela.</source>
     <name>PolygonEditor</name>
     <message>
         <location filename="../sources/editor/ui/polygoneditor.ui" line="14"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_polygoneditor.h" line="75"/>
         <source>Form</source>
         <translation>Form</translation>
     </message>
     <message>
         <location filename="../sources/editor/ui/polygoneditor.ui" line="31"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_polygoneditor.h" line="81"/>
         <source>X</source>
         <translation>X</translation>
     </message>
     <message>
         <location filename="../sources/editor/ui/polygoneditor.ui" line="36"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_polygoneditor.h" line="80"/>
         <source>Y</source>
         <translation>Y</translation>
     </message>
     <message>
         <location filename="../sources/editor/ui/polygoneditor.ui" line="44"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_polygoneditor.h" line="82"/>
         <source>Polygone fermé</source>
         <translation>Geschlossenes Polygon</translation>
     </message>
     <message>
         <location filename="../sources/editor/ui/polygoneditor.ui" line="55"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_polygoneditor.h" line="76"/>
         <source>Ajouter un point</source>
         <translation>Punkt einfügen</translation>
     </message>
     <message>
         <location filename="../sources/editor/ui/polygoneditor.ui" line="64"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_polygoneditor.h" line="77"/>
         <source>Supprimer ce point</source>
         <translation>Punkt löschen</translation>
     </message>
     <message>
         <location filename="../sources/editor/ui/polygoneditor.ui" line="20"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_polygoneditor.h" line="78"/>
         <source>Points du polygone :</source>
         <translation>Eckpunkte des Polygons:</translation>
     </message>
@@ -5225,11 +9351,13 @@ Veuillez utiliser l&apos;éditeur avancé pour cela.</source>
     <name>PotentialSelectorDialog</name>
     <message>
         <location filename="../sources/ui/potentialselectordialog.ui" line="14"/>
+        <location filename="../build/qelectrotech_autogen/ui_potentialselectordialog.h" line="66"/>
         <source>Sélectionner le potentiel éléctrique</source>
         <translation>Elektrisches Potenzial wählen</translation>
     </message>
     <message>
         <location filename="../sources/ui/potentialselectordialog.ui" line="38"/>
+        <location filename="../build/qelectrotech_autogen/ui_potentialselectordialog.h" line="67"/>
         <source>Vous tentez de lier deux potentiels différents ensemble.
 Veuillez choisir les propriétées à appliquer au nouveau potentiel.</source>
         <translation>Sie versuchen, zwei verschiedene Potenziale zu verbinden.
@@ -5406,16 +9534,19 @@ Folgende Variablen sind inkompatibel:
     <name>ProjectDBModelPropertiesWidget</name>
     <message>
         <location filename="../sources/qetgraphicsitem/ViewItem/ui/projectdbmodelpropertieswidget.ui" line="14"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_projectdbmodelpropertieswidget.h" line="65"/>
         <source>Form</source>
         <translation>Formular</translation>
     </message>
     <message>
         <location filename="../sources/qetgraphicsitem/ViewItem/ui/projectdbmodelpropertieswidget.ui" line="20"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_projectdbmodelpropertieswidget.h" line="66"/>
         <source>Requête</source>
         <translation>Datenauswahl ändern</translation>
     </message>
     <message>
         <location filename="../sources/qetgraphicsitem/ViewItem/ui/projectdbmodelpropertieswidget.ui" line="31"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_projectdbmodelpropertieswidget.h" line="67"/>
         <source>Recharger</source>
         <translation>Daten neu laden</translation>
     </message>
@@ -5451,161 +9582,193 @@ Folgende Variablen sind inkompatibel:
     <name>ProjectPrintWindow</name>
     <message>
         <location filename="../sources/print/projectprintwindow.ui" line="20"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_projectprintwindow.h" line="346"/>
         <source>MainWindow</source>
         <translation>Druckoptionen</translation>
     </message>
     <message>
         <location filename="../sources/print/projectprintwindow.ui" line="31"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_projectprintwindow.h" line="361"/>
         <source>Folios à imprimer :</source>
         <translation>Zu druckende Folien:</translation>
     </message>
     <message>
         <location filename="../sources/print/projectprintwindow.ui" line="70"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_projectprintwindow.h" line="362"/>
         <source>Tout cocher</source>
         <translation>Alles auswählen</translation>
     </message>
     <message>
         <location filename="../sources/print/projectprintwindow.ui" line="77"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_projectprintwindow.h" line="363"/>
         <source>Tout décocher</source>
         <translation>Auswahl aufheben</translation>
     </message>
     <message>
         <location filename="../sources/print/projectprintwindow.ui" line="103"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_projectprintwindow.h" line="364"/>
         <source>Toutes les dates</source>
         <translation>Alle Daten</translation>
     </message>
     <message>
         <location filename="../sources/print/projectprintwindow.ui" line="108"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_projectprintwindow.h" line="365"/>
         <source>À partir de la date du :</source>
         <translation>Ab Datum:</translation>
     </message>
     <message>
         <location filename="../sources/print/projectprintwindow.ui" line="113"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_projectprintwindow.h" line="366"/>
         <source>À la date du  :</source>
         <translation>Mit Datum vom:</translation>
     </message>
     <message>
         <location filename="../sources/print/projectprintwindow.ui" line="155"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_projectprintwindow.h" line="369"/>
         <source>Option de rendu</source>
         <translation>Renderoptionen</translation>
     </message>
     <message>
         <location filename="../sources/print/projectprintwindow.ui" line="161"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_projectprintwindow.h" line="370"/>
         <source>Dessiner le cadre</source>
         <translation>Zeichnungsrahmen anzeigen</translation>
     </message>
     <message>
         <location filename="../sources/print/projectprintwindow.ui" line="168"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_projectprintwindow.h" line="371"/>
         <source>Dessiner le cartouche</source>
         <translation>Schriftfeld anzeigen</translation>
     </message>
     <message>
         <location filename="../sources/print/projectprintwindow.ui" line="175"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_projectprintwindow.h" line="372"/>
         <source>Conserver les couleurs des conducteurs</source>
         <translation>Leiterfarben erhalten</translation>
     </message>
     <message>
         <location filename="../sources/print/projectprintwindow.ui" line="182"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_projectprintwindow.h" line="373"/>
         <source>Dessiner les bornes</source>
         <translation>Anschlüsse zeichnen</translation>
     </message>
     <message>
         <location filename="../sources/print/projectprintwindow.ui" line="192"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_projectprintwindow.h" line="374"/>
         <source>Option d&apos;impression</source>
         <translation>Druckoptionen</translation>
     </message>
     <message>
         <location filename="../sources/print/projectprintwindow.ui" line="198"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_projectprintwindow.h" line="375"/>
         <source>Adapter le folio à la page</source>
         <translation>Folie an Seitengröße anpassen</translation>
     </message>
     <message>
         <location filename="../sources/print/projectprintwindow.ui" line="208"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_projectprintwindow.h" line="376"/>
         <source>Utiliser toute la feuille</source>
         <translation>Gesamte Blattfläche verwenden</translation>
     </message>
     <message>
         <location filename="../sources/print/projectprintwindow.ui" line="215"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_projectprintwindow.h" line="377"/>
         <source>Si cette option est cochée, le folio sera agrandi ou rétréci de façon à remplir toute la surface imprimable d&apos;une et une seule page.&quot;</source>
         <translation>Wenn diese Option aktiviert ist, wird das Folio vergrößert oder verkleinert, um den gesamten druckbaren Bereich einer einzigen Seite auszufüllen.&quot;</translation>
     </message>
     <message>
         <location filename="../sources/print/projectprintwindow.ui" line="225"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_projectprintwindow.h" line="378"/>
         <source>Si cette option est cochée, les marges de la feuille seront  ignorées et toute sa surface sera utilisée pour l&apos;impression.  Cela peut ne pas être supporté par votre imprimante.</source>
         <translation>Wenn diese Option aktiviert ist, werden die Seitenränder ignoriert und das gesamte Blatt zum Drucken verwendet. Dies wird von Ihrem Drucker möglicherweise nicht unterstützt.</translation>
     </message>
     <message>
         <location filename="../sources/print/projectprintwindow.ui" line="259"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_projectprintwindow.h" line="379"/>
         <source>toolBar</source>
         <translation>Werkzeugleiste Druckoptionen</translation>
     </message>
     <message>
         <location filename="../sources/print/projectprintwindow.ui" line="292"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_projectprintwindow.h" line="347"/>
         <source>Ajuster la largeur</source>
         <translation>Auf Seitenbreite anpassen</translation>
     </message>
     <message>
         <location filename="../sources/print/projectprintwindow.ui" line="301"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_projectprintwindow.h" line="348"/>
         <source>Ajuster la page</source>
         <translation>Auf ganze Seite anpassen</translation>
     </message>
     <message>
         <location filename="../sources/print/projectprintwindow.ui" line="310"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_projectprintwindow.h" line="349"/>
         <source>Zoom arrière</source>
         <translation>Verkleinern</translation>
     </message>
     <message>
         <location filename="../sources/print/projectprintwindow.ui" line="319"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_projectprintwindow.h" line="350"/>
         <source>Zoom avant</source>
         <translation>Vergrößern</translation>
     </message>
     <message>
         <location filename="../sources/print/projectprintwindow.ui" line="328"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_projectprintwindow.h" line="351"/>
         <source>Paysage</source>
         <translation>Querformat</translation>
     </message>
     <message>
         <location filename="../sources/print/projectprintwindow.ui" line="337"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_projectprintwindow.h" line="352"/>
         <source>Portrait</source>
         <translation>Hochformat</translation>
     </message>
     <message>
         <location filename="../sources/print/projectprintwindow.ui" line="346"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_projectprintwindow.h" line="353"/>
         <source>Première page</source>
         <translation>Erste Seite</translation>
     </message>
     <message>
         <location filename="../sources/print/projectprintwindow.ui" line="355"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_projectprintwindow.h" line="354"/>
         <source>Page précédente</source>
         <translation>Vorherige Seite</translation>
     </message>
     <message>
         <location filename="../sources/print/projectprintwindow.ui" line="364"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_projectprintwindow.h" line="355"/>
         <source>Page suivante</source>
         <translation>Nächste Seite</translation>
     </message>
     <message>
         <location filename="../sources/print/projectprintwindow.ui" line="373"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_projectprintwindow.h" line="356"/>
         <source>Dernière page</source>
         <translation>Letzte Seite</translation>
     </message>
     <message>
         <location filename="../sources/print/projectprintwindow.ui" line="382"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_projectprintwindow.h" line="357"/>
         <source>Afficher une seule page</source>
         <translation>Einzelseite anzeigen</translation>
     </message>
     <message>
         <location filename="../sources/print/projectprintwindow.ui" line="391"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_projectprintwindow.h" line="358"/>
         <source>Afficher deux pages</source>
         <translation>Zwei Seiten anzeigen</translation>
     </message>
     <message>
         <location filename="../sources/print/projectprintwindow.ui" line="400"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_projectprintwindow.h" line="359"/>
         <source>Afficher un aperçu de toutes les pages</source>
         <translation>Alle Seiten anzeigen</translation>
     </message>
     <message>
         <location filename="../sources/print/projectprintwindow.ui" line="409"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_projectprintwindow.h" line="360"/>
         <source>mise en page</source>
         <translation>Seite einrichten</translation>
     </message>
@@ -5693,7 +9856,7 @@ Voulez-vous enregistrer les modifications ?</source>
         <location filename="../sources/projectview.cpp" line="386"/>
         <source>Êtes-vous sûr de vouloir supprimer ce folio du projet ? Ce changement est irréversible.</source>
         <comment>message box content</comment>
-        <translation type="unfinished"></translation>
+        <translation>Möchten Sie diese Seite wirklich aus dem Projekt löschen? Diese Änderung kann nicht rückgängig gemacht werden.</translation>
     </message>
     <message>
         <location filename="../sources/projectview.cpp" line="714"/>
@@ -5775,6 +9938,7 @@ Voulez-vous enregistrer les modifications ?</source>
     <name>PropertiesEditorDockWidget</name>
     <message>
         <location filename="../sources/PropertiesEditor/propertieseditordockwidget.ui" line="14"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_propertieseditordockwidget.h" line="52"/>
         <source>Propriétés de la sélection</source>
         <translation>Auswahleigenschaften</translation>
     </message>
@@ -6938,17 +11102,17 @@ Entfernen Sie die Überbrückung und/oder löschen Sie die Ebenen der betroffene
     <message>
         <location filename="../sources/qetdiagrameditor.cpp" line="2211"/>
         <source>Êtes-vous sûr de vouloir supprimer ce folio ?</source>
-        <translation type="unfinished"></translation>
+        <translation>Möchten Sie diese Seite wirklich löschen?</translation>
     </message>
     <message>
         <location filename="../sources/qetdiagrameditor.cpp" line="2216"/>
         <source>Supprimer les folios</source>
-        <translation type="unfinished"></translation>
+        <translation>Seiten löschen</translation>
     </message>
     <message>
         <location filename="../sources/qetdiagrameditor.cpp" line="2217"/>
         <source>Êtes-vous sûr de vouloir supprimer les %1 folios sélectionnés ?</source>
-        <translation type="unfinished"></translation>
+        <translation>Möchten Sie die ausgewählten %1 Seiten wirklich löschen?</translation>
     </message>
     <message>
         <location filename="../sources/qetdiagrameditor.cpp" line="2428"/>
@@ -6961,246 +11125,295 @@ Entfernen Sie die Überbrückung und/oder löschen Sie die Ebenen der betroffene
     <name>QETElementEditor</name>
     <message>
         <location filename="../sources/editor/ui/qetelementeditor.ui" line="217"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_qetelementeditor.h" line="386"/>
         <source>&amp;Nouveau</source>
         <translation>&amp;Neu</translation>
     </message>
     <message>
         <location filename="../sources/editor/ui/qetelementeditor.ui" line="226"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_qetelementeditor.h" line="387"/>
         <source>&amp;Ouvrir</source>
         <translation>&amp;Öffnen</translation>
     </message>
     <message>
         <location filename="../sources/editor/ui/qetelementeditor.ui" line="235"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_qetelementeditor.h" line="388"/>
         <source>&amp;Ouvrir depuis un fichier</source>
         <translation>Aus &amp;Datei öffnen</translation>
     </message>
     <message>
         <location filename="../sources/editor/ui/qetelementeditor.ui" line="244"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_qetelementeditor.h" line="389"/>
         <source>&amp;Enregistrer</source>
         <translation>&amp;Speichern</translation>
     </message>
     <message>
         <location filename="../sources/editor/ui/qetelementeditor.ui" line="253"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_qetelementeditor.h" line="390"/>
         <source>Enregistrer sous</source>
         <translation>Speichern &amp;unter</translation>
     </message>
     <message>
         <location filename="../sources/editor/ui/qetelementeditor.ui" line="262"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_qetelementeditor.h" line="391"/>
         <source>Enregistrer dans un fichier</source>
         <translation>In einer Datei speichern</translation>
     </message>
     <message>
         <location filename="../sources/editor/ui/qetelementeditor.ui" line="271"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_qetelementeditor.h" line="392"/>
         <source>Recharger</source>
         <translation>Neu laden</translation>
     </message>
     <message>
         <location filename="../sources/editor/ui/qetelementeditor.ui" line="208"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_qetelementeditor.h" line="385"/>
         <source>Tout sélectionner</source>
         <translation>Alles auswählen</translation>
     </message>
     <message>
         <location filename="../sources/editor/ui/qetelementeditor.ui" line="14"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_qetelementeditor.h" line="384"/>
         <source>QElectroTech - Éditeur d&apos;élément</source>
         <translation>QElectroTech - Bauteileditor</translation>
     </message>
     <message>
         <location filename="../sources/editor/ui/qetelementeditor.ui" line="96"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_qetelementeditor.h" line="443"/>
         <source>&amp;Aide</source>
         <translation>&amp;Hilfe</translation>
     </message>
     <message>
         <location filename="../sources/editor/ui/qetelementeditor.ui" line="115"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_qetelementeditor.h" line="444"/>
         <source>Annulations</source>
         <translation>Arbeitsschritte</translation>
     </message>
     <message>
         <location filename="../sources/editor/ui/qetelementeditor.ui" line="127"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_qetelementeditor.h" line="445"/>
         <source>Parties</source>
         <translation>Bestandteile</translation>
     </message>
     <message>
         <location filename="../sources/editor/ui/qetelementeditor.ui" line="139"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_qetelementeditor.h" line="446"/>
         <source>Informations</source>
         <translation>Informationen</translation>
     </message>
     <message>
         <location filename="../sources/editor/ui/qetelementeditor.ui" line="148"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_qetelementeditor.h" line="447"/>
         <source>Outils</source>
         <translation>Werkzeuge</translation>
     </message>
     <message>
         <location filename="../sources/editor/ui/qetelementeditor.ui" line="165"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_qetelementeditor.h" line="448"/>
         <source>Affichage</source>
         <translation>Anzeige</translation>
     </message>
     <message>
         <location filename="../sources/editor/ui/qetelementeditor.ui" line="180"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_qetelementeditor.h" line="449"/>
         <source>Élément</source>
         <translation>Bauteil</translation>
     </message>
     <message>
         <location filename="../sources/editor/ui/qetelementeditor.ui" line="193"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_qetelementeditor.h" line="450"/>
         <source>Annulation</source>
         <translation>Rückgängig</translation>
     </message>
     <message>
         <location filename="../sources/editor/ui/qetelementeditor.ui" line="280"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_qetelementeditor.h" line="393"/>
         <source>&amp;Fermer cet éditeur</source>
         <translation>&amp;Editor schließen</translation>
     </message>
     <message>
         <location filename="../sources/editor/ui/qetelementeditor.ui" line="283"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_qetelementeditor.h" line="395"/>
         <source>Fermer cet éditeur</source>
         <translation>Editor schließen</translation>
     </message>
     <message>
         <location filename="../sources/editor/ui/qetelementeditor.ui" line="292"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_qetelementeditor.h" line="397"/>
         <source>Désélectionner tout</source>
         <translation>Auswahl aufheben</translation>
     </message>
     <message>
         <location filename="../sources/editor/ui/qetelementeditor.ui" line="301"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_qetelementeditor.h" line="398"/>
         <source>Co&amp;uper</source>
         <translation>&amp;Ausschneiden</translation>
     </message>
     <message>
         <location filename="../sources/editor/ui/qetelementeditor.ui" line="310"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_qetelementeditor.h" line="399"/>
         <source>Cop&amp;ier</source>
         <translation>Kop&amp;ieren</translation>
     </message>
     <message>
         <location filename="../sources/editor/ui/qetelementeditor.ui" line="319"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_qetelementeditor.h" line="400"/>
         <source>C&amp;oller</source>
         <translation>E&amp;infügen</translation>
     </message>
     <message>
         <location filename="../sources/editor/ui/qetelementeditor.ui" line="328"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_qetelementeditor.h" line="401"/>
         <source>C&amp;oller dans la zone</source>
         <translation>In einen Bereich einfügen... </translation>
     </message>
     <message>
         <location filename="../sources/editor/ui/qetelementeditor.ui" line="337"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_qetelementeditor.h" line="402"/>
         <source>Un fichier</source>
         <translation>einer Datei</translation>
     </message>
     <message>
         <location filename="../sources/editor/ui/qetelementeditor.ui" line="346"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_qetelementeditor.h" line="403"/>
         <source>Un élément</source>
         <translation>einem Bauteil</translation>
     </message>
     <message>
         <location filename="../sources/editor/ui/qetelementeditor.ui" line="436"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_qetelementeditor.h" line="413"/>
         <source>À &amp;propos de QElectroTech</source>
         <translation>Ü&amp;ber QElectroTech</translation>
     </message>
     <message>
         <location filename="../sources/editor/ui/qetelementeditor.ui" line="439"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_qetelementeditor.h" line="415"/>
         <source>Affiche des informations sur QElectroTech</source>
         <translation>Informationen zu QElectroTech anzeigen</translation>
     </message>
     <message>
         <location filename="../sources/editor/ui/qetelementeditor.ui" line="448"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_qetelementeditor.h" line="417"/>
         <source>Manuel en ligne</source>
         <translation>Online-Dokumentation (englisch)</translation>
     </message>
     <message>
         <location filename="../sources/editor/ui/qetelementeditor.ui" line="451"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_qetelementeditor.h" line="419"/>
         <source>Lance le navigateur par défaut vers le manuel en ligne de QElectroTech</source>
         <translation>Online-Dokumentation von QElectroTech im Standard Webbrowser öffnen</translation>
     </message>
     <message>
         <location filename="../sources/editor/ui/qetelementeditor.ui" line="460"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_qetelementeditor.h" line="421"/>
         <source>Chaine Youtube</source>
         <translation>Youtube-Kanal</translation>
     </message>
     <message>
         <location filename="../sources/editor/ui/qetelementeditor.ui" line="463"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_qetelementeditor.h" line="423"/>
         <source>Lance le navigateur par défaut vers la chaine Youtube de QElectroTech</source>
         <translation>Den Youtube-Kanal von QElectroTech im Standard Webbrowser öffnen</translation>
     </message>
     <message>
         <location filename="../sources/editor/ui/qetelementeditor.ui" line="472"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_qetelementeditor.h" line="425"/>
         <source>Soutenir le projet par un don</source>
         <translation>QElectroTech durch eine Spende unterstützen</translation>
     </message>
     <message>
         <location filename="../sources/editor/ui/qetelementeditor.ui" line="475"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_qetelementeditor.h" line="427"/>
         <source>Soutenir le projet QElectroTech par un don</source>
         <translation>Das QElectroTech-Projekt durch eine Spende unterstützen</translation>
     </message>
     <message>
         <location filename="../sources/editor/ui/qetelementeditor.ui" line="484"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_qetelementeditor.h" line="429"/>
         <source>À propos de &amp;Qt</source>
         <translation>Über &amp;Qt</translation>
     </message>
     <message>
         <location filename="../sources/editor/ui/qetelementeditor.ui" line="487"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_qetelementeditor.h" line="431"/>
         <source>Affiche des informations sur la bibliothèque Qt</source>
         <translation>Informationen zur Qt-Bibliothek anzeigen</translation>
     </message>
     <message>
         <location filename="../sources/editor/ui/qetelementeditor.ui" line="496"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_qetelementeditor.h" line="433"/>
         <source>Rotation</source>
         <translation>Drehen</translation>
     </message>
     <message>
         <location filename="../sources/editor/ui/qetelementeditor.ui" line="505"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_qetelementeditor.h" line="434"/>
         <source>Fine-Rotation</source>
         <translation>Fein drehen</translation>
     </message>
     <message>
         <location filename="../sources/editor/ui/qetelementeditor.ui" line="514"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_qetelementeditor.h" line="435"/>
         <source>Mirror</source>
         <translation>Spiegeln</translation>
     </message>
     <message>
         <location filename="../sources/editor/ui/qetelementeditor.ui" line="523"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_qetelementeditor.h" line="436"/>
         <source>Flip</source>
         <translation>Umdrehen</translation>
     </message>
     <message>
         <location filename="../sources/editor/ui/qetelementeditor.ui" line="532"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_qetelementeditor.h" line="437"/>
         <source>Importer un dxf</source>
         <translation>DXF &amp;importieren</translation>
     </message>
     <message>
         <location filename="../sources/editor/ui/qetelementeditor.ui" line="541"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_qetelementeditor.h" line="438"/>
         <source>importer un élément à redimensionner</source>
         <translation>Importiere skaliertes Element</translation>
     </message>
     <message>
         <location filename="../sources/editor/ui/qetelementeditor.ui" line="355"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_qetelementeditor.h" line="404"/>
         <source>Inverser la sélection</source>
         <translation>Auswahl umkehren</translation>
     </message>
     <message>
         <location filename="../sources/editor/ui/qetelementeditor.ui" line="364"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_qetelementeditor.h" line="405"/>
         <source>&amp;Supprimer</source>
         <translation>&amp;Löschen</translation>
     </message>
     <message>
         <location filename="../sources/editor/ui/qetelementeditor.ui" line="400"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_qetelementeditor.h" line="409"/>
         <source>Zoom avant</source>
         <translation>Vergrößern</translation>
     </message>
     <message>
         <location filename="../sources/editor/ui/qetelementeditor.ui" line="409"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_qetelementeditor.h" line="410"/>
         <source>Zoom arrière</source>
         <translation>Verkleinern</translation>
     </message>
     <message>
         <location filename="../sources/editor/ui/qetelementeditor.ui" line="418"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_qetelementeditor.h" line="411"/>
         <source>Zoom adapté</source>
         <translation>Folie einpassen</translation>
     </message>
     <message>
         <location filename="../sources/editor/ui/qetelementeditor.ui" line="427"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_qetelementeditor.h" line="412"/>
         <source>Pas de zoom</source>
         <translation>Kein Zoom</translation>
     </message>
     <message>
         <location filename="../sources/editor/ui/qetelementeditor.ui" line="382"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_qetelementeditor.h" line="407"/>
         <source>Éditer les informations sur l&apos;auteur</source>
         <translation>Informationen über Autoren bearbeiten</translation>
     </message>
@@ -7285,11 +11498,13 @@ veuillez patienter durant l&apos;import...</source>
     </message>
     <message>
         <location filename="../sources/editor/ui/qetelementeditor.ui" line="373"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_qetelementeditor.h" line="406"/>
         <source>Éditer le nom et les traductions de l&apos;élément</source>
         <translation>Bauteilname und Übersetzungen bearbeiten</translation>
     </message>
     <message>
         <location filename="../sources/editor/ui/qetelementeditor.ui" line="391"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_qetelementeditor.h" line="408"/>
         <source>Éditer les propriétés de l&apos;élément</source>
         <translation>Bauteileigenschaften bearbeiten</translation>
     </message>
@@ -7300,21 +11515,25 @@ veuillez patienter durant l&apos;import...</source>
     </message>
     <message>
         <location filename="../sources/editor/ui/qetelementeditor.ui" line="33"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_qetelementeditor.h" line="439"/>
         <source>&amp;Fichier</source>
         <translation>&amp;Datei</translation>
     </message>
     <message>
         <location filename="../sources/editor/ui/qetelementeditor.ui" line="50"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_qetelementeditor.h" line="440"/>
         <source>&amp;Édition</source>
         <translation>&amp;Bearbeiten</translation>
     </message>
     <message>
         <location filename="../sources/editor/ui/qetelementeditor.ui" line="86"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_qetelementeditor.h" line="442"/>
         <source>Afficha&amp;ge</source>
         <translation>&amp;Anzeige</translation>
     </message>
     <message>
         <location filename="../sources/editor/ui/qetelementeditor.ui" line="54"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_qetelementeditor.h" line="441"/>
         <source>Coller depuis...</source>
         <translation>Einfügen aus...</translation>
     </message>
@@ -7486,12 +11705,12 @@ veuillez patienter durant l&apos;import...</source>
     <message>
         <location filename="../sources/editor/ui/qetelementeditor.cpp" line="788"/>
         <source>Nombre de bornes incorrect</source>
-        <translation type="unfinished"></translation>
+        <translation>Falsche Anzahl von Anschlüssen</translation>
     </message>
     <message>
         <location filename="../sources/editor/ui/qetelementeditor.cpp" line="789"/>
         <source>&lt;br&gt;&lt;b&gt;Erreur&lt;/b&gt; :&lt;br&gt;Les définitions de conducteur ne peuvent posséder qu&apos;une seule borne.&lt;br&gt;&lt;b&gt;Solution&lt;/b&gt; :&lt;br&gt;Vérifier que l&apos;élément ne possède qu&apos;une seule borne</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;br&gt;&lt;b&gt;Fehler&lt;/b&gt;:&lt;br&gt;Leiterdefinitionen dürfen nur einen Anschluss haben.&lt;br&gt;&lt;b&gt;Lösung&lt;/b&gt;:&lt;br&gt;Stellen Sie sicher, dass das Element nur einen Anschluss hat</translation>
     </message>
     <message numerus="yes">
         <location filename="../sources/editor/ui/qetelementeditor.cpp" line="811"/>
@@ -9405,15 +13624,15 @@ Möchten Sie sie ersetzen?</translation>
         <translation>Einfügen</translation>
     </message>
     <message>
+        <location filename="../sources/conductorproperties.cpp" line="826"/>
         <location filename="../sources/ElementsCollection/elementslocation.cpp" line="401"/>
+        <location filename="../sources/factory/elementpicturefactory.cpp" line="582"/>
+        <location filename="../sources/qetapp.cpp" line="2379"/>
         <location filename="../sources/SearchAndReplace/searchandreplaceworker.cpp" line="351"/>
         <location filename="../sources/SearchAndReplace/searchandreplaceworker.cpp" line="474"/>
         <location filename="../sources/SearchAndReplace/searchandreplaceworker.cpp" line="509"/>
         <location filename="../sources/SearchAndReplace/searchandreplaceworker.cpp" line="538"/>
         <location filename="../sources/SearchAndReplace/ui/searchandreplacewidget.cpp" line="425"/>
-        <location filename="../sources/conductorproperties.cpp" line="826"/>
-        <location filename="../sources/factory/elementpicturefactory.cpp" line="582"/>
-        <location filename="../sources/qetapp.cpp" line="2379"/>
         <location filename="../sources/titleblock/templatelocation.cpp" line="108"/>
         <source>this is an error in the code</source>
         <translation>dies ist ein Programmfehler</translation>
@@ -9706,6 +13925,27 @@ Bitte laden Sie diese über den Link herunter und entpacken Sie sie in den Insta
         <source>Automatic terminal numbering</source>
         <translation>Automatische Klemmennummerierung</translation>
     </message>
+    <message>
+        <location filename="../build/_deps/kcoreaddons-src/src/lib/util/klistopenfilesjob_unix.cpp" line="37"/>
+        <source>Path %1 doesn&apos;t exist</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kcoreaddons-src/src/lib/util/klistopenfilesjob_unix.cpp" line="50"/>
+        <source>Failed to execute `lsof&apos; error code %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kcoreaddons-src/src/lib/util/klistopenfilesjob_win.cpp" line="27"/>
+        <source>KListOpenFilesJob is not supported on Windows</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/src/kpasswordlineedit.cpp" line="42"/>
+        <source>Change the visibility of the password</source>
+        <comment>@info:tooltip</comment>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>QTextOrientationWidget</name>
@@ -9806,37 +14046,45 @@ Bitte fügen Sie eine neue Tabelle hinzu oder passen Sie die vorhandene Tabelle 
     <name>RectangleEditor</name>
     <message>
         <location filename="../sources/editor/ui/rectangleeditor.ui" line="42"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_rectangleeditor.h" line="156"/>
         <source>Dimensions :</source>
         <translation>Maße:</translation>
     </message>
     <message>
         <location filename="../sources/editor/ui/rectangleeditor.ui" line="49"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_rectangleeditor.h" line="157"/>
         <source>y</source>
         <translation>y</translation>
     </message>
     <message>
         <location filename="../sources/editor/ui/rectangleeditor.ui" line="86"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_rectangleeditor.h" line="158"/>
         <source>Coin supérieur gauche :</source>
         <translation>Obere linke Ecke:</translation>
     </message>
     <message>
         <location filename="../sources/editor/ui/rectangleeditor.ui" line="93"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_rectangleeditor.h" line="159"/>
         <source>Largeur :</source>
         <translation>Breite:</translation>
     </message>
     <message>
         <location filename="../sources/editor/ui/rectangleeditor.ui" line="103"/>
         <location filename="../sources/editor/ui/rectangleeditor.ui" line="133"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_rectangleeditor.h" line="160"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_rectangleeditor.h" line="162"/>
         <source>Arrondi :</source>
         <translation>Rundung:</translation>
     </message>
     <message>
         <location filename="../sources/editor/ui/rectangleeditor.ui" line="113"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_rectangleeditor.h" line="161"/>
         <source>x</source>
         <translation>x</translation>
     </message>
     <message>
         <location filename="../sources/editor/ui/rectangleeditor.ui" line="32"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_rectangleeditor.h" line="155"/>
         <source>Hauteur :</source>
         <translation>Höhe:</translation>
     </message>
@@ -9850,31 +14098,37 @@ Bitte fügen Sie eine neue Tabelle hinzu oder passen Sie die vorhandene Tabelle 
     <name>RenameDialog</name>
     <message>
         <location filename="../sources/ElementsCollection/ui/renamedialog.ui" line="14"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_renamedialog.h" line="79"/>
         <source>Dialog</source>
         <translation>Dialog</translation>
     </message>
     <message>
         <location filename="../sources/ElementsCollection/ui/renamedialog.ui" line="20"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_renamedialog.h" line="80"/>
         <source>Nouveau nom :</source>
         <translation>Neuer Name:</translation>
     </message>
     <message>
         <location filename="../sources/ElementsCollection/ui/renamedialog.ui" line="30"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_renamedialog.h" line="81"/>
         <source>Écraser</source>
         <translation>Überschreiben</translation>
     </message>
     <message>
         <location filename="../sources/ElementsCollection/ui/renamedialog.ui" line="37"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_renamedialog.h" line="82"/>
         <source>Renommer</source>
         <translation>Umbenennen</translation>
     </message>
     <message>
         <location filename="../sources/ElementsCollection/ui/renamedialog.ui" line="44"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_renamedialog.h" line="83"/>
         <source>Annuler</source>
         <translation>Abbrechen</translation>
     </message>
     <message>
         <location filename="../sources/ElementsCollection/ui/renamedialog.ui" line="54"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_renamedialog.h" line="84"/>
         <source>TextLabel</source>
         <translation>TextLabel</translation>
     </message>
@@ -9888,11 +14142,13 @@ Bitte fügen Sie eine neue Tabelle hinzu oder passen Sie die vorhandene Tabelle 
     <name>ReplaceConductorDialog</name>
     <message>
         <location filename="../sources/SearchAndReplace/ui/replaceconductordialog.ui" line="21"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_replaceconductordialog.h" line="560"/>
         <source>Type</source>
         <translation>Typ</translation>
     </message>
     <message>
         <location filename="../sources/SearchAndReplace/ui/replaceconductordialog.ui" line="30"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_replaceconductordialog.h" line="482"/>
         <source>&amp;Multifilaire</source>
         <translation>&amp;Mehrpolig</translation>
     </message>
@@ -9909,27 +14165,43 @@ Bitte fügen Sie eine neue Tabelle hinzu oder passen Sie die vorhandene Tabelle 
         <location filename="../sources/SearchAndReplace/ui/replaceconductordialog.ui" line="288"/>
         <location filename="../sources/SearchAndReplace/ui/replaceconductordialog.ui" line="571"/>
         <location filename="../sources/SearchAndReplace/ui/replaceconductordialog.ui" line="590"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_replaceconductordialog.h" line="483"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_replaceconductordialog.h" line="485"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_replaceconductordialog.h" line="489"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_replaceconductordialog.h" line="497"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_replaceconductordialog.h" line="504"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_replaceconductordialog.h" line="512"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_replaceconductordialog.h" line="513"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_replaceconductordialog.h" line="520"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_replaceconductordialog.h" line="522"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_replaceconductordialog.h" line="529"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_replaceconductordialog.h" line="577"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_replaceconductordialog.h" line="579"/>
         <location filename="../sources/SearchAndReplace/ui/replaceconductordialog.cpp" line="203"/>
         <source>Ne pas modifier</source>
         <translation>Nicht verändern</translation>
     </message>
     <message>
         <location filename="../sources/SearchAndReplace/ui/replaceconductordialog.ui" line="156"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_replaceconductordialog.h" line="505"/>
         <source>En haut</source>
         <translation>Oberhalb</translation>
     </message>
     <message>
         <location filename="../sources/SearchAndReplace/ui/replaceconductordialog.ui" line="161"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_replaceconductordialog.h" line="506"/>
         <source>En bas</source>
         <translation>Unterhalb</translation>
     </message>
     <message>
         <location filename="../sources/SearchAndReplace/ui/replaceconductordialog.ui" line="298"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_replaceconductordialog.h" line="530"/>
         <source>Texte sur conducteur horizontal :</source>
         <translation>Text auf waagerechtem Leiter:</translation>
     </message>
     <message>
         <location filename="../sources/SearchAndReplace/ui/replaceconductordialog.ui" line="305"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_replaceconductordialog.h" line="531"/>
         <source>Tension / protocol :</source>
         <translation>Spannung / Protokoll:</translation>
     </message>
@@ -9938,171 +14210,212 @@ Bitte fügen Sie eine neue Tabelle hinzu oder passen Sie die vorhandene Tabelle 
         <location filename="../sources/SearchAndReplace/ui/replaceconductordialog.ui" line="140"/>
         <location filename="../sources/SearchAndReplace/ui/replaceconductordialog.ui" line="169"/>
         <location filename="../sources/SearchAndReplace/ui/replaceconductordialog.ui" line="218"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_replaceconductordialog.h" line="494"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_replaceconductordialog.h" line="501"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_replaceconductordialog.h" line="509"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_replaceconductordialog.h" line="517"/>
         <source>Supprimer ce texte</source>
         <translation>Diesen Text löschen</translation>
     </message>
     <message>
         <location filename="../sources/SearchAndReplace/ui/replaceconductordialog.ui" line="261"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_replaceconductordialog.h" line="523"/>
         <source>Fonction :</source>
         <translation>Funktion:</translation>
     </message>
     <message>
         <location filename="../sources/SearchAndReplace/ui/replaceconductordialog.ui" line="211"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_replaceconductordialog.h" line="515"/>
         <source>Formule du texte :</source>
         <translation>Textformel:</translation>
     </message>
     <message>
         <location filename="../sources/SearchAndReplace/ui/replaceconductordialog.ui" line="278"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_replaceconductordialog.h" line="526"/>
         <source>Texte visible</source>
         <translation>Sichtbarer Text</translation>
     </message>
     <message>
         <location filename="../sources/SearchAndReplace/ui/replaceconductordialog.ui" line="81"/>
         <location filename="../sources/SearchAndReplace/ui/replaceconductordialog.ui" line="268"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_replaceconductordialog.h" line="490"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_replaceconductordialog.h" line="524"/>
         <source>Angle :</source>
         <translation>Winkel:</translation>
     </message>
     <message>
         <location filename="../sources/SearchAndReplace/ui/replaceconductordialog.ui" line="238"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_replaceconductordialog.h" line="521"/>
         <source>Texte sur conducteur vertical :</source>
         <translation>Text auf senkrechtem Leiter:</translation>
     </message>
     <message>
         <location filename="../sources/SearchAndReplace/ui/replaceconductordialog.ui" line="52"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_replaceconductordialog.h" line="484"/>
         <source>Taille du texte :</source>
         <translation>Textgröße:</translation>
     </message>
     <message>
         <location filename="../sources/SearchAndReplace/ui/replaceconductordialog.ui" line="98"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_replaceconductordialog.h" line="492"/>
         <source>Texte :</source>
         <translation>Text:</translation>
     </message>
     <message>
         <location filename="../sources/SearchAndReplace/ui/replaceconductordialog.ui" line="68"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_replaceconductordialog.h" line="486"/>
         <source>À gauche</source>
         <translation>Links</translation>
     </message>
     <message>
         <location filename="../sources/SearchAndReplace/ui/replaceconductordialog.ui" line="73"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_replaceconductordialog.h" line="487"/>
         <source>À droite</source>
         <translation>Rechts</translation>
     </message>
     <message>
         <location filename="../sources/SearchAndReplace/ui/replaceconductordialog.ui" line="91"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_replaceconductordialog.h" line="491"/>
         <source>Couleur du conducteur</source>
         <translation>Leiterfarbe:</translation>
     </message>
     <message>
         <location filename="../sources/SearchAndReplace/ui/replaceconductordialog.ui" line="121"/>
         <location filename="../sources/SearchAndReplace/ui/replaceconductordialog.ui" line="195"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_replaceconductordialog.h" line="498"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_replaceconductordialog.h" line="514"/>
         <source>°</source>
         <translation>°</translation>
     </message>
     <message>
         <location filename="../sources/SearchAndReplace/ui/replaceconductordialog.ui" line="312"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_replaceconductordialog.h" line="532"/>
         <source>Section du conducteur</source>
         <translation>Leiterquerschnitt:</translation>
     </message>
     <message>
         <location filename="../sources/SearchAndReplace/ui/replaceconductordialog.ui" line="342"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_replaceconductordialog.h" line="535"/>
         <source>Unifilaire</source>
         <translation>Einpolig</translation>
     </message>
     <message>
         <location filename="../sources/SearchAndReplace/ui/replaceconductordialog.ui" line="357"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_replaceconductordialog.h" line="537"/>
         <source>Protective Earth Neutral</source>
         <translation>PEN-Leiter (protective earth neutral)</translation>
     </message>
     <message>
         <location filename="../sources/SearchAndReplace/ui/replaceconductordialog.ui" line="360"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_replaceconductordialog.h" line="539"/>
         <source>PEN</source>
         <translation>PEN</translation>
     </message>
     <message>
         <location filename="../sources/SearchAndReplace/ui/replaceconductordialog.ui" line="367"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_replaceconductordialog.h" line="541"/>
         <source>Phase</source>
         <translation>Phase</translation>
     </message>
     <message>
         <location filename="../sources/SearchAndReplace/ui/replaceconductordialog.ui" line="370"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_replaceconductordialog.h" line="543"/>
         <source>phase</source>
         <translation>Phase</translation>
     </message>
     <message>
         <location filename="../sources/SearchAndReplace/ui/replaceconductordialog.ui" line="381"/>
         <location filename="../sources/SearchAndReplace/ui/replaceconductordialog.ui" line="414"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_replaceconductordialog.h" line="545"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_replaceconductordialog.h" line="552"/>
         <source>Nombre de phase</source>
         <translation>Phasenanzahl</translation>
     </message>
     <message>
         <location filename="../sources/SearchAndReplace/ui/replaceconductordialog.ui" line="394"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_replaceconductordialog.h" line="548"/>
         <source>Neutre</source>
         <translation>Neutralleiter</translation>
     </message>
     <message>
         <location filename="../sources/SearchAndReplace/ui/replaceconductordialog.ui" line="397"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_replaceconductordialog.h" line="550"/>
         <source>neutre</source>
         <translation>Neutralleiter</translation>
     </message>
     <message>
         <location filename="../sources/SearchAndReplace/ui/replaceconductordialog.ui" line="430"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_replaceconductordialog.h" line="555"/>
         <source>Terre</source>
         <translation>Erde</translation>
     </message>
     <message>
         <location filename="../sources/SearchAndReplace/ui/replaceconductordialog.ui" line="433"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_replaceconductordialog.h" line="557"/>
         <source>terre</source>
         <translation>Erde</translation>
     </message>
     <message>
         <location filename="../sources/SearchAndReplace/ui/replaceconductordialog.ui" line="444"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_replaceconductordialog.h" line="558"/>
         <source>TextLabel</source>
         <translation>TextLabel</translation>
     </message>
     <message>
         <location filename="../sources/SearchAndReplace/ui/replaceconductordialog.ui" line="454"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_replaceconductordialog.h" line="559"/>
         <source>PushButton</source>
         <translation>Taste</translation>
     </message>
     <message>
         <location filename="../sources/SearchAndReplace/ui/replaceconductordialog.ui" line="465"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_replaceconductordialog.h" line="580"/>
         <source>Apparence</source>
         <translation>Darstellung</translation>
     </message>
     <message>
         <location filename="../sources/SearchAndReplace/ui/replaceconductordialog.ui" line="471"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_replaceconductordialog.h" line="561"/>
         <source>Taille :</source>
         <translation>Größe:</translation>
     </message>
     <message>
         <location filename="../sources/SearchAndReplace/ui/replaceconductordialog.ui" line="478"/>
         <location filename="../sources/SearchAndReplace/ui/replaceconductordialog.ui" line="554"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_replaceconductordialog.h" line="562"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_replaceconductordialog.h" line="572"/>
         <source>Couleur :</source>
         <translation>Farbe:</translation>
     </message>
     <message>
         <location filename="../sources/SearchAndReplace/ui/replaceconductordialog.ui" line="508"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_replaceconductordialog.h" line="564"/>
         <source>Style :</source>
         <translation>Stil:</translation>
     </message>
     <message>
         <location filename="../sources/SearchAndReplace/ui/replaceconductordialog.ui" line="515"/>
         <location filename="../sources/SearchAndReplace/ui/replaceconductordialog.ui" line="561"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_replaceconductordialog.h" line="566"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_replaceconductordialog.h" line="574"/>
         <source>Modifier</source>
         <translation>Verändern</translation>
     </message>
     <message>
         <location filename="../sources/SearchAndReplace/ui/replaceconductordialog.ui" line="525"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_replaceconductordialog.h" line="569"/>
         <source>Couleur secondaire :</source>
         <translation>Zweite Farbe:</translation>
     </message>
     <message>
         <location filename="../sources/SearchAndReplace/ui/replaceconductordialog.ui" line="547"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_replaceconductordialog.h" line="571"/>
         <source>Taille de trait :</source>
         <translation>Größe:</translation>
     </message>
     <message>
         <location filename="../sources/SearchAndReplace/ui/replaceconductordialog.ui" line="574"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_replaceconductordialog.h" line="578"/>
         <source>px</source>
         <translation>px</translation>
     </message>
@@ -10137,31 +14450,37 @@ Bitte fügen Sie eine neue Tabelle hinzu oder passen Sie die vorhandene Tabelle 
     <name>ReplaceFolioWidget</name>
     <message>
         <location filename="../sources/SearchAndReplace/ui/replacefoliowidget.ui" line="14"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_replacefoliowidget.h" line="288"/>
         <source>Form</source>
         <translation>Form</translation>
     </message>
     <message>
         <location filename="../sources/SearchAndReplace/ui/replacefoliowidget.ui" line="45"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_replacefoliowidget.h" line="367"/>
         <source>Principales</source>
         <translation>Standard-Eigenschaften</translation>
     </message>
     <message>
         <location filename="../sources/SearchAndReplace/ui/replacefoliowidget.ui" line="53"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_replacefoliowidget.h" line="289"/>
         <source>Indice Rev</source>
         <translation>Revision:</translation>
     </message>
     <message>
         <location filename="../sources/SearchAndReplace/ui/replacefoliowidget.ui" line="60"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_replacefoliowidget.h" line="290"/>
         <source>Localisation</source>
         <translation>Ort:</translation>
     </message>
     <message>
         <location filename="../sources/SearchAndReplace/ui/replacefoliowidget.ui" line="67"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_replacefoliowidget.h" line="291"/>
         <source>Fichier :</source>
         <translation>Datei:</translation>
     </message>
     <message>
         <location filename="../sources/SearchAndReplace/ui/replacefoliowidget.ui" line="74"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_replacefoliowidget.h" line="293"/>
         <source>Disponible en tant que %title pour les modèles de cartouches</source>
         <translation>In der Schriftfeld-Vorlage als %title verfügbar</translation>
     </message>
@@ -10174,71 +14493,92 @@ Bitte fügen Sie eine neue Tabelle hinzu oder passen Sie die vorhandene Tabelle 
         <location filename="../sources/SearchAndReplace/ui/replacefoliowidget.ui" line="207"/>
         <location filename="../sources/SearchAndReplace/ui/replacefoliowidget.ui" line="217"/>
         <location filename="../sources/SearchAndReplace/ui/replacefoliowidget.ui" line="227"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_replacefoliowidget.h" line="295"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_replacefoliowidget.h" line="299"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_replacefoliowidget.h" line="306"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_replacefoliowidget.h" line="310"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_replacefoliowidget.h" line="321"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_replacefoliowidget.h" line="329"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_replacefoliowidget.h" line="333"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_replacefoliowidget.h" line="337"/>
         <source>Ne pas modifier</source>
         <translation>Nicht verändern</translation>
     </message>
     <message>
         <location filename="../sources/SearchAndReplace/ui/replacefoliowidget.ui" line="84"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_replacefoliowidget.h" line="297"/>
         <source>Disponible en tant que %author pour les modèles de cartouches</source>
         <translation>In der Schriftfeld-Vorlage als %author verfügbar</translation>
     </message>
     <message>
         <location filename="../sources/SearchAndReplace/ui/replacefoliowidget.ui" line="94"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_replacefoliowidget.h" line="300"/>
         <source>Auteur :</source>
         <translation>Bearbeiter:</translation>
     </message>
     <message>
         <location filename="../sources/SearchAndReplace/ui/replacefoliowidget.ui" line="101"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_replacefoliowidget.h" line="301"/>
         <source>Date :</source>
         <translation>Datum:</translation>
     </message>
     <message>
         <location filename="../sources/SearchAndReplace/ui/replacefoliowidget.ui" line="111"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_replacefoliowidget.h" line="302"/>
         <source>Installation :</source>
         <translation>Anlage:</translation>
     </message>
     <message>
         <location filename="../sources/SearchAndReplace/ui/replacefoliowidget.ui" line="118"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_replacefoliowidget.h" line="304"/>
         <source>Disponible en tant que %indexrev pour les modèles de cartouches</source>
         <translation>In der Schriftfeld-Vorlage als %indexrev verfügbar</translation>
     </message>
     <message>
         <location filename="../sources/SearchAndReplace/ui/replacefoliowidget.ui" line="128"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_replacefoliowidget.h" line="308"/>
         <source>Disponible en tant que %filename pour les modèles de cartouches</source>
         <translation>In der Schriftfeld-Vorlage als %filename verfügbar</translation>
     </message>
     <message>
         <location filename="../sources/SearchAndReplace/ui/replacefoliowidget.ui" line="141"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_replacefoliowidget.h" line="311"/>
         <source>Folio :</source>
         <translation>Foliennummer:</translation>
     </message>
     <message>
         <location filename="../sources/SearchAndReplace/ui/replacefoliowidget.ui" line="150"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_replacefoliowidget.h" line="312"/>
         <source>Pas de date</source>
         <translation>Kein Datum</translation>
     </message>
     <message>
         <location filename="../sources/SearchAndReplace/ui/replacefoliowidget.ui" line="157"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_replacefoliowidget.h" line="314"/>
         <source>Disponible en tant que %date pour les modèles de cartouches</source>
         <translation>In der Schriftfeld-Vorlage als %date verfügbar</translation>
     </message>
     <message>
         <location filename="../sources/SearchAndReplace/ui/replacefoliowidget.ui" line="170"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_replacefoliowidget.h" line="316"/>
         <source>Date fixe :</source>
         <translation>Festes Datum:</translation>
     </message>
     <message>
         <location filename="../sources/SearchAndReplace/ui/replacefoliowidget.ui" line="177"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_replacefoliowidget.h" line="318"/>
         <source>Appliquer la date actuelle</source>
         <translation>Aktuelles Datum anwenden</translation>
     </message>
     <message>
         <location filename="../sources/SearchAndReplace/ui/replacefoliowidget.ui" line="224"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_replacefoliowidget.h" line="335"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Disponible en tant que %plant pour les modèles de cartouches&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;In Schriftfeld-Vorlagen als %plant verfügbar&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
         <location filename="../sources/SearchAndReplace/ui/replacefoliowidget.ui" line="200"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_replacefoliowidget.h" line="323"/>
         <source>Disponible en tant que %folio pour les modèles de cartouches
 Les variables suivantes sont utilisables :
 - %id : numéro du folio courant dans le projet 
@@ -10252,11 +14592,13 @@ Folgende Variablen stehen im Feld Folie zur Verfügung:
     </message>
     <message>
         <location filename="../sources/SearchAndReplace/ui/replacefoliowidget.ui" line="214"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_replacefoliowidget.h" line="331"/>
         <source>Disponible en tant que %locmach pour les modèles de cartouches</source>
         <translation>In der Schriftfeld-Vorlage als %locmach verfügbar</translation>
     </message>
     <message>
         <location filename="../sources/SearchAndReplace/ui/replacefoliowidget.ui" line="234"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_replacefoliowidget.h" line="338"/>
         <source>Titre :</source>
         <translation>Titel:</translation>
     </message>
@@ -10268,16 +14610,25 @@ Folgende Variablen stehen im Feld Folie zur Verfügung:
         <location filename="../sources/SearchAndReplace/ui/replacefoliowidget.ui" line="281"/>
         <location filename="../sources/SearchAndReplace/ui/replacefoliowidget.ui" line="291"/>
         <location filename="../sources/SearchAndReplace/ui/replacefoliowidget.ui" line="301"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_replacefoliowidget.h" line="340"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_replacefoliowidget.h" line="344"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_replacefoliowidget.h" line="348"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_replacefoliowidget.h" line="352"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_replacefoliowidget.h" line="356"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_replacefoliowidget.h" line="360"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_replacefoliowidget.h" line="364"/>
         <source>Supprimer ce texte</source>
         <translation>Diesen Text löschen</translation>
     </message>
     <message>
         <location filename="../sources/SearchAndReplace/ui/replacefoliowidget.ui" line="327"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_replacefoliowidget.h" line="370"/>
         <source>Personnalisées</source>
         <translation>Benutzer-Eigenschaften</translation>
     </message>
     <message>
         <location filename="../sources/SearchAndReplace/ui/replacefoliowidget.ui" line="335"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_replacefoliowidget.h" line="368"/>
         <source>Vous pouvez définir ici vos propres associations noms/valeurs pour que le cartouche en tienne compte. Exemple :
 associer le nom &quot;volta&quot; et la valeur &quot;1745&quot; remplacera %{volta} par 1745 dans le cartouche.</source>
         <translation>Hier können Sie Ihre eigenen Kombinationen Variablen/Werte für die Einträge der Datenfelder im Schriftfeld definieren. Zum Beispiel:
@@ -10288,16 +14639,19 @@ die Variable &quot;volta&quot; kombiniert mit dem Wert &quot;1745&quot; lässt i
     <name>ReportPropertieWidget</name>
     <message>
         <location filename="../sources/ui/reportpropertiewidget.ui" line="14"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_reportpropertiewidget.h" line="84"/>
         <source>Form</source>
         <translation>Form</translation>
     </message>
     <message>
         <location filename="../sources/ui/reportpropertiewidget.ui" line="20"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_reportpropertiewidget.h" line="85"/>
         <source>Label de report de folio</source>
         <translation>Querverweistext der Folienverweise</translation>
     </message>
     <message>
         <location filename="../sources/ui/reportpropertiewidget.ui" line="35"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_reportpropertiewidget.h" line="86"/>
         <source>Vous pouvez définir un label personnalisé pour les reports de folio.
 Créer votre propre texte en vous aidant des variables suivantes :
 %f : la position du folio dans le projet 
@@ -10320,121 +14674,145 @@ Folgende Variablen sind verfügbar:
     <name>SearchAndReplaceWidget</name>
     <message>
         <location filename="../sources/SearchAndReplace/ui/searchandreplacewidget.ui" line="14"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_searchandreplacewidget.h" line="250"/>
         <source>Form</source>
         <translation>Form</translation>
     </message>
     <message>
         <location filename="../sources/SearchAndReplace/ui/searchandreplacewidget.ui" line="103"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_searchandreplacewidget.h" line="260"/>
         <source>Aller à la correspondance suivante</source>
         <translation>Zur nächsten Übereinstimmung gehen</translation>
     </message>
     <message>
         <location filename="../sources/SearchAndReplace/ui/searchandreplacewidget.ui" line="154"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_searchandreplacewidget.h" line="272"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Afficher les options avancées&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Fortgeschrittene Optionen anzeigen&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
         <location filename="../sources/SearchAndReplace/ui/searchandreplacewidget.ui" line="120"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_searchandreplacewidget.h" line="264"/>
         <source>Aller à la correspondance précédente</source>
         <translation>Zur vorherigen Übereinstimmung gehen</translation>
     </message>
     <message>
         <location filename="../sources/SearchAndReplace/ui/searchandreplacewidget.ui" line="339"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_searchandreplacewidget.h" line="299"/>
         <source>Quitter</source>
         <translation>Beenden</translation>
     </message>
     <message>
         <location filename="../sources/SearchAndReplace/ui/searchandreplacewidget.ui" line="201"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_searchandreplacewidget.h" line="276"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Définir les propriétés à remplacer dans les éléments&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Zu ersetzende Bauteileigenschaften definieren&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
         <location filename="../sources/SearchAndReplace/ui/searchandreplacewidget.ui" line="264"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_searchandreplacewidget.h" line="293"/>
         <source>Champ texte de folio</source>
         <translation>Textfeld in Folie</translation>
     </message>
     <message>
         <location filename="../sources/SearchAndReplace/ui/searchandreplacewidget.ui" line="211"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_searchandreplacewidget.h" line="280"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Définir les propriétés à remplacer dans les conducteurs&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Zu ersetzende Leitereigenschaften definieren&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
         <location filename="../sources/SearchAndReplace/ui/searchandreplacewidget.ui" line="248"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_searchandreplacewidget.h" line="290"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Définir les propriétés à remplacer dans les folios&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Zu ersetzende Folieneigenschaften definieren&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
         <location filename="../sources/SearchAndReplace/ui/searchandreplacewidget.ui" line="251"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_searchandreplacewidget.h" line="292"/>
         <source>Folio</source>
         <translation>Folie</translation>
     </message>
     <message>
         <location filename="../sources/SearchAndReplace/ui/searchandreplacewidget.ui" line="80"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_searchandreplacewidget.h" line="252"/>
         <source>Texte brut</source>
         <translation>Roher Text</translation>
     </message>
     <message>
         <location filename="../sources/SearchAndReplace/ui/searchandreplacewidget.ui" line="73"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_searchandreplacewidget.h" line="256"/>
         <source>Mode</source>
         <translation>Modus</translation>
     </message>
     <message>
         <location filename="../sources/SearchAndReplace/ui/searchandreplacewidget.ui" line="85"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_searchandreplacewidget.h" line="253"/>
         <source>Mots entiers</source>
         <translation>Ganze Worte</translation>
     </message>
     <message>
         <location filename="../sources/SearchAndReplace/ui/searchandreplacewidget.ui" line="93"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_searchandreplacewidget.h" line="258"/>
         <source>Sensible à la casse</source>
         <translation>Klein-/Großschreibung berücksichtigen</translation>
     </message>
     <message>
         <location filename="../sources/SearchAndReplace/ui/searchandreplacewidget.ui" line="277"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_searchandreplacewidget.h" line="295"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Remplacer la correspondance sélectionnée&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Ausgewählte Übereinstimmungen ersetzen&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
         <location filename="../sources/SearchAndReplace/ui/searchandreplacewidget.ui" line="224"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_searchandreplacewidget.h" line="284"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Remplacer les correspondances cochées&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Angekreuzte Übereinstimmungen ersetzen&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
         <location filename="../sources/SearchAndReplace/ui/searchandreplacewidget.ui" line="234"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_searchandreplacewidget.h" line="287"/>
         <source>avancé</source>
         <translation>fortgeschritten</translation>
     </message>
     <message>
         <location filename="../sources/SearchAndReplace/ui/searchandreplacewidget.ui" line="204"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_searchandreplacewidget.h" line="278"/>
         <source>Élément</source>
         <translation>Bauteil</translation>
     </message>
     <message>
         <location filename="../sources/SearchAndReplace/ui/searchandreplacewidget.ui" line="214"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_searchandreplacewidget.h" line="282"/>
         <source>Conducteur</source>
         <translation>Leiter</translation>
     </message>
     <message>
         <location filename="../sources/SearchAndReplace/ui/searchandreplacewidget.ui" line="241"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_searchandreplacewidget.h" line="288"/>
         <source>Remplacer :</source>
         <translation>Ersetzen:</translation>
     </message>
     <message>
         <location filename="../sources/SearchAndReplace/ui/searchandreplacewidget.ui" line="280"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_searchandreplacewidget.h" line="297"/>
         <source>Remplacer</source>
         <translation>Ersetzen</translation>
     </message>
     <message>
         <location filename="../sources/SearchAndReplace/ui/searchandreplacewidget.ui" line="227"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_searchandreplacewidget.h" line="286"/>
         <source>Tout remplacer</source>
         <translation>Alles ersetzen</translation>
     </message>
     <message>
         <location filename="../sources/SearchAndReplace/ui/searchandreplacewidget.ui" line="38"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_searchandreplacewidget.h" line="251"/>
         <source>Chercher :</source>
         <translation>Suchen:</translation>
     </message>
     <message>
         <location filename="../sources/SearchAndReplace/ui/searchandreplacewidget.ui" line="137"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_searchandreplacewidget.h" line="268"/>
         <source>Actualiser</source>
         <translation>Aktualisieren</translation>
     </message>
@@ -10541,61 +14919,73 @@ Folgende Variablen sind verfügbar:
     <name>SelectAutonumW</name>
     <message>
         <location filename="../sources/autoNum/ui/selectautonumw.ui" line="20"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_selectautonumw.h" line="225"/>
         <source>Form</source>
         <translation>Formular</translation>
     </message>
     <message>
         <location filename="../sources/autoNum/ui/selectautonumw.ui" line="133"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_selectautonumw.h" line="235"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Supprimer une variable de numérotation&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Nummerierungsvariable löschen&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
         <location filename="../sources/autoNum/ui/selectautonumw.ui" line="150"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_selectautonumw.h" line="239"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Ajouter une variable de numérotation&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Nummerierungsvariable einfügen&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
         <location filename="../sources/autoNum/ui/selectautonumw.ui" line="100"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_selectautonumw.h" line="233"/>
         <source>Définition</source>
         <translation>Definition</translation>
     </message>
     <message>
         <location filename="../sources/autoNum/ui/selectautonumw.ui" line="28"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_selectautonumw.h" line="226"/>
         <source>Numérotations disponibles :</source>
         <translation>Verfügbare Nummerierungsregeln:</translation>
     </message>
     <message>
         <location filename="../sources/autoNum/ui/selectautonumw.ui" line="52"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_selectautonumw.h" line="227"/>
         <source>Nom de la nouvelle numérotation</source>
         <translation>Name der neuen Nummerierungsregel</translation>
     </message>
     <message>
         <location filename="../sources/autoNum/ui/selectautonumw.ui" line="60"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_selectautonumw.h" line="230"/>
         <source>Supprimer la numérotation</source>
         <translation>Nummerierungsregel löschen</translation>
     </message>
     <message>
         <location filename="../sources/autoNum/ui/selectautonumw.ui" line="167"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_selectautonumw.h" line="243"/>
         <source>Précédent</source>
         <translation>Vorheriges</translation>
     </message>
     <message>
         <location filename="../sources/autoNum/ui/selectautonumw.ui" line="181"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_selectautonumw.h" line="247"/>
         <source>Suivant</source>
         <translation>Nächstes</translation>
     </message>
     <message>
         <location filename="../sources/autoNum/ui/selectautonumw.ui" line="226"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_selectautonumw.h" line="250"/>
         <source>Type</source>
         <translation>Typ</translation>
     </message>
     <message>
         <location filename="../sources/autoNum/ui/selectautonumw.ui" line="236"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_selectautonumw.h" line="251"/>
         <source>Valeur</source>
         <translation>Wert</translation>
     </message>
     <message>
         <location filename="../sources/autoNum/ui/selectautonumw.ui" line="252"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_selectautonumw.h" line="252"/>
         <source>Incrémentation</source>
         <translation>Inkrementierung</translation>
     </message>
@@ -10726,152 +15116,183 @@ Andere Felder werden nicht verwendet.</translation>
     <name>ShapeGraphicsItemPropertiesWidget</name>
     <message>
         <location filename="../sources/ui/shapegraphicsitempropertieswidget.ui" line="14"/>
+        <location filename="../build/qelectrotech_autogen/ui_shapegraphicsitempropertieswidget.h" line="178"/>
         <source>Form</source>
         <translation>Form</translation>
     </message>
     <message>
         <location filename="../sources/ui/shapegraphicsitempropertieswidget.ui" line="20"/>
+        <location filename="../build/qelectrotech_autogen/ui_shapegraphicsitempropertieswidget.h" line="179"/>
         <source>Trait</source>
         <translation>Linie</translation>
     </message>
     <message>
         <location filename="../sources/ui/shapegraphicsitempropertieswidget.ui" line="33"/>
+        <location filename="../build/qelectrotech_autogen/ui_shapegraphicsitempropertieswidget.h" line="181"/>
         <source>Épaisseur</source>
         <translation>Dicke</translation>
     </message>
     <message>
         <location filename="../sources/ui/shapegraphicsitempropertieswidget.ui" line="85"/>
+        <location filename="../build/qelectrotech_autogen/ui_shapegraphicsitempropertieswidget.h" line="183"/>
         <source>Normal</source>
         <translation>Normal</translation>
     </message>
     <message>
         <location filename="../sources/ui/shapegraphicsitempropertieswidget.ui" line="90"/>
+        <location filename="../build/qelectrotech_autogen/ui_shapegraphicsitempropertieswidget.h" line="184"/>
         <source>Tiret</source>
         <translation>Strich</translation>
     </message>
     <message>
         <location filename="../sources/ui/shapegraphicsitempropertieswidget.ui" line="95"/>
+        <location filename="../build/qelectrotech_autogen/ui_shapegraphicsitempropertieswidget.h" line="185"/>
         <source>Pointillé</source>
         <translation>Gestrichelt</translation>
     </message>
     <message>
         <location filename="../sources/ui/shapegraphicsitempropertieswidget.ui" line="100"/>
+        <location filename="../build/qelectrotech_autogen/ui_shapegraphicsitempropertieswidget.h" line="186"/>
         <source>Traits et points</source>
         <translation>Strichpunkt</translation>
     </message>
     <message>
         <location filename="../sources/ui/shapegraphicsitempropertieswidget.ui" line="105"/>
+        <location filename="../build/qelectrotech_autogen/ui_shapegraphicsitempropertieswidget.h" line="187"/>
         <source>Traits points points</source>
         <translation>Strich-Punkt-Punkt</translation>
     </message>
     <message>
         <location filename="../sources/ui/shapegraphicsitempropertieswidget.ui" line="110"/>
+        <location filename="../build/qelectrotech_autogen/ui_shapegraphicsitempropertieswidget.h" line="188"/>
         <source>Tiret custom</source>
         <translation>Benutzerdefiniertes Strichmuster</translation>
     </message>
     <message>
         <location filename="../sources/ui/shapegraphicsitempropertieswidget.ui" line="26"/>
+        <location filename="../build/qelectrotech_autogen/ui_shapegraphicsitempropertieswidget.h" line="180"/>
         <source>Type</source>
         <translation>Typ</translation>
     </message>
     <message>
         <location filename="../sources/ui/shapegraphicsitempropertieswidget.ui" line="40"/>
         <location filename="../sources/ui/shapegraphicsitempropertieswidget.ui" line="213"/>
+        <location filename="../build/qelectrotech_autogen/ui_shapegraphicsitempropertieswidget.h" line="182"/>
+        <location filename="../build/qelectrotech_autogen/ui_shapegraphicsitempropertieswidget.h" line="208"/>
         <source>Couleur</source>
         <translation>Farbe</translation>
     </message>
     <message>
         <location filename="../sources/ui/shapegraphicsitempropertieswidget.ui" line="121"/>
+        <location filename="../build/qelectrotech_autogen/ui_shapegraphicsitempropertieswidget.h" line="190"/>
         <source>Remplissage</source>
         <translation>Füllung</translation>
     </message>
     <message>
         <location filename="../sources/ui/shapegraphicsitempropertieswidget.ui" line="206"/>
+        <location filename="../build/qelectrotech_autogen/ui_shapegraphicsitempropertieswidget.h" line="207"/>
         <source>Style</source>
         <translation>Stil</translation>
     </message>
     <message>
         <location filename="../sources/ui/shapegraphicsitempropertieswidget.ui" line="128"/>
+        <location filename="../build/qelectrotech_autogen/ui_shapegraphicsitempropertieswidget.h" line="191"/>
         <source>Aucun</source>
         <translation>Kein</translation>
     </message>
     <message>
         <location filename="../sources/ui/shapegraphicsitempropertieswidget.ui" line="133"/>
+        <location filename="../build/qelectrotech_autogen/ui_shapegraphicsitempropertieswidget.h" line="192"/>
         <source>Plein</source>
         <translation>Gefüllt</translation>
     </message>
     <message>
         <location filename="../sources/ui/shapegraphicsitempropertieswidget.ui" line="138"/>
+        <location filename="../build/qelectrotech_autogen/ui_shapegraphicsitempropertieswidget.h" line="193"/>
         <source>Densité 1</source>
         <translation>Dichte 1</translation>
     </message>
     <message>
         <location filename="../sources/ui/shapegraphicsitempropertieswidget.ui" line="143"/>
+        <location filename="../build/qelectrotech_autogen/ui_shapegraphicsitempropertieswidget.h" line="194"/>
         <source>Densité 2</source>
         <translation>Dichte 2</translation>
     </message>
     <message>
         <location filename="../sources/ui/shapegraphicsitempropertieswidget.ui" line="148"/>
+        <location filename="../build/qelectrotech_autogen/ui_shapegraphicsitempropertieswidget.h" line="195"/>
         <source>Densité 3</source>
         <translation>Dichte 3</translation>
     </message>
     <message>
         <location filename="../sources/ui/shapegraphicsitempropertieswidget.ui" line="153"/>
+        <location filename="../build/qelectrotech_autogen/ui_shapegraphicsitempropertieswidget.h" line="196"/>
         <source>Densité 4</source>
         <translation>Dichte 4</translation>
     </message>
     <message>
         <location filename="../sources/ui/shapegraphicsitempropertieswidget.ui" line="158"/>
+        <location filename="../build/qelectrotech_autogen/ui_shapegraphicsitempropertieswidget.h" line="197"/>
         <source>Densité 5</source>
         <translation>Dichte 5</translation>
     </message>
     <message>
         <location filename="../sources/ui/shapegraphicsitempropertieswidget.ui" line="163"/>
+        <location filename="../build/qelectrotech_autogen/ui_shapegraphicsitempropertieswidget.h" line="198"/>
         <source>Densité 6</source>
         <translation>Dichte 6</translation>
     </message>
     <message>
         <location filename="../sources/ui/shapegraphicsitempropertieswidget.ui" line="168"/>
+        <location filename="../build/qelectrotech_autogen/ui_shapegraphicsitempropertieswidget.h" line="199"/>
         <source>Densité 7</source>
         <translation>Dichte 7</translation>
     </message>
     <message>
         <location filename="../sources/ui/shapegraphicsitempropertieswidget.ui" line="173"/>
+        <location filename="../build/qelectrotech_autogen/ui_shapegraphicsitempropertieswidget.h" line="200"/>
         <source>Horizontal</source>
         <translation>Horizontal</translation>
     </message>
     <message>
         <location filename="../sources/ui/shapegraphicsitempropertieswidget.ui" line="178"/>
+        <location filename="../build/qelectrotech_autogen/ui_shapegraphicsitempropertieswidget.h" line="201"/>
         <source>Vertical</source>
         <translation>Vertikal</translation>
     </message>
     <message>
         <location filename="../sources/ui/shapegraphicsitempropertieswidget.ui" line="183"/>
+        <location filename="../build/qelectrotech_autogen/ui_shapegraphicsitempropertieswidget.h" line="202"/>
         <source>Croix</source>
         <translation>Gekreuzt</translation>
     </message>
     <message>
         <location filename="../sources/ui/shapegraphicsitempropertieswidget.ui" line="188"/>
+        <location filename="../build/qelectrotech_autogen/ui_shapegraphicsitempropertieswidget.h" line="203"/>
         <source>Diagonal arrière</source>
         <translation>Diagonal rückwärts</translation>
     </message>
     <message>
         <location filename="../sources/ui/shapegraphicsitempropertieswidget.ui" line="193"/>
+        <location filename="../build/qelectrotech_autogen/ui_shapegraphicsitempropertieswidget.h" line="204"/>
         <source>Diagonal avant</source>
         <translation>Diagonal vorwärts</translation>
     </message>
     <message>
         <location filename="../sources/ui/shapegraphicsitempropertieswidget.ui" line="198"/>
+        <location filename="../build/qelectrotech_autogen/ui_shapegraphicsitempropertieswidget.h" line="205"/>
         <source>Diagonal en croix</source>
         <translation>Diagonal gekreuzt</translation>
     </message>
     <message>
         <location filename="../sources/ui/shapegraphicsitempropertieswidget.ui" line="226"/>
+        <location filename="../build/qelectrotech_autogen/ui_shapegraphicsitempropertieswidget.h" line="209"/>
         <source>Verrouiller la position</source>
         <translation>Position sperren</translation>
     </message>
     <message>
         <location filename="../sources/ui/shapegraphicsitempropertieswidget.ui" line="233"/>
+        <location filename="../build/qelectrotech_autogen/ui_shapegraphicsitempropertieswidget.h" line="210"/>
         <source>Polygone fermé</source>
         <translation>Geschlossenes Polygon</translation>
     </message>
@@ -12900,26 +17321,31 @@ Andere Felder werden nicht verwendet.</translation>
     <name>SummaryQueryWidget</name>
     <message>
         <location filename="../sources/dataBase/ui/summaryquerywidget.ui" line="14"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_summaryquerywidget.h" line="179"/>
         <source>Form</source>
         <translation>Informationen auswählen</translation>
     </message>
     <message>
         <location filename="../sources/dataBase/ui/summaryquerywidget.ui" line="38"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_summaryquerywidget.h" line="180"/>
         <source>Informations disponibles</source>
         <translation>Verfügbare Informationen</translation>
     </message>
     <message>
         <location filename="../sources/dataBase/ui/summaryquerywidget.ui" line="51"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_summaryquerywidget.h" line="181"/>
         <source>Information à afficher</source>
         <translation>Anzuzeigende Informationen</translation>
     </message>
     <message>
         <location filename="../sources/dataBase/ui/summaryquerywidget.ui" line="145"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_summaryquerywidget.h" line="186"/>
         <source>Configuration</source>
         <translation>Konfiguration</translation>
     </message>
     <message>
         <location filename="../sources/dataBase/ui/summaryquerywidget.ui" line="161"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_summaryquerywidget.h" line="187"/>
         <source>Requête SQL :</source>
         <translation>SQL-Abfrage:</translation>
     </message>
@@ -12979,17 +17405,17 @@ Andere Felder werden nicht verwendet.</translation>
     <message>
         <location filename="../sources/editor/ui/terminaleditor.cpp" line="125"/>
         <source>NO (contact SW)</source>
-        <translation type="unfinished"></translation>
+        <translation>NO (Wechslerkontakt(</translation>
     </message>
     <message>
         <location filename="../sources/editor/ui/terminaleditor.cpp" line="126"/>
         <source>NC (contact SW)</source>
-        <translation type="unfinished"></translation>
+        <translation>NC (Wechslerkontakt)</translation>
     </message>
     <message>
         <location filename="../sources/editor/ui/terminaleditor.cpp" line="127"/>
         <source>Commun (contact SW)</source>
-        <translation type="unfinished"></translation>
+        <translation>Gemeinsam(Wechslerkontakt)</translation>
     </message>
     <message>
         <location filename="../sources/editor/ui/terminaleditor.cpp" line="190"/>
@@ -13003,31 +17429,37 @@ Andere Felder werden nicht verwendet.</translation>
     </message>
     <message>
         <location filename="../sources/editor/ui/terminaleditor.ui" line="14"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_terminaleditor.h" line="113"/>
         <source>Form</source>
         <translation>Form</translation>
     </message>
     <message>
         <location filename="../sources/editor/ui/terminaleditor.ui" line="20"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_terminaleditor.h" line="114"/>
         <source>y :</source>
         <translation>y:</translation>
     </message>
     <message>
         <location filename="../sources/editor/ui/terminaleditor.ui" line="47"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_terminaleditor.h" line="115"/>
         <source>Orientation :</source>
         <translation>Ausrichtung:</translation>
     </message>
     <message>
         <location filename="../sources/editor/ui/terminaleditor.ui" line="60"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_terminaleditor.h" line="116"/>
         <source>x :</source>
         <translation>x:</translation>
     </message>
     <message>
         <location filename="../sources/editor/ui/terminaleditor.ui" line="67"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_terminaleditor.h" line="117"/>
         <source>Nom :</source>
         <translation>Name:</translation>
     </message>
     <message>
         <location filename="../sources/editor/ui/terminaleditor.ui" line="74"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_terminaleditor.h" line="118"/>
         <source>Type :</source>
         <translation>Typ:</translation>
     </message>
@@ -13036,41 +17468,49 @@ Andere Felder werden nicht verwendet.</translation>
     <name>TerminalNumberingDialog</name>
     <message>
         <location filename="../sources/ui/terminalnumberingdialog.ui" line="14"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_terminalnumberingdialog.h" line="110"/>
         <source>Numérotation automatique des bornes</source>
         <translation>Automatische Klemmennummerierung</translation>
     </message>
     <message>
         <location filename="../sources/ui/terminalnumberingdialog.ui" line="20"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_terminalnumberingdialog.h" line="111"/>
         <source>Cette fonction numérote les bornes du projet selon leur position. Les bornes vides ou verrouillées sont ignorées.Le marquage des bornes doit être configuré au préalable comme suit : &apos;-X:AB&apos;. La partie avant les deux-points (le bornier) peut être nommée au choix. &apos;AB&apos; peut être composé de chiffres ou de lettres.&quot;</source>
         <translation>Diese Funktion nummeriert die Klemmen des Projekts entsprechend ihrer Position. Leere oder gesperrte Klemmen werden dabei ignoriert. Die Klemmenbezeichnung muss zuvor wie folgt konfiguriert werden: „-X:AB“. Der Teil vor dem Doppelpunkt (die Klemmenleiste) kann beliebig benannt werden. „AB“ kann aus Ziffern oder Buchstaben bestehen.</translation>
     </message>
     <message>
         <location filename="../sources/ui/terminalnumberingdialog.ui" line="30"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_terminalnumberingdialog.h" line="112"/>
         <source>Priorité des axes</source>
         <translation>Priorität der Achsen</translation>
     </message>
     <message>
         <location filename="../sources/ui/terminalnumberingdialog.ui" line="36"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_terminalnumberingdialog.h" line="113"/>
         <source>Priorité à l&apos;axe X (horizontal)</source>
         <translation>Priorität für die X-Achse (horizontal)</translation>
     </message>
     <message>
         <location filename="../sources/ui/terminalnumberingdialog.ui" line="46"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_terminalnumberingdialog.h" line="114"/>
         <source>Priorité à l&apos;axe Y (vertical)</source>
         <translation>Priorität für die Y-Achse (vertikal)</translation>
     </message>
     <message>
         <location filename="../sources/ui/terminalnumberingdialog.ui" line="56"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_terminalnumberingdialog.h" line="115"/>
         <source>Type de numérotation</source>
         <translation>Art der Nummerierung</translation>
     </message>
     <message>
         <location filename="../sources/ui/terminalnumberingdialog.ui" line="62"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_terminalnumberingdialog.h" line="116"/>
         <source>Numérique uniquement (1, 2, 3...)</source>
         <translation>Nur Ziffern (1, 2, 3...)</translation>
     </message>
     <message>
         <location filename="../sources/ui/terminalnumberingdialog.ui" line="72"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_terminalnumberingdialog.h" line="117"/>
         <source>Alphanumérique (A, B, C... 1, 2...)</source>
         <translation>Alphanumerisch (A, B, C... 1, 2...)</translation>
     </message>
@@ -13079,31 +17519,37 @@ Andere Felder werden nicht verwendet.</translation>
     <name>TerminalStripCreatorDialog</name>
     <message>
         <location filename="../sources/TerminalStrip/ui/terminalstripcreatordialog.ui" line="14"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_terminalstripcreatordialog.h" line="139"/>
         <source>Création groupe de bornes</source>
         <translation>Klemmleiste erstellen</translation>
     </message>
     <message>
         <location filename="../sources/TerminalStrip/ui/terminalstripcreatordialog.ui" line="20"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_terminalstripcreatordialog.h" line="140"/>
         <source>Localisation :</source>
         <translation>Ort:</translation>
     </message>
     <message>
         <location filename="../sources/TerminalStrip/ui/terminalstripcreatordialog.ui" line="27"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_terminalstripcreatordialog.h" line="141"/>
         <source>Nom :</source>
         <translation>Name:</translation>
     </message>
     <message>
         <location filename="../sources/TerminalStrip/ui/terminalstripcreatordialog.ui" line="34"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_terminalstripcreatordialog.h" line="142"/>
         <source>Installation :</source>
         <translation>Anlage:</translation>
     </message>
     <message>
         <location filename="../sources/TerminalStrip/ui/terminalstripcreatordialog.ui" line="65"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_terminalstripcreatordialog.h" line="143"/>
         <source>Description :</source>
         <translation>Beschreibung:</translation>
     </message>
     <message>
         <location filename="../sources/TerminalStrip/ui/terminalstripcreatordialog.ui" line="95"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_terminalstripcreatordialog.h" line="144"/>
         <source>Commentaire :</source>
         <translation>Kommentar:</translation>
     </message>
@@ -13112,147 +17558,177 @@ Andere Felder werden nicht verwendet.</translation>
     <name>TerminalStripEditor</name>
     <message>
         <location filename="../sources/TerminalStrip/ui/terminalstripeditor.ui" line="24"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_terminalstripeditor.h" line="339"/>
         <source>Disposition</source>
         <translation>Anordnung</translation>
     </message>
     <message>
         <location filename="../sources/TerminalStrip/ui/terminalstripeditor.ui" line="240"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_terminalstripeditor.h" line="337"/>
         <source>Ponter les bornes</source>
         <translation>Klemmen brücken</translation>
     </message>
     <message>
         <location filename="../sources/TerminalStrip/ui/terminalstripeditor.ui" line="247"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_terminalstripeditor.h" line="338"/>
         <source>Déponter les bornes</source>
         <translation>Brücker entfernen</translation>
     </message>
     <message>
         <location filename="../sources/TerminalStrip/ui/terminalstripeditor.ui" line="258"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_terminalstripeditor.h" line="345"/>
         <source>Propriétés</source>
         <translation>Eigenschaften</translation>
     </message>
     <message>
         <location filename="../sources/TerminalStrip/ui/terminalstripeditor.ui" line="264"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_terminalstripeditor.h" line="340"/>
         <source>Nom :</source>
         <translation>Name:</translation>
     </message>
     <message>
         <location filename="../sources/TerminalStrip/ui/terminalstripeditor.ui" line="271"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_terminalstripeditor.h" line="341"/>
         <source>Commentaire :</source>
         <translation>Kommentar:</translation>
     </message>
     <message>
         <location filename="../sources/TerminalStrip/ui/terminalstripeditor.ui" line="301"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_terminalstripeditor.h" line="344"/>
         <source>Description</source>
         <translation>Beschreibung</translation>
     </message>
     <message>
         <location filename="../sources/TerminalStrip/ui/terminalstripeditor.ui" line="278"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_terminalstripeditor.h" line="342"/>
         <source>Installation :</source>
         <translation>Anlage:</translation>
     </message>
     <message>
         <location filename="../sources/TerminalStrip/ui/terminalstripeditor.ui" line="294"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_terminalstripeditor.h" line="343"/>
         <source>Localisation :</source>
         <translation>Ort:</translation>
     </message>
     <message>
         <location filename="../sources/TerminalStrip/ui/terminalstripeditor.ui" line="87"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_terminalstripeditor.h" line="319"/>
         <source>Type :</source>
         <translation>Typ:</translation>
     </message>
     <message>
         <location filename="../sources/TerminalStrip/ui/terminalstripeditor.ui" line="233"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_terminalstripeditor.h" line="336"/>
         <source>Degrouper les bornes</source>
         <translation>Gruppierung aufheben</translation>
     </message>
     <message>
         <location filename="../sources/TerminalStrip/ui/terminalstripeditor.ui" line="108"/>
         <location filename="../sources/TerminalStrip/ui/terminalstripeditor.ui" line="187"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_terminalstripeditor.h" line="321"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_terminalstripeditor.h" line="330"/>
         <source>Générique</source>
         <translation>Generisch</translation>
     </message>
     <message>
         <location filename="../sources/TerminalStrip/ui/terminalstripeditor.ui" line="14"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_terminalstripeditor.h" line="310"/>
         <source>Form</source>
         <translation>Form</translation>
     </message>
     <message>
         <location filename="../sources/TerminalStrip/ui/terminalstripeditor.ui" line="60"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_terminalstripeditor.h" line="315"/>
         <source>Effectuer le déplacement</source>
         <translation>Verschieben anwenden</translation>
     </message>
     <message>
         <location filename="../sources/TerminalStrip/ui/terminalstripeditor.ui" line="97"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_terminalstripeditor.h" line="320"/>
         <source>Couleur pont :</source>
         <translation>Brückerfarbe:</translation>
     </message>
     <message>
         <location filename="../sources/TerminalStrip/ui/terminalstripeditor.ui" line="113"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_terminalstripeditor.h" line="322"/>
         <source>Fusible</source>
         <translation>Sicherungsklemme</translation>
     </message>
     <message>
         <location filename="../sources/TerminalStrip/ui/terminalstripeditor.ui" line="118"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_terminalstripeditor.h" line="323"/>
         <source>Sectionnable</source>
         <translation>Trennklemme</translation>
     </message>
     <message>
         <location filename="../sources/TerminalStrip/ui/terminalstripeditor.ui" line="123"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_terminalstripeditor.h" line="324"/>
         <source>Diode</source>
         <translation>Klemme mit Diode</translation>
     </message>
     <message>
         <location filename="../sources/TerminalStrip/ui/terminalstripeditor.ui" line="128"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_terminalstripeditor.h" line="325"/>
         <source>Terre</source>
         <translation>Erdungsklemme</translation>
     </message>
     <message>
         <location filename="../sources/TerminalStrip/ui/terminalstripeditor.ui" line="176"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_terminalstripeditor.h" line="329"/>
         <source>Déplacer dans :</source>
         <translation>verschieben nach:</translation>
     </message>
     <message>
         <location filename="../sources/TerminalStrip/ui/terminalstripeditor.ui" line="192"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_terminalstripeditor.h" line="331"/>
         <source>Phase</source>
         <translation>Phase</translation>
     </message>
     <message>
         <location filename="../sources/TerminalStrip/ui/terminalstripeditor.ui" line="197"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_terminalstripeditor.h" line="332"/>
         <source>Neutre</source>
         <translation>Neutralleiter</translation>
     </message>
     <message>
         <location filename="../sources/TerminalStrip/ui/terminalstripeditor.ui" line="219"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_terminalstripeditor.h" line="334"/>
         <source>Position automatique</source>
         <translation>automatisch anordnen</translation>
     </message>
     <message>
         <location filename="../sources/TerminalStrip/ui/terminalstripeditor.ui" line="77"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_terminalstripeditor.h" line="318"/>
         <source>Étage :</source>
         <translation>Etage:</translation>
     </message>
     <message>
         <location filename="../sources/TerminalStrip/ui/terminalstripeditor.ui" line="226"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_terminalstripeditor.h" line="335"/>
         <source>Grouper les bornes</source>
         <translation>Klemmen gruppieren</translation>
     </message>
     <message>
         <location filename="../sources/TerminalStrip/ui/terminalstripeditor.ui" line="166"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_terminalstripeditor.h" line="328"/>
         <source>Fonction :</source>
         <translation>Funktion:</translation>
     </message>
     <message>
         <location filename="../sources/TerminalStrip/ui/terminalstripeditor.ui" line="40"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_terminalstripeditor.h" line="311"/>
         <source>Sans</source>
         <translation>Ohne</translation>
     </message>
     <message>
         <location filename="../sources/TerminalStrip/ui/terminalstripeditor.ui" line="45"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_terminalstripeditor.h" line="312"/>
         <source>Avec</source>
         <translation>Mit</translation>
     </message>
     <message>
         <location filename="../sources/TerminalStrip/ui/terminalstripeditor.ui" line="136"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_terminalstripeditor.h" line="327"/>
         <source>LED :</source>
         <translation>LED:</translation>
     </message>
@@ -13271,41 +17747,49 @@ Andere Felder werden nicht verwendet.</translation>
     <name>TerminalStripEditorWindow</name>
     <message>
         <location filename="../sources/TerminalStrip/ui/terminalstripeditorwindow.ui" line="14"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_terminalstripeditorwindow.h" line="98"/>
         <source>Gestionnaire de borniers</source>
         <translation>Klemmleisten-Planer</translation>
     </message>
     <message>
         <location filename="../sources/TerminalStrip/ui/terminalstripeditorwindow.ui" line="43"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_terminalstripeditorwindow.h" line="111"/>
         <source>toolBar</source>
         <translation>Werkzeugleiste</translation>
     </message>
     <message>
         <location filename="../sources/TerminalStrip/ui/terminalstripeditorwindow.ui" line="61"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_terminalstripeditorwindow.h" line="99"/>
         <source>Ajouter un bornier</source>
         <translation>Klemmleiste hinzufügen</translation>
     </message>
     <message>
         <location filename="../sources/TerminalStrip/ui/terminalstripeditorwindow.ui" line="64"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_terminalstripeditorwindow.h" line="101"/>
         <source>Ajouter un bornier au projet</source>
         <translation>Klemmleiste hinzufügen</translation>
     </message>
     <message>
         <location filename="../sources/TerminalStrip/ui/terminalstripeditorwindow.ui" line="73"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_terminalstripeditorwindow.h" line="103"/>
         <source>Supprimer le bornier</source>
         <translation>Klemmleiste entfernen</translation>
     </message>
     <message>
         <location filename="../sources/TerminalStrip/ui/terminalstripeditorwindow.ui" line="76"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_terminalstripeditorwindow.h" line="105"/>
         <source>Supprimer le bornier du projet</source>
         <translation>Klemmleiste aus Projekt entfernen</translation>
     </message>
     <message>
         <location filename="../sources/TerminalStrip/ui/terminalstripeditorwindow.ui" line="85"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_terminalstripeditorwindow.h" line="107"/>
         <source>Recharger</source>
         <translation>neu laden</translation>
     </message>
     <message>
         <location filename="../sources/TerminalStrip/ui/terminalstripeditorwindow.ui" line="88"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_terminalstripeditorwindow.h" line="109"/>
         <source>Recharger les borniers</source>
         <translation>Klemmleisten neu laden</translation>
     </message>
@@ -13322,91 +17806,109 @@ Andere Felder werden nicht verwendet.</translation>
     <name>TerminalStripLayoutEditor</name>
     <message>
         <location filename="../sources/TerminalStrip/ui/terminalstriplayouteditor.ui" line="14"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_terminalstriplayouteditor.h" line="516"/>
         <source>Form</source>
         <translation>Formular</translation>
     </message>
     <message>
         <location filename="../sources/TerminalStrip/ui/terminalstriplayouteditor.ui" line="65"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_terminalstriplayouteditor.h" line="518"/>
         <source>Borne niveau 0 :</source>
         <translation>Klemme Ebene 0:</translation>
     </message>
     <message>
         <location filename="../sources/TerminalStrip/ui/terminalstriplayouteditor.ui" line="482"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_terminalstriplayouteditor.h" line="555"/>
         <source>En tête :</source>
         <translation>Titel:</translation>
     </message>
     <message>
         <location filename="../sources/TerminalStrip/ui/terminalstriplayouteditor.ui" line="531"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_terminalstriplayouteditor.h" line="557"/>
         <source>Point de pont</source>
         <translation>Brückenpunkt</translation>
     </message>
     <message>
         <location filename="../sources/TerminalStrip/ui/terminalstriplayouteditor.ui" line="44"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_terminalstriplayouteditor.h" line="517"/>
         <source>Décalage vertical</source>
         <translation>vertikaler Versatz</translation>
     </message>
     <message>
         <location filename="../sources/TerminalStrip/ui/terminalstriplayouteditor.ui" line="145"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_terminalstriplayouteditor.h" line="521"/>
         <source>Afficher l&apos;aide</source>
         <translation>Hilfe anzeigen</translation>
     </message>
     <message>
         <location filename="../sources/TerminalStrip/ui/terminalstriplayouteditor.ui" line="155"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_terminalstriplayouteditor.h" line="522"/>
         <source>Largeur</source>
         <translation>Breite</translation>
     </message>
     <message>
         <location filename="../sources/TerminalStrip/ui/terminalstriplayouteditor.ui" line="252"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_terminalstriplayouteditor.h" line="532"/>
         <source>Orientation</source>
         <translation>Orientierung</translation>
     </message>
     <message>
         <location filename="../sources/TerminalStrip/ui/terminalstriplayouteditor.ui" line="259"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_terminalstriplayouteditor.h" line="533"/>
         <source>Alignement</source>
         <translation>Ausrichtung</translation>
     </message>
     <message>
         <location filename="../sources/TerminalStrip/ui/terminalstriplayouteditor.ui" line="281"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_terminalstriplayouteditor.h" line="534"/>
         <source>Police :</source>
         <translation>Schriftart:</translation>
     </message>
     <message>
         <location filename="../sources/TerminalStrip/ui/terminalstriplayouteditor.ui" line="291"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_terminalstriplayouteditor.h" line="535"/>
         <source>Taille :</source>
         <translation>Größe:</translation>
     </message>
     <message>
         <location filename="../sources/TerminalStrip/ui/terminalstriplayouteditor.ui" line="321"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_terminalstriplayouteditor.h" line="536"/>
         <source>Texte d&apos;en tête</source>
         <translation>Kopfzeile</translation>
     </message>
     <message>
         <location filename="../sources/TerminalStrip/ui/terminalstriplayouteditor.ui" line="331"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_terminalstriplayouteditor.h" line="537"/>
         <source>Origine vertical</source>
         <translation>Vertikaler Ursprung</translation>
     </message>
     <message>
         <location filename="../sources/TerminalStrip/ui/terminalstriplayouteditor.ui" line="338"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_terminalstriplayouteditor.h" line="538"/>
         <source>Longueur maximal</source>
         <translation>Maximale Länge</translation>
     </message>
     <message>
         <location filename="../sources/TerminalStrip/ui/terminalstriplayouteditor.ui" line="395"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_terminalstriplayouteditor.h" line="546"/>
         <source>Texte borne</source>
         <translation>Anschlusstext</translation>
     </message>
     <message>
         <location filename="../sources/TerminalStrip/ui/terminalstriplayouteditor.ui" line="405"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_terminalstriplayouteditor.h" line="547"/>
         <source>Référence croisée</source>
         <translation>Querverweis</translation>
     </message>
     <message>
         <location filename="../sources/TerminalStrip/ui/terminalstriplayouteditor.ui" line="524"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_terminalstriplayouteditor.h" line="556"/>
         <source>Hauteur</source>
         <translation>Höhe</translation>
     </message>
     <message>
         <location filename="../sources/TerminalStrip/ui/terminalstriplayouteditor.ui" line="545"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_terminalstriplayouteditor.h" line="558"/>
         <source>Prévisualisation :</source>
         <translation>Vorschau:</translation>
     </message>
@@ -13414,6 +17916,9 @@ Andere Felder werden nicht verwendet.</translation>
         <location filename="../sources/TerminalStrip/ui/terminalstriplayouteditor.ui" line="234"/>
         <location filename="../sources/TerminalStrip/ui/terminalstriplayouteditor.ui" line="363"/>
         <location filename="../sources/TerminalStrip/ui/terminalstriplayouteditor.ui" line="430"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_terminalstriplayouteditor.h" line="528"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_terminalstriplayouteditor.h" line="539"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_terminalstriplayouteditor.h" line="551"/>
         <source>Gauche</source>
         <translation>Linksbündig</translation>
     </message>
@@ -13421,6 +17926,9 @@ Andere Felder werden nicht verwendet.</translation>
         <location filename="../sources/TerminalStrip/ui/terminalstriplayouteditor.ui" line="239"/>
         <location filename="../sources/TerminalStrip/ui/terminalstriplayouteditor.ui" line="368"/>
         <location filename="../sources/TerminalStrip/ui/terminalstriplayouteditor.ui" line="435"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_terminalstriplayouteditor.h" line="529"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_terminalstriplayouteditor.h" line="540"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_terminalstriplayouteditor.h" line="552"/>
         <source>Centre</source>
         <translation>Zentriert</translation>
     </message>
@@ -13428,6 +17936,9 @@ Andere Felder werden nicht verwendet.</translation>
         <location filename="../sources/TerminalStrip/ui/terminalstriplayouteditor.ui" line="244"/>
         <location filename="../sources/TerminalStrip/ui/terminalstriplayouteditor.ui" line="373"/>
         <location filename="../sources/TerminalStrip/ui/terminalstriplayouteditor.ui" line="440"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_terminalstriplayouteditor.h" line="530"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_terminalstriplayouteditor.h" line="541"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_terminalstriplayouteditor.h" line="553"/>
         <source>Droite</source>
         <translation>Rechtsbündig</translation>
     </message>
@@ -13435,6 +17946,9 @@ Andere Felder werden nicht verwendet.</translation>
         <location filename="../sources/TerminalStrip/ui/terminalstriplayouteditor.ui" line="220"/>
         <location filename="../sources/TerminalStrip/ui/terminalstriplayouteditor.ui" line="382"/>
         <location filename="../sources/TerminalStrip/ui/terminalstriplayouteditor.ui" line="416"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_terminalstriplayouteditor.h" line="525"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_terminalstriplayouteditor.h" line="543"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_terminalstriplayouteditor.h" line="548"/>
         <source>Horizontal</source>
         <translation>Horizontal</translation>
     </message>
@@ -13442,26 +17956,33 @@ Andere Felder werden nicht verwendet.</translation>
         <location filename="../sources/TerminalStrip/ui/terminalstriplayouteditor.ui" line="225"/>
         <location filename="../sources/TerminalStrip/ui/terminalstriplayouteditor.ui" line="387"/>
         <location filename="../sources/TerminalStrip/ui/terminalstriplayouteditor.ui" line="421"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_terminalstriplayouteditor.h" line="526"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_terminalstriplayouteditor.h" line="544"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_terminalstriplayouteditor.h" line="549"/>
         <source>Vertical</source>
         <translation>Vertikal</translation>
     </message>
     <message>
         <location filename="../sources/TerminalStrip/ui/terminalstriplayouteditor.ui" line="117"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_terminalstriplayouteditor.h" line="520"/>
         <source>Borne niveau 2 :</source>
         <translation>Klemme Ebene 2:</translation>
     </message>
     <message>
         <location filename="../sources/TerminalStrip/ui/terminalstriplayouteditor.ui" line="169"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_terminalstriplayouteditor.h" line="523"/>
         <source>Espace :</source>
         <translation>Abstand:</translation>
     </message>
     <message>
         <location filename="../sources/TerminalStrip/ui/terminalstriplayouteditor.ui" line="110"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_terminalstriplayouteditor.h" line="519"/>
         <source>Borne niveau 3 :</source>
         <translation>Klemme Ebene 3:</translation>
     </message>
     <message>
         <location filename="../sources/TerminalStrip/ui/terminalstriplayouteditor.ui" line="197"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_terminalstriplayouteditor.h" line="524"/>
         <source>Borne niveau 1 :</source>
         <translation>Klemme Ebene 1:</translation>
     </message>
@@ -13531,6 +18052,7 @@ Andere Felder werden nicht verwendet.</translation>
     <name>TerminalStripTreeDockWidget</name>
     <message>
         <location filename="../sources/TerminalStrip/ui/terminalstriptreedockwidget.ui" line="14"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_terminalstriptreedockwidget.h" line="57"/>
         <source>Explorateur de bornier</source>
         <translation>Klemmleisten-Planer</translation>
     </message>
@@ -13605,12 +18127,12 @@ Andere Felder werden nicht verwendet.</translation>
         <translation>x:</translation>
     </message>
     <message>
-        <location filename="../sources/editor/ui/texteditor.cpp" line="344"/>
+        <location filename="../sources/editor/ui/texteditor.cpp" line="345"/>
         <source>Entrer votre texte ici</source>
         <translation>Text hier eintragen</translation>
     </message>
     <message>
-        <location filename="../sources/editor/ui/texteditor.cpp" line="365"/>
+        <location filename="../sources/editor/ui/texteditor.cpp" line="366"/>
         <source>Couleur :</source>
         <translation>Farbe:</translation>
     </message>
@@ -13619,16 +18141,19 @@ Andere Felder werden nicht verwendet.</translation>
     <name>ThirdPartyBinaryInstallDialog</name>
     <message>
         <location filename="../sources/ui/thirdpartybinaryinstalldialog.ui" line="14"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_thirdpartybinaryinstalldialog.h" line="80"/>
         <source>Logiciel tiers requis</source>
         <translation>Software von Drittanbietern erforderlich</translation>
     </message>
     <message>
         <location filename="../sources/ui/thirdpartybinaryinstalldialog.ui" line="33"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_thirdpartybinaryinstalldialog.h" line="81"/>
         <source>Télechargement</source>
         <translation>Download</translation>
     </message>
     <message>
         <location filename="../sources/ui/thirdpartybinaryinstalldialog.ui" line="44"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_thirdpartybinaryinstalldialog.h" line="82"/>
         <source>Dossier installation</source>
         <translation>Installationsordner</translation>
     </message>
@@ -13704,81 +18229,97 @@ Andere Felder werden nicht verwendet.</translation>
     </message>
     <message>
         <location filename="../sources/ui/titleblockpropertieswidget.ui" line="49"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_titleblockpropertieswidget.h" line="374"/>
         <source>Modèle :</source>
         <translation>Vorlage:</translation>
     </message>
     <message>
         <location filename="../sources/ui/titleblockpropertieswidget.ui" line="26"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_titleblockpropertieswidget.h" line="372"/>
         <source>Form</source>
         <translation>Form</translation>
     </message>
     <message>
         <location filename="../sources/ui/titleblockpropertieswidget.ui" line="258"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_titleblockpropertieswidget.h" line="393"/>
         <source>Folio :</source>
         <translation>Foliennummer:</translation>
     </message>
     <message>
         <location filename="../sources/ui/titleblockpropertieswidget.ui" line="223"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_titleblockpropertieswidget.h" line="382"/>
         <source>Auteur :</source>
         <translation>Bearbeiter:</translation>
     </message>
     <message>
         <location filename="../sources/ui/titleblockpropertieswidget.ui" line="230"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_titleblockpropertieswidget.h" line="383"/>
         <source>Indice Rev:</source>
         <translation>Revisionsindex:</translation>
     </message>
     <message>
         <location filename="../sources/ui/titleblockpropertieswidget.ui" line="244"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_titleblockpropertieswidget.h" line="388"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Disponible en tant que %plant pour les modèles de cartouches&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;In Schriftfeld-Vorlagen als %plant verfügbar&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
         <location filename="../sources/ui/titleblockpropertieswidget.ui" line="279"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_titleblockpropertieswidget.h" line="399"/>
         <source>Disponible en tant que %filename pour les modèles de cartouches</source>
         <translation>In Schriftfeld-Vorlagen als %filename verfügbar</translation>
     </message>
     <message>
         <location filename="../sources/ui/titleblockpropertieswidget.ui" line="288"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_titleblockpropertieswidget.h" line="401"/>
         <source>Pas de date</source>
         <translation>Kein Datum</translation>
     </message>
     <message>
         <location filename="../sources/ui/titleblockpropertieswidget.ui" line="295"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_titleblockpropertieswidget.h" line="402"/>
         <source>Date courante</source>
         <translation>Aktuelles Datum</translation>
     </message>
     <message>
         <location filename="../sources/ui/titleblockpropertieswidget.ui" line="302"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_titleblockpropertieswidget.h" line="404"/>
         <source>Appliquer la date actuelle</source>
         <translation>Aktuelles Datum anwenden</translation>
     </message>
     <message>
         <location filename="../sources/ui/titleblockpropertieswidget.ui" line="168"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_titleblockpropertieswidget.h" line="425"/>
         <source>Principales</source>
         <translation>Standard-Eigenschaften</translation>
     </message>
     <message>
         <location filename="../sources/ui/titleblockpropertieswidget.ui" line="32"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_titleblockpropertieswidget.h" line="373"/>
         <source>Informations des cartouches</source>
         <translation>Daten im Schriftfeld</translation>
     </message>
     <message>
         <location filename="../sources/ui/titleblockpropertieswidget.ui" line="237"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_titleblockpropertieswidget.h" line="385"/>
         <source>Disponible en tant que %locmach pour les modèles de cartouches</source>
         <translation>In Schriftfeld-Vorlagen als %locmach verfügbar</translation>
     </message>
     <message>
         <location filename="../sources/ui/titleblockpropertieswidget.ui" line="316"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_titleblockpropertieswidget.h" line="408"/>
         <source>Disponible en tant que %date pour les modèles de cartouches</source>
         <translation>In Schriftfeld-Vorlagen als %date verfügbar</translation>
     </message>
     <message>
         <location filename="../sources/ui/titleblockpropertieswidget.ui" line="329"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_titleblockpropertieswidget.h" line="410"/>
         <source>Date fixe :</source>
         <translation>Festes Datum:</translation>
     </message>
     <message>
         <location filename="../sources/ui/titleblockpropertieswidget.ui" line="338"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_titleblockpropertieswidget.h" line="412"/>
         <source>Disponible en tant que %folio pour les modèles de cartouches
 Les variables suivantes sont utilisables :
 - %id : numéro du folio courant dans le projet 
@@ -13792,61 +18333,73 @@ Folgende Variablen stehen im Feld Folie zur Verfügung:
     </message>
     <message>
         <location filename="../sources/ui/titleblockpropertieswidget.ui" line="349"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_titleblockpropertieswidget.h" line="418"/>
         <source>Titre :</source>
         <translation>Titel:</translation>
     </message>
     <message>
         <location filename="../sources/ui/titleblockpropertieswidget.ui" line="84"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_titleblockpropertieswidget.h" line="377"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Affiche le cartouche en bas (horizontalement) ou à droite (verticalement) du folio.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Zeigt das Schriftfeld unter der Folie (waagerecht) oder rechts davon (senkrecht) an.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
         <location filename="../sources/ui/titleblockpropertieswidget.ui" line="265"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_titleblockpropertieswidget.h" line="394"/>
         <source>Fichier :</source>
         <translation>Datei:</translation>
     </message>
     <message>
         <location filename="../sources/ui/titleblockpropertieswidget.ui" line="176"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_titleblockpropertieswidget.h" line="380"/>
         <source>Date :</source>
         <translation>Datum:</translation>
     </message>
     <message>
         <location filename="../sources/ui/titleblockpropertieswidget.ui" line="272"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_titleblockpropertieswidget.h" line="396"/>
         <source>Disponible en tant que %author pour les modèles de cartouches</source>
         <translation>In Schriftfeld-Vorlagen als %author verfügbar</translation>
     </message>
     <message>
         <location filename="../sources/ui/titleblockpropertieswidget.ui" line="251"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_titleblockpropertieswidget.h" line="391"/>
         <source>Disponible en tant que %title pour les modèles de cartouches</source>
         <translation>In Schriftfeld-Vorlagen als %title verfügbar</translation>
     </message>
     <message>
         <location filename="../sources/ui/titleblockpropertieswidget.ui" line="362"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_titleblockpropertieswidget.h" line="419"/>
         <source>Page Num:</source>
         <translation>Auto-Nummerierung:</translation>
     </message>
     <message>
         <location filename="../sources/ui/titleblockpropertieswidget.ui" line="376"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_titleblockpropertieswidget.h" line="423"/>
         <source>Installation :</source>
         <translation>Anlage:</translation>
     </message>
     <message>
         <location filename="../sources/ui/titleblockpropertieswidget.ui" line="369"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_titleblockpropertieswidget.h" line="421"/>
         <source>Disponible en tant que %indexrev pour les modèles de cartouches</source>
         <translation>In Schriftfeld-Vorlagen als %indexrev verfügbar</translation>
     </message>
     <message>
         <location filename="../sources/ui/titleblockpropertieswidget.ui" line="383"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_titleblockpropertieswidget.h" line="424"/>
         <source>Localisation:</source>
         <translation>Ort:</translation>
     </message>
     <message>
         <location filename="../sources/ui/titleblockpropertieswidget.ui" line="406"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_titleblockpropertieswidget.h" line="428"/>
         <source>Personnalisées</source>
         <translation>Benutzer-Eigenschaften</translation>
     </message>
     <message>
         <location filename="../sources/ui/titleblockpropertieswidget.ui" line="414"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_titleblockpropertieswidget.h" line="426"/>
         <source>Vous pouvez définir ici vos propres associations noms/valeurs pour que le cartouche en tienne compte. Exemple :
 associer le nom &quot;volta&quot; et la valeur &quot;1745&quot; remplacera %{volta} par 1745 dans le cartouche.</source>
         <translation>Hier können Sie Ihre eigenen Kombinationen Variablen/Werte für die Einträge der Datenfelder im Schriftfeld definieren. Zum Beispiel:
@@ -14344,7 +18897,7 @@ Maximale Länge: %2px
     <name>WiringListExport</name>
     <message>
         <location filename="../sources/wiringlistexport.cpp" line="157"/>
-        <location filename="../sources/wiringlistexport.cpp" line="172"/>
+        <location filename="../sources/wiringlistexport.cpp" line="211"/>
         <source>Erreur</source>
         <translation>Fehler</translation>
     </message>
@@ -14354,81 +18907,81 @@ Maximale Länge: %2px
         <translation>Die Speicherstruktur des Projekts kann nicht gelesen werden.</translation>
     </message>
     <message>
-        <location filename="../sources/wiringlistexport.cpp" line="163"/>
+        <location filename="../sources/wiringlistexport.cpp" line="202"/>
         <source>Exporter le plan de câblage</source>
         <translation>Verdrahtungsplan erstellen</translation>
     </message>
     <message>
-        <location filename="../sources/wiringlistexport.cpp" line="165"/>
+        <location filename="../sources/wiringlistexport.cpp" line="204"/>
         <source>Fichiers CSV (*.csv)</source>
         <translation>CSV-Dateien (*.csv)</translation>
     </message>
     <message>
-        <location filename="../sources/wiringlistexport.cpp" line="172"/>
+        <location filename="../sources/wiringlistexport.cpp" line="211"/>
         <source>Impossible d&apos;ouvrir le fichier pour l&apos;écriture.</source>
         <translation>Die Datei kann nicht zum Schreiben geöffnet werden.</translation>
     </message>
     <message>
-        <location filename="../sources/wiringlistexport.cpp" line="314"/>
+        <location filename="../sources/wiringlistexport.cpp" line="357"/>
         <source>Page</source>
         <comment>Wiring list CSV header</comment>
         <translation>Seite</translation>
     </message>
     <message>
-        <location filename="../sources/wiringlistexport.cpp" line="315"/>
+        <location filename="../sources/wiringlistexport.cpp" line="358"/>
         <source>Composant 1</source>
         <comment>Wiring list CSV header</comment>
         <translation>Bauteil 1</translation>
     </message>
     <message>
-        <location filename="../sources/wiringlistexport.cpp" line="316"/>
+        <location filename="../sources/wiringlistexport.cpp" line="359"/>
         <source>Borne 1</source>
         <comment>Wiring list CSV header</comment>
         <translation>Anschluss 1</translation>
     </message>
     <message>
-        <location filename="../sources/wiringlistexport.cpp" line="317"/>
+        <location filename="../sources/wiringlistexport.cpp" line="360"/>
         <source>Composant 2</source>
         <comment>Wiring list CSV header</comment>
         <translation>Bauteil 2</translation>
     </message>
     <message>
-        <location filename="../sources/wiringlistexport.cpp" line="318"/>
+        <location filename="../sources/wiringlistexport.cpp" line="361"/>
         <source>Borne 2</source>
         <comment>Wiring list CSV header</comment>
         <translation>Anschluss 2</translation>
     </message>
     <message>
-        <location filename="../sources/wiringlistexport.cpp" line="319"/>
+        <location filename="../sources/wiringlistexport.cpp" line="362"/>
         <source>Tension / Protocole</source>
         <comment>Wiring list CSV header</comment>
         <translation>Spannung / Protokoll</translation>
     </message>
     <message>
-        <location filename="../sources/wiringlistexport.cpp" line="320"/>
+        <location filename="../sources/wiringlistexport.cpp" line="363"/>
         <source>Couleur du fil</source>
         <comment>Wiring list CSV header</comment>
         <translation>Leiterfarbe</translation>
     </message>
     <message>
-        <location filename="../sources/wiringlistexport.cpp" line="321"/>
+        <location filename="../sources/wiringlistexport.cpp" line="364"/>
         <source>Section du fil</source>
         <comment>Wiring list CSV header</comment>
         <translation>Leiterquerschnitt</translation>
     </message>
     <message>
-        <location filename="../sources/wiringlistexport.cpp" line="322"/>
+        <location filename="../sources/wiringlistexport.cpp" line="365"/>
         <source>Fonction</source>
         <comment>Wiring list CSV header</comment>
         <translation>Funktion</translation>
     </message>
     <message>
-        <location filename="../sources/wiringlistexport.cpp" line="337"/>
+        <location filename="../sources/wiringlistexport.cpp" line="380"/>
         <source>Export réussi</source>
         <translation>Export erfolgreich</translation>
     </message>
     <message>
-        <location filename="../sources/wiringlistexport.cpp" line="337"/>
+        <location filename="../sources/wiringlistexport.cpp" line="380"/>
         <source>Le plan de câblage a été exporté avec succès !</source>
         <translation>Der Verdrahtungsplan wurde erfolgreich exportiert!</translation>
     </message>
@@ -14437,91 +18990,109 @@ Maximale Länge: %2px
     <name>XRefPropertiesWidget</name>
     <message>
         <location filename="../sources/ui/xrefpropertieswidget.ui" line="14"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_xrefpropertieswidget.h" line="301"/>
         <source>Form</source>
         <translation>Eigenschaften Querverweise</translation>
     </message>
     <message>
         <location filename="../sources/ui/xrefpropertieswidget.ui" line="22"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_xrefpropertieswidget.h" line="302"/>
         <source>Type :</source>
         <translation>Typ:</translation>
     </message>
     <message>
         <location filename="../sources/ui/xrefpropertieswidget.ui" line="34"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_xrefpropertieswidget.h" line="303"/>
         <source>Représentation:</source>
         <translation>Darstellung:</translation>
     </message>
     <message>
         <location filename="../sources/ui/xrefpropertieswidget.ui" line="42"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_xrefpropertieswidget.h" line="304"/>
         <source>Positionner :</source>
         <translation>Position:</translation>
     </message>
     <message>
         <location filename="../sources/ui/xrefpropertieswidget.ui" line="56"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_xrefpropertieswidget.h" line="305"/>
         <source>XRef Vertical Offset:</source>
         <translation>Abstand zum Schriftfeld:</translation>
     </message>
     <message>
         <location filename="../sources/ui/xrefpropertieswidget.ui" line="63"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_xrefpropertieswidget.h" line="307"/>
         <source>10px corresponds to 1 tile displacement</source>
         <translation>10px entsprechen einer Rastereinheit</translation>
     </message>
     <message>
         <location filename="../sources/ui/xrefpropertieswidget.ui" line="66"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_xrefpropertieswidget.h" line="310"/>
         <source>Set Vertical Offset for the Cross References. 10px corresponds to 1 tile displacement.</source>
         <translation>Lege den Abstand vom Kontaktspiegel fest. 10px entsprechen einer Rastereinheit.</translation>
     </message>
     <message>
         <location filename="../sources/ui/xrefpropertieswidget.ui" line="69"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_xrefpropertieswidget.h" line="312"/>
         <source>Default - Fit to XRef height</source>
         <translation>Standard - ganz unten</translation>
     </message>
     <message>
         <location filename="../sources/ui/xrefpropertieswidget.ui" line="98"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_xrefpropertieswidget.h" line="313"/>
         <source>XRef slave position</source>
         <translation>Position vom Querverweis bei Slave-Bauteilen</translation>
     </message>
     <message>
         <location filename="../sources/ui/xrefpropertieswidget.ui" line="114"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_xrefpropertieswidget.h" line="314"/>
         <source>Afficher les numéros de bornes dans les Xrefs</source>
-        <translation type="unfinished"></translation>
+        <translation>Klemmenummern im Kontaktkamm anzeigen</translation>
     </message>
     <message>
         <location filename="../sources/ui/xrefpropertieswidget.ui" line="121"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_xrefpropertieswidget.h" line="315"/>
         <source>Affiche&amp;r en contacts</source>
         <translation>als &amp;Kontakte anzeigen</translation>
     </message>
     <message>
         <location filename="../sources/ui/xrefpropertieswidget.ui" line="128"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_xrefpropertieswidget.h" line="316"/>
         <source>Afficher en croix</source>
         <translation>als Tabelle anzeigen</translation>
     </message>
     <message>
         <location filename="../sources/ui/xrefpropertieswidget.ui" line="141"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_xrefpropertieswidget.h" line="317"/>
         <source>Label des références croisées</source>
         <translation>Querverweistexte</translation>
     </message>
     <message>
         <location filename="../sources/ui/xrefpropertieswidget.ui" line="161"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_xrefpropertieswidget.h" line="318"/>
         <source>Maitre</source>
         <translation>Master</translation>
     </message>
     <message>
         <location filename="../sources/ui/xrefpropertieswidget.ui" line="171"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_xrefpropertieswidget.h" line="320"/>
         <source>%f-%l%c</source>
         <translation>%f-%l%c</translation>
     </message>
     <message>
         <location filename="../sources/ui/xrefpropertieswidget.ui" line="194"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_xrefpropertieswidget.h" line="321"/>
         <source>Esclave</source>
         <translation>Slave</translation>
     </message>
     <message>
         <location filename="../sources/ui/xrefpropertieswidget.ui" line="204"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_xrefpropertieswidget.h" line="322"/>
         <source>(%f-%l%c)</source>
         <translation>(%f-%l%c)</translation>
     </message>
     <message>
         <location filename="../sources/ui/xrefpropertieswidget.ui" line="213"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_xrefpropertieswidget.h" line="323"/>
         <source>Créer votre propre texte en vous aidant des variables suivantes :
 %f : le numéro de folio 
 %F: le label de folio
@@ -14539,26 +19110,31 @@ Maximale Länge: %2px
     </message>
     <message>
         <location filename="../sources/ui/xrefpropertieswidget.ui" line="234"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_xrefpropertieswidget.h" line="330"/>
         <source>Option d&apos;affichage en croix</source>
         <translation>Optionen für die Darstellung als Tabelle</translation>
     </message>
     <message>
         <location filename="../sources/ui/xrefpropertieswidget.ui" line="240"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_xrefpropertieswidget.h" line="331"/>
         <source>Afficher les contacts de puissance dans la croix</source>
         <translation>Leistungskontakte anzeigen</translation>
     </message>
     <message>
         <location filename="../sources/ui/xrefpropertieswidget.ui" line="249"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_xrefpropertieswidget.h" line="332"/>
         <source>Préfixe des contacts de puissance :</source>
         <translation>Präfix für Leistungskontakte:</translation>
     </message>
     <message>
         <location filename="../sources/ui/xrefpropertieswidget.ui" line="256"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_xrefpropertieswidget.h" line="333"/>
         <source>Préfixe des contacts temporisés :</source>
         <translation>Präfix für zeitverzögerte Kontakte:</translation>
     </message>
     <message>
         <location filename="../sources/ui/xrefpropertieswidget.ui" line="269"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_xrefpropertieswidget.h" line="334"/>
         <source>Préfixe des contacts inverseurs :</source>
         <translation>Präfix für Wechslerkontakte:</translation>
     </message>
@@ -14617,11 +19193,13 @@ Maximale Länge: %2px
     <name>diagramselection</name>
     <message>
         <location filename="../sources/ui/diagramselection.ui" line="14"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_diagramselection.h" line="62"/>
         <source>Form</source>
         <translation>Form</translation>
     </message>
     <message>
         <location filename="../sources/ui/diagramselection.ui" line="22"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_diagramselection.h" line="63"/>
         <source>TextLabel</source>
         <translation>TextLabel</translation>
     </message>
@@ -14659,6 +19237,14 @@ Maximale Länge: %2px
         <location filename="../sources/ui/diagramselection.cpp" line="107"/>
         <source>Sélectionner tout</source>
         <translation>Alles auswählen</translation>
+    </message>
+</context>
+<context>
+    <name>main</name>
+    <message>
+        <location filename="../build/_deps/kwidgetsaddons-src/tests/knewpassworddialogtest.cpp" line="19"/>
+        <source>Enter a password for the test</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -14785,53 +19371,81 @@ Maximale Länge: %2px
     <name>replaceAdvancedDialog</name>
     <message>
         <location filename="../sources/SearchAndReplace/ui/replaceadvanceddialog.ui" line="14"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_replaceadvanceddialog.h" line="113"/>
         <source>Rechercher/Remplacer avancé</source>
         <translation>Fortgeschrittenes Suchen/Ersetzen</translation>
     </message>
     <message>
         <location filename="../sources/SearchAndReplace/ui/replaceadvanceddialog.ui" line="27"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_replaceadvanceddialog.h" line="114"/>
         <source>par :</source>
         <translation>durch:</translation>
     </message>
     <message>
         <location filename="../sources/SearchAndReplace/ui/replaceadvanceddialog.ui" line="34"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_replaceadvanceddialog.h" line="115"/>
         <source>Remplacer :</source>
         <translation>Ersetzen:</translation>
     </message>
     <message>
         <location filename="../sources/SearchAndReplace/ui/replaceadvanceddialog.ui" line="51"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_replaceadvanceddialog.h" line="116"/>
         <source>Qui :</source>
         <translation>Wo:</translation>
     </message>
     <message>
         <location filename="../sources/SearchAndReplace/ui/replaceadvanceddialog.ui" line="58"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_replaceadvanceddialog.h" line="117"/>
         <source>Texte ou expression régulière</source>
         <translation>Text oder regulärer Ausdruck</translation>
     </message>
     <message>
         <location filename="../sources/SearchAndReplace/ui/replaceadvanceddialog.ui" line="69"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_replaceadvanceddialog.h" line="118"/>
         <source>Folio</source>
         <translation>Folie</translation>
     </message>
     <message>
         <location filename="../sources/SearchAndReplace/ui/replaceadvanceddialog.ui" line="74"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_replaceadvanceddialog.h" line="119"/>
         <source>Élément</source>
         <translation>Bauteil</translation>
     </message>
     <message>
         <location filename="../sources/SearchAndReplace/ui/replaceadvanceddialog.ui" line="79"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_replaceadvanceddialog.h" line="120"/>
         <source>Conducteur</source>
         <translation>Leiter</translation>
     </message>
     <message>
         <location filename="../sources/SearchAndReplace/ui/replaceadvanceddialog.ui" line="84"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_replaceadvanceddialog.h" line="121"/>
         <source>Texte indépendant</source>
         <translation>Textfeld</translation>
     </message>
     <message>
         <location filename="../sources/SearchAndReplace/ui/replaceadvanceddialog.ui" line="92"/>
+        <location filename="../build/qelectrotech_autogen/include/ui_replaceadvanceddialog.h" line="123"/>
         <source>Quoi :</source>
         <translation>Was:</translation>
+    </message>
+</context>
+<context>
+    <name>testcontext</name>
+    <message>
+        <location filename="../build/_deps/ecm-src/tests/ECMPoQmToolsTest/tr_test.cpp" line="18"/>
+        <location filename="../build/_deps/ecm-src/tests/ECMPoQmToolsTest/tr_thread_test_module.cpp" line="16"/>
+        <source>test string</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../build/_deps/ecm-src/tests/ECMPoQmToolsTest/tr_test.cpp" line="19"/>
+        <location filename="../build/_deps/ecm-src/tests/ECMPoQmToolsTest/tr_thread_test_module.cpp" line="17"/>
+        <source>test plural %n</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
     </message>
 </context>
 </TS>

--- a/sources/qetgraphicsitem/terminal.cpp
+++ b/sources/qetgraphicsitem/terminal.cpp
@@ -788,6 +788,12 @@ QList<Terminal *> relatedPotentialTerminal (
 	// If terminal parent element is a Terminal element.
 	else if (terminal -> parentElement() -> linkType() & Element::Terminale)
 	{
+		// English: Check if the user activated the potential isolation checkbox for this terminal
+		if (terminal->parentElement()->elementInformations().value(QStringLiteral("potential_isolating")).toString() == QLatin1String("true")) {
+			// English: Potential is isolated. Return an empty list so it does not propagate to the other side.
+			return QList<Terminal *>();
+		}
+
 		QList <Terminal *> terminals = terminal->parentElement()->terminals();
 		terminals.removeAll(const_cast<Terminal *>(terminal));
 		return terminals;

--- a/sources/ui/elementinfowidget.cpp
+++ b/sources/ui/elementinfowidget.cpp
@@ -16,7 +16,7 @@
 	along with QElectroTech.  If not, see <http://www.gnu.org/licenses/>.
 */
 #include "elementinfowidget.h"
-
+#include <QCheckBox>
 #include "../diagram.h"
 #include "../qetapp.h"
 #include "../qetgraphicsitem/element.h"
@@ -161,6 +161,10 @@ void ElementInfoWidget::enableLiveEdit()
 	for (ElementInfoPartWidget *eipw : m_eipw_list)
 		connect(eipw, &ElementInfoPartWidget::textChanged, this, &ElementInfoWidget::apply);
 	connect(ui->m_auto_num_locked_cb, &QCheckBox::clicked, this, &ElementInfoWidget::apply);
+
+	if (m_potential_isolating_cb) {
+		connect(m_potential_isolating_cb, &QCheckBox::clicked, this, &ElementInfoWidget::apply);
+	}
 }
 
 /**
@@ -172,6 +176,10 @@ void ElementInfoWidget::disableLiveEdit()
 	for (ElementInfoPartWidget *eipw : m_eipw_list)
 		disconnect(eipw, &ElementInfoPartWidget::textChanged, this, &ElementInfoWidget::apply);
 	disconnect(ui->m_auto_num_locked_cb, &QCheckBox::clicked, this, &ElementInfoWidget::apply);
+
+	if (m_potential_isolating_cb) {
+		disconnect(m_potential_isolating_cb, &QCheckBox::clicked, this, &ElementInfoWidget::apply);
+	}
 }
 
 /**
@@ -195,14 +203,25 @@ void ElementInfoWidget::buildInterface()
 	}
 
 	ui->scroll_vlayout->addStretch();
+
+	m_potential_isolating_cb = new QCheckBox(tr("Séparation de potentiel"), this);
+
+	m_potential_isolating_cb->setStyleSheet(QStringLiteral("margin: 5px; font-weight: bold;"));
+
+	if (QVBoxLayout *mainLayout = qobject_cast<QVBoxLayout*>(this->layout())) {
+		mainLayout->insertWidget(1, m_potential_isolating_cb);
+	}
+
 	// Show checkbox only if the element is a terminal
+
 	if (m_element.data()->elementData().m_type == ElementData::Terminal) {
 		ui->m_auto_num_locked_cb->setVisible(true);
+		m_potential_isolating_cb->setVisible(true);
 	} else {
 		ui->m_auto_num_locked_cb->setVisible(false);
+		m_potential_isolating_cb->setVisible(false);
 	}
 }
-
 /**
 	@brief ElementInfoWidget::infoPartWidgetForKey
 	@param key
@@ -243,6 +262,12 @@ void ElementInfoWidget::updateUi()
 	if (m_element->elementData().m_type == ElementData::Terminal) {
 		QString lock_value = element_info.value(QStringLiteral("auto_num_locked")).toString();
 		ui->m_auto_num_locked_cb->setChecked(lock_value == QLatin1String("true"));
+
+		// English: Load the potential isolating status from the element information mapping
+		if (m_potential_isolating_cb) {
+			QString isolating_value = element_info.value(QStringLiteral("potential_isolating")).toString();
+			m_potential_isolating_cb->setChecked(isolating_value == QLatin1String("true"));
+		}
 	}
 
 	if (m_live_edit) {
@@ -275,6 +300,10 @@ DiagramContext ElementInfoWidget::currentInfo() const
 	// Save the auto numbering lock status
 	if (m_element->elementData().m_type == ElementData::Terminal) {
 		info_.addValue(QStringLiteral("auto_num_locked"), ui->m_auto_num_locked_cb->isChecked() ? QStringLiteral("true") : QStringLiteral("false"));
+
+		if (m_potential_isolating_cb) {
+			info_.addValue(QStringLiteral("potential_isolating"), m_potential_isolating_cb->isChecked() ? QStringLiteral("true") : QStringLiteral("false"));
+		}
 	}
 	return info_;
 }

--- a/sources/ui/elementinfowidget.h
+++ b/sources/ui/elementinfowidget.h
@@ -27,6 +27,7 @@ class Element;
 class QUndoCommand;
 class ElementInfoPartWidget;
 class ChangeElementInformationCommand;
+class QCheckBox;
 
 namespace Ui {
 	class ElementInfoWidget;
@@ -71,6 +72,7 @@ class ElementInfoWidget : public AbstractElementPropertiesEditorWidget
 	private:
 		Ui::ElementInfoWidget           *ui;
 		QList <ElementInfoPartWidget *>  m_eipw_list;
+		QCheckBox                       *m_potential_isolating_cb = nullptr;
 		bool m_first_activation;
 		bool m_ui_builded = false;
 };


### PR DESCRIPTION
This PR introduces a new property for terminal elements (potential_isolating) that allows users to logically disconnect the electrical potential between the two sides of a terminal without altering or deleting the physical conductors.