### PR TITLE
Clear read-only state when a project is saved to a writable file

### DIFF
--- a/sources/qetproject.cpp
+++ b/sources/qetproject.cpp
@@ -1006,15 +1006,29 @@ QETResult QETProject::write()
 	if (m_file_path.isEmpty())
 		return(QString("unable to save project to file: no filepath was specified"));
 
-		// if the project was opened read-only
-		// and the file is still non-writable, do not save the project
-	if (isReadOnly() && !QFileInfo(m_file_path).isWritable())
-		return(QString("the file %1 was opened read-only and thus will not be written").arg(m_file_path));
+		// If the project was opened read-only, only refuse when the target
+		// really can't be written: an existing file that is not writable, or a
+		// new file (e.g. "Save As" to another location) whose directory is not
+		// writable.  A non-existent file reports isWritable() == false, so the
+		// old check wrongly blocked saving a read-only project elsewhere.
+	if (isReadOnly()) {
+		const QFileInfo file_info(m_file_path);
+		const bool can_write = file_info.exists()
+			? file_info.isWritable()
+			: QFileInfo(file_info.absolutePath()).isWritable();
+		if (!can_write)
+			return(QString("the file %1 was opened read-only and thus will not be written").arg(m_file_path));
+	}
 
 	QDomDocument xml_project(toXml());
 	QString error_message;
 	if (!QET::writeXmlFile(xml_project, m_file_path, &error_message))
 		return(error_message);
+
+		// The project has just been written to a writable file (e.g. saved to
+		// a new location with "Save As"), so it is no longer read-only.
+	if (isReadOnly())
+		setReadOnly(false);
 
 		//title block variables should be updated after file save dialog is confirmed, before file is saved.
 	m_project_properties.addValue("saveddate",     QLocale::system().toString(QDate::currentDate(), QLocale::ShortFormat));


### PR DESCRIPTION
Fixes #217.

Saving a read-only project to a writable location (Save As to /tmp, etc.) left it marked read-only, so it stayed uneditable until the user closed and reopened it.

Two problems in `QETProject::write()`:

1. **The guard could block the save.** It refused whenever `QFileInfo(path).isWritable()` was false — but for a *Save As* to a new file that's always false (the file doesn't exist yet). It now checks the **directory's** writability for a new file. (Confirmed with a small harness: `isWritable()` is `false` for a non-existent file but `true` for its directory.)
2. **Read-only was never cleared.** After a successful write the file is, by definition, writable — so clear the flag. `setReadOnly(false)` emits `readOnlyChanged`, which re-enables editing live (no reopen needed).

**Testing:** built clean on Qt5 + KF5 (Ubuntu); verified the `isWritable()` directory-vs-file behaviour the guard relies on. The full Save As menu flow goes through the GUI-instantiated project (not reachable from the CLI), so I reviewed that path rather than clicking it — a quick manual check (open a read-only .qet → Save As to a writable folder → confirm it's editable) would be worth doing before merge.

*Developed with assistance from Claude (Anthropic).*