### PR TITLE
snap: stage libxcb-cursor0 to fix xcb plugin crash on Ubuntu 24.04 (issue #373)

### DIFF
--- a/build-aux/snap/snapcraft.yaml
+++ b/build-aux/snap/snapcraft.yaml
@@ -77,7 +77,16 @@ parts:
     after: [kde-sdk-setup]
     plugin: nil
     source: .
-    stage-packages: [ git, sqlite3, xdg-user-dirs ]
+    stage-packages:
+      - git
+      - sqlite3
+      - xdg-user-dirs
+      # libxcb-cursor0 was added as a hard dependency of the Qt5 xcb platform
+      # plugin in Qt 5.15.x.  The kf5-5-110-qt-5-15-11-core22 content snap does
+      # not bundle it, so dlopen() of libqxcb.so fails on Ubuntu 24.04 hosts
+      # with "found but could not load" (issue #373).  Staging the 22.04 build
+      # of this library satisfies the dep without changing base or Qt version.
+      - libxcb-cursor0
     build-packages:
       - git
       - libsqlite3-dev


### PR DESCRIPTION
## Problem

Issue #373: the snap crashes on Ubuntu 24.04 Wayland/X11 hosts with:

```
qt.qpa.plugin: Could not load the Qt platform plugin "xcb" in "" even though it was found.
This application failed to start because no Qt platform plugin could be initialized.
```

## Root cause

Qt 5.15.x added `libxcb-cursor.so.0` as a **hard runtime dependency** of its xcb platform plugin (`libqxcb.so`). The `kf5-5-110-qt-5-15-11-core22` content snap does not bundle this library. When the snap runs on Ubuntu 24.04 the confined sandbox cannot reach the host's `/usr/lib`, so `dlopen()` of the xcb plugin fails — even though the plugin file itself is present — producing the misleading "found but could not load" error.

## Fix

Add `libxcb-cursor0` to `stage-packages` in the `qelectrotech` part. This bundles the Ubuntu 22.04 build of the library inside the snap, satisfying the plugin's dependency with no ABI mismatch (plugin and library are both built against core22/22.04).

**No other changes** — base stays `core22`, Qt version stays 5.15.11, no cmake migration.

## What this is not

This is the small targeted fix discussed in PR #507. The larger `core24`/Qt6 migration in PR #507 remains parked until after the Qt5 stable release, as agreed with @scorpio810.

## Testing

To verify: build the snap with `snapcraft --destructive-mode` on Ubuntu 22.04, install on Ubuntu 24.04, run `snap run qelectrotech`. The xcb plugin should load cleanly without `QT_QPA_PLATFORM=wayland` workaround.

Fixes #373.