### PR TITLE
Fix #527: use ApplicationModal for Project Properties and app config dialogs

### DIFF
--- a/sources/qetapp.cpp
+++ b/sources/qetapp.cpp
@@ -1969,7 +1969,10 @@ void QETApp::configureQET()
 	// cree le dialogue
 	ConfigDialog cd;
 	cd.setWindowTitle(tr("Configurer QElectroTech", "window title"));
-	cd.setWindowModality(Qt::WindowModal);
+	// ApplicationModal so no other window can dispatch events while the dialog
+	// holds raw pointers derived from the current project list.  Same class of
+	// bug as ProjectPropertiesDialog — see issue #527.
+	cd.setWindowModality(Qt::ApplicationModal);
 	cd.addPage(new GeneralConfigurationPage());
 	cd.addPage(new NewDiagramPage());
 	cd.addPage(new ExportConfigPage());

--- a/sources/ui/projectpropertiesdialog.cpp
+++ b/sources/ui/projectpropertiesdialog.cpp
@@ -63,7 +63,13 @@ ProjectPropertiesDialog::~ProjectPropertiesDialog ()
 */
 void ProjectPropertiesDialog::exec()
 {
-	m_properties_dialog->setWindowModality(Qt::WindowModal);
+	// ApplicationModal (not WindowModal) so no other window — including other
+	// MDI subwindows — can dispatch events while the dialog holds raw
+	// QETProject* pointers in its config pages.  WindowModal only blocks the
+	// parent ProjectView; the rest of the MDI area stays live, which allowed
+	// new_project / close_project to replace the project under the dialog
+	// and cause a SIGSEGV.  See issue #527.
+	m_properties_dialog->setWindowModality(Qt::ApplicationModal);
 	m_properties_dialog -> exec();
 }
 


### PR DESCRIPTION
## Summary

Fixes two dialogs that used `Qt::WindowModal` where they should use `Qt::ApplicationModal`:

1. **`ProjectPropertiesDialog::exec()`** (`sources/ui/projectpropertiesdialog.cpp`) — four config pages hold raw `QETProject*` pointers
2. **`QETApp::configureQET()`** (`sources/qetapp.cpp`) — app-level settings dialog, identical exposure

`WindowModal` only blocks the direct parent `ProjectView`; the rest of the MDI area stays live. If `new_project` or `close_project` fires while either dialog is open, the raw pointers held by the config pages become stale → SIGSEGV (exit code -11).

`ApplicationModal` blocks all windows for the lifetime of each dialog, closing the race entirely.

## Reproduction (from issue #527)

1. Open a project and open **Project Properties** (`Edit → Project Properties`) — or open **Settings → Configure QElectroTech**
2. While the dialog is open, use the main menu or keyboard shortcut to create or close a project
3. QElectroTech crashes with SIGSEGV

Discovered by the QET GUI fuzzer after an 8-hour run; one confirmed crash (exit code -11) with `new_project` as the triggering action while the Project Properties dialog was on screen. `configureQET` carries the identical structural vulnerability.

## Test plan

- [ ] Open Project Properties / App Settings, leave open, attempt File → New, File → Open, File → Close — all actions should be blocked while dialog is visible
- [ ] Confirm both dialogs still apply and cancel changes correctly
- [ ] Run 8-hour fuzzer with no SIGSEGV regression

Fixes #527

🤖 Generated with [Claude Code](https://claude.com/claude-code)