### PR TITLE
Find translations when lang/ is beside bin/, not inside it (fixes #86)

### DIFF
--- a/sources/qetapp.cpp
+++ b/sources/qetapp.cpp
@@ -1228,7 +1228,21 @@ QString QETApp::languagesPath()
 	 * en l'absence d'option de compilation, on utilise le dossier lang,
 	 *  situe a cote du binaire executable
 	 */
-	return(QCoreApplication::applicationDirPath() + "/lang/");
+	{
+		const QString bin_dir = QCoreApplication::applicationDirPath();
+		const QString next_to_bin = bin_dir + "/lang/";
+		// Some packagings (notably the Windows installer) put the binary in a
+		// "bin" subfolder while "lang" sits beside it (../lang). Fall back to
+		// that layout when the folder next to the binary is absent, so the
+		// translations are found without a --lang-dir argument. See issue #86.
+		if (!QDir(next_to_bin).exists()) {
+			const QString sibling_of_bin =
+				QDir::cleanPath(bin_dir + "/../lang") + "/";
+			if (QDir(sibling_of_bin).exists())
+				return(sibling_of_bin);
+		}
+		return(next_to_bin);
+	}
 #else
 	#ifndef QET_LANG_PATH_RELATIVE_TO_BINARY_PATH
 		/* the compilation option represents


### PR DESCRIPTION
Fixes #86 (and the related #421).

**Root cause.** `QETApp::languagesPath()` defaults to `applicationDirPath() + "/lang/"`. The Windows installer puts the executable in a `bin/` subfolder while `lang/` sits *next to* `bin/` (i.e. `../lang`), so the default points at a non-existent `bin\lang\`. `qetTranslator.load("qet_en", …)` then fails and `setLanguage()` **silently falls back to French** (the source language) — which is the long-standing "language won't change / resets to French" symptom. It also explains why launching via the bundled `Lancer QET.bat` (which passes `--lang-dir=lang/`) works around it, while a normal Start-Menu/desktop/file-association launch does not.

I traced this on a live Windows install — its own log shows:
```
System language defined in QET configuration: "en"
language Path: "C:/Program Files/QElectroTech/bin/lang/"
```
…but on disk `…\bin\lang\` does not exist and the 320 `.qm` files are in `…\QElectroTech\lang\`. Full diagnosis in #86.

**Fix.** When the folder next to the binary (`bin/lang/`) doesn't exist, fall back to the sibling `../lang/` if it's present. Behaviour is unchanged for builds that already ship `lang/` next to the binary, and for the `QET_LANG_PATH` and `--lang-dir` code paths.

**Verified** on Qt5 (Ubuntu): built clean, and a small harness exercising the exact resolution logic against both layouts:

| layout | resolves to |
|--------|-------------|
| `lang/` beside the binary (normal) | `<bin>/lang/` (unchanged) |
| `bin/` exe with `../lang` (Windows installer) | `<root>/lang/` (the fix) |
| neither present | `<bin>/lang/` (unchanged default) |

This is the code-side fix; alternatively the installer could place the translations in `bin\lang\` — happy to go whichever way you prefer.

*Developed with assistance from Claude (Anthropic).*
