### PR TITLE
[Draft / PoC] Database-driven from-to wiring list + "Add a wiring list" (RFC for #503)

### DIFF
--- a/docs/wiring-list-demo/README.md
+++ b/docs/wiring-list-demo/README.md
@@ -1,0 +1,73 @@
+# Database‑driven from‑to wiring list — Proof of Concept
+
+> ## ⚠️ NOT FOR PRODUCTION USE
+> This branch is a **proof of concept / demonstration** to support discussion
+> [#503](https://github.com/qelectrotech/qelectrotech-source-mirror/discussions/503).
+> It is **not production‑ready**, has **not** been through full review or QA, and
+> the schema, SQL view, table format and GUI wording are all **subject to change**.
+> Do not ship it, and do not rely on the `wire_list_view` schema staying stable.
+
+## What this demonstrates
+
+A **from‑to wiring list** built additively on QElectroTech's existing
+`projectDataBase`, plus a GUI action to drop it onto a folio:
+
+1. **`wire_list_view`** — for every conductor, resolves both ends to
+   `element : terminal` on a folio number, with the wire number:
+
+   | wire | from_point | from_folio | to_point | to_folio |
+   |------|------------|------------|----------|----------|
+   | 1001 | X2:4       | 10         | 10QF2    | 10       |
+   | 1011 | XV2:1      | 8          | 8F2      | 8        |
+
+   It is rebuilt from the scene in `updateDB()` like the existing tables
+   (no stored state), and **handles the cross‑folio case** (each end can be
+   on a different folio).
+
+2. **Project → "Add a wiring list"** — a menu action that renders the view as
+   a table on the current folio and spills onto new folios, exactly like the
+   existing *Add a nomenclature* / *Add a summary* actions. No new rendering
+   code: it reuses QET's generic `ProjectDBModel`.
+
+## What's in the branch
+
+| Commit | Contents |
+|--------|----------|
+| DB slice | `terminal` + `conductor` tables + `wire_list_view` in `projectdatabase.cpp/.h` (additive, existing tables untouched) |
+| GUI action | `m_add_wiring_list` action + `QetGraphicsTableFactory::createAndAddWiringList` |
+| Demo (this) | these support files |
+
+## How to try it
+
+1. Build QElectroTech from this branch as usual (`cmake -S . -B build && cmake --build build`).
+2. Open any wired project, e.g. `examples/industrial.qet`.
+3. **Project → Add a wiring list.** A from‑to table appears on the folio and
+   spills onto new "Wiring list" folios.
+
+### Quick visual without the menu
+
+To see the view rendered without using the menu, generate a demo project that
+points an existing table at `wire_list_view`:
+
+```bash
+python3 docs/wiring-list-demo/make_demo.py        # writes examples/wire_list_demo.qet
+```
+
+Then open `examples/wire_list_demo.qet` and go to the **Nomenclature** folio —
+its table now shows the wiring list. (This file is a throwaway; delete it when done.)
+
+## Known limitations (because it's a PoC)
+
+- **Coverage:** the terminal scan uses QET's existing element‑table filter
+  (`Simple | Terminal | Master | Thumbnail`), so conductors that terminate on
+  **folio‑report arrows** (`NextReport`/`PreviousReport`) or **slave** contacts
+  are not yet resolved. Element‑to‑element wires are complete and correct.
+- **No column‑picker dialog** — the wiring‑list query is fixed (unlike the
+  nomenclature/summary, which let you choose columns).
+- **Not reviewed for performance** on very large projects.
+- The view schema is provisional and **will change** if this goes forward.
+
+## Feedback
+
+This exists to make the #503 idea concrete and testable. Schema, naming and
+scope are all open to change based on maintainer feedback.

--- a/docs/wiring-list-demo/make_demo.py
+++ b/docs/wiring-list-demo/make_demo.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+"""Generate a throwaway demo project that renders wire_list_view in the GUI.
+
+PROOF OF CONCEPT — NOT FOR PRODUCTION USE.
+
+Copies examples/industrial.qet to examples/wire_list_demo.qet and repoints the
+existing "Nomenclature" folio table at the wire_list_view, so you can open the
+file and see the from-to wiring list rendered as a table (without using the new
+"Add a wiring list" menu action).
+
+Run from the repository root:
+    python3 docs/wiring-list-demo/make_demo.py
+"""
+import os
+import re
+import sys
+
+ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+SRC = os.path.join(ROOT, "examples", "industrial.qet")
+DST = os.path.join(ROOT, "examples", "wire_list_demo.qet")
+
+WIRING_QUERY = ("SELECT wire, from_point, from_folio, to_point, to_folio "
+                "FROM wire_list_view ORDER BY wire")
+
+
+def main() -> int:
+    if not os.path.exists(SRC):
+        print(f"source not found: {SRC}", file=sys.stderr)
+        return 1
+    with open(SRC, encoding="utf-8") as f:
+        s = f.read()
+
+    def repl(m: "re.Match") -> str:
+        return "<query>" + WIRING_QUERY + "</query>" \
+            if "element_nomenclature_view" in m.group(1) else m.group(0)
+
+    s2, _ = re.subn(r"<query>(.*?)</query>", repl, s, flags=re.S)
+    s2 = s2.replace('<project title="Example project"',
+                    '<project title="WIRE-LIST-DEMO (proof of concept)"', 1)
+
+    if WIRING_QUERY not in s2:
+        print("no element_nomenclature_view table found to repoint", file=sys.stderr)
+        return 2
+    with open(DST, "w", encoding="utf-8") as f:
+        f.write(s2)
+    print(f"wrote {DST}")
+    print("Open it in QElectroTech and go to the Nomenclature folio.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/lang/qet_en.ts
+++ b/lang/qet_en.ts
@@ -6674,6 +6674,11 @@ Available options:
         <translation>Add a summary</translation>
     </message>
     <message>
+        <location filename="../sources/qetdiagrameditor.cpp" line="451"/>
+        <source>Ajouter une liste de câblage</source>
+        <translation>Add a wiring list</translation>
+    </message>
+    <message>
         <location filename="../sources/qetdiagrameditor.cpp" line="654"/>
         <source>Zoom sur le contenu</source>
         <translation>Zoom content</translation>
@@ -9400,6 +9405,11 @@ Do you want to replace it ?</translation>
         <location filename="../sources/factory/qetgraphicstablefactory.cpp" line="48"/>
         <source>Ajouter une nomenclature</source>
         <translation>Add a nomenclature</translation>
+    </message>
+    <message>
+        <location filename="../sources/factory/qetgraphicstablefactory.cpp" line="84"/>
+        <source>Liste de câblage</source>
+        <translation>Wiring list</translation>
     </message>
     <message>
         <location filename="../sources/factory/qetgraphicstablefactory.cpp" line="67"/>

--- a/sources/dataBase/projectdatabase.cpp
+++ b/sources/dataBase/projectdatabase.cpp
@@ -21,7 +21,9 @@
 #include "../diagramposition.h"
 #include "../elementprovider.h"
 #include "../qetapp.h"
+#include "../qetgraphicsitem/conductor.h"
 #include "../qetgraphicsitem/element.h"
+#include "../qetgraphicsitem/terminal.h"
 #include "../qetinformation.h"
 #include "../qetproject.h"
 
@@ -87,6 +89,8 @@ void projectDataBase::updateDB()
 	populateDiagramInfoTable();
 	populateElementTable();
 	populateElementInfoTable();
+	populateTerminalTable();   //after element table (terminals reference elements)
+	populateConductorTable();
 	emit dataBaseUpdated();
 }
 
@@ -318,8 +322,37 @@ bool projectDataBase::createDataBase()
 		qDebug() << " element_info_table query : " << query_.lastError();
 	}
 
+	//Connectivity (discussion #503): terminal + conductor tables + a from-to
+	//wire list view. Rebuilt from the scene in updateDB() like every other
+	//table here - purely additive, no stored state.
+	//tid = element_uuid + '#' + terminal index in its element : unique per
+	//PLACED terminal. A terminal's own uuid is NOT a reliable key - it can be
+	//null or repeated across the terminals of an element - so we key by the
+	//element's (unique) uuid plus the terminal's position in element->terminals().
+	QString terminal_table("CREATE TABLE terminal ("
+						   "tid VARCHAR(110) PRIMARY KEY NOT NULL,"
+						   "element_uuid VARCHAR(50),"
+						   "diagram_uuid VARCHAR(50),"
+						   "name VARCHAR(50),"
+						   "FOREIGN KEY (element_uuid) REFERENCES element (uuid))");
+	if (!query_.exec(terminal_table)) {
+		qDebug() << "terminal_table query : " << query_.lastError();
+	}
+
+	QString conductor_table("CREATE TABLE conductor ("
+							"id INTEGER PRIMARY KEY,"
+							"diagram_uuid VARCHAR(50),"
+							"terminal1_tid VARCHAR(110),"
+							"terminal2_tid VARCHAR(110),"
+							"wire_num VARCHAR(50),"
+							"type VARCHAR(10))");
+	if (!query_.exec(conductor_table)) {
+		qDebug() << "conductor_table query : " << query_.lastError();
+	}
+
 	createElementNomenclatureView();
 	createSummaryView();
+	createWireListView();
 	prepareQuery();
 	updateDB();
 	return true;
@@ -428,6 +461,114 @@ void projectDataBase::createSummaryView()
 	QSqlQuery query(m_data_base);
 	if (!query.exec(create_view)) {
 		qDebug() << query.lastError();
+	}
+}
+
+/**
+	@brief projectDataBase::createWireListView
+	From-to wire list (RSWire WIRELIST equivalent): each conductor resolved to
+	its two end points = element label + terminal name + folio position.
+*/
+void projectDataBase::createWireListView()
+{
+	QString create_view (
+		"CREATE VIEW wire_list_view AS SELECT "
+		"c.wire_num AS wire, "
+		"(COALESCE(ei1.label,'') || ':' || COALESCE(t1.name,'')) AS from_point, d1.pos AS from_folio, "
+		"(COALESCE(ei2.label,'') || ':' || COALESCE(t2.name,'')) AS to_point,   d2.pos AS to_folio "
+		"FROM conductor c "
+		"JOIN terminal t1 ON c.terminal1_tid = t1.tid "
+		"JOIN terminal t2 ON c.terminal2_tid = t2.tid "
+		"LEFT JOIN element_info ei1 ON t1.element_uuid = ei1.element_uuid "
+		"LEFT JOIN element_info ei2 ON t2.element_uuid = ei2.element_uuid "
+		"LEFT JOIN diagram d1 ON t1.diagram_uuid = d1.uuid "
+		"LEFT JOIN diagram d2 ON t2.diagram_uuid = d2.uuid");
+
+	QSqlQuery query(m_data_base);
+	if (!query.exec(create_view)) {
+		qDebug() << "wire_list_view query : " << query.lastError();
+	}
+}
+
+/**
+	@brief projectDataBase::populateTerminalTable
+	One row per terminal of every element, rebuilt from the scene.
+*/
+void projectDataBase::populateTerminalTable()
+{
+	m_terminal_tid.clear();
+	QSqlQuery del(m_data_base);
+	del.exec(QStringLiteral("DELETE FROM terminal"));
+
+	QSqlQuery q(m_data_base);
+	q.prepare(QStringLiteral("INSERT INTO terminal (tid, element_uuid, diagram_uuid, name) "
+							 "VALUES (:tid, :element_uuid, :diagram_uuid, :name)"));
+	for (auto *diagram : m_project->diagrams())
+	{
+		const ElementProvider ep(diagram);
+		const auto elmt_vector = ep.find(ElementData::Simple | ElementData::Terminal | ElementData::Master | ElementData::Thumbnail);
+		for (const auto &elmt : elmt_vector)
+		{
+			const QString element_uuid = elmt->uuid().toString();
+			const auto terms = elmt->terminals();
+			for (int i = 0; i < terms.size(); ++i)
+			{
+				Terminal *t = terms.at(i);
+				if (!t) continue;
+				const QString tid = element_uuid + QStringLiteral("#") + QString::number(i);
+				m_terminal_tid.insert(t, tid);
+				q.bindValue(QStringLiteral(":tid"), tid);
+				q.bindValue(QStringLiteral(":element_uuid"), element_uuid);
+				q.bindValue(QStringLiteral(":diagram_uuid"), diagram->uuid().toString());
+				q.bindValue(QStringLiteral(":name"), t->name());
+				if (!q.exec()) {
+					qDebug() << "populateTerminalTable insert error : " << q.lastError();
+				}
+			}
+		}
+	}
+}
+
+/**
+	@brief projectDataBase::terminalTid
+	The tid assigned to this placed terminal in populateTerminalTable (which runs
+	first in the same updateDB pass, on the same live Terminal objects). Looking
+	it up here - rather than recomputing element_uuid + index - guarantees the
+	conductor endpoint joins to the exact terminal row, independent of any
+	element->terminals() ordering differences between the two passes.
+*/
+QString projectDataBase::terminalTid(Terminal *t) const
+{
+	return m_terminal_tid.value(t);
+}
+
+/**
+	@brief projectDataBase::populateConductorTable
+	One row per drawn conductor (edge between two terminals), rebuilt from scene.
+*/
+void projectDataBase::populateConductorTable()
+{
+	QSqlQuery del(m_data_base);
+	del.exec(QStringLiteral("DELETE FROM conductor"));
+
+	QSqlQuery q(m_data_base);
+	q.prepare(QStringLiteral("INSERT INTO conductor (diagram_uuid, terminal1_tid, terminal2_tid, wire_num, type) "
+							 "VALUES (:diagram_uuid, :t1, :t2, :wire_num, :type)"));
+	for (auto *diagram : m_project->diagrams())
+	{
+		for (Conductor *c : diagram->conductors())
+		{
+			if (!c || !c->terminal1 || !c->terminal2) continue;
+			const ConductorProperties cp = c->properties();
+			q.bindValue(QStringLiteral(":diagram_uuid"), diagram->uuid().toString());
+			q.bindValue(QStringLiteral(":t1"), terminalTid(c->terminal1));
+			q.bindValue(QStringLiteral(":t2"), terminalTid(c->terminal2));
+			q.bindValue(QStringLiteral(":wire_num"), cp.text);
+			q.bindValue(QStringLiteral(":type"), cp.type == ConductorProperties::Single ? "Single" : "Multi");
+			if (!q.exec()) {
+				qDebug() << "populateConductorTable insert error : " << q.lastError();
+			}
+		}
 	}
 }
 

--- a/sources/dataBase/projectdatabase.h
+++ b/sources/dataBase/projectdatabase.h
@@ -27,6 +27,7 @@
 class Element;
 class QETProject;
 class Diagram;
+class Terminal;
 class sqlite3;
 
 /**
@@ -65,6 +66,10 @@ class projectDataBase : public QObject
 		bool createDataBase();
 		void createElementNomenclatureView();
 		void createSummaryView();
+		void createWireListView();
+		QString terminalTid(Terminal *t) const;
+		void populateTerminalTable();
+		void populateConductorTable();
 		void populateDiagramTable();
 		void populateElementTable();
 		void populateElementInfoTable();
@@ -87,6 +92,10 @@ class projectDataBase : public QObject
 				  m_update_diagram_info_query,
 				  m_diagram_order_changed,
 				  m_diagram_info_order_changed;
+			//Terminal -> tid, assigned in populateTerminalTable and reused by
+			//populateConductorTable (same updateDB pass, same live objects) so
+			//conductor endpoints join to the exact terminal row.
+			QHash<Terminal *, QString> m_terminal_tid;
 
 #ifdef QET_EXPORT_PROJECT_DB
 	public:

--- a/sources/factory/qetgraphicstablefactory.cpp
+++ b/sources/factory/qetgraphicstablefactory.cpp
@@ -71,6 +71,68 @@ void QetGraphicsTableFactory::createAndAddSummary(Diagram *diagram)
 	}
 }
 
+/**
+	@brief QetGraphicsTableFactory::createAndAddWiringList
+	Create a from-to wiring list table (built on the projectDataBase
+	wire_list_view) and add it to diagram. Unlike the nomenclature/summary
+	there is no column-picker dialog: the query is fixed. A long list spills
+	onto new folios, like the nomenclature does.
+	@param diagram
+*/
+void QetGraphicsTableFactory::createAndAddWiringList(Diagram *diagram)
+{
+	const QString base_name = QObject::tr("Liste de câblage");
+	const QString query = QStringLiteral(
+		"SELECT wire, from_point, from_folio, to_point, to_folio "
+		"FROM wire_list_view ORDER BY wire");
+
+	auto newWiringTable = [&query, &base_name](Diagram *diag, QetGraphicsTableItem *previous) {
+		auto table = new QetGraphicsTableItem();
+		table->setTableName(base_name);
+		if (!previous) {
+			auto model = new ProjectDBModel(diag->project(), diag->project());
+			model->setIdentifier(QStringLiteral("wiringlist"));
+			model->setQuery(query);
+			model->setData(model->index(0,0), int(Qt::AlignLeft | Qt::AlignVCenter), Qt::TextAlignmentRole);
+			table->setModel(model);
+		} else {
+			table->setPreviousTable(previous);
+		}
+		diag->addItem(table);
+		table->setPos(50, 50);
+		QetGraphicsTableItem::adjustTableToFolio(table);
+		return table;
+	};
+
+	auto table_ = newWiringTable(diagram, nullptr);
+
+		//Spill the remaining rows onto new folios, like the nomenclature does.
+	if (table_->displayNRow() > 0
+		&& table_->model()->rowCount() > table_->displayNRow())
+	{
+		auto already_displayed_rows = table_->displayNRow();
+		auto project_ = diagram->project();
+		auto actual_diagram = diagram;
+		auto previous_table = table_;
+
+		table_->setTableName(base_name + QStringLiteral(" 1"));
+		int table_number = 2;
+		while (already_displayed_rows < table_->model()->rowCount())
+		{
+			actual_diagram = project_->addNewDiagram(project_->folioIndex(actual_diagram)+1);
+				//Title the auto-created folio so it reads as a wiring list.
+			auto tbp = actual_diagram->border_and_titleblock.exportTitleBlock();
+			tbp.title = base_name;
+			actual_diagram->border_and_titleblock.importTitleBlock(tbp);
+			auto next_table = newWiringTable(actual_diagram, previous_table);
+			next_table->setTableName(base_name + QStringLiteral(" %1").arg(table_number));
+			already_displayed_rows += next_table->displayNRow();
+			previous_table = next_table;
+			++table_number;
+		}
+	}
+}
+
 void QetGraphicsTableFactory::create(Diagram *diagram, AddTableDialog *dialog)
 {
 	auto table_ = newTable(diagram, dialog);

--- a/sources/factory/qetgraphicstablefactory.h
+++ b/sources/factory/qetgraphicstablefactory.h
@@ -32,6 +32,7 @@ class QetGraphicsTableFactory
 
 		static void createAndAddNomenclature(Diagram *diagram);
 		static void createAndAddSummary(Diagram *diagram);
+		static void createAndAddWiringList(Diagram *diagram);
 	private:
 		static void create(Diagram *diagram, AddTableDialog *dialog);
 		static QetGraphicsTableItem *newTable(

--- a/sources/qetdiagrameditor.cpp
+++ b/sources/qetdiagrameditor.cpp
@@ -446,6 +446,14 @@ void QETDiagramEditor::setUpActions()
 		}
 	});
 
+		//Add a from-to wiring list item (database-driven, from wire_list_view)
+	m_add_wiring_list = new QAction(QET::Icons::TableOfContent, tr("Ajouter une liste de câblage"), this);
+	connect(m_add_wiring_list, &QAction::triggered, this, [=]() {
+		if(this->currentDiagramView()) {
+			QetGraphicsTableFactory::createAndAddWiringList(this->currentDiagramView()->diagram());
+		}
+	});
+
 	m_terminal_strip_dialog = new QAction(QET::Icons::TerminalStrip, tr("Gestionnaire de borniers (DEV)"), this);
 	connect(m_terminal_strip_dialog, &QAction::triggered, this, [=]()
 	{
@@ -849,6 +857,7 @@ void QETDiagramEditor::setUpMenu()
 	menu_project -> addSeparator();
 	menu_project -> addAction(m_add_summary);
 	menu_project -> addAction(m_add_nomenclature);
+	menu_project -> addAction(m_add_wiring_list);
 	menu_project -> addAction(m_csv_export);
 	menu_project -> addAction(m_project_export_conductor_num);
 	menu_project -> addAction(m_terminal_strip_dialog);
@@ -1584,6 +1593,7 @@ void QETDiagramEditor::slot_updateActions()
 	m_clean_project               -> setEnabled(editable_project);
 	m_add_summary                 -> setEnabled(editable_project);
 	m_add_nomenclature            -> setEnabled(editable_project);
+	m_add_wiring_list             -> setEnabled(editable_project);
 	m_csv_export                  -> setEnabled(editable_project);
 	m_project_export_conductor_num-> setEnabled(opened_project);
 	m_terminal_strip_dialog       -> setEnabled(editable_project);

--- a/sources/qetdiagrameditor.h
+++ b/sources/qetdiagrameditor.h
@@ -202,6 +202,7 @@ class QETDiagramEditor : public QETMainWindow
 		*m_csv_export,			///< generate nomenclature
 		*m_add_nomenclature,		///< Add nomenclature graphics item;
 		*m_add_summary,			///<Add summary graphics item
+		*m_add_wiring_list,		///< Add from-to wiring list graphics item
 		*m_terminal_strip_dialog = nullptr, ///<Launch terminal strip dialog
 		*m_project_terminalBloc,	///< generate terminal block
 		*m_project_export_conductor_num,///<Export the wire num to csv


### PR DESCRIPTION
> ## ⚠️ DRAFT — PROOF OF CONCEPT — NOT FOR PRODUCTION USE
> This is a **demonstration / RFC** to make the idea in discussion #503 concrete
> and testable. It has **not** been through full review or QA. The schema, the
> `wire_list_view` SQL, the table format and the GUI wording are all **subject to
> change**. Please don't merge as‑is — it's here to gather feedback on direction.

Follows up on discussion **#503** (database‑driven from‑to wiring list). It adds, **additively** to `projectDataBase`:

### 1. A from‑to wiring list view
Two small tables (`terminal`, `conductor`) and a `wire_list_view`, rebuilt from the scene in `updateDB()` exactly like the existing tables (no stored state, existing tables/views untouched). Each conductor resolves to its two `element : terminal` endpoints + wire number + folio number, including the **cross‑folio** case:

| wire | from_point | from_folio | to_point | to_folio |
|------|------------|------------|----------|----------|
| 1001 | X2:4 | 10 | 10QF2 | 10 |
| 1011 | XV2:1 | 8 | 8F2 | 8 |

Terminals are keyed by element‑uuid + a per‑element index (a terminal's own uuid can be null/repeated), with a `Terminal*→id` map so conductor endpoints join to the exact row.

### 2. A "Add a wiring list" menu action
`Project → Add a wiring list` renders the view as a table on the current folio and spills onto new folios — mirroring the existing *Add a nomenclature* / *Add a summary*. It reuses QET's generic `ProjectDBModel`, so there's **no new rendering code**.

### Try it
1. Build this branch, open e.g. `examples/industrial.qet`.
2. `Project → Add a wiring list`.
3. Or `python3 docs/wiring-list-demo/make_demo.py` for a pre‑built demo project.

See `docs/wiring-list-demo/README.md` for details.

### Known limitations (it's a PoC)
- Coverage uses QET's existing element‑table filter (`Simple | Terminal | Master | Thumbnail`), so conductors ending on **folio‑report arrows** or **slave** contacts aren't resolved yet; element‑to‑element wires are complete.
- The wiring‑list query is fixed (no column‑picker dialog).
- Not performance‑reviewed; view schema is provisional.

### Commits
- `db:` terminal + conductor tables + `wire_list_view`
- `gui:` the "Add a wiring list" action
- `demo:` the support files in `docs/wiring-list-demo/`

Feedback on schema, naming and scope very welcome.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
