### PR TITLE
feat: add backup dialog when opening an existing project

### DIFF
--- a/cmake/qet_compilation_vars.cmake
+++ b/cmake/qet_compilation_vars.cmake
@@ -632,6 +632,8 @@ set(QET_SRC_FILES
   ${QET_DIR}/sources/ui/diagrampropertieseditordockwidget.h
   ${QET_DIR}/sources/ui/diagramselection.cpp
   ${QET_DIR}/sources/ui/diagramselection.h
+  ${QET_DIR}/sources/ui/backupdialog.cpp
+  ${QET_DIR}/sources/ui/backupdialog.h
   ${QET_DIR}/sources/ui/dialogwaiting.cpp
   ${QET_DIR}/sources/ui/dialogwaiting.h
   ${QET_DIR}/sources/ui/dynamicelementtextitemeditor.cpp

--- a/sources/qetdiagrameditor.cpp
+++ b/sources/qetdiagrameditor.cpp
@@ -37,6 +37,7 @@
 #include "recentfiles.h"
 #include "ui/bomexportdialog.h"
 #include "ui/diagrampropertieseditordockwidget.h"
+#include "ui/backupdialog.h"
 #include "ui/dialogwaiting.h"
 #include "undocommand/addelementtextcommand.h"
 #include "undocommand/rotateselectioncommand.h"
@@ -47,7 +48,9 @@
 #include "TerminalStrip/ui/addterminalstripitemdialog.h"
 #include "wiringlistexport.h"
 #include "ui/terminalnumberingdialog.h"
+#include <QDateTime>
 #include <QDebug>
+#include <QDir>
 #ifdef BUILD_WITHOUT_KF5
 #	include "ui/nokde/kautosavefile.h"
 #else
@@ -1187,6 +1190,16 @@ bool QETDiagramEditor::openAndAddProject(
 	QETApp::projectsRecentFiles() -> fileWasOpened(filepath);
 	addProject(project);
 	DialogWaiting::dropInstance();
+
+	BackupDialog backup_dialog(this);
+	if (backup_dialog.exec() == QDialog::Accepted)
+	{
+		QString backup_path = filepath_info.absolutePath() + QDir::separator() +
+			QDateTime::currentDateTime().toString("yyyy-MM-dd-hh-mm") + "_" +
+			filepath_info.fileName();
+		QFile::copy(filepath, backup_path);
+	}
+
 	return true;
 }
 

--- a/sources/ui/backupdialog.cpp
+++ b/sources/ui/backupdialog.cpp
@@ -1,0 +1,63 @@
+/*
+	Copyright 2006-2026 The QElectroTech Team
+	This file is part of QElectroTech.
+
+	QElectroTech is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 2 of the License, or
+	(at your option) any later version.
+
+	QElectroTech is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with QElectroTech.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "backupdialog.h"
+
+#include <QLabel>
+#include <QPushButton>
+#include <QVBoxLayout>
+#include <QHBoxLayout>
+
+/**
+	@brief BackupDialog::BackupDialog
+	@param parent parent widget
+*/
+BackupDialog::BackupDialog(QWidget *parent) :
+	QDialog(parent)
+{
+	setWindowTitle(tr("Créer une copie de sauvegarde ?", "window title"));
+	setFixedSize(450, 100);
+
+	auto main_layout = new QVBoxLayout(this);
+
+	auto label = new QLabel(
+		tr("Souhaitez-vous créer une copie de sauvegarde ?",
+		   "dialog message"));
+	label->setWordWrap(true);
+	main_layout->addWidget(label);
+
+	main_layout->addStretch();
+
+	auto button_layout = new QHBoxLayout();
+	button_layout->addStretch();
+
+	auto yes_button = new QPushButton(tr("Oui", "yes button"));
+	auto no_button = new QPushButton(tr("Non", "no button"));
+
+	button_layout->addWidget(yes_button);
+	button_layout->addWidget(no_button);
+	main_layout->addLayout(button_layout);
+
+	connect(yes_button, &QPushButton::clicked, this, &QDialog::accept);
+	connect(no_button, &QPushButton::clicked, this, &QDialog::reject);
+}
+
+/**
+	@brief BackupDialog::~BackupDialog
+*/
+BackupDialog::~BackupDialog() = default;

--- a/sources/ui/backupdialog.h
+++ b/sources/ui/backupdialog.h
@@ -1,0 +1,32 @@
+/*
+	Copyright 2006-2026 The QElectroTech Team
+	This file is part of QElectroTech.
+
+	QElectroTech is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 2 of the License, or
+	(at your option) any later version.
+
+	QElectroTech is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with QElectroTech.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef BACKUPDIALOG_H
+#define BACKUPDIALOG_H
+
+#include <QDialog>
+
+class BackupDialog : public QDialog
+{
+	Q_OBJECT
+	public:
+		explicit BackupDialog(QWidget *parent = nullptr);
+		~BackupDialog() override;
+};
+
+#endif // BACKUPDIALOG_H


### PR DESCRIPTION
Show a dialog asking the user whether to create a backup copy when
opening an existing .qet project. If accepted, the file is copied
to the same directory with a YYYY-MM-DD-hh-mm_ prefix.

- Add BackupDialog (QDialog) with French UI text prepared for translation
  (title: "Créer une copie de sauvegarde ?", message:
  "Souhaitez-vous créer une copie de sauvegarde ?", buttons: Oui/Non)
- Integrate into QETDiagramEditor::openAndAddProject() after successful load
- Register new files in cmake/qet_compilation_vars.cmake