### PR TITLE
Folio properties: auto-add a title block's custom variables

### DIFF
--- a/sources/titleblocktemplate.cpp
+++ b/sources/titleblocktemplate.cpp
@@ -1756,6 +1756,10 @@ QString TitleBlockTemplate::interpreteVariables(
 QStringList TitleBlockTemplate::listOfVariables()
 {
 	QStringList list;
+	// Match every "%{name}" placeholder. The bare "%name" form can't be
+	// extracted reliably without the variable list, and templates use the
+	// braced form, so only that is collected here.
+	static const QRegularExpression rx(QStringLiteral("%\\{([^}]+)\\}"));
 	// run through each individual cell
 	for (int j = 0 ; j < rows_heights_.count() ; ++ j) {
 		for (int i = 0 ; i < columns_width_.count() ; ++ i) {
@@ -1763,14 +1767,15 @@ QStringList TitleBlockTemplate::listOfVariables()
 					|| cells_[i][j] -> cell_type
 					== TitleBlockCell::EmptyCell)
 				continue;
-#if TODO_LIST
-#pragma message("@TODO not works on all cases...")
-#endif
-			// TODO: not works on all cases...
-			list << cells_[i][j] -> value.name().replace("%","");
+			const QString cell_value = cells_[i][j] -> value.name();
+			auto it = rx.globalMatch(cell_value);
+			while (it.hasNext()) {
+				const QString name = it.next().captured(1);
+				if (!name.isEmpty() && !list.contains(name))
+					list << name;
+			}
 		}
 	}
-	qDebug() << list;
 	return list;
 }
 

--- a/sources/ui/titleblockpropertieswidget.cpp
+++ b/sources/ui/titleblockpropertieswidget.cpp
@@ -24,6 +24,7 @@
 #include "ui_titleblockpropertieswidget.h"
 
 #include <QMenu>
+#include <QSet>
 #include <utility>
 
 /**
@@ -162,7 +163,11 @@ void TitleBlockPropertiesWidget::setProperties(
 	}
 	ui -> m_tbt_cb -> setCurrentIndex(index);
 
-	m_dcw -> setContext(properties.context);
+	// Show the saved custom values, plus any of the template's custom variables
+	// that aren't defined yet, so the user only fills in the missing ones (#271).
+	DiagramContext context = properties.context;
+	addTemplateVariables(context, index);
+	m_dcw -> setContext(context);
 }
 
 /**
@@ -435,12 +440,15 @@ void TitleBlockPropertiesWidget::updateTemplateList()
 }
 
 /**
-	@brief TitleBlockPropertiesWidget::changeCurrentTitleBlockTemplate
-	Load the additional field of title block "text"
+	@brief TitleBlockPropertiesWidget::templateForIndex
+	@param index : index in the collection-type map (= the template combo index)
+	@return the TitleBlockTemplate currently selected for that collection, or
+	nullptr.
 */
-void TitleBlockPropertiesWidget::changeCurrentTitleBlockTemplate(int index)
+TitleBlockTemplate *TitleBlockPropertiesWidget::templateForIndex(int index) const
 {
-	m_dcw -> clear();
+	if (index < 0 || index >= m_map_index_to_collection_type.count())
+		return nullptr;
 
 	QET::QetCollection qc = m_map_index_to_collection_type.at(index);
 	TitleBlockTemplatesCollection *collection = nullptr;
@@ -448,19 +456,53 @@ void TitleBlockPropertiesWidget::changeCurrentTitleBlockTemplate(int index)
 		if (c -> collection() == qc)
 			collection = c;
 
-	if (!collection) return;
+	if (!collection) return nullptr;
+	return collection -> getTemplate(ui -> m_tbt_cb -> currentText());
+}
 
-		// get template
-	TitleBlockTemplate *tpl = collection -> getTemplate(ui -> m_tbt_cb -> currentText());
-	if(tpl != nullptr) {
-			// get all template fields
-		QStringList fields = tpl -> listOfVariables();
-			// set fields to additional_fields_ widget
-		DiagramContext templateContext;
-		for(int i =0; i<fields.count(); i++)
-			templateContext.addValue(fields.at(i), "");
-		m_dcw -> setContext(templateContext);
+/**
+	@brief TitleBlockPropertiesWidget::addTemplateVariables
+	Add to @p context every CUSTOM variable used by the currently selected
+	template that is not already present, with an empty value — so the user
+	only has to fill in the values instead of declaring the variables (#271).
+	The standard fields (title, author, date, …) are handled by their own
+	widgets and are skipped. Existing values in @p context are preserved.
+*/
+void TitleBlockPropertiesWidget::addTemplateVariables(
+		DiagramContext &context, int index) const
+{
+	TitleBlockTemplate *tpl = templateForIndex(index);
+	if (!tpl) return;
+
+	// Variables rendered from the dedicated standard-field widgets; they must
+	// not appear in the "Custom" tab.
+	static const QSet<QString> reserved {
+		QStringLiteral("author"), QStringLiteral("date"),
+		QStringLiteral("title"), QStringLiteral("filename"),
+		QStringLiteral("plant"), QStringLiteral("locmach"),
+		QStringLiteral("indexrev"), QStringLiteral("version"),
+		QStringLiteral("folio"), QStringLiteral("folio-id"),
+		QStringLiteral("folio-total"), QStringLiteral("auto_page_num"),
+		QStringLiteral("previous-folio-num"), QStringLiteral("next-folio-num")
+	};
+
+	const QStringList variables = tpl -> listOfVariables();
+	for (const QString &name : variables) {
+		if (name.isEmpty() || reserved.contains(name)) continue;
+		if (!context.contains(name)) context.addValue(name, "");
 	}
+}
+
+/**
+	@brief TitleBlockPropertiesWidget::changeCurrentTitleBlockTemplate
+	When the user picks a template, append its missing custom variables to the
+	"Custom" tab while keeping the values already entered (#271).
+*/
+void TitleBlockPropertiesWidget::changeCurrentTitleBlockTemplate(int index)
+{
+	DiagramContext context = m_dcw -> context();
+	addTemplateVariables(context, index);
+	m_dcw -> setContext(context);
 }
 
 /**

--- a/sources/ui/titleblockpropertieswidget.h
+++ b/sources/ui/titleblockpropertieswidget.h
@@ -30,6 +30,7 @@ class NumerotationContext;
 class QETProject;
 class QMenu;
 class TitleBlockTemplatesCollection;
+class TitleBlockTemplate;
 
 namespace Ui {
 	class TitleBlockPropertiesWidget;
@@ -77,6 +78,8 @@ class TitleBlockPropertiesWidget : public QWidget
 		void initDialog(const bool &current_date, QETProject *project);
 		int getIndexFor (const QString &tbt_name,
 				 const QET::QetCollection collection) const;
+		TitleBlockTemplate *templateForIndex (int index) const;
+		void addTemplateVariables (DiagramContext &context, int index) const;
 
 	private slots:
 		void editCurrentTitleBlockTemplate();


### PR DESCRIPTION
Implements the main request in #271.

When a title block template uses custom variables (e.g. `%{department}`, `%{owner}`), the user had to declare each one by hand in the folio properties **Custom** tab before a value could be entered. This adds them automatically, so the user only fills in values.

**Changes**
- `TitleBlockTemplate::listOfVariables()` now extracts `%{name}` placeholders with a regex (deduplicated). Previously it did `value.name().replace("%","")`, which returned `{name}` (with braces) and was flagged with a `// TODO: not works on all cases`. It's only called from the folio-properties widget.
- The folio-properties widget merges the template's custom variables into the Custom tab **both on open (`setProperties`) and when the template is changed**, instead of clearing/overwriting. Existing values are preserved, and the 14 standard fields (title, author, date, …) are skipped since they have their own inputs.

Scope: the variable auto-population only. The revision-history idea raised in the issue thread is a separate, larger feature and isn't included here.

**Testing**
Built clean on Qt5 + KF5 (Ubuntu); the logic is covered by code review (regex extraction, merge-preserving-existing, standard-field exclusion). I have **not** been able to click through the actual dialog — my environment is a headless CI-style build, so I couldn't visually confirm the Custom tab in the running GUI. A quick manual check (new folio → add `ISO7200_A4_V1` → open folio properties → Custom tab) would be worth doing before merge. Happy to adjust based on what you see.

*Developed with assistance from Claude (Anthropic).*