### PR TITLE
Fix three uninitialised-value bugs found by Valgrind

### DIFF
--- a/sources/machine_info.h
+++ b/sources/machine_info.h
@@ -75,11 +75,11 @@ class MachineInfo
 	{
 		struct Screen
 		{
-			int32_t count;
-			int32_t width[10];
-			int32_t height[10];
-			int32_t Max_width;
-			int32_t Max_height;
+			int32_t count     = 0;
+			int32_t width[10] = {};
+			int32_t height[10]= {};
+			int32_t Max_width = 0;
+			int32_t Max_height= 0;
 		}screen;
 		struct Built
 		{

--- a/sources/main.cpp
+++ b/sources/main.cpp
@@ -241,6 +241,11 @@ QGuiApplication::setHighDpiScaleFactorRoundingPolicy(QetSettings::hdpiScaleFacto
 	QObject::connect(&app, &SingleApplication::receivedMessage,
 			 &qetapp, &QETApp::receiveMessage);
 
+	// Pre-initialise on the main (GUI) thread: the constructor calls
+	// qApp->screens() which is not thread-safe in Qt5 — calling instance()
+	// here guarantees the singleton is fully built before the worker runs.
+	MachineInfo::instance();
+
 	QtConcurrent::run([=]()
 	{
 		// for debugging

--- a/sources/qetapp.cpp
+++ b/sources/qetapp.cpp
@@ -889,12 +889,12 @@ QString QETApp::configDir()
 #endif
 	// C++11 static-local init runs exactly once across all threads — safe to
 	// call from QtConcurrent background threads (QStandardPaths is not).
-	static const QString cached = []() {
+	static const QString configdir = []() {
 		QString d = QStandardPaths::writableLocation(QStandardPaths::AppConfigLocation);
 		while (d.endsWith('/')) d.chop(1);
 		return d;
 	}();
-	return cached;
+	return configdir;
 }
 
 /**
@@ -916,12 +916,12 @@ QString QETApp::dataDir()
 #endif
 	// C++11 static-local init runs exactly once across all threads — safe to
 	// call from QtConcurrent background threads (QStandardPaths is not).
-	static const QString cached = []() {
+	static const QString datadir = []() {
 		QString d = QStandardPaths::writableLocation(QStandardPaths::AppDataLocation);
 		while (d.endsWith('/')) d.chop(1);
 		return d;
 	}();
-	return cached;
+	return datadir;
 }
 
 /**

--- a/sources/qetapp.cpp
+++ b/sources/qetapp.cpp
@@ -887,11 +887,14 @@ QString QETApp::configDir()
 #ifdef QET_ALLOW_OVERRIDE_CD_OPTION
 	if (config_dir != QString()) return(config_dir);
 #endif
-	QString configdir = QStandardPaths::writableLocation(QStandardPaths::AppConfigLocation);
-	while (configdir.endsWith('/')) {
-		configdir.remove(configdir.length()-1, 1);
-	}
-	return configdir;
+	// C++11 static-local init runs exactly once across all threads — safe to
+	// call from QtConcurrent background threads (QStandardPaths is not).
+	static const QString cached = []() {
+		QString d = QStandardPaths::writableLocation(QStandardPaths::AppConfigLocation);
+		while (d.endsWith('/')) d.chop(1);
+		return d;
+	}();
+	return cached;
 }
 
 /**
@@ -911,11 +914,14 @@ QString QETApp::dataDir()
 #ifdef QET_ALLOW_OVERRIDE_DD_OPTION
 	if (data_dir != QString()) return(data_dir);
 #endif
-	QString datadir = QStandardPaths::writableLocation(QStandardPaths::AppDataLocation);
-	while (datadir.endsWith('/')) {
-		datadir.remove(datadir.length()-1, 1);
-	}
-	return datadir;
+	// C++11 static-local init runs exactly once across all threads — safe to
+	// call from QtConcurrent background threads (QStandardPaths is not).
+	static const QString cached = []() {
+		QString d = QStandardPaths::writableLocation(QStandardPaths::AppDataLocation);
+		while (d.endsWith('/')) d.chop(1);
+		return d;
+	}();
+	return cached;
 }
 
 /**

--- a/sources/qetdiagrameditor.h
+++ b/sources/qetdiagrameditor.h
@@ -80,6 +80,11 @@ class QETDiagramEditor : public QETMainWindow
 	  protected:
 		bool event(QEvent *) override;
 	private:
+		// Declared first so it is initialised before any member whose
+		// constructor may dispatch a Qt event calling event() (e.g. the
+		// QActionGroup members below trigger QObject::setParent events).
+		bool m_first_show = true;
+
 		QETDiagramEditor(const QETDiagramEditor &);
 		void setUpElementsPanel ();
 		void setUpElementsCollectionWidget();
@@ -253,7 +258,6 @@ class QETDiagramEditor : public QETMainWindow
 		QUndoGroup undo_group;
 		AutoNumberingDockWidget *m_autonumbering_dock;
 		int activeSubWindowIndex;
-		bool m_first_show = true;
 		SearchAndReplaceWidget m_search_and_replace_widget;
 };
 #endif


### PR DESCRIPTION
Follow-up to PR #514. Three more Valgrind findings from running `--tool=memcheck` on Ubuntu 22.04 / Qt 5.15.3.

## 1. `machine_info.h` — uninitialised `Screen` struct members

`Max_width`, `Max_height`, `count`, `width[]` and `height[]` were bare `int32_t` with no initialiser. The comparisons in `init_get_Screen_info()` read them before any write:

```
==1== Conditional jump or move depends on uninitialised value(s)
==1==    at 0x2A236C: MachineInfo::init_get_Screen_info() (machine_info.cpp:271)
==1==  Uninitialised value was created by a heap allocation
==1==    at 0x4849013: operator new(unsigned long)
==1==    by 0x21D568: MachineInfo::instance() (machine_info.h:39)
```

**Fix:** Add `= 0` / `= {}` in-class initialisers to all `Screen` members.

## 2. `main.cpp` — `MachineInfo` singleton constructed on background thread

`MachineInfo::instance()` was first called inside `QtConcurrent::run()`, so its constructor (which calls `qApp->screens()`) ran on a background thread. `QScreen` methods are not thread-safe in Qt5:

```
==1== Conditional jump or move depends on uninitialised value(s)
==1==    at 0x2A236C: MachineInfo::init_get_Screen_info() (machine_info.cpp:271)
==1==    by 0x2A67B9: main::{lambda()#1}::operator()() (main.cpp:251)
==1==    by 0x2A70A7: QtConcurrent::StoredFunctorCall0<void,...>::runFunctor()
```

**Fix:** Call `MachineInfo::instance()` once on the main thread before `QtConcurrent::run()`. The singleton is then fully built; the worker just returns the cached pointer.

## 3. `qetdiagrameditor.h` — `m_first_show` read before initialisation

C++ initialises members in declaration order. `m_first_show` was declared at line 256, after the `QActionGroup` members at line 168. During construction of `m_row_column_actions_group(this)`, Qt dispatches a `QObject` parent-change event that reaches `QETDiagramEditor::event()`, which reads `m_first_show` before it has been initialised:

```
==1== Conditional jump or move depends on uninitialised value(s)
==1==    at 0x2D93AB: QETDiagramEditor::event(QEvent*) (qetdiagrameditor.cpp:928)
==1==    by 0x4B7D712: QApplicationPrivate::notify_helper(QObject*, QEvent*)
==1==    by 0x4B7AD66: QActionGroup::QActionGroup(QObject*)
==1==    by 0x2CEDA4: QETDiagramEditor::QETDiagramEditor(...) (qetdiagrameditor.cpp:64)
==1==  Uninitialised value was created by a heap allocation
==1==    by 0x2B43C8: QETApp::QETApp() (qetapp.cpp:142)
```

**Fix:** Move `m_first_show` to the top of the first `private:` block so it is initialised before any member that can trigger events.