### PR TITLE
Fix #159: reset unused-element highlight when elements become used again

### DIFF
--- a/sources/ElementsCollection/elementscollectionmodel.cpp
+++ b/sources/ElementsCollection/elementscollectionmodel.cpp
@@ -538,10 +538,15 @@ QList<QETProject *> ElementsCollectionModel::project() const
 */
 void ElementsCollectionModel::highlightUnusedElement()
 {
-		//Reset the background of every item first, so elements that are no
-		//longer unused lose their previous red highlight (issue #159).
+		//Reset only the items currently highlighted in red, so elements that
+		//are no longer unused lose the highlight. Scoping to the red
+		//Dense4Pattern avoids touching other backgrounds (e.g. the amber
+		//"show this dir" highlight) and avoids needless updates on big
+		//collections (issue #159).
 	for (ElementCollectionItem *eci : items())
-		eci->setBackground(QBrush());
+		if (eci->background().style() == Qt::Dense4Pattern &&
+		    eci->background().color() == Qt::red)
+			eci->setBackground(QBrush());
 
 	QList <ElementsLocation> unused;
 

--- a/sources/ElementsCollection/elementscollectionmodel.cpp
+++ b/sources/ElementsCollection/elementscollectionmodel.cpp
@@ -538,6 +538,11 @@ QList<QETProject *> ElementsCollectionModel::project() const
 */
 void ElementsCollectionModel::highlightUnusedElement()
 {
+		//Reset the background of every item first, so elements that are no
+		//longer unused lose their previous red highlight (issue #159).
+	for (ElementCollectionItem *eci : items())
+		eci->setBackground(QBrush());
+
 	QList <ElementsLocation> unused;
 
 	foreach (QETProject *project, m_project_list)


### PR DESCRIPTION
Fixes #159.

### Problem
`ElementsCollectionModel::highlightUnusedElement()` is add-only: it paints the currently-unused elements with a red `Dense4Pattern` background but never clears the background of items that are no longer unused. So in the reported flow — remove an element + save (it goes red), then re-add it + save — the function is called again on the existing model and re-reds the still-unused set, but the now-used element keeps its stale red highlight. It only clears when the whole model is rebuilt from scratch.

### Fix
Reset every item's background before re-applying the highlight to the current unused set:

```cpp
for (ElementCollectionItem *eci : items())
    eci->setBackground(QBrush());
```

`items()` already returns every `ElementCollectionItem` in the model, and resetting via `setBackground(QBrush())` is the same idiom already used in `elementscollectionwidget.cpp`. The reset loop is the same order of magnitude as the existing refresh, so no meaningful cost.

5-line change, no API/behaviour change beyond clearing stale highlights. Original report and root-cause analysis by @Murmele.
