### PR TITLE
fix(editor): suppress spurious first-click element moves

### DIFF
--- a/sources/editor/graphicspart/customelementgraphicpart.cpp
+++ b/sources/editor/graphicspart/customelementgraphicpart.cpp
@@ -20,6 +20,7 @@
 #include "../../QPropertyUndoCommand/qpropertyundocommand.h"
 #include "../elementscene.h"
 
+#include <QApplication>
 #include <QRegularExpression>
 
 /**
@@ -35,6 +36,7 @@ CustomElementGraphicPart::CustomElementGraphicPart(QETElementEditor *editor,
 	QGraphicsObject (parent),
 	CustomElementPart(editor),
 	m_hovered (false),
+	m_first_move (false),
 	_linestyle(NormalStyle),
 	_lineweight(NormalWeight),
 	_filling(NoneFilling),
@@ -1332,26 +1334,24 @@ void CustomElementGraphicPart::mousePressEvent(QGraphicsSceneMouseEvent *event)
 
 void CustomElementGraphicPart::mouseMoveEvent(QGraphicsSceneMouseEvent *event)
 {
-		//m_first_move is used to avoid an unwanted behavior
-		//when the properties dock widget is displayed :
-		//1 there is no selection
-		//2 the dock widget width is set to minimum
-		//3 select a part, the dock widget gain new widgets used to edit
-		//the current selected part and the width of the dock grow
-		//so the width of the QGraphicsView is reduced and cause a mouse move event.
-		//When this case occur the part is moved but they should not. This bool fix it.
-	if (Q_UNLIKELY(m_first_move)) {
+	if (m_first_move) {
+		// Suppress spurious move events fired when the properties dock
+		// widget expands on first selection of a new item type, causing
+		// the QGraphicsView to shrink and re-map coordinates.  Screen
+		// coordinates are stable across viewport changes; scene coords
+		// are not — so use screenPos() for the threshold check.
+		const QPointF d = event->screenPos() - event->buttonDownScreenPos(Qt::LeftButton);
+		if (d.manhattanLength() < QApplication::startDragDistance())
+			return;
 		m_first_move = false;
-		return;
 	}
 
-	if((event->buttons() & Qt::LeftButton) && (flags() & QGraphicsItem::ItemIsMovable))
-	{
+	if ((event->buttons() & Qt::LeftButton) && (flags() & QGraphicsItem::ItemIsMovable)) {
 		QPointF pos = event->scenePos() + (m_origin_pos - event->buttonDownScenePos(Qt::LeftButton));
 		event->modifiers() == Qt::ControlModifier ? setPos(pos) : setPos(elementScene()->snapToGrid(pos));
-	}
-	else
+	} else {
 		QGraphicsObject::mouseMoveEvent(event);
+	}
 }
 
 void CustomElementGraphicPart::mouseReleaseEvent(QGraphicsSceneMouseEvent *event)

--- a/sources/editor/graphicspart/customelementgraphicpart.cpp
+++ b/sources/editor/graphicspart/customelementgraphicpart.cpp
@@ -36,12 +36,12 @@ CustomElementGraphicPart::CustomElementGraphicPart(QETElementEditor *editor,
 	QGraphicsObject (parent),
 	CustomElementPart(editor),
 	m_hovered (false),
-	m_first_move (false),
 	_linestyle(NormalStyle),
 	_lineweight(NormalWeight),
 	_filling(NoneFilling),
 	_color(BlackColor),
-	_antialiased(false)
+	_antialiased(false),
+	m_first_move (false)
 {
 	setFlags(QGraphicsItem::ItemIsSelectable
 		 | QGraphicsItem::ItemIsMovable

--- a/sources/editor/graphicspart/partdynamictextfield.cpp
+++ b/sources/editor/graphicspart/partdynamictextfield.cpp
@@ -20,6 +20,7 @@
 #include "../../QPropertyUndoCommand/qpropertyundocommand.h"
 #include "../../qetapp.h"
 #include "../elementscene.h"
+#include <QApplication>
 
 #include <QColor>
 #include <QFont>
@@ -495,12 +496,16 @@ bool PartDynamicTextField::keepVisualRotation() const {
 	@param event
 */
 void PartDynamicTextField::mouseMoveEvent(QGraphicsSceneMouseEvent *event) {
-	if((event -> buttons() & Qt::LeftButton) && (flags() & QGraphicsItem::ItemIsMovable)) {
-		QPointF pos = event -> scenePos() + (m_origin_pos - event -> buttonDownScenePos(Qt::LeftButton));
-		event -> modifiers() == Qt::ControlModifier ? setPos(pos) : setPos(elementScene() -> snapToGrid(pos));
-	}
-	else
+	if ((event->buttons() & Qt::LeftButton) && (flags() & QGraphicsItem::ItemIsMovable)) {
+		// Suppress spurious moves from the properties dock resizing the viewport.
+		const QPointF d = event->screenPos() - event->buttonDownScreenPos(Qt::LeftButton);
+		if (d.manhattanLength() < QApplication::startDragDistance())
+			return;
+		QPointF pos = event->scenePos() + (m_origin_pos - event->buttonDownScenePos(Qt::LeftButton));
+		event->modifiers() == Qt::ControlModifier ? setPos(pos) : setPos(elementScene()->snapToGrid(pos));
+	} else {
 		QGraphicsObject::mouseMoveEvent(event);
+	}
 }
 
 /**

--- a/sources/editor/graphicspart/parttext.cpp
+++ b/sources/editor/graphicspart/parttext.cpp
@@ -18,6 +18,7 @@
 #include "parttext.h"
 
 #include "../../QPropertyUndoCommand/qpropertyundocommand.h"
+#include <QApplication>
 #include "../../qetapp.h"
 #include "../elementprimitivedecorator.h"
 #include "../elementscene.h"
@@ -324,11 +325,14 @@ void PartText::setFont(const QFont &font) {
 }
 
 void PartText::mouseMoveEvent(QGraphicsSceneMouseEvent *event) {
-	if((event -> buttons() & Qt::LeftButton) && (flags() & QGraphicsItem::ItemIsMovable)) {
-		QPointF pos = event -> scenePos() + (m_origin_pos - event -> buttonDownScenePos(Qt::LeftButton));
-		event -> modifiers() == Qt::ControlModifier ? setPos(pos) : setPos(elementScene() -> snapToGrid(pos));
-	}
-	else {
+	if ((event->buttons() & Qt::LeftButton) && (flags() & QGraphicsItem::ItemIsMovable)) {
+		// Suppress spurious moves from the properties dock resizing the viewport.
+		const QPointF d = event->screenPos() - event->buttonDownScreenPos(Qt::LeftButton);
+		if (d.manhattanLength() < QApplication::startDragDistance())
+			return;
+		QPointF pos = event->scenePos() + (m_origin_pos - event->buttonDownScenePos(Qt::LeftButton));
+		event->modifiers() == Qt::ControlModifier ? setPos(pos) : setPos(elementScene()->snapToGrid(pos));
+	} else {
 		QGraphicsObject::mouseMoveEvent(event);
 	}
 }


### PR DESCRIPTION
## Problem (closes #481)

When an item type is selected for the **first time** in the element editor, the properties dock widget gains new widgets and expands. This shrinks the `QGraphicsView` viewport, which causes Qt to re-map the mouse position into scene coordinates and fire one or more synthetic `mouseMoveEvent`s — even though the user has not moved the mouse.

**Previous behaviour**

`CustomElementGraphicPart` had a single-shot `m_first_move` flag that absorbed exactly one spurious event. This was not enough when the dock expands significantly (multiple synthetic events generated). `PartText` and `PartDynamicTextField` had **no protection at all**, so they moved on every first click.

## Fix

Replace the single-shot flag with a screen-coordinate distance threshold (`QApplication::startDragDistance()`, ~4 px).

Screen coordinates are stable across viewport resizes — the cursor has not physically moved, so `screenPos() - buttonDownScreenPos()` remains near zero for all synthetic events. Scene coordinates are not stable (they depend on the viewport mapping), which is why the original scene-coordinate code misfired.

The fix is applied to all three movable part types:
- `CustomElementGraphicPart::mouseMoveEvent` — replaced single-shot flag with threshold check
- `PartText::mouseMoveEvent` — added threshold check (previously unprotected)
- `PartDynamicTextField::mouseMoveEvent` — added threshold check (previously unprotected)

## Test plan

- [ ] Open element editor, select a **new** item type (e.g. first time selecting a line after selecting a terminal) — element must **not** move on click
- [ ] Drag an element — it must move normally
- [ ] Repeat for static text and dynamic text field items
- [ ] Existing catch2 unit tests: `All tests passed (19 assertions in 2 test cases)` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)