### PR TITLE
fix(terminal-strip): free-terminal move button disabled and unresponsive (#409)

### DIFF
--- a/sources/TerminalStrip/ui/freeterminaleditor.cpp
+++ b/sources/TerminalStrip/ui/freeterminaleditor.cpp
@@ -46,10 +46,11 @@ FreeTerminalEditor::FreeTerminalEditor(QETProject *project, QWidget *parent) :
         connect(m_project, &QObject::destroyed, this, &FreeTerminalEditor::reload);
     }
 
-		//Disabled the move if the table is currently edited (yellow cell)
-	connect(m_model, &FreeTerminalModel::dataChanged, this, [=] {
-		this->setDisabledMove();
-	});
+		//Disable the move button while cells are edited (yellow), re-evaluate on every change
+	connect(m_model, &FreeTerminalModel::dataChanged, this, &FreeTerminalEditor::selectionChanged);
+
+	connect(ui->m_table_view->selectionModel(), &QItemSelectionModel::selectionChanged,
+			this, &FreeTerminalEditor::selectionChanged);
 
 	connect(ui->m_table_view, &QAbstractItemView::doubleClicked, this, [=](const QModelIndex &index)
 	{
@@ -102,7 +103,7 @@ void FreeTerminalEditor::reload()
 			QString str(strip->installation() + " " + strip->location() + " " + strip->name());
 			ui->m_move_in_cb->addItem(str, strip->uuid());
 		}
-		setDisabledMove(false);
+		selectionChanged();
 	}
 }
 
@@ -273,10 +274,19 @@ void FreeTerminalEditor::on_m_move_pb_clicked()
 	reload();
 }
 
+void FreeTerminalEditor::selectionChanged()
+{
+	const bool has_selection = !ui->m_table_view->selectionModel()->selectedIndexes().isEmpty();
+	const bool has_pending   = !m_model->modifiedModelRealTerminalData().isEmpty();
+	setDisabledMove(!has_selection || has_pending);
+}
+
 void FreeTerminalEditor::setDisabledMove(bool b)
 {
 	ui->m_move_label->setDisabled(b);
 	ui->m_move_in_cb->setDisabled(b);
 	ui->m_move_pb->setDisabled(b);
+	ui->m_move_pb->setToolTip(b ? tr("Apply or discard pending edits before moving")
+								: tr("Move selected terminals to the chosen terminal strip"));
 }
 

--- a/sources/TerminalStrip/ui/freeterminalmodel.cpp
+++ b/sources/TerminalStrip/ui/freeterminalmodel.cpp
@@ -182,7 +182,7 @@ bool FreeTerminalModel::setData(const QModelIndex &index, const QVariant &value,
 		modified_ = true;
 		modified_cell = FUNCTION_CELL;
 	}
-	else if (column_ == LED_CELL)
+	else if (column_ == LED_CELL && mrtd.led_ != value.toBool())
 	{
 		mrtd.led_ = value.toBool();
 		modified_ = true;


### PR DESCRIPTION
## Root cause

Three bugs stacked to produce the symptom reported in #409 (move button does nothing / appears broken):

**Bug 1 — `selectionChanged()` declared but never implemented or connected**
`freeterminaleditor.h` declares `void selectionChanged()` as a private slot but the body was never written and it was never connected to the selection model. The move button had no awareness of whether a terminal was actually selected, so it could appear enabled with nothing selected and then silently return early inside `on_m_move_pb_clicked()` at the `real_t_vector.isEmpty()` guard.

**Bug 2 — `dataChanged → setDisabledMove(true)` was a one-way trap**
Any cell edit — including accidentally opening and closing a Type/Function combo, or toggling the LED combo back to its existing value — permanently disabled the move button until `reload()` was called. There was no tooltip explaining why the button was greyed out, so the user had no way to understand or recover.

**Bug 3 — LED cell missing a change guard in `setData()`**
`LABEL_CELL` checks `label != value` before marking the cell modified. `LED_CELL` did not, so clicking the LED combo while it was already set to the same value still emitted `dataChanged` and triggered the disable.

## Fix

- Implement `selectionChanged()`: enable the move controls only when ≥1 row is selected **and** there are no pending (yellow) edits.
- Connect it to both `selectionModel::selectionChanged` and `model::dataChanged` so button state is always consistent.
- Route `reload()`'s re-enable through `selectionChanged()` instead of `setDisabledMove(false)` directly, so selection state is respected immediately after a successful move.
- Add a tooltip to `m_move_pb` that explains the disabled state: *"Apply or discard pending edits before moving"*.
- Add the missing change guard to `LED_CELL` in `setData()`.

## Not included

Drag-and-drop between the free-terminal list and the strip tree (#409 also mentions D&D). Neither `FreeTerminalModel` nor `TerminalStripModel` has `Qt::ItemIsDragEnabled` or any `mimeData()`/`dropMimeData()` implementation — D&D was never built for this panel. That is a separate feature request.

## Test plan

- [ ] Open Terminal Block Manager with at least one independent terminal and one terminal strip
- [ ] Confirm move button is **disabled** with nothing selected
- [ ] Select a terminal row — confirm button becomes **enabled**
- [ ] Edit a Type/Function/LED cell (row turns yellow) — confirm button becomes **disabled** with explanatory tooltip
- [ ] Click Apply to commit the edit — confirm button becomes **enabled** again (if row still selected)
- [ ] Select a row, choose a target strip, click move — confirm terminal disappears from the free list and appears in the strip
- [ ] Toggle LED combo to its current value — confirm row does **not** turn yellow and button remains enabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)