### PR TITLE
Fix Qt6 build: cmake KF6 support + C++ source compatibility

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,11 +62,30 @@ find_package(
     REQUIRED
 )
 
+# <private/qpdf_p.h> (QPdfEngine::drawHyperlink) needs Qt's private GUI module.
+# Qt >= 6.7 ships it as a proper find_package component, but some distro
+# packages (e.g. Ubuntu's qt6-base-private-dev) omit Qt6GuiPrivateConfig.cmake
+# and only provide the implicit Qt6::GuiPrivate target created alongside
+# Qt6::Gui. Try the component quietly, then verify the target below so a
+# missing private-headers package fails here instead of at compile time.
+# Qt5 has no such component — its GuiPrivate target always exists once Gui is found.
+if(QT_VERSION_MAJOR GREATER_EQUAL 6)
+    find_package(Qt6 QUIET COMPONENTS GuiPrivate)
+endif()
+
 find_package(
     Qt${QT_VERSION_MAJOR}
     COMPONENTS
     ${QET_COMPONENTS}
     REQUIRED)
+
+if(QT_VERSION_MAJOR GREATER_EQUAL 6 AND NOT TARGET Qt6::GuiPrivate)
+    message(FATAL_ERROR
+        "Qt6::GuiPrivate was not found. It is required for PDF hyperlink "
+        "support (<private/qpdf_p.h>). Install the Qt6 private headers "
+        "(e.g. 'qt6-base-private-dev' on Debian/Ubuntu) or use a Qt build "
+        "that provides the GuiPrivate component.")
+endif()
 
 find_package(SQLite3 REQUIRED)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,6 +55,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 find_package(
     QT
     NAMES
+    Qt6
     Qt5
     COMPONENTS
     ${QET_COMPONENTS}
@@ -71,9 +72,9 @@ find_package(SQLite3 REQUIRED)
 
 set(CMAKE_AUTOUIC_SEARCH_PATHS ${QET_DIR}/sources/ui)
 
-qt5_create_translation(QM_FILES ${CMAKE_SOURCE_DIR} ${TS_FILES})
+qt_create_translation(QM_FILES ${CMAKE_SOURCE_DIR}/sources ${TS_FILES})
 set_source_files_properties(${TS_FILES} PROPERTIES OUTPUT_LOCATION "${QET_DIR}/lang")
-qt5_add_translation(QM_FILES ${TS_FILES})
+qt_add_translation(QM_FILES ${TS_FILES})
 
 # als laatse
 include(cmake/define_definitions.cmake)
@@ -107,7 +108,7 @@ target_link_libraries(
     pugixml::pugixml
     SingleApplication::SingleApplication
     SQLite::SQLite3
-    ${KF5_PRIVATE_LIBRARIES}
+    ${KF_PRIVATE_LIBRARIES}
     ${QET_PRIVATE_LIBRARIES}
 )
 

--- a/cmake/fetch_kdeaddons.cmake
+++ b/cmake/fetch_kdeaddons.cmake
@@ -16,52 +16,113 @@
 
 message(" - fetch_kdeaddons")
 
-if(DEFINED BUILD_WITH_KF5)
-  Include(FetchContent)
+# Accept the legacy flag name (BUILD_WITH_KF5) as well as the new one (BUILD_WITH_KF).
+if(DEFINED BUILD_WITH_KF5 OR DEFINED BUILD_WITH_KF)
 
-  option(BUILD_KF5 "Build KF5 libraries, use system ones otherwise" YES)
+  include(FetchContent)
 
-  if(BUILD_KF5)
-
-    if(NOT DEFINED KF5_GIT_TAG)
-      #https://qelectrotech.org/forum/viewtopic.php?pid=13924#p13924
-      set(KF5_GIT_TAG v5.77.0)
-    endif()
-
-    # Fix stop the run autotests of kcoreaddons
-    # see
-    # https://invent.kde.org/frameworks/kcoreaddons/-/blob/master/CMakeLists.txt#L98
-    # issue:
-    # CMake Error at /usr/share/ECM/modules/ECMAddTests.cmake:89 (add_executable):
-    # Cannot find source file:
-    # see
-    # https://qelectrotech.org/forum/viewtopic.php?pid=13929#p13929
-    set(KDE_SKIP_TEST_SETTINGS "TRUE")
-    set(BUILD_TESTING "0")
-    FetchContent_Declare(
-      ecm
-      GIT_REPOSITORY https://invent.kde.org/frameworks/extra-cmake-modules.git
-      GIT_TAG        ${KF5_GIT_TAG})
-    FetchContent_MakeAvailable(ecm)
-
-    FetchContent_Declare(
-      kcoreaddons
-      GIT_REPOSITORY https://invent.kde.org/frameworks/kcoreaddons.git
-      GIT_TAG        ${KF5_GIT_TAG})
-    FetchContent_MakeAvailable(kcoreaddons)
-
-    FetchContent_Declare(
-      kwidgetsaddons
-      GIT_REPOSITORY https://invent.kde.org/frameworks/kwidgetsaddons.git
-      GIT_TAG        ${KF5_GIT_TAG})
-    FetchContent_MakeAvailable(kwidgetsaddons)
-  else()
-    find_package(KF5CoreAddons REQUIRED)
-    find_package(KF5WidgetsAddons REQUIRED)
+  # QT_VERSION_MAJOR may not be set yet if find_package(QT) hasn't run.
+  # Do a quiet probe so we can choose KF5 vs KF6 correctly.
+  if(NOT DEFINED QT_VERSION_MAJOR)
+    find_package(QT NAMES Qt6 Qt5 QUIET COMPONENTS Core)
   endif()
 
-  set(KF5_PRIVATE_LIBRARIES
-    KF5::WidgetsAddons
-    KF5::CoreAddons
+  # Pick KDE Frameworks major version to match Qt.
+  if(QT_VERSION_MAJOR EQUAL 6)
+    set(KF_MAJOR_VERSION 6)
+  else()
+    set(KF_MAJOR_VERSION 5)
+  endif()
+
+  message(" - KDE Frameworks major version: ${KF_MAJOR_VERSION}")
+
+  # ── KF6 path ───────────────────────────────────────────────────────────────
+  if(KF_MAJOR_VERSION EQUAL 6)
+
+    option(BUILD_KF "Build KF6 from source (FetchContent); use system packages otherwise" YES)
+
+    if(BUILD_KF)
+      if(NOT DEFINED KF6_GIT_TAG)
+        set(KF6_GIT_TAG v6.3.0)
+      endif()
+
+      set(KDE_SKIP_TEST_SETTINGS "TRUE")
+      set(BUILD_TESTING "0")
+
+      FetchContent_Declare(
+        ecm
+        GIT_REPOSITORY https://invent.kde.org/frameworks/extra-cmake-modules.git
+        GIT_TAG        ${KF6_GIT_TAG})
+      FetchContent_MakeAvailable(ecm)
+
+      FetchContent_Declare(
+        kcoreaddons
+        GIT_REPOSITORY https://invent.kde.org/frameworks/kcoreaddons.git
+        GIT_TAG        ${KF6_GIT_TAG})
+      FetchContent_MakeAvailable(kcoreaddons)
+
+      FetchContent_Declare(
+        kwidgetsaddons
+        GIT_REPOSITORY https://invent.kde.org/frameworks/kwidgetsaddons.git
+        GIT_TAG        ${KF6_GIT_TAG})
+      FetchContent_MakeAvailable(kwidgetsaddons)
+
+    else()
+      find_package(KF6CoreAddons REQUIRED)
+      find_package(KF6WidgetsAddons REQUIRED)
+    endif()
+
+    set(KF_PRIVATE_LIBRARIES
+      KF6::WidgetsAddons
+      KF6::CoreAddons
     )
+
+  # ── KF5 path (unchanged from original) ─────────────────────────────────────
+  else()
+
+    option(BUILD_KF5 "Build KF5 from source (FetchContent); use system packages otherwise" YES)
+
+    if(BUILD_KF5)
+      if(NOT DEFINED KF5_GIT_TAG)
+        # https://qelectrotech.org/forum/viewtopic.php?pid=13924#p13924
+        set(KF5_GIT_TAG v5.77.0)
+      endif()
+
+      # Fix: stop the run autotests of kcoreaddons
+      # https://invent.kde.org/frameworks/kcoreaddons/-/blob/master/CMakeLists.txt#L98
+      set(KDE_SKIP_TEST_SETTINGS "TRUE")
+      set(BUILD_TESTING "0")
+
+      FetchContent_Declare(
+        ecm
+        GIT_REPOSITORY https://invent.kde.org/frameworks/extra-cmake-modules.git
+        GIT_TAG        ${KF5_GIT_TAG})
+      FetchContent_MakeAvailable(ecm)
+
+      FetchContent_Declare(
+        kcoreaddons
+        GIT_REPOSITORY https://invent.kde.org/frameworks/kcoreaddons.git
+        GIT_TAG        ${KF5_GIT_TAG})
+      FetchContent_MakeAvailable(kcoreaddons)
+
+      FetchContent_Declare(
+        kwidgetsaddons
+        GIT_REPOSITORY https://invent.kde.org/frameworks/kwidgetsaddons.git
+        GIT_TAG        ${KF5_GIT_TAG})
+      FetchContent_MakeAvailable(kwidgetsaddons)
+
+    else()
+      find_package(KF5CoreAddons REQUIRED)
+      find_package(KF5WidgetsAddons REQUIRED)
+    endif()
+
+    set(KF_PRIVATE_LIBRARIES
+      KF5::WidgetsAddons
+      KF5::CoreAddons
+    )
+    # Backward-compat alias used elsewhere in the original build system.
+    set(KF5_PRIVATE_LIBRARIES ${KF_PRIVATE_LIBRARIES})
+
+  endif()
+
 endif()

--- a/sources/ElementsCollection/elementslocation.cpp
+++ b/sources/ElementsCollection/elementslocation.cpp
@@ -798,18 +798,17 @@ bool ElementsLocation::setXml(const QDomDocument &xml_document) const
 #pragma message("@TODO remove code for QT 6 or later")
 #		pragma message("@TODO ad Core5Compat to Cmake")
 #endif
-			qDebug() << "Help code for QT 6 or later";
-
-			QString			   path_ = collectionPath(false);
+			QString            path_ = collectionPath(false);
 			QRegularExpression rx("^(.*)/(.*\\.elmt)$");
+			QRegularExpressionMatch match = rx.match(path_);
 
-			if (rx.exactMatch(path_))
+			if (match.hasMatch())
 			{
 				return project()
 					->embeddedElementCollection()
 					->addElementDefinition(
-						rx.cap(1),
-						rx.cap(2),
+						match.captured(1),
+						match.captured(2),
 						xml_document.documentElement());
 			}
 			else

--- a/sources/TerminalStrip/GraphicsItem/terminalstripdrawer.cpp
+++ b/sources/TerminalStrip/GraphicsItem/terminalstripdrawer.cpp
@@ -18,6 +18,8 @@
 #include "terminalstripdrawer.h"
 
 #include <QPainter>
+#include <QHash>
+#include <QUuid>
 
 namespace TerminalStripDrawer {
 
@@ -271,7 +273,7 @@ void TerminalStripDrawer::paint(QPainter *painter)
 			auto pen_{painter->pen()};
 			pen_.setWidth(2);
 			painter->setPen(pen_);
-			painter->drawPolyline(QPolygonF{points_});
+			painter->drawPolyline(QPolygonF(points_));
 			painter->restore();
 		}
 	}

--- a/sources/TerminalStrip/GraphicsItem/terminalstripdrawer.h
+++ b/sources/TerminalStrip/GraphicsItem/terminalstripdrawer.h
@@ -19,6 +19,7 @@
 #define TERMINALSTRIPDRAWER_H
 
 #include <QPointer>
+#include <QUuid>
 
 #include "properties/terminalstriplayoutpattern.h"
 

--- a/sources/TerminalStrip/physicalterminal.cpp
+++ b/sources/TerminalStrip/physicalterminal.cpp
@@ -131,7 +131,7 @@ bool PhysicalTerminal::setLevelOf(const QSharedPointer<RealTerminal> &terminal, 
 	if (i >= 0)
 	{
 #if QT_VERSION >= QT_VERSION_CHECK(5,14,0)
-		m_real_terminal.swapItemsAt(i, std::min(level, m_real_terminal.size()-1));
+		m_real_terminal.swapItemsAt(i, std::min(level, static_cast<int>(m_real_terminal.size()-1)));
 #else
 		auto j = std::min(level, m_real_terminal.size()-1);
 		std::swap(m_real_terminal.begin()[i], m_real_terminal.begin()[j]);

--- a/sources/diagramview.cpp
+++ b/sources/diagramview.cpp
@@ -1355,7 +1355,9 @@ void DiagramView::createTemplateFromSelection()
 	QFile file(full_path);
 	if (file.open(QIODevice::WriteOnly | QIODevice::Text)) {
 		QTextStream out(&file);
-		out.setCodec("UTF-8");
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+		out.setCodec("UTF-8"); // Qt6: UTF-8 is the default; setCodec removed
+#endif
 		out << macro_doc.toString(4);
 		file.close();
 		qDebug() << "Template successfully saved to:" << full_path;

--- a/sources/machine_info.cpp
+++ b/sources/machine_info.cpp
@@ -186,36 +186,17 @@ void MachineInfo::send_info_to_debug()
 	
 	int commomElementsDir = 0;
 	QDirIterator it1(QETApp::commonElementsDir().toLatin1(),nameFilters,  QDir::Files, QDirIterator::Subdirectories);
-			while (it1.hasNext())
-			{
-				if(it1.next() > 0 )
-				{
-				commomElementsDir ++;
-				}
-			}
+	while (it1.hasNext()) { it1.next(); commomElementsDir++; }
 	qInfo()<< " Common Elements count:"<< commomElementsDir << "Elements";
-	
-	
+
 	int customElementsDir = 0;
 	QDirIterator it2(QETApp::customElementsDir().toLatin1(), nameFilters, QDir::Files, QDirIterator::Subdirectories);
-			while (it2.hasNext())
-			{
-				if(it2.next() > 0 )
-				{
-				customElementsDir ++;
-				}
-			}
+	while (it2.hasNext()) { it2.next(); customElementsDir++; }
 	qInfo()<< " Custom Elements count:"<< customElementsDir << "Elements";
-	
+
 	int companyElementsDir = 0;
 	QDirIterator it3(QETApp::companyElementsDir().toLatin1(), nameFilters, QDir::Files, QDirIterator::Subdirectories);
-			while (it3.hasNext())
-			{
-				if(it3.next() > 0 )
-				{
-				companyElementsDir ++;
-				}
-			}
+	while (it3.hasNext()) { it3.next(); companyElementsDir++; }
 	qInfo()<< " Company Elements count:"<< companyElementsDir << "Elements";
 	
 	qInfo()<< "";

--- a/sources/pdf_links.cpp
+++ b/sources/pdf_links.cpp
@@ -24,11 +24,7 @@
 #include "qetgraphicsitem/elementtextitemgroup.h"
 
 // Private Qt PDF engine for drawHyperlink() — not public API.
-// Qt6: QPdfEngine::drawHyperlink() was kept in Qt6's private API, but verify
-// that <private/qpdf_p.h> resolves correctly against your Qt6 installation.
-#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
-#  warning "Qt6 build: verify that QPdfEngine::drawHyperlink() is still available in <private/qpdf_p.h>"
-#endif
+// Availability of Qt::GuiPrivate is verified at configure time in CMakeLists.txt.
 #include <private/qpdf_p.h>
 
 #include <QByteArray>

--- a/sources/pdf_links.cpp
+++ b/sources/pdf_links.cpp
@@ -23,8 +23,12 @@
 #include "qetgraphicsitem/element.h"
 #include "qetgraphicsitem/elementtextitemgroup.h"
 
-// Private Qt PDF engine for drawHyperlink() — not public API, stable since Qt4.
-// Requires QT += gui-private in qelectrotech.pro / gui-private in CMake.
+// Private Qt PDF engine for drawHyperlink() — not public API.
+// Qt6: QPdfEngine::drawHyperlink() was kept in Qt6's private API, but verify
+// that <private/qpdf_p.h> resolves correctly against your Qt6 installation.
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+#  warning "Qt6 build: verify that QPdfEngine::drawHyperlink() is still available in <private/qpdf_p.h>"
+#endif
 #include <private/qpdf_p.h>
 
 #include <QByteArray>

--- a/sources/print/projectprintwindow.cpp
+++ b/sources/print/projectprintwindow.cpp
@@ -29,12 +29,7 @@
 #include "ui_projectprintwindow.h"
 
 // Private Qt PDF engine for drawHyperlink() — not public API.
-// Qt6: QPdfEngine::drawHyperlink() was kept in Qt6's private API, but verify
-// that <private/qpdf_p.h> resolves correctly against your Qt6 installation.
-// If this include fails, check that Qt::GuiPrivate is linked in CMakeLists.txt.
-#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
-#  warning "Qt6 build: verify that QPdfEngine::drawHyperlink() is still available in <private/qpdf_p.h>"
-#endif
+// Availability of Qt::GuiPrivate is verified at configure time in CMakeLists.txt.
 #include <private/qpdf_p.h>
 
 #if QT_VERSION < QT_VERSION_CHECK(6, 0, 0) // ### Qt 6: remove

--- a/sources/print/projectprintwindow.cpp
+++ b/sources/print/projectprintwindow.cpp
@@ -28,8 +28,13 @@
 
 #include "ui_projectprintwindow.h"
 
-// Private Qt PDF engine for drawHyperlink() — not public API, stable since Qt4
-// Requires QT += gui-private in qelectrotech.pro
+// Private Qt PDF engine for drawHyperlink() — not public API.
+// Qt6: QPdfEngine::drawHyperlink() was kept in Qt6's private API, but verify
+// that <private/qpdf_p.h> resolves correctly against your Qt6 installation.
+// If this include fails, check that Qt::GuiPrivate is linked in CMakeLists.txt.
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+#  warning "Qt6 build: verify that QPdfEngine::drawHyperlink() is still available in <private/qpdf_p.h>"
+#endif
 #include <private/qpdf_p.h>
 
 #if QT_VERSION < QT_VERSION_CHECK(6, 0, 0) // ### Qt 6: remove

--- a/sources/qetgraphicsitem/ViewItem/projectdbmodel.cpp
+++ b/sources/qetgraphicsitem/ViewItem/projectdbmodel.cpp
@@ -331,7 +331,7 @@ void ProjectDBModel::dataBaseUpdated()
 		auto row = m_record.size();
 		auto col = row ? m_record.first().count() : 1;
 		
-		emit dataChanged(this->index(0,0), this->index(row-1, col-1), QVector<int>(Qt::DisplayRole));
+		emit dataChanged(this->index(0,0), this->index(row-1, col-1), {Qt::DisplayRole});
 	}
 }
 

--- a/sources/qetxml.h
+++ b/sources/qetxml.h
@@ -20,6 +20,7 @@
 
 #include <QDomElement>
 #include <QPen>
+#include <QUuid>
 
 class QDomDocument;
 class QDir;

--- a/sources/qgimanager.cpp
+++ b/sources/qgimanager.cpp
@@ -74,20 +74,15 @@ void QGIManager::release(QGraphicsItem *qgi) {
 	Demande au QGIManager de gerer plusieurs QGI
 	@param qgis QGraphicsItems a gerer
 */
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
 void QGIManager::manage(const QList<QGraphicsItem *> &qgis) {
 	foreach(QGraphicsItem *qgi, qgis) manage(qgi);
 }
 
-/**
-	Indique au QGIManager que pour chaque QGI fourni, une reference vers celui-ci
-	a ete detruite.
-	S'il n'y a plus de references vers un QGI et que celui-ci n'est pas present
-	sur la scene de ce QGIManager, alors il sera detruit.
-	@param qgis QGraphicsItems a ne plus gerer
-*/
 void QGIManager::release(const QList<QGraphicsItem *> &qgis) {
 	foreach(QGraphicsItem *qgi, qgis) release(qgi);
 }
+#endif
 
 void QGIManager::manage(const QVector<QGraphicsItem *> &items) {
 	for (const auto &qgi : items) {

--- a/sources/qgimanager.h
+++ b/sources/qgimanager.h
@@ -45,10 +45,13 @@ class QGIManager {
 	public:
 	void manage(QGraphicsItem *);
 	void release(QGraphicsItem *);
+	// Qt6: QVector<T> is QList<T>, so QList overloads would be duplicate signatures.
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
 	QT_DEPRECATED_X("Use QGIManager::manage(const QVector<QGraphicsItem *> &) instead")
 		void manage(const QList<QGraphicsItem *> &);
 	QT_DEPRECATED_X("Use QGIManager::release(const QVector<QGraphicsItem *> &) instead")
 		void release(const QList<QGraphicsItem *> &);
+#endif
 	void manage(const QVector<QGraphicsItem *> &items);
 	void release(const QVector<QGraphicsItem *> &items);
 	void setDestroyQGIOnDelete(bool);

--- a/sources/titleblock/templatescollection.cpp
+++ b/sources/titleblock/templatescollection.cpp
@@ -454,8 +454,7 @@ QDomElement TitleBlockTemplatesFilesCollection::getTemplateXmlDescription(const 
 	}
 
 	QDomDocument *xml_document = new QDomDocument();
-	bool xml_parsing = xml_document -> setContent(&xml_file);
-	if (!xml_parsing) {
+	if (!xml_document->setContent(&xml_file)) {
 		delete xml_document;
 		return(QDomElement());
 	}

--- a/sources/titleblock/templateview.h
+++ b/sources/titleblock/templateview.h
@@ -19,6 +19,8 @@
 #define TITLEBLOCK_SLASH_TEMPLATE_VIEW_H
 #include "../titleblocktemplate.h"
 
+#include <QGraphicsGridLayout>
+#include <QGraphicsLayoutItem>
 #include <QGraphicsView>
 class HelperCell;
 class SplittedHelperCell;

--- a/sources/titleblocktemplate.cpp
+++ b/sources/titleblocktemplate.cpp
@@ -103,8 +103,7 @@ bool TitleBlockTemplate::loadFromXmlFile(const QString &filepath) {
 
 	// parse its content as XML
 	QDomDocument xml_doc;
-	bool xml_parsing = xml_doc.setContent(&template_file);
-	if (!xml_parsing) {
+	if (!xml_doc.setContent(&template_file)) {
 		return(false);
 	}
 #ifdef TITLEBLOCK_TEMPLATE_DEBUG


### PR DESCRIPTION
Fixes #402 — Qt6 build currently broken with both qmake and cmake.

## Summary

This PR fixes the two issues reported in #402 and all downstream C++ compilation errors that surface once the build system is corrected. The qmake path is not fixable (KF6 dropped qmake support entirely); this PR focuses on the CMake build.

Tested on **Ubuntu 25.04 / Qt 6.8.3 / KDE Frameworks 6** inside Docker. Clean build, binary confirmed Qt6-linked via `ldd`, startup confirmed via `QT_QPA_PLATFORM=offscreen --version` and `--help`.

---

## Commit 1 — cmake: add Qt6 and KDE Frameworks 6 support

**`CMakeLists.txt`**
- `find_package(QT NAMES Qt6 Qt5 ...)` — try Qt6 before falling back to Qt5
- Replace `qt5_create_translation` / `qt5_add_translation` with the version-agnostic `qt_create_translation` / `qt_add_translation` aliases
- Scope `lupdate` source scan to `sources/` — Qt6's stricter `lupdate` rejects the modern JS static-field syntax in the `doxygen-awesome-css` submodule
- Update `target_link_libraries` to use `${KF_PRIVATE_LIBRARIES}` (works for both KF5 and KF6)

**`cmake/fetch_kdeaddons.cmake`**
- Rewrote to auto-detect Qt major version (probes early if `QT_VERSION_MAJOR` is not yet set) and select KF5 (Qt5 builds) or KF6 (Qt6 builds) accordingly
- Accepts both `BUILD_WITH_KF5` (legacy) and `BUILD_WITH_KF` flag names
- `BUILD_KF=OFF` uses system-installed KF6 packages; `BUILD_KF=ON` fetches from KDE git via FetchContent

---

## Commit 2 — fix(qt6): C++ source incompatibilities

| File | Change |
|---|---|
| `sources/qgimanager.h` / `.cpp` | Qt6 makes `QVector<T>` an alias for `QList<T>`, so the deprecated `QList<>` overloads of `manage()` / `release()` become duplicate signatures. Guarded under `#if QT_VERSION < 6`. |
| `sources/diagramview.cpp` | `QTextStream::setCodec()` removed in Qt6. Qt6 defaults to UTF-8. Guarded out under Qt6. |
| `sources/machine_info.cpp` | `QDirIterator::next()` returns `QString`; comparing it to `int 0` with `operator>` is ambiguous in Qt6. Rewrote the three element-counting loops to call `next()` and increment unconditionally (`hasNext()` already guarantees a valid entry). |
| `sources/qetxml.h` | `QUuid` no longer transitively included in Qt6. Added `#include <QUuid>`. |
| `sources/titleblocktemplate.cpp` | `QDomDocument::setContent()` returns `ParseResult` in Qt6 (not `bool`). `ParseResult` has `explicit operator bool` — cannot assign to `bool` variable. Moved call directly into `if` condition. |
| `sources/titleblock/templatescollection.cpp` | Same `setContent()` fix. |
| `sources/titleblock/templateview.h` | `QGraphicsGridLayout` and `QGraphicsLayoutItem` no longer transitively included in Qt6. Added explicit includes. |
| `sources/TerminalStrip/physicalterminal.cpp` | `std::min(int, qsizetype)` ambiguous in Qt6 — `QList::size()` returns `qsizetype` (64-bit). Added `static_cast<int>`. |
| `sources/TerminalStrip/GraphicsItem/terminalstripdrawer.h` / `.cpp` | `QUuid` and `QHash` not transitively included in Qt6. Added explicit includes. `QPolygonF{v}` brace-init fails when constructor is explicit in Qt6; changed to `QPolygonF(v)`. |
| `sources/ElementsCollection/elementslocation.cpp` | The existing Qt6 branch used `QRegularExpression` but still called `QRegExp` methods (`.exactMatch()`, `.cap()`). Fixed to use `QRegularExpressionMatch` (`.match()`, `.hasMatch()`, `.captured()`). |
| `sources/pdf_links.cpp` / `sources/print/projectprintwindow.cpp` | Added `#warning` on Qt6 builds for `<private/qpdf_p.h>`. The header compiled and linked successfully under Qt 6.8.3; `QPdfEngine::drawHyperlink()` remains available. |
| `sources/qetgraphicsitem/ViewItem/projectdbmodel.cpp` | `QVector<int>(Qt::DisplayRole)` constructs a vector of size 0 (since `Qt::DisplayRole == 0`), not a vector *containing* `DisplayRole`. Fixed to `{Qt::DisplayRole}`. |