### PR TITLE
Fix #391: collection panel blank when path contains accented chars or is too long (Windows)

### DIFF
--- a/sources/ElementsCollection/elementslocation.cpp
+++ b/sources/ElementsCollection/elementslocation.cpp
@@ -701,11 +701,11 @@ pugi::xml_document ElementsLocation::pugiXml() const
 	if (!m_project)
 	{
 #ifndef Q_OS_LINUX
-		if (docu.load_file(m_file_system_path.toStdString().c_str())) {
+		if (docu.load_file(m_file_system_path.toStdWString().c_str())) {
 			docu.save(m_string_stream);
 		}
 #else
-		docu.load_file(m_file_system_path.toStdString().c_str());
+		docu.load_file(m_file_system_path.toStdWString().c_str());
 #endif
 	}
 	else

--- a/sources/ElementsCollection/fileelementcollectionitem.cpp
+++ b/sources/ElementsCollection/fileelementcollectionitem.cpp
@@ -138,7 +138,7 @@ QString FileElementCollectionItem::localName()
 		{
 			QString str(fileSystemPath() % "/qet_directory");
 			pugi::xml_document docu;
-			if(docu.load_file(str.toStdString().c_str()))
+			if(docu.load_file(str.toStdWString().c_str()))
 			{
 				if (QString(docu.document_element().name())
 					== "qet-directory")


### PR DESCRIPTION
## Problem

On Windows, the **Collection** panel shows no element names and no illustrations when:
- the path to the collection folder contains **accented or non-ASCII characters** (e.g. `C:\Projets\Réseau\`), or
- the path is **longer than ~260 characters** (Windows MAX_PATH for narrow APIs).

Both symptoms were reported in #391. The workaround found by users was to move the collection to a shorter, ASCII-only path — confirming the root cause is path handling, not the collection data itself.

## Root cause

Two call sites open XML files via pugixml using the narrow `const char*` overload:

```cpp
// fileelementcollectionitem.cpp
docu.load_file(str.toStdString().c_str())

// elementslocation.cpp (two places)
docu.load_file(m_file_system_path.toStdString().c_str())
```

`QString::toStdString()` returns **UTF-8** bytes. On Windows, `pugi::xml_document::load_file(const char*)` calls `fopen_s(path, "rb")` which uses the Windows **ANSI codepage** — not UTF-8. Non-ASCII characters encoded in UTF-8 are misinterpreted as ANSI, the file is not found, `load_file` returns failure silently, and the XML document stays empty. Result: no name, no illustration.

This is confirmed directly from pugixml 1.15 source (`pugixml.cpp`):
```cpp
// const char* overload — uses ANSI fopen on Windows
PUGI_IMPL_FN xml_parse_result xml_document::load_file(const char* path_, ...)
{
    auto_deleter<FILE> file(impl::open_file(path_, "rb"), ...);  // → fopen_s
    ...
}

// const wchar_t* overload — uses _wfopen (wide Unicode API) on Windows
PUGI_IMPL_FN xml_parse_result xml_document::load_file(const wchar_t* path_, ...)
{
    auto_deleter<FILE> file(impl::open_file_wide(path_, L"rb"), ...);  // → _wfopen
    ...
}
```

## Fix

Switch all three call sites to `toStdWString().c_str()`, which invokes the `const wchar_t*` overload:

```cpp
docu.load_file(path.toStdWString().c_str())
```

On **Windows**: pugixml calls `_wfopen`, the wide Unicode file API — handles all valid Unicode paths regardless of the ANSI codepage or path length.

On **Linux / macOS**: the `const wchar_t*` overload converts the wchar_t string to UTF-8 internally (`convert_path_heap`) then calls `fopen` — identical in effect to the narrow overload, so no regression.

No `#ifdef Q_OS_WIN` guard is needed because pugixml's wide overload is safe on all platforms.

## Files changed

| File | Change |
|------|--------|
| `sources/ElementsCollection/fileelementcollectionitem.cpp` | `qet_directory` name loading |
| `sources/ElementsCollection/elementslocation.cpp` | `.elmt` element XML loading (both the cached and non-cached branch) |

## Test plan

- [ ] Windows: place a collection folder at a path with accented characters (e.g. `C:\Utilisateurs\Réseau\éléments\`) — element names and illustrations should now appear in the Collection panel.
- [ ] Windows: place the collection at a deep path exceeding 200 characters — same check.
- [ ] Linux / macOS: smoke-test that element names and illustrations still load normally (no regression).

Fixes #391.

🤖 Generated with [Claude Code](https://claude.com/claude-code)