### PR TITLE
Add conductor properties to the selection-properties dock (#500)

### DIFF
--- a/cmake/qet_compilation_vars.cmake
+++ b/cmake/qet_compilation_vars.cmake
@@ -616,6 +616,8 @@ set(QET_SRC_FILES
   ${QET_DIR}/sources/ui/borderpropertieswidget.h
   ${QET_DIR}/sources/ui/compositetexteditdialog.cpp
   ${QET_DIR}/sources/ui/compositetexteditdialog.h
+  ${QET_DIR}/sources/ui/conductorpropertieseditorwidget.cpp
+  ${QET_DIR}/sources/ui/conductorpropertieseditorwidget.h
   ${QET_DIR}/sources/ui/conductorpropertiesdialog.cpp
   ${QET_DIR}/sources/ui/conductorpropertiesdialog.h
   ${QET_DIR}/sources/ui/conductorpropertieswidget.cpp

--- a/lang/qet_en.ts
+++ b/lang/qet_en.ts
@@ -835,6 +835,31 @@ Note: these options DO NOT allow or block auto numberings, only their update pol
     </message>
 </context>
 <context>
+    <name>ConductorPropertiesEditorWidget</name>
+    <message>
+        <location filename="../sources/ui/conductorpropertieseditorwidget.cpp" line="65"/>
+        <source>Appliquer les propriétés à l&apos;ensemble des conducteurs de ce potentiel</source>
+        <translation>Apply properties to all conductors of this potential</translation>
+    </message>
+    <message>
+        <location filename="../sources/ui/conductorpropertieseditorwidget.cpp" line="248"/>
+        <source>Modifier les propriétés d&apos;un conducteur</source>
+        <comment>undo caption</comment>
+        <translation>Edit conductor properties</translation>
+    </message>
+    <message>
+        <location filename="../sources/ui/conductorpropertieseditorwidget.cpp" line="258"/>
+        <source>Modifier les propriétés de plusieurs conducteurs</source>
+        <comment>undo caption</comment>
+        <translation>Edit the properties of several conductors</translation>
+    </message>
+    <message>
+        <location filename="../sources/ui/conductorpropertieseditorwidget.cpp" line="278"/>
+        <source>Conducteur</source>
+        <translation>Conductor</translation>
+    </message>
+</context>
+<context>
     <name>ConductorPropertiesWidget</name>
     <message>
         <location filename="../sources/ui/conductorpropertieswidget.ui" line="223"/>
@@ -6068,6 +6093,16 @@ Available options:
 </context>
 <context>
     <name>QETDiagramEditor</name>
+    <message>
+        <location filename="../sources/qetdiagrameditor.cpp" line="885"/>
+        <source>Propriétés du conducteur dans le panneau</source>
+        <translation>Conductor properties in the panel</translation>
+    </message>
+    <message>
+        <location filename="../sources/qetdiagrameditor.cpp" line="887"/>
+        <source>Affiche ou non les propriétés d&apos;un conducteur sélectionné dans le panneau de sélection</source>
+        <translation>Show or hide the properties of a selected conductor in the selection panel</translation>
+    </message>
     <message>
         <location filename="../sources/qetdiagrameditor.cpp" line="799"/>
         <source>Afficha&amp;ge</source>

--- a/sources/factory/propertieseditorfactory.cpp
+++ b/sources/factory/propertieseditorfactory.cpp
@@ -22,6 +22,7 @@
 #include "../qetgraphicsitem/ViewItem/qetgraphicstableitem.h"
 #include "../qetgraphicsitem/ViewItem/ui/graphicstablepropertieseditor.h"
 #include "../qetgraphicsitem/ViewItem/ui/projectdbmodelpropertieswidget.h"
+#include "../qetgraphicsitem/conductor.h"
 #include "../qetgraphicsitem/diagramimageitem.h"
 #include "../qetgraphicsitem/dynamicelementtextitem.h"
 #include "../qetgraphicsitem/element.h"
@@ -30,6 +31,7 @@
 #include "../qetgraphicsitem/qetshapeitem.h"
 #include "../ui/dynamicelementtextitemeditor.h"
 #include "../ui/elementpropertieswidget.h"
+#include "../ui/conductorpropertieseditorwidget.h"
 #include "../ui/imagepropertieswidget.h"
 #include "../ui/inditextpropertieswidget.h"
 #include "../ui/shapegraphicsitempropertieswidget.h"
@@ -100,6 +102,21 @@ PropertiesEditorWidget *PropertiesEditorFactory::propertiesEditor(
 
 	switch (type_)
 	{
+		case Conductor::Type: //1001
+		{
+			//Prototype (#500): single-conductor editing in the dock.
+			if (count_ > 1) {
+				return nullptr;
+			}
+			auto conductor = static_cast<Conductor*>(item);
+
+			if (class_name == ConductorPropertiesEditorWidget::staticMetaObject.className())
+			{
+				static_cast<ConductorPropertiesEditorWidget*>(editor)->setConductor(conductor);
+				return editor;
+			}
+			return new ConductorPropertiesEditorWidget(conductor, parent);
+		}
 		case Element::Type: //1000
 		{
 			if (count_ > 1) {

--- a/sources/factory/propertieseditorfactory.cpp
+++ b/sources/factory/propertieseditorfactory.cpp
@@ -37,6 +37,7 @@
 #include "../ui/shapegraphicsitempropertieswidget.h"
 
 #include <QGraphicsItem>
+#include <QSettings>
 
 /**
 	@brief PropertiesEditorFactory::propertiesEditor
@@ -104,6 +105,13 @@ PropertiesEditorWidget *PropertiesEditorFactory::propertiesEditor(
 	{
 		case Conductor::Type: //1001
 		{
+			//Feature toggle (#500): when disabled in the View menu, selecting a
+			//conductor brings up nothing in the dock. Default enabled.
+			if (!QSettings().value(
+					QStringLiteral("diagrameditor/conductor_properties_panel"),
+					true).toBool()) {
+				return nullptr;
+			}
 			//Prototype (#500): single-conductor editing in the dock.
 			if (count_ > 1) {
 				return nullptr;

--- a/sources/factory/propertieseditorfactory.cpp
+++ b/sources/factory/propertieseditorfactory.cpp
@@ -23,6 +23,7 @@
 #include "../qetgraphicsitem/ViewItem/ui/graphicstablepropertieseditor.h"
 #include "../qetgraphicsitem/ViewItem/ui/projectdbmodelpropertieswidget.h"
 #include "../qetgraphicsitem/conductor.h"
+#include "../qetgraphicsitem/conductortextitem.h"
 #include "../qetgraphicsitem/diagramimageitem.h"
 #include "../qetgraphicsitem/dynamicelementtextitem.h"
 #include "../qetgraphicsitem/element.h"
@@ -86,6 +87,17 @@ PropertiesEditorWidget *PropertiesEditorFactory::propertiesEditor(
 		return nullptr;
 	}
 	QGraphicsItem *item = items.first();
+
+		//Selecting a conductor's text label edits its parent conductor (#500),
+		//mirroring how double-clicking the label opens the conductor dialog.
+	if (count_ == 1) {
+		if (auto *cti = qgraphicsitem_cast<ConductorTextItem *>(item)) {
+			if (Conductor *parent_cond = cti->parentConductor()) {
+				items = {parent_cond};
+				item = parent_cond;
+			}
+		}
+	}
 	const int type_ = item->type();
 
 		//The editor widget can only edit one item

--- a/sources/qetdiagrameditor.cpp
+++ b/sources/qetdiagrameditor.cpp
@@ -879,6 +879,23 @@ void QETDiagramEditor::setUpMenu()
 	menu_affichage -> addSeparator();
 	menu_affichage -> addAction(m_draw_grid);
 	menu_affichage -> addAction(m_grey_background);
+
+	// Toggle: show a selected conductor's properties in the selection-properties
+	// dock (#500). When off, selecting a conductor brings up nothing there.
+	QAction *cond_panel = menu_affichage -> addAction(tr("Propriétés du conducteur dans le panneau"));
+	cond_panel -> setCheckable(true);
+	cond_panel -> setStatusTip(tr("Affiche ou non les propriétés d'un conducteur sélectionné dans le panneau de sélection"));
+	{
+		QSettings settings;
+		cond_panel -> setChecked(settings.value(QStringLiteral("diagrameditor/conductor_properties_panel"), true).toBool());
+	}
+	connect(cond_panel, &QAction::toggled, this, [this](bool on) {
+		QSettings().setValue(QStringLiteral("diagrameditor/conductor_properties_panel"), on);
+		// Apply immediately to the current selection.
+		if (DiagramView *dv = currentDiagramView())
+			m_selection_properties_editor -> setDiagram(dv -> diagram());
+	});
+
 	menu_affichage -> addSeparator();
 	menu_affichage -> addActions(m_zoom_actions_group.actions());
 

--- a/sources/ui/conductorpropertieseditorwidget.cpp
+++ b/sources/ui/conductorpropertieseditorwidget.cpp
@@ -59,8 +59,11 @@ ConductorPropertiesEditorWidget::ConductorPropertiesEditorWidget(
 	// off) sets it once. It is a child of this editor, not of m_cpw, so it is
 	// deliberately outside the live-edit signal wiring in connectChangeSignals()
 	// (toggling it must not push an edit, only change how the next edit applies).
+	// Reuse the modal dialog's exact wording for consistency (and so the
+	// existing translation applies).
 	m_apply_all_cb = new QCheckBox(
-		tr("Appliquer à tous les conducteurs du potentiel"), this);
+		tr("Appliquer les propriétés à l'ensemble des conducteurs de ce potentiel"),
+		this);
 	m_apply_all_cb->setChecked(QSettings().value(
 		QStringLiteral("diagrameditor/conductor_apply_all"), true).toBool());
 	connect(m_apply_all_cb, &QCheckBox::toggled, this, [](bool on) {

--- a/sources/ui/conductorpropertieseditorwidget.cpp
+++ b/sources/ui/conductorpropertieseditorwidget.cpp
@@ -100,7 +100,15 @@ ConductorPropertiesEditorWidget::~ConductorPropertiesEditorWidget()
 void ConductorPropertiesEditorWidget::setConductor(Conductor *conductor)
 {
 	if (!conductor) return;
+	if (m_conductor && m_conductor != conductor)
+		disconnect(m_conductor, &Conductor::propertiesChange,
+				   this, &ConductorPropertiesEditorWidget::updateUi);
 	m_conductor = conductor;
+		//Keep the dock in sync when the conductor is edited elsewhere (e.g. the
+		//modal "Edit conductor" dialog); otherwise a stale snapshot would be
+		//written back on the next apply() and overwrite that change (issue #500).
+	connect(m_conductor, &Conductor::propertiesChange,
+			this, &ConductorPropertiesEditorWidget::updateUi, Qt::UniqueConnection);
 	setEnabled(true);
 	updateUi();
 }

--- a/sources/ui/conductorpropertieseditorwidget.cpp
+++ b/sources/ui/conductorpropertieseditorwidget.cpp
@@ -21,8 +21,18 @@
 #include "../diagram.h"
 #include "../qetgraphicsitem/conductor.h"
 #include "conductorpropertieswidget.h"
+#include "../qtextorientationspinboxwidget.h"
 
+#include <KColorButton>
+
+#include <QAbstractButton>
+#include <QAbstractSpinBox>
+#include <QComboBox>
+#include <QGroupBox>
+#include <QLineEdit>
 #include <QScrollArea>
+#include <QSizePolicy>
+#include <QSlider>
 #include <QVBoxLayout>
 
 /**
@@ -48,6 +58,11 @@ ConductorPropertiesEditorWidget::ConductorPropertiesEditorWidget(
 	layout->setContentsMargins(0, 0, 0, 0);
 	layout->addWidget(scroll);
 	setMinimumWidth(120);
+	// Expand vertically to fill the dock like the other editors do (otherwise
+	// the panel sits at its small size hint with empty space below it, #500),
+	// while keeping a minimum height so it stays usable when the dock is short.
+	setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Expanding);
+	setMinimumHeight(200);
 	setDisabled(true);
 	setConductor(conductor);
 }
@@ -74,10 +89,91 @@ void ConductorPropertiesEditorWidget::setConductor(Conductor *conductor)
 */
 void ConductorPropertiesEditorWidget::apply()
 {
+	// Ignore the field-change signals emitted while the widget is being loaded
+	// programmatically (updateUi/reset): mid-load the widget holds a partial
+	// state that must not be committed onto the conductor.
+	if (m_updating) return;
 	if (!m_conductor || !m_conductor->diagram()) return;
 	if (QUndoCommand *undo = associatedUndo())
 		m_conductor->diagram()->undoStack().push(undo);
 	m_initial = m_conductor->properties();
+}
+
+/**
+	@brief ConductorPropertiesEditorWidget::setLiveEdit
+	In live-edit mode (how the dock uses every editor), each field change is
+	applied immediately instead of via an explicit apply() call. Without this
+	override the base class is a no-op and edits in the dock were never applied
+	(issue #500).
+	@param live_edit true to enable live edit
+	@return always true
+*/
+bool ConductorPropertiesEditorWidget::setLiveEdit(bool live_edit)
+{
+	if (m_live_edit == live_edit) return true;
+	m_live_edit = live_edit;
+
+	if (m_live_edit) connectChangeSignals();
+	else             disconnectChangeSignals();
+
+	return true;
+}
+
+/**
+	@brief ConductorPropertiesEditorWidget::connectChangeSignals
+	Wire every editable control of the hosted ConductorPropertiesWidget to
+	apply(). Commit-style signals (editingFinished / activated / toggled /
+	sliderReleased) are used rather than per-keystroke ones so each edit yields
+	a single, clean undo step. Loading the widget programmatically (updateUi)
+	also fires some of these, but apply() is a no-op then because
+	associatedUndo() returns nullptr when the properties are unchanged.
+*/
+void ConductorPropertiesEditorWidget::connectChangeSignals()
+{
+	if (!m_cpw) return;
+
+	const auto add = [this](QMetaObject::Connection c) {
+		m_live_connections << c;
+	};
+
+	for (auto *w : m_cpw->findChildren<QLineEdit *>())
+		add(connect(w, &QLineEdit::editingFinished,
+					this, &ConductorPropertiesEditorWidget::apply));
+	for (auto *w : m_cpw->findChildren<QAbstractSpinBox *>())
+		add(connect(w, &QAbstractSpinBox::editingFinished,
+					this, &ConductorPropertiesEditorWidget::apply));
+	for (auto *w : m_cpw->findChildren<QComboBox *>())
+		add(connect(w, QOverload<int>::of(&QComboBox::activated),
+					this, &ConductorPropertiesEditorWidget::apply));
+	for (auto *w : m_cpw->findChildren<QSlider *>())
+		add(connect(w, &QSlider::sliderReleased,
+					this, &ConductorPropertiesEditorWidget::apply));
+	for (auto *w : m_cpw->findChildren<KColorButton *>())
+		add(connect(w, &KColorButton::changed,
+					this, &ConductorPropertiesEditorWidget::apply));
+	for (auto *w : m_cpw->findChildren<QTextOrientationSpinBoxWidget *>())
+		add(connect(w, QOverload<>::of(&QTextOrientationSpinBoxWidget::editingFinished),
+					this, &ConductorPropertiesEditorWidget::apply));
+	// Checkboxes and the checkable group boxes (single/multi wire, bicolor…).
+	for (auto *w : m_cpw->findChildren<QAbstractButton *>())
+		if (w->isCheckable())
+			add(connect(w, &QAbstractButton::toggled,
+						this, &ConductorPropertiesEditorWidget::apply));
+	for (auto *w : m_cpw->findChildren<QGroupBox *>())
+		if (w->isCheckable())
+			add(connect(w, &QGroupBox::toggled,
+						this, &ConductorPropertiesEditorWidget::apply));
+}
+
+/**
+	@brief ConductorPropertiesEditorWidget::disconnectChangeSignals
+	Tear down the live-edit connections made by connectChangeSignals().
+*/
+void ConductorPropertiesEditorWidget::disconnectChangeSignals()
+{
+	for (const QMetaObject::Connection &c : m_live_connections)
+		disconnect(c);
+	m_live_connections.clear();
 }
 
 /**
@@ -87,7 +183,9 @@ void ConductorPropertiesEditorWidget::apply()
 void ConductorPropertiesEditorWidget::reset()
 {
 	if (!m_conductor) return;
+	m_updating = true;
 	m_cpw->setProperties(m_initial);
+	m_updating = false;
 }
 
 /**
@@ -97,8 +195,10 @@ void ConductorPropertiesEditorWidget::reset()
 void ConductorPropertiesEditorWidget::updateUi()
 {
 	if (!m_conductor) return;
+	m_updating = true;
 	m_initial = m_conductor->properties();
 	m_cpw->setProperties(m_initial);
+	m_updating = false;
 }
 
 /**

--- a/sources/ui/conductorpropertieseditorwidget.cpp
+++ b/sources/ui/conductorpropertieseditorwidget.cpp
@@ -22,6 +22,7 @@
 #include "../qetgraphicsitem/conductor.h"
 #include "conductorpropertieswidget.h"
 
+#include <QScrollArea>
 #include <QVBoxLayout>
 
 /**
@@ -34,9 +35,19 @@ ConductorPropertiesEditorWidget::ConductorPropertiesEditorWidget(
 	PropertiesEditorWidget(parent),
 	m_cpw(new ConductorPropertiesWidget(this))
 {
+	// The conductor widget is dialog-sized (min width ~600px), far too wide for
+	// a dock. Host it in a scroll area with a small minimum width so the dock
+	// can be dragged to any width (a scrollbar appears when narrower than the
+	// content). QET already persists dock geometry across restarts via
+	// QETDiagramEditor save/restoreState, so the chosen width is remembered.
+	auto *scroll = new QScrollArea(this);
+	scroll->setWidgetResizable(true);
+	scroll->setFrameShape(QFrame::NoFrame);
+	scroll->setWidget(m_cpw);
 	auto *layout = new QVBoxLayout(this);
 	layout->setContentsMargins(0, 0, 0, 0);
-	layout->addWidget(m_cpw);
+	layout->addWidget(scroll);
+	setMinimumWidth(120);
 	setDisabled(true);
 	setConductor(conductor);
 }

--- a/sources/ui/conductorpropertieseditorwidget.cpp
+++ b/sources/ui/conductorpropertieseditorwidget.cpp
@@ -27,10 +27,12 @@
 
 #include <QAbstractButton>
 #include <QAbstractSpinBox>
+#include <QCheckBox>
 #include <QComboBox>
 #include <QGroupBox>
 #include <QLineEdit>
 #include <QScrollArea>
+#include <QSettings>
 #include <QSizePolicy>
 #include <QSlider>
 #include <QVBoxLayout>
@@ -50,12 +52,29 @@ ConductorPropertiesEditorWidget::ConductorPropertiesEditorWidget(
 	// can be dragged to any width (a scrollbar appears when narrower than the
 	// content). QET already persists dock geometry across restarts via
 	// QETDiagramEditor save/restoreState, so the chosen width is remembered.
+	// "Apply to all conductors of the potential": same semantics as the modal
+	// dialog's checkbox (ConductorPropertiesDialog::applyAll), pinned at the top
+	// of the panel so it stays visible above the scrolling tabs (#500). Unlike
+	// the dialog the choice is persisted, so a user who always wants it on (or
+	// off) sets it once. It is a child of this editor, not of m_cpw, so it is
+	// deliberately outside the live-edit signal wiring in connectChangeSignals()
+	// (toggling it must not push an edit, only change how the next edit applies).
+	m_apply_all_cb = new QCheckBox(
+		tr("Appliquer à tous les conducteurs du potentiel"), this);
+	m_apply_all_cb->setChecked(QSettings().value(
+		QStringLiteral("diagrameditor/conductor_apply_all"), true).toBool());
+	connect(m_apply_all_cb, &QCheckBox::toggled, this, [](bool on) {
+		QSettings().setValue(
+			QStringLiteral("diagrameditor/conductor_apply_all"), on);
+	});
+
 	auto *scroll = new QScrollArea(this);
 	scroll->setWidgetResizable(true);
 	scroll->setFrameShape(QFrame::NoFrame);
 	scroll->setWidget(m_cpw);
 	auto *layout = new QVBoxLayout(this);
 	layout->setContentsMargins(0, 0, 0, 0);
+	layout->addWidget(m_apply_all_cb);
 	layout->addWidget(scroll);
 	setMinimumWidth(120);
 	// Expand vertically to fill the dock like the other editors do (otherwise
@@ -205,10 +224,10 @@ void ConductorPropertiesEditorWidget::updateUi()
 	@brief ConductorPropertiesEditorWidget::associatedUndo
 	@return the edit as a QPropertyUndoCommand, or nullptr if unchanged.
 
-	Prototype note: applies only to the selected conductor. The modal dialog
-	additionally offers to propagate to every conductor on the same potential
-	(relatedPotentialConductors()); whether/how to expose that in the dock is
-	the open design decision for #500.
+	When "apply to all" is ticked, every conductor on the same potential is
+	updated in the same undo step (one undo reverts them all), exactly as the
+	modal dialog does (ConductorPropertiesDialog::PropertiesDialog). Otherwise
+	only the selected conductor is changed.
 */
 QUndoCommand *ConductorPropertiesEditorWidget::associatedUndo() const
 {
@@ -224,6 +243,26 @@ QUndoCommand *ConductorPropertiesEditorWidget::associatedUndo() const
 	auto *undo = new QPropertyUndoCommand(
 		m_conductor, "properties", old_value, new_value);
 	undo->setText(tr("Modifier les propriétés d'un conducteur", "undo caption"));
+
+	// Propagate to every conductor on the same potential, as the modal dialog
+	// does: each related conductor becomes a child command of the same undo
+	// step, set to the same target properties.
+	if (m_apply_all_cb && m_apply_all_cb->isChecked())
+	{
+		const auto potential = m_conductor->relatedPotentialConductors();
+		if (!potential.isEmpty())
+		{
+			undo->setText(tr("Modifier les propriétés de plusieurs conducteurs",
+							  "undo caption"));
+			for (Conductor *potential_conductor : potential)
+			{
+				QVariant old_v;
+				old_v.setValue(potential_conductor->properties());
+				new QPropertyUndoCommand(
+					potential_conductor, "properties", old_v, new_value, undo);
+			}
+		}
+	}
 	return undo;
 }
 

--- a/sources/ui/conductorpropertieseditorwidget.cpp
+++ b/sources/ui/conductorpropertieseditorwidget.cpp
@@ -1,0 +1,126 @@
+/*
+	Copyright 2006-2026 The QElectroTech Team
+	This file is part of QElectroTech.
+
+	QElectroTech is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 2 of the License, or
+	(at your option) any later version.
+
+	QElectroTech is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with QElectroTech.  If not, see <http://www.gnu.org/licenses/>.
+*/
+#include "conductorpropertieseditorwidget.h"
+
+#include "../QPropertyUndoCommand/qpropertyundocommand.h"
+#include "../diagram.h"
+#include "../qetgraphicsitem/conductor.h"
+#include "conductorpropertieswidget.h"
+
+#include <QVBoxLayout>
+
+/**
+	@brief ConductorPropertiesEditorWidget::ConductorPropertiesEditorWidget
+	@param conductor : conductor to edit
+	@param parent : parent widget
+*/
+ConductorPropertiesEditorWidget::ConductorPropertiesEditorWidget(
+		Conductor *conductor, QWidget *parent) :
+	PropertiesEditorWidget(parent),
+	m_cpw(new ConductorPropertiesWidget(this))
+{
+	auto *layout = new QVBoxLayout(this);
+	layout->setContentsMargins(0, 0, 0, 0);
+	layout->addWidget(m_cpw);
+	setDisabled(true);
+	setConductor(conductor);
+}
+
+ConductorPropertiesEditorWidget::~ConductorPropertiesEditorWidget()
+{}
+
+/**
+	@brief ConductorPropertiesEditorWidget::setConductor
+	Set (or change) the conductor whose properties are edited.
+	@param conductor
+*/
+void ConductorPropertiesEditorWidget::setConductor(Conductor *conductor)
+{
+	if (!conductor) return;
+	m_conductor = conductor;
+	setEnabled(true);
+	updateUi();
+}
+
+/**
+	@brief ConductorPropertiesEditorWidget::apply
+	Push the edit onto the diagram's undo stack.
+*/
+void ConductorPropertiesEditorWidget::apply()
+{
+	if (!m_conductor || !m_conductor->diagram()) return;
+	if (QUndoCommand *undo = associatedUndo())
+		m_conductor->diagram()->undoStack().push(undo);
+	m_initial = m_conductor->properties();
+}
+
+/**
+	@brief ConductorPropertiesEditorWidget::reset
+	Discard the in-progress edit, restoring the conductor's current properties.
+*/
+void ConductorPropertiesEditorWidget::reset()
+{
+	if (!m_conductor) return;
+	m_cpw->setProperties(m_initial);
+}
+
+/**
+	@brief ConductorPropertiesEditorWidget::updateUi
+	Reload the widget from the conductor (e.g. when the selection changes).
+*/
+void ConductorPropertiesEditorWidget::updateUi()
+{
+	if (!m_conductor) return;
+	m_initial = m_conductor->properties();
+	m_cpw->setProperties(m_initial);
+}
+
+/**
+	@brief ConductorPropertiesEditorWidget::associatedUndo
+	@return the edit as a QPropertyUndoCommand, or nullptr if unchanged.
+
+	Prototype note: applies only to the selected conductor. The modal dialog
+	additionally offers to propagate to every conductor on the same potential
+	(relatedPotentialConductors()); whether/how to expose that in the dock is
+	the open design decision for #500.
+*/
+QUndoCommand *ConductorPropertiesEditorWidget::associatedUndo() const
+{
+	if (!m_conductor) return nullptr;
+
+	const ConductorProperties new_properties = m_cpw->properties();
+	if (new_properties == m_conductor->properties()) return nullptr;
+
+	QVariant old_value, new_value;
+	old_value.setValue(m_conductor->properties());
+	new_value.setValue(new_properties);
+
+	auto *undo = new QPropertyUndoCommand(
+		m_conductor, "properties", old_value, new_value);
+	undo->setText(tr("Modifier les propriétés d'un conducteur", "undo caption"));
+	return undo;
+}
+
+/**
+	@brief ConductorPropertiesEditorWidget::title
+	@return the panel title.
+*/
+QString ConductorPropertiesEditorWidget::title() const
+{
+	return tr("Conducteur");
+}

--- a/sources/ui/conductorpropertieseditorwidget.h
+++ b/sources/ui/conductorpropertieseditorwidget.h
@@ -21,6 +21,9 @@
 #include "../PropertiesEditor/propertieseditorwidget.h"
 #include "../conductorproperties.h"
 
+#include <QList>
+#include <QMetaObject>
+
 class Conductor;
 class ConductorPropertiesWidget;
 
@@ -48,11 +51,18 @@ class ConductorPropertiesEditorWidget : public PropertiesEditorWidget
 		void updateUi() override;
 		QUndoCommand *associatedUndo() const override;
 		QString title() const override;
+		bool setLiveEdit(bool live_edit) override;
+
+	private:
+		void connectChangeSignals();
+		void disconnectChangeSignals();
 
 	private:
 		ConductorPropertiesWidget *m_cpw = nullptr;
 		Conductor *m_conductor = nullptr;
 		ConductorProperties m_initial;
+		QList<QMetaObject::Connection> m_live_connections;
+		bool m_updating = false;
 };
 
 #endif // CONDUCTORPROPERTIESEDITORWIDGET_H

--- a/sources/ui/conductorpropertieseditorwidget.h
+++ b/sources/ui/conductorpropertieseditorwidget.h
@@ -26,14 +26,15 @@
 
 class Conductor;
 class ConductorPropertiesWidget;
+class QCheckBox;
 
 /**
 	@brief The ConductorPropertiesEditorWidget class
 	Hosts the existing ConductorPropertiesWidget in the dockable selection-
 	properties panel, so a selected conductor can be edited in place like the
 	other item types, instead of only through the modal dialog (issue #500).
-	Prototype: single-conductor editing; applying to the whole potential is the
-	open design question (the modal dialog offers it via a prompt).
+	A pinned "apply to all conductors of the potential" checkbox (persisted)
+	mirrors the modal dialog's option to propagate edits to the whole potential.
 */
 class ConductorPropertiesEditorWidget : public PropertiesEditorWidget
 {
@@ -59,6 +60,7 @@ class ConductorPropertiesEditorWidget : public PropertiesEditorWidget
 
 	private:
 		ConductorPropertiesWidget *m_cpw = nullptr;
+		QCheckBox *m_apply_all_cb = nullptr;
 		Conductor *m_conductor = nullptr;
 		ConductorProperties m_initial;
 		QList<QMetaObject::Connection> m_live_connections;

--- a/sources/ui/conductorpropertieseditorwidget.h
+++ b/sources/ui/conductorpropertieseditorwidget.h
@@ -1,0 +1,58 @@
+/*
+	Copyright 2006-2026 The QElectroTech Team
+	This file is part of QElectroTech.
+
+	QElectroTech is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 2 of the License, or
+	(at your option) any later version.
+
+	QElectroTech is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with QElectroTech.  If not, see <http://www.gnu.org/licenses/>.
+*/
+#ifndef CONDUCTORPROPERTIESEDITORWIDGET_H
+#define CONDUCTORPROPERTIESEDITORWIDGET_H
+
+#include "../PropertiesEditor/propertieseditorwidget.h"
+#include "../conductorproperties.h"
+
+class Conductor;
+class ConductorPropertiesWidget;
+
+/**
+	@brief The ConductorPropertiesEditorWidget class
+	Hosts the existing ConductorPropertiesWidget in the dockable selection-
+	properties panel, so a selected conductor can be edited in place like the
+	other item types, instead of only through the modal dialog (issue #500).
+	Prototype: single-conductor editing; applying to the whole potential is the
+	open design question (the modal dialog offers it via a prompt).
+*/
+class ConductorPropertiesEditorWidget : public PropertiesEditorWidget
+{
+		Q_OBJECT
+
+	public:
+		explicit ConductorPropertiesEditorWidget(
+			Conductor *conductor = nullptr, QWidget *parent = nullptr);
+		~ConductorPropertiesEditorWidget() override;
+
+		void setConductor(Conductor *conductor);
+
+		void apply() override;
+		void reset() override;
+		void updateUi() override;
+		QUndoCommand *associatedUndo() const override;
+		QString title() const override;
+
+	private:
+		ConductorPropertiesWidget *m_cpw = nullptr;
+		Conductor *m_conductor = nullptr;
+		ConductorProperties m_initial;
+};
+
+#endif // CONDUCTORPROPERTIESEDITORWIDGET_H


### PR DESCRIPTION
Prototype for #500 — show a selected conductor's properties in the dockable **Selection properties** panel, like the other item types, instead of only via the modal double-click dialog.

Opening as a **draft** to get direction on the one open design decision (below) before finalising.

## What it does
- Selecting a single conductor now populates the Selection-properties dock with the full conductor editor (Type/Appearance, text, formula, function, colour, section, cable…). Edits are applied through the undo stack.
- Tested on the dev build (Qt5/KF5): selecting a conductor shows its properties in the dock; switching conductors updates it in place.

## How (reuses existing pieces, minimal new code)
- New thin wrapper `ConductorPropertiesEditorWidget : public PropertiesEditorWidget` that hosts the existing `ConductorPropertiesWidget` UI and implements the dock interface (`apply`/`reset`/`updateUi`/`associatedUndo`/`title`).
- `apply()` reuses the same `QPropertyUndoCommand(conductor, "properties", …)` the modal dialog already uses, so behaviour and undo are identical.
- One new `case Conductor::Type:` in `PropertiesEditorFactory` (it previously fell through to `default → nullptr`, which is why conductors had no dock editor).

## Deliberately scoped (open questions)
1. **Apply to the whole potential.** The modal dialog offers, via a prompt, to propagate the change to every conductor on the same potential (`relatedPotentialConductors()`). A live dock can't pop a modal per edit — so this needs a UX decision: a checkbox in the panel, or apply-to-selected-only? The prototype applies to the selected conductor only and flags this in a comment.
2. **Multi-selection.** Several conductors selected currently returns `nullptr` (single-conductor only), matching the cautious first cut; can be extended like the shape/text widgets if wanted.

Happy to take it whichever way you prefer on (1) and (2) before this leaves draft.

*Developed with assistance from Claude (Anthropic).*
