### PR TITLE
Make the 'Shift to move element text' hint discoverable

### DIFF
--- a/lang/qet_en.ts
+++ b/lang/qet_en.ts
@@ -1195,11 +1195,9 @@ Note: these options DO NOT allow or block auto numberings, only their update pol
         <translation>Hold ctrl to free movement</translation>
     </message>
     <message>
-        <location filename="../sources/qetgraphicsitem/diagramtextitem.cpp" line="489"/>
-        <source>
-&lt;Shift&gt; to move</source>
-        <translation>
-&lt;Shift&gt; to move</translation>
+        <location filename="../sources/qetgraphicsitem/diagramtextitem.cpp" line="493"/>
+        <source>Hold Shift and drag to move this text independently of the element</source>
+        <translation>Hold Shift and drag to move this text independently of the element</translation>
     </message>
 </context>
 <context>

--- a/sources/qetgraphicsitem/diagramtextitem.cpp
+++ b/sources/qetgraphicsitem/diagramtextitem.cpp
@@ -483,12 +483,17 @@ void DiagramTextItem::hoverEnterEvent(QGraphicsSceneHoverEvent *e) {
 
 	m_mouse_hover = true;
 	QString str_ToolTip = toPlainText();
-	
-	// Add movement instruction for DynamicElementTextItem
+
+	// The text of an element moves the whole element by default; holding Shift
+	// while dragging moves the text on its own (relative to the element). This
+	// is not discoverable otherwise, so spell it out in the tooltip.
 	if (inherits("DynamicElementTextItem")) {
-		str_ToolTip += tr("\n<Shift> to move");
+		if (!str_ToolTip.isEmpty())
+			str_ToolTip += "\n";
+		str_ToolTip += tr("Hold Shift and drag to move this text independently "
+						  "of the element");
 	}
-	
+
 	setToolTip(str_ToolTip);
 	update();
 }


### PR DESCRIPTION
A small discoverability fix.

An element's text moves the **whole element** when dragged; holding **Shift** while dragging moves the **text on its own**, relative to the element (`DynamicElementTextItem::mousePressEvent` sets `m_move_parent` from the Shift modifier). That's genuinely useful — reposition a label without moving the symbol, and it stays attached — but there's no way to discover it: the only hint was a cryptic tooltip reading `<Shift> to move`.

This reword spells it out: **"Hold Shift and drag to move this text independently of the element."**

Tooltip text only — **no behaviour change**. Updates `qet_en.ts`; verified on a Qt5 build (Ubuntu) that the new string is present in the compiled `qet_en.qm`.

(Separately: a few users expect to just click the label and have it move by itself, KiCad/Altium-style, rather than needing a modifier. That's a behaviour-model change affecting everyone, so I've left it as a possible discussion rather than touching it here — happy to open one if it's of interest.)

*Developed with assistance from Claude (Anthropic).*
