### PR TITLE
snap: migrate to core24, kde-neon-6 (Qt6), cmake build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,6 +55,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 find_package(
     QT
     NAMES
+    Qt6
     Qt5
     COMPONENTS
     ${QET_COMPONENTS}
@@ -71,9 +72,9 @@ find_package(SQLite3 REQUIRED)
 
 set(CMAKE_AUTOUIC_SEARCH_PATHS ${QET_DIR}/sources/ui)
 
-qt5_create_translation(QM_FILES ${CMAKE_SOURCE_DIR} ${TS_FILES})
+qt_create_translation(QM_FILES ${CMAKE_SOURCE_DIR}/sources ${TS_FILES})
 set_source_files_properties(${TS_FILES} PROPERTIES OUTPUT_LOCATION "${QET_DIR}/lang")
-qt5_add_translation(QM_FILES ${TS_FILES})
+qt_add_translation(QM_FILES ${TS_FILES})
 
 # als laatse
 include(cmake/define_definitions.cmake)
@@ -107,7 +108,7 @@ target_link_libraries(
     pugixml::pugixml
     SingleApplication::SingleApplication
     SQLite::SQLite3
-    ${KF5_PRIVATE_LIBRARIES}
+    ${KF_PRIVATE_LIBRARIES}
     ${QET_PRIVATE_LIBRARIES}
 )
 

--- a/build-aux/snap/snapcraft.yaml
+++ b/build-aux/snap/snapcraft.yaml
@@ -1,48 +1,47 @@
 name: qelectrotech
 title: QElectroTech
-base: core22
+base: core24
 adopt-info: qelectrotech
 license: GPL-2.0
 summary: Electrical diagram editor
 description: |
-  QElectroTech, or QET in short, is a libre and open source desktop application 
+  QElectroTech, or QET in short, is a libre and open source desktop application
   to create diagrams and schematics.
 
 grade: stable
 confinement: strict
 compression: lzo
 
-architectures:
-  - build-on: amd64
-    build-for: amd64
-  - build-on: arm64
-    build-for: arm64
-    
+# core24 uses 'platforms' instead of the deprecated 'architectures' key
+platforms:
+  amd64:
+  arm64:
+
 layout:
   /usr/local/share/qelectrotech:
     symlink: $SNAP/usr/local/share/qelectrotech
-  
+
 
 apps:
   qelectrotech:
     command: usr/local/bin/qelectrotech
     common-id: qelectrotech.desktop
-    extensions: 
-     - kde-neon
+    extensions:
+     - kde-neon-6
     plugs: &plugs [opengl, unity7, home, removable-media, gsettings, network, cups-control, wayland, x11]
     environment: &env
       TCL_LIBRARY: $SNAP/usr/share/tcltk/tcl8.6
       HOME: $SNAP_USER_COMMON
-      PYTHONPATH: $SNAP:$SNAP/lib/python3.10/site-packages:$SNAP/usr/lib/python3.10:$SNAP/usr/lib/python3.10/lib-dynload
+      PYTHONPATH: $SNAP:$SNAP/lib/python3.12/site-packages:$SNAP/usr/lib/python3.12:$SNAP/usr/lib/python3.12/lib-dynload
 
   qet-tb-generator:
     command: bin/qet_tb_generator
-    extensions: 
-     - kde-neon
+    extensions:
+     - kde-neon-6
     plugs: *plugs
     environment: *env
-      
-  
+
+
 parts:
   launchers:
     plugin: dump
@@ -53,32 +52,24 @@ parts:
   qet-tb-generator:
     plugin: python
     source: https://github.com/raulroda/qet_tb_generator-plugin.git
+    source-tag: v1.31
     python-packages: [PySimpleGUI]
-    stage-packages: 
+    stage-packages:
       - python3-lxml
       - python3-tk
       - libtk8.6
 
-  kde-sdk-setup:
-    plugin: nil
-    build-snaps:
-      - kf5-5-110-qt-5-15-11-core22-sdk
-    build-packages:
-      - g++
-      - mesa-common-dev
-      - libglvnd-dev
-      - rsync
-    override-build: |
-      rsync -a --ignore-existing /snap/kf5-5-110-qt-5-15-11-core22-sdk/current/ /
-
-  
   qelectrotech:
-    after: [kde-sdk-setup]
     plugin: nil
     source: .
-    stage-packages: [ git, sqlite3, xdg-user-dirs ]
+    stage-packages:
+      - git
+      - sqlite3
+      - xdg-user-dirs
     build-packages:
       - git
+      - cmake
+      - ninja-build
       - libsqlite3-dev
     override-build: |
       displayed_version=$(cat sources/qetversion.cpp | grep "return QVersionNumber{"| head -n 1| awk -F "{" '{ print $2 }' | awk -F "}" '{ print $1 }' | sed -e 's/,/./g' -e 's/ //g')
@@ -86,22 +77,28 @@ parts:
       modified_displayed_version="${snap_version}.snap"
       sed -i -E "s|const QString displayedVersion =.*|const QString displayedVersion =\"$modified_displayed_version\";|" sources/qet.h
       craftctl set version="$snap_version"
-      qmake "$CRAFT_PART_SRC/qelectrotech.pro"
-      make -j${CRAFT_PARALLEL_BUILD_COUNT}
-      make install INSTALL_ROOT="$CRAFT_PART_INSTALL"
+      cmake -B "$CRAFT_PART_BUILD/build" -S "$CRAFT_PART_SRC" \
+        -GNinja \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DCMAKE_INSTALL_PREFIX=/usr/local \
+        -DBUILD_WITH_KF=ON \
+        -DBUILD_KF=OFF \
+        -DPACKAGE_TESTS=OFF
+      cmake --build "$CRAFT_PART_BUILD/build" -j${CRAFT_PARALLEL_BUILD_COUNT}
+      DESTDIR="$CRAFT_PART_INSTALL" cmake --install "$CRAFT_PART_BUILD/build"
     override-stage: |
       craftctl default
       # patch desktop file with correct icon path
-      SED_CMD="sed -i -E s|^Icon=(.*)|Icon=\${SNAP}/usr/local/share/icons/hicolor/128x128/apps/\1.png|g" 
+      SED_CMD="sed -i -E s|^Icon=(.*)|Icon=\${SNAP}/usr/local/share/icons/hicolor/128x128/apps/\1.png|g"
       $SED_CMD usr/local/share/applications/org.qelectrotech.qelectrotech.desktop
 
   cleanup:
     after: [qelectrotech, qet-tb-generator]
     plugin: nil
-    build-snaps: [kf5-5-110-qt-5-15-11-core22]
+    build-snaps: [kf6-core24]
     override-prime: |
       set -eux
-      for snap in "kf5-5-110-qt-5-15-11-core22"; do  # List all content-snaps you're using here
+      for snap in "kf6-core24"; do
         cd "/snap/$snap/current" && find . -type f,l -exec rm -f "$CRAFT_PRIME/{}" "$CRAFT_PRIME/usr/{}" \;
       done
       for cruft in bug lintian man; do

--- a/build-aux/snap/snapcraft.yaml
+++ b/build-aux/snap/snapcraft.yaml
@@ -66,6 +66,10 @@ parts:
       - git
       - sqlite3
       - xdg-user-dirs
+      # libxcb-cursor0 is a hard runtime dependency of Qt's xcb platform
+      # plugin since Qt 5.15.x / Qt 6.x; the kf6-core24 content snap does
+      # not bundle it.  Without this the plugin loads but immediately aborts.
+      - libxcb-cursor0
     build-packages:
       - git
       - cmake

--- a/cmake/fetch_kdeaddons.cmake
+++ b/cmake/fetch_kdeaddons.cmake
@@ -16,52 +16,113 @@
 
 message(" - fetch_kdeaddons")
 
-if(DEFINED BUILD_WITH_KF5)
-  Include(FetchContent)
+# Accept the legacy flag name (BUILD_WITH_KF5) as well as the new one (BUILD_WITH_KF).
+if(DEFINED BUILD_WITH_KF5 OR DEFINED BUILD_WITH_KF)
 
-  option(BUILD_KF5 "Build KF5 libraries, use system ones otherwise" YES)
+  include(FetchContent)
 
-  if(BUILD_KF5)
-
-    if(NOT DEFINED KF5_GIT_TAG)
-      #https://qelectrotech.org/forum/viewtopic.php?pid=13924#p13924
-      set(KF5_GIT_TAG v5.77.0)
-    endif()
-
-    # Fix stop the run autotests of kcoreaddons
-    # see
-    # https://invent.kde.org/frameworks/kcoreaddons/-/blob/master/CMakeLists.txt#L98
-    # issue:
-    # CMake Error at /usr/share/ECM/modules/ECMAddTests.cmake:89 (add_executable):
-    # Cannot find source file:
-    # see
-    # https://qelectrotech.org/forum/viewtopic.php?pid=13929#p13929
-    set(KDE_SKIP_TEST_SETTINGS "TRUE")
-    set(BUILD_TESTING "0")
-    FetchContent_Declare(
-      ecm
-      GIT_REPOSITORY https://invent.kde.org/frameworks/extra-cmake-modules.git
-      GIT_TAG        ${KF5_GIT_TAG})
-    FetchContent_MakeAvailable(ecm)
-
-    FetchContent_Declare(
-      kcoreaddons
-      GIT_REPOSITORY https://invent.kde.org/frameworks/kcoreaddons.git
-      GIT_TAG        ${KF5_GIT_TAG})
-    FetchContent_MakeAvailable(kcoreaddons)
-
-    FetchContent_Declare(
-      kwidgetsaddons
-      GIT_REPOSITORY https://invent.kde.org/frameworks/kwidgetsaddons.git
-      GIT_TAG        ${KF5_GIT_TAG})
-    FetchContent_MakeAvailable(kwidgetsaddons)
-  else()
-    find_package(KF5CoreAddons REQUIRED)
-    find_package(KF5WidgetsAddons REQUIRED)
+  # QT_VERSION_MAJOR may not be set yet if find_package(QT) hasn't run.
+  # Do a quiet probe so we can choose KF5 vs KF6 correctly.
+  if(NOT DEFINED QT_VERSION_MAJOR)
+    find_package(QT NAMES Qt6 Qt5 QUIET COMPONENTS Core)
   endif()
 
-  set(KF5_PRIVATE_LIBRARIES
-    KF5::WidgetsAddons
-    KF5::CoreAddons
+  # Pick KDE Frameworks major version to match Qt.
+  if(QT_VERSION_MAJOR EQUAL 6)
+    set(KF_MAJOR_VERSION 6)
+  else()
+    set(KF_MAJOR_VERSION 5)
+  endif()
+
+  message(" - KDE Frameworks major version: ${KF_MAJOR_VERSION}")
+
+  # ── KF6 path ───────────────────────────────────────────────────────────────
+  if(KF_MAJOR_VERSION EQUAL 6)
+
+    option(BUILD_KF "Build KF6 from source (FetchContent); use system packages otherwise" YES)
+
+    if(BUILD_KF)
+      if(NOT DEFINED KF6_GIT_TAG)
+        set(KF6_GIT_TAG v6.3.0)
+      endif()
+
+      set(KDE_SKIP_TEST_SETTINGS "TRUE")
+      set(BUILD_TESTING "0")
+
+      FetchContent_Declare(
+        ecm
+        GIT_REPOSITORY https://invent.kde.org/frameworks/extra-cmake-modules.git
+        GIT_TAG        ${KF6_GIT_TAG})
+      FetchContent_MakeAvailable(ecm)
+
+      FetchContent_Declare(
+        kcoreaddons
+        GIT_REPOSITORY https://invent.kde.org/frameworks/kcoreaddons.git
+        GIT_TAG        ${KF6_GIT_TAG})
+      FetchContent_MakeAvailable(kcoreaddons)
+
+      FetchContent_Declare(
+        kwidgetsaddons
+        GIT_REPOSITORY https://invent.kde.org/frameworks/kwidgetsaddons.git
+        GIT_TAG        ${KF6_GIT_TAG})
+      FetchContent_MakeAvailable(kwidgetsaddons)
+
+    else()
+      find_package(KF6CoreAddons REQUIRED)
+      find_package(KF6WidgetsAddons REQUIRED)
+    endif()
+
+    set(KF_PRIVATE_LIBRARIES
+      KF6::WidgetsAddons
+      KF6::CoreAddons
     )
+
+  # ── KF5 path (unchanged from original) ─────────────────────────────────────
+  else()
+
+    option(BUILD_KF5 "Build KF5 from source (FetchContent); use system packages otherwise" YES)
+
+    if(BUILD_KF5)
+      if(NOT DEFINED KF5_GIT_TAG)
+        # https://qelectrotech.org/forum/viewtopic.php?pid=13924#p13924
+        set(KF5_GIT_TAG v5.77.0)
+      endif()
+
+      # Fix: stop the run autotests of kcoreaddons
+      # https://invent.kde.org/frameworks/kcoreaddons/-/blob/master/CMakeLists.txt#L98
+      set(KDE_SKIP_TEST_SETTINGS "TRUE")
+      set(BUILD_TESTING "0")
+
+      FetchContent_Declare(
+        ecm
+        GIT_REPOSITORY https://invent.kde.org/frameworks/extra-cmake-modules.git
+        GIT_TAG        ${KF5_GIT_TAG})
+      FetchContent_MakeAvailable(ecm)
+
+      FetchContent_Declare(
+        kcoreaddons
+        GIT_REPOSITORY https://invent.kde.org/frameworks/kcoreaddons.git
+        GIT_TAG        ${KF5_GIT_TAG})
+      FetchContent_MakeAvailable(kcoreaddons)
+
+      FetchContent_Declare(
+        kwidgetsaddons
+        GIT_REPOSITORY https://invent.kde.org/frameworks/kwidgetsaddons.git
+        GIT_TAG        ${KF5_GIT_TAG})
+      FetchContent_MakeAvailable(kwidgetsaddons)
+
+    else()
+      find_package(KF5CoreAddons REQUIRED)
+      find_package(KF5WidgetsAddons REQUIRED)
+    endif()
+
+    set(KF_PRIVATE_LIBRARIES
+      KF5::WidgetsAddons
+      KF5::CoreAddons
+    )
+    # Backward-compat alias used elsewhere in the original build system.
+    set(KF5_PRIVATE_LIBRARIES ${KF_PRIVATE_LIBRARIES})
+
+  endif()
+
 endif()

--- a/cmake/qet_compilation_vars.cmake
+++ b/cmake/qet_compilation_vars.cmake
@@ -29,7 +29,6 @@ set(QET_COMPONENTS
 set(QET_PRIVATE_LIBRARIES
   Qt::PrintSupport
   Qt::Gui
-  Qt::GuiPrivate   # Required for QPdfEngine::drawHyperlink (PDF internal links)
   Qt::Xml
   Qt::Svg
   Qt::Sql
@@ -37,6 +36,17 @@ set(QET_PRIVATE_LIBRARIES
   Qt::Widgets
   Qt::Concurrent
   )
+
+# Qt::GuiPrivate (for QPdfEngine::drawHyperlink) requires Qt private headers.
+# These are present in full desktop Qt6 installs but absent in some SDK snaps.
+# Enable the feature only when the target actually exists.
+if(TARGET Qt::GuiPrivate)
+  list(APPEND QET_PRIVATE_LIBRARIES Qt::GuiPrivate)
+  add_compile_definitions(QET_PDF_PRIVATE_HEADERS=1)
+  message(STATUS "Qt::GuiPrivate found — PDF hyperlink injection enabled")
+else()
+  message(STATUS "Qt::GuiPrivate not found — PDF hyperlink injection disabled (no Qt private headers)")
+endif()
 
 set(QET_RES_FILES
   ${QET_DIR}/sources/autoNum/ui/autonumberingdockwidget.ui

--- a/sources/ElementsCollection/elementslocation.cpp
+++ b/sources/ElementsCollection/elementslocation.cpp
@@ -798,18 +798,17 @@ bool ElementsLocation::setXml(const QDomDocument &xml_document) const
 #pragma message("@TODO remove code for QT 6 or later")
 #		pragma message("@TODO ad Core5Compat to Cmake")
 #endif
-			qDebug() << "Help code for QT 6 or later";
-
-			QString			   path_ = collectionPath(false);
+			QString            path_ = collectionPath(false);
 			QRegularExpression rx("^(.*)/(.*\\.elmt)$");
+			QRegularExpressionMatch match = rx.match(path_);
 
-			if (rx.exactMatch(path_))
+			if (match.hasMatch())
 			{
 				return project()
 					->embeddedElementCollection()
 					->addElementDefinition(
-						rx.cap(1),
-						rx.cap(2),
+						match.captured(1),
+						match.captured(2),
 						xml_document.documentElement());
 			}
 			else

--- a/sources/TerminalStrip/GraphicsItem/terminalstripdrawer.cpp
+++ b/sources/TerminalStrip/GraphicsItem/terminalstripdrawer.cpp
@@ -18,6 +18,8 @@
 #include "terminalstripdrawer.h"
 
 #include <QPainter>
+#include <QHash>
+#include <QUuid>
 
 namespace TerminalStripDrawer {
 
@@ -271,7 +273,7 @@ void TerminalStripDrawer::paint(QPainter *painter)
 			auto pen_{painter->pen()};
 			pen_.setWidth(2);
 			painter->setPen(pen_);
-			painter->drawPolyline(QPolygonF{points_});
+			painter->drawPolyline(QPolygonF(points_));
 			painter->restore();
 		}
 	}

--- a/sources/TerminalStrip/GraphicsItem/terminalstripdrawer.h
+++ b/sources/TerminalStrip/GraphicsItem/terminalstripdrawer.h
@@ -19,6 +19,7 @@
 #define TERMINALSTRIPDRAWER_H
 
 #include <QPointer>
+#include <QUuid>
 
 #include "properties/terminalstriplayoutpattern.h"
 

--- a/sources/TerminalStrip/physicalterminal.cpp
+++ b/sources/TerminalStrip/physicalterminal.cpp
@@ -131,7 +131,7 @@ bool PhysicalTerminal::setLevelOf(const QSharedPointer<RealTerminal> &terminal, 
 	if (i >= 0)
 	{
 #if QT_VERSION >= QT_VERSION_CHECK(5,14,0)
-		m_real_terminal.swapItemsAt(i, std::min(level, m_real_terminal.size()-1));
+		m_real_terminal.swapItemsAt(i, std::min(level, static_cast<int>(m_real_terminal.size()-1)));
 #else
 		auto j = std::min(level, m_real_terminal.size()-1);
 		std::swap(m_real_terminal.begin()[i], m_real_terminal.begin()[j]);

--- a/sources/cli_export.cpp
+++ b/sources/cli_export.cpp
@@ -31,8 +31,11 @@
 #include "titleblockproperties.h"
 #include "wiringlistexport.h"
 
-// Private Qt PDF engine for drawHyperlink() — see pdf_links / projectprintwindow.
-#include <private/qpdf_p.h>
+// QPdfEngine is needed for dynamic_cast to inject PDF hyperlinks.
+// Only available when Qt private headers are present.
+#ifdef QET_PDF_PRIVATE_HEADERS
+#  include <private/qpdf_p.h>
+#endif
 
 #include <QDir>
 #include <QDirIterator>
@@ -167,6 +170,7 @@ int exportPdf(QETProject &project, const QString &output)
 		// page.  The geometry is rebuilt from the QPdfWriter (not a QPrinter):
 		// render() anchors the diagram top-left with KeepAspectRatio, and the
 		// page is sized to the diagram so the scale is ~1.
+#ifdef QET_PDF_PRIVATE_HEADERS
 		if (auto *engine = dynamic_cast<QPdfEngine *>(painter.paintEngine())) {
 			const QRectF source(r);
 			const qreal s = qMin(target.width()  / source.width(),
@@ -199,6 +203,7 @@ int exportPdf(QETProject &project, const QString &output)
 			};
 			PdfLinks::injectCrossRefLinks(engine, diagram, geom, pageMap, output);
 		}
+#endif // QET_PDF_PRIVATE_HEADERS
 	}
 	painter.end();
 

--- a/sources/diagramview.cpp
+++ b/sources/diagramview.cpp
@@ -1355,7 +1355,9 @@ void DiagramView::createTemplateFromSelection()
 	QFile file(full_path);
 	if (file.open(QIODevice::WriteOnly | QIODevice::Text)) {
 		QTextStream out(&file);
-		out.setCodec("UTF-8");
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+		out.setCodec("UTF-8"); // Qt6: UTF-8 is the default; setCodec removed
+#endif
 		out << macro_doc.toString(4);
 		file.close();
 		qDebug() << "Template successfully saved to:" << full_path;

--- a/sources/machine_info.cpp
+++ b/sources/machine_info.cpp
@@ -186,36 +186,17 @@ void MachineInfo::send_info_to_debug()
 	
 	int commomElementsDir = 0;
 	QDirIterator it1(QETApp::commonElementsDir().toLatin1(),nameFilters,  QDir::Files, QDirIterator::Subdirectories);
-			while (it1.hasNext())
-			{
-				if(it1.next() > 0 )
-				{
-				commomElementsDir ++;
-				}
-			}
+	while (it1.hasNext()) { it1.next(); commomElementsDir++; }
 	qInfo()<< " Common Elements count:"<< commomElementsDir << "Elements";
-	
-	
+
 	int customElementsDir = 0;
 	QDirIterator it2(QETApp::customElementsDir().toLatin1(), nameFilters, QDir::Files, QDirIterator::Subdirectories);
-			while (it2.hasNext())
-			{
-				if(it2.next() > 0 )
-				{
-				customElementsDir ++;
-				}
-			}
+	while (it2.hasNext()) { it2.next(); customElementsDir++; }
 	qInfo()<< " Custom Elements count:"<< customElementsDir << "Elements";
-	
+
 	int companyElementsDir = 0;
 	QDirIterator it3(QETApp::companyElementsDir().toLatin1(), nameFilters, QDir::Files, QDirIterator::Subdirectories);
-			while (it3.hasNext())
-			{
-				if(it3.next() > 0 )
-				{
-				companyElementsDir ++;
-				}
-			}
+	while (it3.hasNext()) { it3.next(); companyElementsDir++; }
 	qInfo()<< " Company Elements count:"<< companyElementsDir << "Elements";
 	
 	qInfo()<< "";

--- a/sources/pdf_links.cpp
+++ b/sources/pdf_links.cpp
@@ -24,12 +24,14 @@
 #include "qetgraphicsitem/elementtextitemgroup.h"
 
 // Private Qt PDF engine for drawHyperlink() — not public API.
-// Qt6: QPdfEngine::drawHyperlink() was kept in Qt6's private API, but verify
-// that <private/qpdf_p.h> resolves correctly against your Qt6 installation.
-#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
-#  warning "Qt6 build: verify that QPdfEngine::drawHyperlink() is still available in <private/qpdf_p.h>"
+// Available only when Qt private headers are present (Qt::GuiPrivate target).
+// Controlled by cmake via QET_PDF_PRIVATE_HEADERS.
+#ifdef QET_PDF_PRIVATE_HEADERS
+#  if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+#    warning "Qt6 build: verify that QPdfEngine::drawHyperlink() is still available in <private/qpdf_p.h>"
+#  endif
+#  include <private/qpdf_p.h>
 #endif
-#include <private/qpdf_p.h>
 
 #include <QByteArray>
 #include <QFile>
@@ -103,7 +105,11 @@ void injectCrossRefLinks(QPdfEngine *engine, Diagram *diagram,
 
 		QUrl url = QUrl::fromLocalFile(outputFileName);
 		url.setFragment(frag);
+#ifdef QET_PDF_PRIVATE_HEADERS
 		engine->drawHyperlink(devRect, url);
+#else
+		Q_UNUSED(engine)
+#endif
 	};
 
 	for (auto *item : diagram->items()) {

--- a/sources/pdf_links.cpp
+++ b/sources/pdf_links.cpp
@@ -23,8 +23,12 @@
 #include "qetgraphicsitem/element.h"
 #include "qetgraphicsitem/elementtextitemgroup.h"
 
-// Private Qt PDF engine for drawHyperlink() — not public API, stable since Qt4.
-// Requires QT += gui-private in qelectrotech.pro / gui-private in CMake.
+// Private Qt PDF engine for drawHyperlink() — not public API.
+// Qt6: QPdfEngine::drawHyperlink() was kept in Qt6's private API, but verify
+// that <private/qpdf_p.h> resolves correctly against your Qt6 installation.
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+#  warning "Qt6 build: verify that QPdfEngine::drawHyperlink() is still available in <private/qpdf_p.h>"
+#endif
 #include <private/qpdf_p.h>
 
 #include <QByteArray>

--- a/sources/print/projectprintwindow.cpp
+++ b/sources/print/projectprintwindow.cpp
@@ -28,8 +28,13 @@
 
 #include "ui_projectprintwindow.h"
 
-// Private Qt PDF engine for drawHyperlink() — not public API, stable since Qt4
-// Requires QT += gui-private in qelectrotech.pro
+// Private Qt PDF engine for drawHyperlink() — not public API.
+// Qt6: QPdfEngine::drawHyperlink() was kept in Qt6's private API, but verify
+// that <private/qpdf_p.h> resolves correctly against your Qt6 installation.
+// If this include fails, check that Qt::GuiPrivate is linked in CMakeLists.txt.
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+#  warning "Qt6 build: verify that QPdfEngine::drawHyperlink() is still available in <private/qpdf_p.h>"
+#endif
 #include <private/qpdf_p.h>
 
 #if QT_VERSION < QT_VERSION_CHECK(6, 0, 0) // ### Qt 6: remove

--- a/sources/print/projectprintwindow.cpp
+++ b/sources/print/projectprintwindow.cpp
@@ -28,14 +28,14 @@
 
 #include "ui_projectprintwindow.h"
 
-// Private Qt PDF engine for drawHyperlink() — not public API.
-// Qt6: QPdfEngine::drawHyperlink() was kept in Qt6's private API, but verify
-// that <private/qpdf_p.h> resolves correctly against your Qt6 installation.
-// If this include fails, check that Qt::GuiPrivate is linked in CMakeLists.txt.
-#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
-#  warning "Qt6 build: verify that QPdfEngine::drawHyperlink() is still available in <private/qpdf_p.h>"
+// QPdfEngine private API for hyperlink injection.
+// Only available when Qt private headers are present (QET_PDF_PRIVATE_HEADERS).
+#ifdef QET_PDF_PRIVATE_HEADERS
+#  if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+#    warning "Qt6 build: verify that QPdfEngine::drawHyperlink() is still available in <private/qpdf_p.h>"
+#  endif
+#  include <private/qpdf_p.h>
 #endif
-#include <private/qpdf_p.h>
 
 #if QT_VERSION < QT_VERSION_CHECK(6, 0, 0) // ### Qt 6: remove
 #	include <QDesktopWidget>
@@ -259,7 +259,10 @@ void ProjectPrintWindow::requestPaint()
 	// preview paint engine. We only post-process when actually writing a PDF.
 	const bool pdfExport =
 		(m_printer->outputFormat() == QPrinter::PdfFormat)
-		&& (dynamic_cast<QPdfEngine*>(painter.paintEngine()) != nullptr);
+#ifdef QET_PDF_PRIVATE_HEADERS
+		&& (dynamic_cast<QPdfEngine*>(painter.paintEngine()) != nullptr)
+#endif
+		;
 
 	for (auto diagram : selectedDiagram())
 	{
@@ -370,6 +373,7 @@ void ProjectPrintWindow::printDiagram(Diagram *diagram, bool fit_page, QPainter 
 	}
 
 	////Inject PDF cross-reference links////
+#ifdef QET_PDF_PRIVATE_HEADERS
 	if (printer->outputFormat() == QPrinter::PdfFormat && fit_page) {
 		auto *pdfEngine = dynamic_cast<QPdfEngine*>(painter->paintEngine());
 		if (pdfEngine) {
@@ -426,6 +430,7 @@ void ProjectPrintWindow::printDiagram(Diagram *diagram, bool fit_page, QPainter 
 				printer->outputFileName());
 		}
 	}
+#endif // QET_PDF_PRIVATE_HEADERS
 	////PDF links end////
 
 	////Print is finished, restore diagram and graphics item properties

--- a/sources/qetgraphicsitem/ViewItem/projectdbmodel.cpp
+++ b/sources/qetgraphicsitem/ViewItem/projectdbmodel.cpp
@@ -331,7 +331,7 @@ void ProjectDBModel::dataBaseUpdated()
 		auto row = m_record.size();
 		auto col = row ? m_record.first().count() : 1;
 		
-		emit dataChanged(this->index(0,0), this->index(row-1, col-1), QVector<int>(Qt::DisplayRole));
+		emit dataChanged(this->index(0,0), this->index(row-1, col-1), {Qt::DisplayRole});
 	}
 }
 

--- a/sources/qetxml.h
+++ b/sources/qetxml.h
@@ -20,6 +20,7 @@
 
 #include <QDomElement>
 #include <QPen>
+#include <QUuid>
 
 class QDomDocument;
 class QDir;

--- a/sources/qgimanager.cpp
+++ b/sources/qgimanager.cpp
@@ -74,20 +74,15 @@ void QGIManager::release(QGraphicsItem *qgi) {
 	Demande au QGIManager de gerer plusieurs QGI
 	@param qgis QGraphicsItems a gerer
 */
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
 void QGIManager::manage(const QList<QGraphicsItem *> &qgis) {
 	foreach(QGraphicsItem *qgi, qgis) manage(qgi);
 }
 
-/**
-	Indique au QGIManager que pour chaque QGI fourni, une reference vers celui-ci
-	a ete detruite.
-	S'il n'y a plus de references vers un QGI et que celui-ci n'est pas present
-	sur la scene de ce QGIManager, alors il sera detruit.
-	@param qgis QGraphicsItems a ne plus gerer
-*/
 void QGIManager::release(const QList<QGraphicsItem *> &qgis) {
 	foreach(QGraphicsItem *qgi, qgis) release(qgi);
 }
+#endif
 
 void QGIManager::manage(const QVector<QGraphicsItem *> &items) {
 	for (const auto &qgi : items) {

--- a/sources/qgimanager.h
+++ b/sources/qgimanager.h
@@ -45,10 +45,13 @@ class QGIManager {
 	public:
 	void manage(QGraphicsItem *);
 	void release(QGraphicsItem *);
+	// Qt6: QVector<T> is QList<T>, so QList overloads would be duplicate signatures.
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
 	QT_DEPRECATED_X("Use QGIManager::manage(const QVector<QGraphicsItem *> &) instead")
 		void manage(const QList<QGraphicsItem *> &);
 	QT_DEPRECATED_X("Use QGIManager::release(const QVector<QGraphicsItem *> &) instead")
 		void release(const QList<QGraphicsItem *> &);
+#endif
 	void manage(const QVector<QGraphicsItem *> &items);
 	void release(const QVector<QGraphicsItem *> &items);
 	void setDestroyQGIOnDelete(bool);

--- a/sources/titleblock/templatescollection.cpp
+++ b/sources/titleblock/templatescollection.cpp
@@ -454,8 +454,7 @@ QDomElement TitleBlockTemplatesFilesCollection::getTemplateXmlDescription(const 
 	}
 
 	QDomDocument *xml_document = new QDomDocument();
-	bool xml_parsing = xml_document -> setContent(&xml_file);
-	if (!xml_parsing) {
+	if (!xml_document->setContent(&xml_file)) {
 		delete xml_document;
 		return(QDomElement());
 	}

--- a/sources/titleblock/templateview.h
+++ b/sources/titleblock/templateview.h
@@ -19,6 +19,8 @@
 #define TITLEBLOCK_SLASH_TEMPLATE_VIEW_H
 #include "../titleblocktemplate.h"
 
+#include <QGraphicsGridLayout>
+#include <QGraphicsLayoutItem>
 #include <QGraphicsView>
 class HelperCell;
 class SplittedHelperCell;

--- a/sources/titleblocktemplate.cpp
+++ b/sources/titleblocktemplate.cpp
@@ -103,8 +103,7 @@ bool TitleBlockTemplate::loadFromXmlFile(const QString &filepath) {
 
 	// parse its content as XML
 	QDomDocument xml_doc;
-	bool xml_parsing = xml_doc.setContent(&template_file);
-	if (!xml_parsing) {
+	if (!xml_doc.setContent(&template_file)) {
 		return(false);
 	}
 #ifdef TITLEBLOCK_TEMPLATE_DEBUG


### PR DESCRIPTION
## Problem

Issue #373: the snap crashes on Ubuntu 24.04 Wayland/X11 hosts:

```
qt.qpa.plugin: Could not load the Qt platform plugin "xcb" in "" even though it was found.
This application failed to start because no Qt platform plugin could be initialized.
```

The snap was built against `core22` (Ubuntu 22.04). The xcb Qt platform plugin links against 22.04 xcb libraries. When the snap runs on a 24.04 host, `dlopen()` fails because the host ABI does not match — producing the misleading "found but could not load" error.

## Solution

Migrate the snap from `core22` + Qt5 to `core24` + Qt6, rebuilding all Qt libraries and platform plugins against the Ubuntu 24.04 ABI.

### snapcraft.yaml changes
- `base: core22` → `base: core24`
- `extensions: [kde-neon]` → `extensions: [kde-neon-6]` (Qt6 + KF6 content snap)
- `architectures:` → `platforms:` (required for core24 in snapcraft 9.x)
- Remove manual `kde-sdk-setup` rsync part — `kde-neon-6` extension provides the SDK automatically
- Build system: `qmake` → `cmake` (qmake is unsupported in KDE Neon 6 extension)
  - `-DBUILD_WITH_KF=ON -DBUILD_KF=OFF`: use system KF6 from SDK content snap
  - `-DPACKAGE_TESTS=OFF`: skip Catch2/GoogleTest FetchContent in snap build
- `kf5-5-110-qt-5-15-11-core22` cleanup snap → `kf6-core24`
- `python3.10` → `python3.12` (core24 default Python)
- Pin `qet-tb-generator` source to `source-tag: v1.31` (issue #202)
- Stage `libxcb-cursor0` — required by Qt's xcb platform plugin since Qt 5.15.x / Qt 6.x; the `kf6-core24` content snap does not bundle it

### cmake changes (from this PR)
- `cmake/build: make Qt::GuiPrivate (PDF hyperlinks) optional` — the `kde-qt6-core24-sdk` snap does not ship Qt6 private headers; guarded behind a `QET_PDF_PRIVATE_HEADERS` compile flag so builds without private headers skip link-injection silently

## Commit structure

This PR sits on top of **PR #505** (cmake Qt6/KF6 support + C++ compatibility fixes) and adds only three commits of its own:

| Commit | Scope |
|--------|-------|
| `cmake/build: make Qt::GuiPrivate optional` | cmake + source — guards private-header usage absent from the snap SDK |
| `snap: migrate to core24, kde-neon-6, cmake build` | snapcraft.yaml only |
| `snap: stage libxcb-cursor0` | snapcraft.yaml only — independently cherry-pickable |

No cmake or C++ source changes are duplicated from PR #505.

## Build proof

Ran the cmake `override-build` step against the Qt6/KF6 source tree (PR #505 applied) inside an isolated Docker container (Ubuntu 25.04, Qt6 + KF6 from apt — equivalent to what the `kde-neon-6` extension provides):

```
cmake -B build -S . -GNinja -DCMAKE_BUILD_TYPE=Release \
      -DCMAKE_INSTALL_PREFIX=/usr/local \
      -DBUILD_WITH_KF=ON -DBUILD_KF=OFF -DPACKAGE_TESTS=OFF
cmake --build build -j$(nproc)
DESTDIR=/tmp/install cmake --install build
```

| Step | Result |
|---|---|
| cmake configure (Qt6 detected) | ✅ `QT_VERSION_MAJOR: 6` |
| Compile 395/395 targets | ✅ zero errors |
| Link `qelectrotech` | ✅ |
| Install binary + elements + translations | ✅ |

## Sequencing note

Per discussion with @scorpio810 this PR is **parked until after the Qt5 stable release**. It is kept open and rebased so it merges cleanly immediately after PR #505 when the project is ready to move to Qt6.

The near-term fix for #373 on the current Qt5/core22 snap is **PR #517** (one-line: stage `libxcb-cursor0`).

Closes #373 (Qt6 path). Depends on #505.