### PR TITLE
Fix #492: wait for async backup before destroying QETProject (use-after-free)

### DIFF
--- a/sources/qetproject.cpp
+++ b/sources/qetproject.cpp
@@ -137,6 +137,11 @@ QETProject::QETProject(KAutoSaveFile *backup, QObject *parent) :
 */
 QETProject::~QETProject()
 {
+		//Wait for any in-flight async crash-recovery backup to finish: the worker
+		//writes through &m_backup_file, a member that would otherwise be destroyed
+		//under it (issue #492).
+	m_backup_future.waitForFinished();
+
 		//We block database signal to avoid hundreds of unnecessary emitted signal
 		//due to deletion (diagram, item, etc...) and as much update made in the not yet deleted things.
 	m_data_base.blockSignals(true);
@@ -339,6 +344,8 @@ void QETProject::setFilePath(const QString &filepath)
 	}
 #ifdef BUILD_WITHOUT_KF5
 #else
+		//Don't close/re-point the backup file while a backup is still writing it.
+	m_backup_future.waitForFinished();
 	if (m_backup_file.isOpen()) {
 		m_backup_file.close();
 	}
@@ -1809,8 +1816,12 @@ void QETProject::writeBackup()
 #ifdef BUILD_WITHOUT_KF5
 #else
 #	if QT_VERSION < QT_VERSION_CHECK(6, 0, 0) // ### Qt 6: remove
+		//Don't launch a new backup while the previous one is still writing:
+		//both would write through &m_backup_file on different threads.
+	if (m_backup_future.isRunning())
+		return;
 	QDomDocument xml_project(toXml());
-	QtConcurrent::run(
+	m_backup_future = QtConcurrent::run(
 				QET::writeToFile,xml_project,&m_backup_file,nullptr);
 #	else
 #		if TODO_LIST

--- a/sources/qetproject.h
+++ b/sources/qetproject.h
@@ -35,6 +35,7 @@
 #endif
 
 #include <QHash>
+#include <QFuture>
 
 class Diagram;
 class ElementsLocation;
@@ -295,6 +296,7 @@ class QETProject : public QObject
 		bool m_freeze_new_conductors = false;
 		QTimer m_save_backup_timer,
 			   m_autosave_timer;
+		QFuture<bool> m_backup_future;
 #ifdef BUILD_WITHOUT_KF5
 #else
 		KAutoSaveFile m_backup_file;


### PR DESCRIPTION
Fixes #492.

## Problem
`QETProject::writeBackup()` launches the crash-recovery backup fire-and-forget:
```cpp
QtConcurrent::run(QET::writeToFile, xml_project, &m_backup_file, nullptr);
```
The returned `QFuture` was discarded and nothing keeps `m_backup_file` (a project **member**) alive until the worker finishes. If the `QETProject` is destroyed before the write completes, the worker thread writes through the freed member → use-after-free in `QET::writeToFile`. Backtrace:
```
QObject::connect → QTextStream::QTextStream → QET::writeToFile → QtConcurrent::RunFunctionTask::run
```
It's intermittent (~1/6 on short-lived CLI runs that load a project, e.g. `--resave`; rarer but possible in the GUI on rapid open→close).

## Fix
- Store the `QFuture<bool>` and `waitForFinished()` in `~QETProject()` (at the top, before any member is torn down) and before `setFilePath()` closes/re-points the managed backup file.
- Skip launching a new backup while one is still running (`m_backup_future.isRunning()`), so two threads never write `&m_backup_file` concurrently.

3-line member + ~10 lines. The wait only blocks if a backup write is actually in flight at teardown, and a project XML write is fast, so GUI close latency is unaffected in practice. The `QtConcurrent` backup is KF5-only and the Qt6 path is still a TODO stub, so this only touches the Qt5/KF5 build that has the backup code.

## Verification (Qt5 + KF5, Linux)
The race is timing-dependent and didn't reproduce naturally on a fast machine (0/100). To make it deterministic I temporarily widened the window with a 300 ms `msleep` at the start of `QET::writeToFile` (test-only, **not** in this PR), guaranteeing the worker is still running at teardown, and ran `--resave` in a loop:

| Build (window widened, backup enabled) | Result |
|---|---|
| master (no fix) | **20/20 crash** (SIGSEGV) |
| this fix | **0/30 crash** |

Compiles clean, no new warnings.

This supersedes the CLI-only workaround already merged (`setBackupEnabled(false)` in headless mode), which side-stepped the race for one-shot commands but left the underlying lifetime bug in place for the general/GUI case.
