### PR TITLE
Fix #413: paste no longer adds '_' label to conductors that had no label

### DIFF
--- a/sources/diagramcommands.cpp
+++ b/sources/diagramcommands.cpp
@@ -91,15 +91,22 @@ void PasteDiagramCommand::redo()
 				dc.addValue("comment", "");
 				dc.addValue("location", "");
 				e->setElementInformations(dc);
-				
-				//Reset the text of conductors
-				const QList <Conductor *> conductors_list = content.m_conductors_to_move;
-				for (Conductor *c : conductors_list)
-				{
-					ConductorProperties cp = c -> properties();
-					cp.text = c->diagram() ? c -> diagram() -> defaultConductorProperties.text : "_";
-					c -> setProperties(cp);
-				}
+			}
+		}
+
+		// Reset conductor labels once, outside the per-element loop.
+		// Only reset conductors that already carry a label; conductors with no
+		// label (text == "") must stay unlabelled after paste — they should not
+		// silently gain the diagram default (typically "_") which would enrol
+		// them into autonumbering against the user's intent.
+		if (settings.value("diagramcommands/erase-label-on-copy", true).toBool())
+		{
+			for (Conductor *c : content.m_conductors_to_move)
+			{
+				ConductorProperties cp = c->properties();
+				if (!cp.text.isEmpty())
+					cp.text = diagram->defaultConductorProperties.text;
+				c->setProperties(cp);
 			}
 		}
 	}


### PR DESCRIPTION
## Problem

When **erase-label-on-copy** is enabled (the default), copy-pasting conductors that had no label (`num=""`) caused them to gain a `_` label on the paste. The user's original conductor was visually clean (no text), but every copy came out labelled, requiring manual cleanup.

## Root cause (traced through the code)

`PasteDiagramCommand::redo()` in `diagramcommands.cpp` reset every pasted conductor to the diagram's default text:

```cpp
cp.text = c->diagram() ? c->diagram()->defaultConductorProperties.text : "_";
```

`ConductorProperties` initialises `text` to `"_"` by default (`conductorproperties.cpp:246`), so `diagram->defaultConductorProperties.text` is `"_"` unless the user has explicitly changed it in Project/Diagram Properties. A conductor that arrived from the clipboard with `text = ""` (from `num=""`) was unconditionally overwritten with `"_"`.

Additionally the conductor-reset loop was nested inside the per-element loop, so with N pasted elements the conductors were reset N times (harmless but wasteful).

## Fix

Two changes in `diagramcommands.cpp`:

1. **Move** the conductor-reset loop outside the per-element loop — runs once per paste, not once per element.
2. **Guard** the reset: only reset conductors that already carried a non-empty label. Conductors with `text == ""` keep their empty label after paste.

```cpp
if (!cp.text.isEmpty())
    cp.text = diagram->defaultConductorProperties.text;
```

This preserves the existing behaviour for labelled conductors (they are cleared to the diagram default so autonumbering can renumber them), while leaving blank conductors alone.

## Test plan

- [ ] Draw two elements, connect with a conductor, leave the conductor label empty. Copy+paste — pasted conductor should have no label.
- [ ] Same setup but give the conductor a label (e.g. "L1"). Copy+paste with erase-label-on-copy enabled — pasted conductor should be reset to the diagram default (usually `_`).
- [ ] Undo/redo the paste — behaviour should be stable.
- [ ] Multiple elements pasted at once — conductor reset should happen once, not N times.

Fixes #413.

🤖 Generated with [Claude Code](https://claude.com/claude-code)