### PR TITLE
Fix four memory leaks found by AddressSanitizer

### DIFF
--- a/sources/editor/elementscene.cpp
+++ b/sources/editor/elementscene.cpp
@@ -107,6 +107,9 @@ ElementScene::~ElementScene()
 
 	if (m_decorator)
 		delete m_decorator;
+
+	if (m_paste_area && !m_paste_area->scene())
+		delete m_paste_area;
 }
 
 /**

--- a/sources/editor/styleeditor.cpp
+++ b/sources/editor/styleeditor.cpp
@@ -386,7 +386,7 @@ StyleEditor::StyleEditor(QETElementEditor *editor, CustomElementGraphicPart *p, 
 
 	outline_color->setSizeAdjustPolicy(QComboBox::AdjustToContents);
 	filling_color->setSizeAdjustPolicy(QComboBox::AdjustToContents);
-	auto grid_layout = new QGridLayout(this);
+	auto grid_layout = new QGridLayout();
 	grid_layout->addWidget(new QLabel(tr("Contour :")), 0,0, Qt::AlignRight);
 	grid_layout->addWidget(outline_color, 0, 1);
 	grid_layout->addWidget(new QLabel(tr("Remplissage :")), 1, 0, Qt::AlignRight);

--- a/sources/exportdialog.cpp
+++ b/sources/exportdialog.cpp
@@ -112,6 +112,7 @@ ExportDialog::ExportDialog(
 */
 ExportDialog::~ExportDialog()
 {
+	qDeleteAll(diagram_lines_);
 }
 
 /**

--- a/sources/genericpanel.cpp
+++ b/sources/genericpanel.cpp
@@ -321,9 +321,11 @@ QTreeWidgetItem *GenericPanel::getItemForDiagram(Diagram *diagram,
 		if (created) *created = false;
 		return(diagram_qtwi);
 	}
-	
+
+	if (!created) return(nullptr);
+
 	diagram_qtwi = makeItem(QET::Diagram);
-	if (created) *created = true;
+	*created = true;
 	return(diagram_qtwi);
 }
 


### PR DESCRIPTION
## Summary

Four distinct memory leaks identified and fixed using AddressSanitizer (ASan). Together they eliminate **536 KB** of leaked memory per session (603 KB → 67 KB total after fix; residual is third-party: libdbus, libfontconfig).

### StyleEditor — orphaned `QVBoxLayout` (`sources/editor/styleeditor.cpp`)

`new QGridLayout(this)` internally calls `setLayout()` on the StyleEditor widget, claiming the layout slot. The subsequent explicit `setLayout(main_layout)` silently fails — Qt's `setLayout` returns early if a layout is already installed — permanently orphaning `main_layout`. Every editor type that embeds a `StyleEditor` (Arc, Line, Ellipse, Polygon, Rectangle) leaked one instance per element editor window opened.

**Fix:** `new QGridLayout()` with no parent argument, so `setLayout(main_layout)` succeeds and `main_layout` is properly owned by the widget.

### ExportDialog — `ExportDiagramLine` objects never freed (`sources/exportdialog.cpp`)

`diagram_lines_` holds `ExportDiagramLine*` heap objects. The QWidget members inside each line are parented to the dialog and cleaned up via Qt's parent-child chain, but the `ExportDiagramLine` C++ wrapper structs themselves were never deleted. `~ExportDialog()` was empty.

**Fix:** `qDeleteAll(diagram_lines_)` in the destructor.

### GenericPanel — orphaned `QTreeWidgetItem` (`sources/genericpanel.cpp`)

`getItemForDiagram(diagram)` called without the `bool* created` parameter would still call `makeItem()` and allocate a parentless `QTreeWidgetItem` when the diagram wasn't in the panel cache. Callers (e.g. in `qetdiagrameditor.cpp`) used the returned item only for `setCurrentItem()` then discarded it — the item was never added to any tree and never freed.

**Fix:** Early-return `nullptr` when `created == nullptr` and the item isn't found in the cache. All call sites already guard with `if (item)`.

### ElementScene — paste area never freed (`sources/editor/elementscene.cpp`)

`m_paste_area` (a `QGraphicsRectItem`) is created in `initPasteArea()` and temporarily added/removed from the scene during XML paste operations. At destruction time it is not in the scene, so `~QGraphicsScene()` does not delete it, and `~ElementScene()` did not either.

**Fix:** `delete m_paste_area` in `~ElementScene()`, guarded by `!m_paste_area->scene()` to avoid a double-free if it happens to still be in the scene.

## Verification

Built and run under ASan (`-fsanitize=address -g -O1 -fno-omit-frame-pointer`) in an isolated Docker container on Ubuntu 22.04 / Qt 5:

| | Direct leaks (QET source) | Total leaked |
|---|---|---|
| Before | Multiple (StyleEditor ×5, ExportDiagramLine, QTreeWidgetItem, m_paste_area) | 603,544 bytes |
| After | **0** | 67,448 bytes (libdbus + libfontconfig only) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)