### PR TITLE
Drop dead ~/Application Data/qet fallback for qet_tb_generator (Windows)

### DIFF
--- a/sources/qetdiagrameditor.cpp
+++ b/sources/qetdiagrameditor.cpp
@@ -2474,7 +2474,6 @@ void QETDiagramEditor::generateTerminalBlock()
 	exeList << (QETApp::dataDir() + "/binary/qet_tb_generator.exe")
 			<< (QDir::currentPath() + "/qet_tb_generator.exe")
 			<< QStandardPaths::findExecutable("qet_tb_generator.exe")
-			<< (QDir::homePath() + "/Application Data/qet/qet_tb_generator.exe")
 			<< "qet_tb_generator.exe"
 			<< "qet_tb_generator";    // from original code: missing ".exe" ???
 #elif  defined(Q_OS_MACOS)


### PR DESCRIPTION
Follow-up to the directory discussion in #199. The Windows search list for the `qet_tb_generator` plugin still included `~/Application Data/qet/qet_tb_generator.exe` — the same inaccessible legacy-junction location the standard-directories change moved QET away from.

Verified on Windows that `pip install qet_tb_generator` puts the wrapper in the Python `Scripts\` dir (`...\PythonXX\Scripts` for a default install, on PATH; `%APPDATA%\Python\PythonXX\Scripts` for `--user`), **not** in `QETApp::dataDir()`. So that entry never matched a pip install — pip installs are found via `QStandardPaths::findExecutable` (PATH), manual drops via `dataDir()/binary` and the working dir. This removes only the dead fallback; macOS/Linux are untouched.

Refs #199

🤖 Generated with [Claude Code](https://claude.com/claude-code)