### PR TITLE
Fix regional system locale loading the wrong translation (pt_BR/nl_BE/nl_NL)

### DIFF
--- a/sources/qetapp.cpp
+++ b/sources/qetapp.cpp
@@ -226,20 +226,20 @@ void QETApp::setLanguage(const QString &desired_language) {
 
 	// load translations for the QET application
 	// charge les traductions pour l'application QET
-	if (!qetTranslator.load("qet_" + desired_language, languages_path)) {
-		/* in case of failure,
-		 *  we fall back on the native channels for French
-		 * en cas d'echec,
-		 *  on retombe sur les chaines natives pour le francais
-		 */
-		if (desired_language != "fr") {
-			// use of the English version by default
-			// utilisation de la version anglaise par defaut
-			if(!qetTranslator.load("qet_en", languages_path))
-				qWarning() << "failed to load"
-						   << "qet_en" << languages_path << "(" << __FILE__
-						   << __LINE__ << __FUNCTION__ << ")";
-		}
+	// desired_language may be a full locale such as "pt_BR": try that exact
+	// translation, then the base language ("pt"), then fall back to English.
+	// French is the application's source language and needs no translation.
+	const QString base_language = desired_language.section('_', 0, 0);
+	bool loaded = qetTranslator.load("qet_" + desired_language, languages_path);
+	if (!loaded && base_language != desired_language)
+		loaded = qetTranslator.load("qet_" + base_language, languages_path);
+	if (!loaded && base_language != "fr") {
+		// use of the English version by default
+		// utilisation de la version anglaise par defaut
+		if(!qetTranslator.load("qet_en", languages_path))
+			qWarning() << "failed to load"
+					   << "qet_en" << languages_path << "(" << __FILE__
+					   << __LINE__ << __FUNCTION__ << ")";
 	}
 	qApp->installTranslator(&qetTranslator);
 
@@ -263,7 +263,11 @@ QString QETApp::langFromSetting()
 		QSettings settings;
 		system_language = settings.value("lang", "system").toString();
 		if(system_language == "system") {
-			system_language = QLocale::system().name().left(2);
+			// Keep the full locale (e.g. "pt_BR"), not just the base language
+			// ("pt"): QET ships regional translations (pt_BR, nl_BE, nl_NL) and
+			// truncating here loaded the wrong one. setLanguage() falls back to
+			// the base language when no regional translation exists.
+			system_language = QLocale::system().name();
 		}
 		lang_is_set = true;
 	}


### PR DESCRIPTION
Refs #421.

**Bug.** `QETApp::langFromSetting()` truncated the system locale to two letters:
```cpp
system_language = QLocale::system().name().left(2);   // "pt_BR" -> "pt"
```
So a user on the default **'Système'** language whose system locale is regional got the base-language translation. QET ships three regional translations — `qet_pt_BR`, `qet_nl_BE`, `qet_nl_NL` — so e.g. a Brazilian user saw European Portuguese, and any string only translated in pt_BR fell back to the French source. (This is the code-side half of #421; the rest is pt_BR translation coverage.)

**Fix.** Keep the full locale name, and in `setLanguage()` try the exact translation, then the base language, then English (French stays the native source — including regional French like `fr_CA`, which now resolves to French rather than English).

**Verified** on Qt5 (Ubuntu) — built clean, and a small harness exercising `QTranslator::load()` exactly as `setLanguage()` does confirms the behaviour:

| locale | result |
|--------|--------|
| `pt_BR` | loads **qet_pt_BR** (regional file present) |
| `nl_BE` | loads **qet_nl_BE** |
| `fr_FR` | strips to qet_fr (French) |
| `en_NZ` | strips to qet_en |
| `de_DE` | strips to qet_de |
| `xx_YY` | no match → English fallback |

So Brazilian/Belgian/Dutch users on 'system' now get their regional translation, and non-regional locales are unaffected.

*Developed with assistance from Claude (Anthropic).*