### PR TITLE
Fall back to the base language for element and folder names

### DIFF
--- a/sources/NameList/nameslist.cpp
+++ b/sources/NameList/nameslist.cpp
@@ -263,6 +263,13 @@ QString NamesList::name(const QString &fallback_name) const
 	QString system_language = QETApp::langFromSetting();
 	if (! map_names[system_language].isEmpty())
 		return (map_names[system_language]);
+	// langFromSetting() may return a full locale (e.g. "de_DE") while element
+	// and folder names are keyed by the 2-letter language code ("de"). Try the
+	// base language before falling back to English, mirroring what setLanguage()
+	// does for the UI translations.
+	const QString base_language = system_language.section('_', 0, 0);
+	if (base_language != system_language && ! map_names[base_language].isEmpty())
+		return (map_names[base_language]);
 	if (! map_names["en"].isEmpty()) return (map_names["en"]);
 	if (! fallback_name.isEmpty()) return (fallback_name);
 	if (map_names.count()) return (map_names.begin().value());


### PR DESCRIPTION
NamesList::name() looked up the display name using the full locale from langFromSetting() (e.g. "de_DE") and jumped straight to English if it was absent. Element and folder names in the collection are keyed by 2-letter codes (<name lang="de">), so a "de_DE" UI showed the whole collection in English/French even though German names exist.

Try the base language ("de") before the English fallback, mirroring what setLanguage() already does for the UI translations.