### PR TITLE
Element editor Save As: label the field as a file name, not 'element name'

### DIFF
--- a/lang/qet_en.ts
+++ b/lang/qet_en.ts
@@ -1833,9 +1833,18 @@ Note: these options DO NOT allow or block auto numberings, only their update pol
         <translation>Name of the new template</translation>
     </message>
     <message>
-        <location filename="../sources/elementdialog.cpp" line="127"/>
-        <source>Nom du nouvel élément</source>
-        <translation>New element name</translation>
+        <location filename="../sources/elementdialog.cpp" line="130"/>
+        <source>Nom de fichier de l'élément</source>
+        <comment>placeholder: the element's file name, not its display name</comment>
+        <translation>Element file name</translation>
+    </message>
+    <message>
+        <location filename="../sources/elementdialog.cpp" line="134"/>
+        <source>Nom de fichier de l'élément : chiffres, minuscules, « - », « _ » et « . » uniquement.
+Le nom affiché de l'élément se modifie séparément dans les propriétés de l'élément.</source>
+        <comment>tooltip for the element file-name field</comment>
+        <translation>The element's file name: digits, lowercase letters, '-', '_' and '.' only.
+The element's display name is edited separately in the element properties.</translation>
     </message>
     <message>
         <location filename="../sources/elementdialog.cpp" line="238"/>

--- a/sources/elementdialog.cpp
+++ b/sources/elementdialog.cpp
@@ -124,7 +124,17 @@ void ElementDialog::setUpWidget()
 		} else if (m_mode == SaveTemplate) {
 			m_text_field->setPlaceholderText(tr("Nom du nouveau template"));
 		} else {
-			m_text_field->setPlaceholderText(tr("Nom du nouvel élément"));
+			// This is the element's file name, not its display name: the field
+			// only accepts file-name characters (QFileNameEdit). The visible
+			// element name is edited separately in the element properties.
+			m_text_field->setPlaceholderText(
+				tr("Nom de fichier de l'élément",
+				   "placeholder: the element's file name, not its display name"));
+			m_text_field->setToolTip(
+				tr("Nom de fichier de l'élément : chiffres, minuscules, « - », "
+				   "« _ » et « . » uniquement.\nLe nom affiché de l'élément se "
+				   "modifie séparément dans les propriétés de l'élément.",
+				   "tooltip for the element file-name field"));
 		}
 
 		layout->addWidget(m_text_field);


### PR DESCRIPTION
Fixes #469.

The element editor's *Save As* (save-to-collection) dialog uses a `QFileNameEdit` — it only accepts `[0-9a-z_.-]` — but the placeholder labelled it **'New element name'**. That's misleading: QET also has a separate, translatable *display* name (shown in the collection panel), so users reasonably typed a display name with spaces/capitals and it was silently rejected.

**Change:**
- Placeholder `Nom du nouvel élément` → `Nom de fichier de l'élément` (**'Element file name'**), fixing both the French source and English.
- Added a tooltip noting the accepted characters and that the display name is edited separately in the element properties (addresses the issue's 'ideally explain' ask).
- Updated `qet_en.ts`; other languages fall back until re-translated (normal lupdate flow). Only the *element* case is touched — the folder/template placeholders are left as-is since they have no separate display name.

**Verified** on Qt5 build (Ubuntu): compiles clean, and the compiled `qet_en.qm` carries the new 'Element file name' string (confirmed via lconvert).

*Developed with assistance from Claude (Anthropic).*