### PR TITLE
fix(collection): isCustomCollection() false-positive on company path

### DIFF
--- a/sources/ElementsCollection/elementslocation.cpp
+++ b/sources/ElementsCollection/elementslocation.cpp
@@ -523,7 +523,9 @@ bool ElementsLocation::isCompanyCollection() const
 */
 bool ElementsLocation::isCustomCollection() const
 {
-	return fileSystemPath().startsWith(QETApp::customElementsDirN());
+	const QString dir = QETApp::customElementsDirN();
+	const QString path = fileSystemPath();
+	return path == dir || path.startsWith(dir + QLatin1Char('/'));
 }
 
 /**

--- a/sources/ElementsCollection/fileelementcollectionitem.cpp
+++ b/sources/ElementsCollection/fileelementcollectionitem.cpp
@@ -274,7 +274,9 @@ bool FileElementCollectionItem::isCompanyCollection() const
 */
 bool FileElementCollectionItem::isCustomCollection() const
 {
-	return fileSystemPath().startsWith(QETApp::customElementsDirN());
+	const QString dir = QETApp::customElementsDirN();
+	const QString path = fileSystemPath();
+	return path == dir || path.startsWith(dir + QLatin1Char('/'));
 }
 
 /**


### PR DESCRIPTION
## Problem

After saving an element to the **user collection**, it appeared under the **company collection** in the element panel instead.

### Root cause

The default collection directories are:

| Collection | Path (suffix)       |
|------------|---------------------|
| User       | `.../elements`      |
| Company    | `.../elements-company` |

Both `FileElementCollectionItem::isCustomCollection()` and `ElementsLocation::isCustomCollection()` used:

```cpp
return fileSystemPath().startsWith(QETApp::customElementsDirN());
```

Because `"elements-company"` starts with `"elements"`, this returned `true` for company-collection items too.

`ElementsCollectionModel::addLocation()` iterates collection roots and breaks on the first one where `isCustomCollection()` returns true. With company listed before user in the model, it attached the newly saved element to the company branch.

## Fix

Require an exact root match **or** a slash-separated prefix:

```cpp
const QString dir  = QETApp::customElementsDirN();
const QString path = fileSystemPath();
return path == dir || path.startsWith(dir + QLatin1Char('/'));
```

`"…/elements-company/foo"` no longer matches `"…/elements"` because `"elements-company/foo"` does not start with `"elements/"`.

Applied identically to both `FileElementCollectionItem` and `ElementsLocation`.

## Test plan

- [ ] Save an element via **File → Save As** into the user collection — it must appear under *Collection utilisateur*, not *Collection Company*
- [ ] Elements already in the company collection must still be shown correctly
- [ ] Existing catch2 unit tests: `All tests passed (19 assertions in 2 test cases)` ✓
- [ ] Path logic verified with automated test: company root/items → `false`, user root/items → `true` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)