### PR TITLE
CLI export: don't draw the editor grid in PDF/PNG/SVG output

### DIFF
--- a/sources/cli_export.cpp
+++ b/sources/cli_export.cpp
@@ -74,9 +74,13 @@ QString diagramStem(Diagram *diagram, int index)
 void renderDiagram(Diagram *diagram, QPainter &painter, const QRectF &target)
 {
 	const QRect source = diagramRect(diagram);
-	const bool was_drawing_grid = false; // export without the editor grid
-	Q_UNUSED(was_drawing_grid)
+	// Export without the editor grid: drawBackground() only paints it when
+	// draw_grid_ is set (default true), so toggle it off around the render
+	// and restore it afterwards.
+	const bool was_drawing_grid = diagram->displayGrid();
+	diagram->setDisplayGrid(false);
 	diagram->render(&painter, target, source, Qt::KeepAspectRatio);
+	diagram->setDisplayGrid(was_drawing_grid);
 }
 
 int exportPdf(QETProject &project, const QString &output)


### PR DESCRIPTION
Follow-up to #483.

`renderDiagram()` had a no-op stub — `was_drawing_grid` was assigned `false` and then `Q_UNUSED`'d — so the editor grid was still painted into exported output.

This toggles `Diagram::setDisplayGrid(false)` around the render and restores the previous state afterwards. PDF, PNG and SVG all share `renderDiagram()`, so the fix covers all three formats.

Reported by @scorpio810 on #483.