### PR TITLE
fix(#283): restore center alignment when loading table config

### DIFF
--- a/sources/factory/ui/addtabledialog.cpp
+++ b/sources/factory/ui/addtabledialog.cpp
@@ -268,7 +268,8 @@ void AddTableDialog::loadConfig()
 		case Qt::AlignLeft :
 			ui->m_header_alignment_cb->setCurrentIndex(0);
 			break;
-		case Qt::AlignCenter :
+		case Qt::AlignHCenter :
+		case Qt::AlignCenter :  // accept AlignCenter in case it was hand-edited by the user
 			ui->m_header_alignment_cb->setCurrentIndex(1);
 			break;
 		default:
@@ -284,7 +285,8 @@ void AddTableDialog::loadConfig()
 		case Qt::AlignLeft :
 			ui->m_table_alignment_cb->setCurrentIndex(0);
 			break;
-		case Qt::AlignCenter :
+		case Qt::AlignHCenter :
+		case Qt::AlignCenter :  // accept AlignCenter in case it was hand-edited by the user
 			ui->m_table_alignment_cb->setCurrentIndex(1);
 			break;
 		default:


### PR DESCRIPTION
Fixes #283.

## Root cause

`saveConfig()` serialises the alignment via `QMetaEnum::valueToKey()`, which turns `Qt::AlignHCenter` into the string `"AlignHCenter"`. On reload, `loadConfig()` calls `QMetaEnum::keyToValue("AlignHCenter")` which returns `Qt::AlignHCenter` (value `0x0004`). However the switch statement matched against `Qt::AlignCenter` (value `0x0084` = `AlignHCenter | AlignVCenter`):

```
0x0004 != 0x0084  →  falls to default  →  sets combobox to Right
```

So every saved "Center" configuration was loaded back as "Right".

## Fix

Add `Qt::AlignHCenter` as the primary case in both the header and table switches. Keep `Qt::AlignCenter` as a fallthrough so any config files that were hand-edited with `"AlignCenter"` (the workaround described in the issue) continue to work.

```cpp
case Qt::AlignHCenter :
case Qt::AlignCenter :  // accept AlignCenter in case it was hand-edited by the user
    ui->m_header_alignment_cb->setCurrentIndex(1);
    break;
```

## Verification

Built a standalone Qt test against Qt 5.15.3 (same version as the Docker CI image) that exercises the full `QMetaEnum` round-trip:

```
Qt::AlignHCenter = 4
Qt::AlignCenter  = 132
Saved to JSON as: AlignHCenter
Decoded from JSON: 4

OLD loadConfig combobox index: 2 (Right)  ← BUG
NEW loadConfig combobox index: 1 (Center) ← CORRECT

PASS
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)