### PR TITLE
PartText: keep text position stable across save/reopen on font-size change (#158)

### DIFF
--- a/sources/editor/graphicspart/parttext.cpp
+++ b/sources/editor/graphicspart/parttext.cpp
@@ -313,6 +313,12 @@ void PartText::setPlainText(const QString &text) {
 void PartText::setFont(const QFont &font) {
 	if (font != this -> font()) {
 		QGraphicsTextItem::setFont(font);
+		// Re-anchor: the item's position transform is -margin(), and margin()
+		// depends on the font ascent. Without re-running this on a font change,
+		// the transform keeps the previous font's ascent — so the text renders
+		// at a different spot after save/reopen (the position recomputes from
+		// the saved font on load). See #158.
+		adjustItemPosition();
 		emit fontChanged(font);
 	}
 }


### PR DESCRIPTION
Fixes the static-text position drift reported in #158.

## Problem
A static text in the element editor shifts position after save/reopen when its font size was changed. The saved `(x,y)` is unchanged — only the *rendered* position differs.

## Cause
`PartText` is anchored by a transform of `-margin()`, where `margin().y = documentMargin + fontMetrics.ascent()` — so the rendered position depends on the font's **ascent**. `adjustItemPosition()` (which sets that transform) is only re-run on `blockCountChanged` / `contentsChanged`, **not** on a font/size change. After scaling, the transform keeps the *previous* font's ascent. On reopen, `setPlainText` re-triggers `adjustItemPosition()` with the saved font, recomputing the correct offset — hence the drift.

Verified with a probe in `toXml`: at size 4 the applied transform was `dy = -13` (from the original ~20 pt font) while the correct value is `-6` — a 7 px stale offset that vanishes on reload. This is independent of `real_font_size_`, which stays desynced but is not in the position path.

## Fix
Re-run `adjustItemPosition()` in `setFont()` so the anchor always matches the current font. After the fix the applied transform is `-6` at save (matching reload), and the drift is gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
