### PR TITLE
Fix SIGSEGV: cache QStandardPaths results in dataDir/configDir for thread safety

### DIFF
--- a/sources/qetapp.cpp
+++ b/sources/qetapp.cpp
@@ -889,12 +889,12 @@ QString QETApp::configDir()
 #endif
 	// C++11 static-local init runs exactly once across all threads — safe to
 	// call from QtConcurrent background threads (QStandardPaths is not).
-	static const QString cached = []() {
+	static const QString configdir = []() {
 		QString d = QStandardPaths::writableLocation(QStandardPaths::AppConfigLocation);
 		while (d.endsWith('/')) d.chop(1);
 		return d;
 	}();
-	return cached;
+	return configdir;
 }
 
 /**
@@ -916,12 +916,12 @@ QString QETApp::dataDir()
 #endif
 	// C++11 static-local init runs exactly once across all threads — safe to
 	// call from QtConcurrent background threads (QStandardPaths is not).
-	static const QString cached = []() {
+	static const QString datadir = []() {
 		QString d = QStandardPaths::writableLocation(QStandardPaths::AppDataLocation);
 		while (d.endsWith('/')) d.chop(1);
 		return d;
 	}();
-	return cached;
+	return datadir;
 }
 
 /**

--- a/sources/qetapp.cpp
+++ b/sources/qetapp.cpp
@@ -887,11 +887,14 @@ QString QETApp::configDir()
 #ifdef QET_ALLOW_OVERRIDE_CD_OPTION
 	if (config_dir != QString()) return(config_dir);
 #endif
-	QString configdir = QStandardPaths::writableLocation(QStandardPaths::AppConfigLocation);
-	while (configdir.endsWith('/')) {
-		configdir.remove(configdir.length()-1, 1);
-	}
-	return configdir;
+	// C++11 static-local init runs exactly once across all threads — safe to
+	// call from QtConcurrent background threads (QStandardPaths is not).
+	static const QString cached = []() {
+		QString d = QStandardPaths::writableLocation(QStandardPaths::AppConfigLocation);
+		while (d.endsWith('/')) d.chop(1);
+		return d;
+	}();
+	return cached;
 }
 
 /**
@@ -911,11 +914,14 @@ QString QETApp::dataDir()
 #ifdef QET_ALLOW_OVERRIDE_DD_OPTION
 	if (data_dir != QString()) return(data_dir);
 #endif
-	QString datadir = QStandardPaths::writableLocation(QStandardPaths::AppDataLocation);
-	while (datadir.endsWith('/')) {
-		datadir.remove(datadir.length()-1, 1);
-	}
-	return datadir;
+	// C++11 static-local init runs exactly once across all threads — safe to
+	// call from QtConcurrent background threads (QStandardPaths is not).
+	static const QString cached = []() {
+		QString d = QStandardPaths::writableLocation(QStandardPaths::AppDataLocation);
+		while (d.endsWith('/')) d.chop(1);
+		return d;
+	}();
+	return cached;
 }
 
 /**


### PR DESCRIPTION
## Problem

`QStandardPaths::writableLocation()` is **not thread-safe in Qt5**. `ElementsCollectionModel::reload()` launches:

```cpp
m_future = QtConcurrent::map(m_items_list_to_setUp, setUpData);
```

Each worker thread calls:
```
FileElementCollectionItem::setUpData()
  → collectionPath() / isCollectionRoot()
  → QETApp::userMacrosDir()
  → QETApp::dataDir()
  → QStandardPaths::writableLocation(AppDataLocation)  ← SIGSEGV
```

Valgrind confirms the crash:
```
==1== Process terminating with default action of signal 11 (SIGSEGV)
==1==  Access not within mapped region at address 0x0
==1==    at 0x5854BB6: ??? (in libQt5Core.so.5.15.3)
==1==    by 0x59FDDD2: QStandardPaths::writableLocation(...)
==1==    by 0x2B7709: QETApp::dataDir() (qetapp.cpp:914)
==1==    by 0x2B746C: QETApp::userMacrosDir() (qetapp.cpp:862)
==1==    by 0x449343: FileElementCollectionItem::isCollectionRoot()
==1==    by 0x449A4A: FileElementCollectionItem::setUpData()
==1==    by 0x42E3E9: setUpData(ElementCollectionItem*)
==1==    by 0x436977: QtConcurrent::MapKernel::runIteration(...)
```

The app crashes reliably when opening the element panel after startup triggers the concurrent collection load.

## Fix

Replace the bare `QStandardPaths::writableLocation()` calls in `dataDir()` and `configDir()` with a **C++11 static-local lambda**. The compiler guarantees the lambda body executes exactly once across all threads (magic statics, ISO C++11 §6.7). The first call (always on the main thread, via the `QETApp` constructor) populates the cache; all subsequent calls — including those from `QtConcurrent` workers — return the cached value lock-free.

```cpp
// configDir():
static const QString configdir = []() {
    QString d = QStandardPaths::writableLocation(QStandardPaths::AppConfigLocation);
    while (d.endsWith('/')) d.chop(1);
    return d;
}();
return configdir;

// dataDir():
static const QString datadir = []() {
    QString d = QStandardPaths::writableLocation(QStandardPaths::AppDataLocation);
    while (d.endsWith('/')) d.chop(1);
    return d;
}();
return datadir;
```

The `QET_ALLOW_OVERRIDE_DD_OPTION` / `QET_ALLOW_OVERRIDE_CD_OPTION` CLI override paths are unaffected — they return before reaching the static.

## Notes

- Same QtConcurrent lifetime/safety pattern as the use-after-free fixed in PR #512 / issue #492.
- The Qt6 code path in `ElementsCollectionModel` is a TODO stub and not affected.
- Tested on Ubuntu 22.04, Qt 5.15.3, verified with Valgrind — crash no longer occurs.
- Variable names updated to `configdir` / `datadir` per reviewer feedback to match the original code style.