### PR TITLE
Fix TerminalData memory leak in Terminal destructor

### DIFF
--- a/sources/qetgraphicsitem/terminal.cpp
+++ b/sources/qetgraphicsitem/terminal.cpp
@@ -86,6 +86,7 @@ Terminal::Terminal(TerminalData* data, Element* e) :
  */
 Terminal::~Terminal() {
 	qDeleteAll(m_conductors_list);
+	delete d;
 }
 
 /**


### PR DESCRIPTION
## Summary

- `Terminal` stores its `TerminalData*` as member `d` but `~Terminal()` never deletes it
- Every `Element` creation leaks one `TerminalData` per terminal pin — this hits four separate call sites: placing an element on a diagram, loading its icon in the element browser, starting a drag, and building the drag preview
- AddressSanitizer confirmed 112 leaked objects totalling 9856 bytes in a single short session

**Fix:** add `delete d;` to `Terminal::~Terminal()`. `Terminal` is the sole owner of its `TerminalData` — it is allocated in `Element::parseTerminal`, passed straight into the `Terminal` constructor, and never referenced elsewhere.

## Root cause

```cpp
// element.cpp — parseTerminal()
TerminalData* data = new TerminalData();   // allocated here
// ...
Terminal *new_terminal = new Terminal(data, this);  // Terminal takes ownership
```

```cpp
// terminal.cpp — before this fix
Terminal::~Terminal() {
    qDeleteAll(m_conductors_list);
    // 'd' was never deleted
}
```

## Test plan
- [x] Builds cleanly
- [x] ASan confirmed leak at `element.cpp:627` across all four call sites before fix
- [ ] Re-run under ASan to confirm TerminalData leaks are gone

🤖 Generated with [Claude Code](https://claude.com/claude-code)