### PR TITLE
Cleanup/qt6 deprecation warnings

### DIFF
--- a/sources/ElementsCollection/elementcollectionhandler.cpp
+++ b/sources/ElementsCollection/elementcollectionhandler.cpp
@@ -143,8 +143,12 @@ ElementsLocation ECHSFileToFile::copyElement(ElementsLocation &source, ElementsL
 		//On windows when user drag and drop an element from the common elements collection
 		//to the custom elements collection, the element file stay in read only mode, and so
 		//user can't save the element
+#if QT_VERSION >= QT_VERSION_CHECK(6, 6, 0)
+		QNtfsPermissionCheckGuard ntfs_guard;
+#else
 		extern Q_CORE_EXPORT int qt_ntfs_permission_lookup;
 		qt_ntfs_permission_lookup++;
+#endif
 		QFile file(destination.fileSystemPath() % "/" % new_elmt_name);
 		if (!file.isWritable()) {
 			if (!file.setPermissions(file.permissions() | QFileDevice::WriteUser)) {
@@ -152,7 +156,9 @@ ElementsLocation ECHSFileToFile::copyElement(ElementsLocation &source, ElementsL
 						 << " in ECHSFileToFile::copyElement";
 			}
 		}
+#if QT_VERSION < QT_VERSION_CHECK(6, 6, 0)
 		qt_ntfs_permission_lookup--;
+#endif
 #endif
 		return ElementsLocation (destination.fileSystemPath() % "/" % new_elmt_name);
 	}

--- a/sources/ElementsCollection/elementscollectionwidget.cpp
+++ b/sources/ElementsCollection/elementscollectionwidget.cpp
@@ -830,7 +830,7 @@ void ElementsCollectionWidget::search()
 	}
 
 		//start the search when text have at least 3 letters.
-	if (text.count() < 3) {
+	if (text.size() < 3) {
 		return;
 	}
 

--- a/sources/TerminalStrip/GraphicsItem/terminalstripdrawer.cpp
+++ b/sources/TerminalStrip/GraphicsItem/terminalstripdrawer.cpp
@@ -265,7 +265,7 @@ void TerminalStripDrawer::paint(QPainter *painter)
         painter->restore();
 
 			//Draw the bridges
-		for (const auto &points_ : qAsConst(bridges_anchor_points))
+		for (const auto &points_ : std::as_const(bridges_anchor_points))
 		{
 			painter->save();
 			auto pen_{painter->pen()};

--- a/sources/TerminalStrip/UndoCommand/addterminaltostripcommand.cpp
+++ b/sources/TerminalStrip/UndoCommand/addterminaltostripcommand.cpp
@@ -126,7 +126,7 @@ void RemoveTerminalFromStripCommand::redo()
 	if (m_strip)
 	{
 		QVector<QSharedPointer<RealTerminal>> real_t;
-		for (const auto &real_t_vector : qAsConst(m_terminals)) {
+		for (const auto &real_t_vector : std::as_const(m_terminals)) {
 			real_t.append(real_t_vector);
 		}
 

--- a/sources/TerminalStrip/UndoCommand/groupterminalscommand.cpp
+++ b/sources/TerminalStrip/UndoCommand/groupterminalscommand.cpp
@@ -68,7 +68,7 @@ void UnGroupTerminalsCommand::undo()
 			m_terminal_strip->groupTerminals(key, m_physical_real_H.value(key));
 		}
 			//Second, set level.
-		for (const auto &pair : qAsConst(m_real_t_level)) {
+		for (const auto &pair : std::as_const(m_real_t_level)) {
 			m_terminal_strip->setLevel(pair.first, pair.second);
 		}
 	}
@@ -78,7 +78,7 @@ void UnGroupTerminalsCommand::redo()
 {
 	if (m_terminal_strip)
 	{
-		for (const auto &value : qAsConst(m_physical_real_H)) {
+		for (const auto &value : std::as_const(m_physical_real_H)) {
 			m_terminal_strip->unGroupTerminals(value);
 		}
 	}

--- a/sources/TerminalStrip/terminalstrip.cpp
+++ b/sources/TerminalStrip/terminalstrip.cpp
@@ -466,7 +466,7 @@ QSharedPointer<RealTerminal> TerminalStrip::realTerminalForUuid(const QUuid &uui
 QVector<QSharedPointer<RealTerminal>> TerminalStrip::realTerminals() const
 {
 	QVector<QSharedPointer<RealTerminal>> vector_;
-	for (const auto &phy : qAsConst(m_physical_terminals)) {
+	for (const auto &phy : std::as_const(m_physical_terminals)) {
 		vector_.append(phy->realTerminals());
 	}
 	return vector_;
@@ -856,7 +856,7 @@ QSharedPointer<TerminalStripBridge> TerminalStrip::isBridged(const QSharedPointe
 {
 	if (real_terminal)
 	{
-		for (const auto &bridge_ : qAsConst(m_bridge)) {
+		for (const auto &bridge_ : std::as_const(m_bridge)) {
 			if (bridge_->realTerminals().contains(real_terminal))
 				return bridge_;
 		}
@@ -983,7 +983,7 @@ QDomElement TerminalStrip::toXml(QDomDocument &parent_document)
 	}
 	root_elmt.appendChild(xml_layout);
 
-	for (const auto &bridge_ : qAsConst(m_bridge)) {
+	for (const auto &bridge_ : std::as_const(m_bridge)) {
 		root_elmt.appendChild(bridge_->toXml(parent_document));
 	}
 
@@ -1024,7 +1024,7 @@ bool TerminalStrip::fromXml(QDomElement &xml_element)
 			for (auto &xml_real : QETXML::findInDomElement(xml_physical, RealTerminal::xmlTagName()))
 			{
 				const auto uuid_ = QUuid(xml_real.attribute(QStringLiteral("element_uuid")));
-				for (auto terminal_elmt : qAsConst(free_terminals))
+				for (auto terminal_elmt : std::as_const(free_terminals))
 				{
 					if (terminal_elmt->uuid() == uuid_)
 					{

--- a/sources/TerminalStrip/terminalstripbridge.cpp
+++ b/sources/TerminalStrip/terminalstripbridge.cpp
@@ -85,7 +85,7 @@ QDomElement TerminalStripBridge::toXml(QDomDocument &parent_document) const
 	root_elmt.setAttribute(QStringLiteral("color"), m_color.name());
 
 	auto terminals_elmt = parent_document.createElement(QStringLiteral("real_terminals"));
-	for (const auto &real_t : qAsConst(m_real_terminals))
+	for (const auto &real_t : std::as_const(m_real_terminals))
 	{
 		if (real_t)
 		{

--- a/sources/TerminalStrip/terminalstripbridge.cpp
+++ b/sources/TerminalStrip/terminalstripbridge.cpp
@@ -106,7 +106,7 @@ void TerminalStripBridge::fromXml(const QDomElement &dom_element)
 	}
 
 	m_uuid = QUuid(dom_element.attribute(QStringLiteral("uuid"), m_uuid.toString()));
-	m_color.setNamedColor(dom_element.attribute(QStringLiteral("color")));
+	m_color = QColor(dom_element.attribute(QStringLiteral("color")));
 
 	const auto real_t_vector = QETXML::subChild(dom_element,
 										 QStringLiteral("real_terminals"),

--- a/sources/TerminalStrip/ui/terminalstripmodel.cpp
+++ b/sources/TerminalStrip/ui/terminalstripmodel.cpp
@@ -535,7 +535,7 @@ modelRealTerminalData TerminalStripModel::dataAtRow(int row) const
 	else
 	{
 		auto current_row = 0;
-		for (const auto &physical_data : qAsConst(m_physical_data))
+		for (const auto &physical_data : std::as_const(m_physical_data))
 		{
 			for (const auto &real_data : physical_data.real_data)
 			{
@@ -567,7 +567,7 @@ void TerminalStripModel::replaceDataAtRow(modelRealTerminalData data, int row)
 		auto current_row = 0;
 		auto current_physical = 0;
 
-		for (const auto &physical_data : qAsConst(m_physical_data))
+		for (const auto &physical_data : std::as_const(m_physical_data))
 		{
 			auto current_real = 0;
 			for (int i=0 ; i<physical_data.real_data.count() ; ++i)
@@ -606,7 +606,7 @@ modelPhysicalTerminalData TerminalStripModel::physicalDataAtIndex(int index) con
 	int current_phy = -1;
 	bool match_ = false;
 
-	for (const auto &ptd_ : qAsConst(m_physical_data))
+	for (const auto &ptd_ : std::as_const(m_physical_data))
 	{
 		current_checked_index += ptd_.real_data.size();
 		++current_phy;
@@ -637,9 +637,9 @@ modelRealTerminalData TerminalStripModel::realDataAtIndex(int index) const
 
 	int current_checked_index = -1;
 
-	for (const auto & ptd_ : qAsConst(m_physical_data))
+	for (const auto & ptd_ : std::as_const(m_physical_data))
 	{
-		for (const auto & rtd_ : qAsConst(ptd_.real_data)) {
+		for (const auto & rtd_ : std::as_const(ptd_.real_data)) {
 			++current_checked_index;
 			if (current_checked_index == index) {
 				return rtd_;

--- a/sources/TerminalStrip/ui/terminalstriptreedockwidget.cpp
+++ b/sources/TerminalStrip/ui/terminalstriptreedockwidget.cpp
@@ -85,7 +85,7 @@ void TerminalStripTreeDockWidget::reload()
 	m_uuid_terminal_H.clear();
 	m_uuid_strip_H.clear();
 
-	for (const auto &connection_ : qAsConst(m_strip_changed_connection)) {
+	for (const auto &connection_ : std::as_const(m_strip_changed_connection)) {
 		disconnect(connection_);
 	}
 	m_strip_changed_connection.clear();
@@ -250,7 +250,7 @@ void TerminalStripTreeDockWidget::buildTree()
 		return a->name() < b->name();
 	});
 
-	for (const auto &ts : qAsConst(ts_vector)) {
+	for (const auto &ts : std::as_const(ts_vector)) {
 		addTerminalStrip(ts);
 	}
 	addFreeTerminal();
@@ -352,7 +352,7 @@ void TerminalStripTreeDockWidget::addFreeTerminal()
 
 	auto free_terminal_item = ui->m_tree_view->topLevelItem(1);
 
-	for (const auto terminal : qAsConst(vector_))
+	for (const auto terminal : std::as_const(vector_))
 	{
 		QUuid uuid_ = terminal->uuid();
 		QStringList strl{terminal->actualLabel()};

--- a/sources/autoNum/numerotationcontext.cpp
+++ b/sources/autoNum/numerotationcontext.cpp
@@ -57,9 +57,9 @@ bool NumerotationContext::addValue(const QString &type,
 				   const QVariant &value,
 				   const int increase,
 				   const int initialvalue) {
-	if (!keyIsAcceptable(type) && !value.canConvert(QVariant::String))
+	if (!keyIsAcceptable(type) && !value.canConvert<QString>())
 		return false;
-	if (keyIsNumber(type) && !value.canConvert(QVariant::Int))
+	if (keyIsNumber(type) && !value.canConvert<int>())
 		return false;
 
 	QString valuestr = value.toString();

--- a/sources/cli_export.cpp
+++ b/sources/cli_export.cpp
@@ -422,6 +422,14 @@ int checkOneElement(const QString &path)
 		return 2;
 	}
 	QDomDocument doc;
+#if QT_VERSION >= QT_VERSION_CHECK(6, 5, 0)
+	if (const auto result = doc.setContent(&file); !result) {
+		file.close();
+		out << "FAIL  " << path << "  (XML error line "
+			<< result.errorLine << ": " << result.errorMessage << ")\n";
+		return 2;
+	}
+#else
 	QString error;
 	int line = 0;
 	if (!doc.setContent(&file, &error, &line)) {
@@ -430,6 +438,7 @@ int checkOneElement(const QString &path)
 			<< line << ": " << error << ")\n";
 		return 2;
 	}
+#endif
 	file.close();
 
 	const QDomElement root = doc.documentElement();

--- a/sources/dataBase/projectdatabase.cpp
+++ b/sources/dataBase/projectdatabase.cpp
@@ -253,9 +253,9 @@ bool projectDataBase::createDataBase()
 		return false;
 	}
 
-	m_data_base.exec("PRAGMA temp_store = MEMORY");
-	m_data_base.exec("PRAGMA journal_mode = MEMORY");
-	m_data_base.exec("PRAGMA synchronous = OFF");
+	QSqlQuery(m_data_base).exec("PRAGMA temp_store = MEMORY");
+	QSqlQuery(m_data_base).exec("PRAGMA journal_mode = MEMORY");
+	QSqlQuery(m_data_base).exec("PRAGMA synchronous = OFF");
 	
 	QSqlQuery query_(m_data_base);
 	bool first_ = true;

--- a/sources/diagram.cpp
+++ b/sources/diagram.cpp
@@ -178,7 +178,7 @@ Diagram::~Diagram()
 			continue;
 		deletable_items.append(qgi);
 	}
-	for (const auto &item : qAsConst(deletable_items))
+	for (const auto &item : std::as_const(deletable_items))
 	{
 		removeItem(item);
 		delete item;
@@ -1499,12 +1499,12 @@ bool Diagram::fromXml(QDomElement &document,
 	if (position != QPointF())
 	{
 		QVector <QGraphicsItem *> added_items;
-		for (auto element : qAsConst(added_elements   )) added_items << element;
-		for (auto shape   : qAsConst(added_shapes     )) added_items << shape;
-		for (auto text    : qAsConst(added_texts      )) added_items << text;
-		for (auto image   : qAsConst(added_images     )) added_items << image;
-		for (auto table   : qAsConst(added_tables     )) added_items << table;
-		for (const auto &strip : qAsConst(added_strips)) added_items << strip;
+		for (auto element : std::as_const(added_elements   )) added_items << element;
+		for (auto shape   : std::as_const(added_shapes     )) added_items << shape;
+		for (auto text    : std::as_const(added_texts      )) added_items << text;
+		for (auto image   : std::as_const(added_images     )) added_items << image;
+		for (auto table   : std::as_const(added_tables     )) added_items << table;
+		for (const auto &strip : std::as_const(added_strips)) added_items << strip;
 
 		//Get the top left corner of the rectangle that contain all added items
 		QRectF items_rect;
@@ -1640,11 +1640,11 @@ void Diagram::refreshContents()
 		conductor->refreshText();
 	}
 
-	for (auto &table : qAsConst(dc_.m_tables)) {
+	for (auto &table : std::as_const(dc_.m_tables)) {
 		table->initLink();
 	}
 
-	for (auto &strip :qAsConst(dc_.m_terminal_strip)) {
+	for (auto &strip :std::as_const(dc_.m_terminal_strip)) {
 		strip->refreshPending();
 	}
 }
@@ -1829,7 +1829,7 @@ void Diagram::invertSelection()
 			item_list << item;
 		}
 	}
-	for (auto item : qAsConst(item_list)) {
+	for (auto item : std::as_const(item_list)) {
 		item -> setSelected(!item -> isSelected());
 	}
 

--- a/sources/diagramcontent.cpp
+++ b/sources/diagramcontent.cpp
@@ -55,7 +55,7 @@ DiagramContent::DiagramContent(Diagram *diagram, bool selected) :
 		item_list = diagram->items();
 	}
 
-	for (const auto &item : qAsConst(item_list))
+	for (const auto &item : std::as_const(item_list))
 	{
 		switch (item->type())
 		{
@@ -399,10 +399,10 @@ QList<QGraphicsItem *> DiagramContent::items(int filter) const
 	if (filter & ElementTextFields) for(auto qgi : m_element_texts) items_list << qgi;
 	if (filter & TextGroup)			for(auto qgi : m_texts_groups)  items_list << qgi;
 	if (filter & Tables)            for(auto qgi : m_tables)        items_list << qgi;
-	if (filter & TerminalStrip)     for(const auto qgi : qAsConst(m_terminal_strip)) items_list << qgi;
+	if (filter & TerminalStrip)     for(const auto qgi : std::as_const(m_terminal_strip)) items_list << qgi;
 
 	if (filter & SelectedOnly) {
-		for(const auto &qgi : qAsConst(items_list)) {
+		for(const auto &qgi : std::as_const(items_list)) {
 			if (!qgi -> isSelected()) items_list.removeOne(qgi);
 		}
 	}
@@ -428,7 +428,7 @@ int DiagramContent::count(int filter) const
 		if (filter & ElementTextFields)  for(auto deti      : m_element_texts)        { if (deti      -> isSelected()) ++ count; }
 		if (filter & TextGroup)          for(auto etig      : m_texts_groups)         { if (etig      -> isSelected()) ++ count; }
 		if (filter & Tables)             for(auto table     : m_tables)               { if (table     -> isSelected()) ++ count;  }
-		if (filter & TerminalStrip)      for(const auto &strip : qAsConst(m_terminal_strip)) {if (strip->isSelected()) ++ count;}
+		if (filter & TerminalStrip)      for(const auto &strip : std::as_const(m_terminal_strip)) {if (strip->isSelected()) ++ count;}
 	}
 	else {
 		if (filter & Elements)           count += m_elements.count();

--- a/sources/editor/ui/qetelementeditor.cpp
+++ b/sources/editor/ui/qetelementeditor.cpp
@@ -1093,7 +1093,7 @@ void QETElementEditor::updateAction()
 			<< ui->m_revert_selection_action
 			<< ui->m_paste_from_file_action
 			<< ui->m_paste_from_element_action;
-	for (auto action : qAsConst(ro_list)) {
+	for (auto action : std::as_const(ro_list)) {
 		action->setDisabled(m_read_only);
 	}
 
@@ -1108,7 +1108,7 @@ void QETElementEditor::updateAction()
 				<< ui->m_flip_action
 				<< ui->m_mirror_action;
 	auto items_selected = !m_read_only && m_elmt_scene->selectedItems().count();
-	for (auto action : qAsConst(select_list)) {
+	for (auto action : std::as_const(select_list)) {
 		action->setEnabled(items_selected);
 	}
 

--- a/sources/editor/ui/terminaleditor.cpp
+++ b/sources/editor/ui/terminaleditor.cpp
@@ -428,7 +428,7 @@ void TerminalEditor::activeConnections(bool active)
 		m_editor_connections << connect(ui->m_label_frame_cb, &QCheckBox::toggled,
 										this, &TerminalEditor::labelFrameEdited);
 	} else {
-		for (auto const & con : qAsConst(m_editor_connections)) {
+		for (auto const & con : std::as_const(m_editor_connections)) {
 			QObject::disconnect(con);
 		}
 		m_editor_connections.clear();

--- a/sources/editor/ui/texteditor.cpp
+++ b/sources/editor/ui/texteditor.cpp
@@ -84,7 +84,7 @@ void TextEditor::setUpChangeConnection(QPointer<PartText> part)
 
 void TextEditor::disconnectChangeConnection()
 {
-	for (const auto &connection : qAsConst(m_change_connection)) {
+	for (const auto &connection : std::as_const(m_change_connection)) {
 		disconnect(connection);
 	}
 	m_change_connection.clear();

--- a/sources/elementprovider.cpp
+++ b/sources/elementprovider.cpp
@@ -59,11 +59,11 @@ QVector <QPointer<Element>> ElementProvider::freeElement(ElementData::Types filt
 	QList<Element *> elmt_list;
 
 		//search in all diagram
-	for (const auto &diagram_ : qAsConst(m_diagram_list))
+	for (const auto &diagram_ : std::as_const(m_diagram_list))
 	{
 			//get all element in diagram d
 		elmt_list = diagram_->elements();
-		for (const auto &elmt_ : qAsConst(elmt_list))
+		for (const auto &elmt_ : std::as_const(elmt_list))
 		{
 			if (filter & elmt_->elementData().m_type &&
 				elmt_->isFree())
@@ -106,7 +106,7 @@ QList <Element *> ElementProvider::fromUuids(QList<QUuid> uuid_list) const
 QVector<QPointer<Element>> ElementProvider::find(ElementData::Types elmt_type) const
 {
 	QVector<QPointer<Element>> returned_vector;
-	for (const auto &diagram_ : qAsConst(m_diagram_list))
+	for (const auto &diagram_ : std::as_const(m_diagram_list))
 	{
 		const auto elmt_list = diagram_->elements();
 		for (const auto &elmt_ : elmt_list)
@@ -198,7 +198,7 @@ QVector<TerminalElement *> ElementProvider::freeTerminal() const
 {
 	QVector<TerminalElement *> vector_;
 
-	for (const auto &diagram : qAsConst(m_diagram_list))
+	for (const auto &diagram : std::as_const(m_diagram_list))
 	{
 		const auto elmt_list{diagram->elements()};
 

--- a/sources/elementscollectioncache.cpp
+++ b/sources/elementscollectioncache.cpp
@@ -45,18 +45,18 @@ ElementsCollectionCache::ElementsCollectionCache(const QString &database_path, Q
 		qDebug() << "Unable to open the SQLite database " << database_path << " as " << connection_name << ": " << cache_db_.lastError();
 	else
 	{
-		cache_db_.exec("PRAGMA temp_store = MEMORY");
-		cache_db_.exec("PRAGMA journal_mode = MEMORY");
-		cache_db_.exec("PRAGMA page_size = 4096");
-		cache_db_.exec("PRAGMA cache_size = 16384");
-		cache_db_.exec("PRAGMA locking_mode = EXCLUSIVE");
-		cache_db_.exec("PRAGMA synchronous = OFF");
+		QSqlQuery(cache_db_).exec("PRAGMA temp_store = MEMORY");
+		QSqlQuery(cache_db_).exec("PRAGMA journal_mode = MEMORY");
+		QSqlQuery(cache_db_).exec("PRAGMA page_size = 4096");
+		QSqlQuery(cache_db_).exec("PRAGMA cache_size = 16384");
+		QSqlQuery(cache_db_).exec("PRAGMA locking_mode = EXCLUSIVE");
+		QSqlQuery(cache_db_).exec("PRAGMA synchronous = OFF");
 
 #if TODO_LIST
 #pragma message("@TODO the tables could already exist, handle that case.")
 #endif
 			//@TODO the tables could already exist, handle that case.
-		cache_db_.exec("CREATE TABLE names"
+		QSqlQuery(cache_db_).exec("CREATE TABLE names"
 					   "("
 					   "path VARCHAR(512) NOT NULL,"
 					   "locale VARCHAR(2) NOT NULL,"
@@ -65,7 +65,7 @@ ElementsCollectionCache::ElementsCollectionCache(const QString &database_path, Q
 					   "PRIMARY KEY(path, locale)"
 					   ");");
 
-		cache_db_.exec("CREATE TABLE pixmaps"
+		QSqlQuery(cache_db_).exec("CREATE TABLE pixmaps"
 					   "("
 					   "path VARCHAR(512) NOT NULL UNIQUE,"
 					   "uuid VARCHAR(512) NOT NULL,"

--- a/sources/machine_info.cpp
+++ b/sources/machine_info.cpp
@@ -150,7 +150,11 @@ void MachineInfo::send_info_to_debug()
 	qInfo()<< "";
 	
 	qInfo()<< " OS System language:"<< QLocale::system().name();
+#if QT_VERSION >= QT_VERSION_CHECK(6, 2, 0)
+	qInfo()<< " OS System Native Country Name:"<< QLocale::system().nativeTerritoryName();
+#else
 	qInfo()<< " OS System Native Country Name:"<< QLocale::system().nativeCountryName();
+#endif
 	qInfo()<< " OS System Native Language Name:"<< QLocale::system().nativeLanguageName();	
 	qInfo()<< "";
 	qInfo()<< " System language defined in QET configuration:"<< QString(QETApp::langFromSetting().toLatin1());

--- a/sources/properties/userproperties.cpp
+++ b/sources/properties/userproperties.cpp
@@ -44,17 +44,17 @@ QDomElement UserProperties::toXml(QDomDocument &xml_document) const
 
 	for (auto i = m_properties.begin(); i != m_properties.end(); ++i)
 	{
-		auto type = i.value().type();
+		auto type = i.value().userType();
 		switch(type) {
-		case QVariant::Type::String:
+		case QMetaType::QString:
 			up.appendChild(QETXML::createXmlProperty(i.key(), i.value().toString())); break;
-		case QVariant::Type::Int:
+		case QMetaType::Int:
 			up.appendChild(QETXML::createXmlProperty(i.key(), i.value().toInt())); break;
-		case QVariant::Type::Double:
+		case QMetaType::Double:
 			up.appendChild(QETXML::createXmlProperty(i.key(), i.value().toDouble())); break;
-		case QVariant::Type::Bool:
+		case QMetaType::Bool:
 			up.appendChild(QETXML::createXmlProperty(i.key(), i.value().toBool())); break;
-		case QVariant::Type::Color:
+		case QMetaType::QColor:
 			up.appendChild(QETXML::createXmlProperty(i.key(), QColor(i.value().value<QColor>()))); break;
 		default:
 			break;

--- a/sources/qetgraphicsitem/qetshapeitem.cpp
+++ b/sources/qetgraphicsitem/qetshapeitem.cpp
@@ -594,7 +594,7 @@ void QetShapeItem::addHandler()
 		{
 			m_handler_vector = QetGraphicsHandlerItem::handlerForPoint(mapToScene(points_vector), QETUtils::graphicsHandlerSize(this));
 
-			for(const auto handler : qAsConst(m_handler_vector))
+			for(const auto handler : std::as_const(m_handler_vector))
 			{
 				handler->setZValue(this->zValue()+1);
 				handler->setColor(Qt::blue);

--- a/sources/qetproject.cpp
+++ b/sources/qetproject.cpp
@@ -2029,7 +2029,7 @@ void QETProject::updateDiagramsFolioData()
 		}
 	}
 
-	for (const auto &diagram_ : qAsConst(m_diagrams_list)) {
+	for (const auto &diagram_ : std::as_const(m_diagrams_list)) {
 		diagram_->update();
 	}
 }

--- a/sources/ui/elementinfowidget.cpp
+++ b/sources/ui/elementinfowidget.cpp
@@ -243,7 +243,7 @@ void ElementInfoWidget::buildInterface()
 */
 ElementInfoPartWidget *ElementInfoWidget::infoPartWidgetForKey(const QString &key) const
 {
-	for (const auto &eipw : qAsConst(m_eipw_list))
+	for (const auto &eipw : std::as_const(m_eipw_list))
 	{
 		if (eipw->key() == key)
 			return eipw;
@@ -301,7 +301,7 @@ DiagramContext ElementInfoWidget::currentInfo() const
 {
 	DiagramContext info_;
 
-	for (const auto &eipw : qAsConst(m_eipw_list))
+	for (const auto &eipw : std::as_const(m_eipw_list))
 	{
 		//add value only if they're something to store
 		if (!eipw->text().isEmpty())

--- a/sources/ui/shapegraphicsitempropertieswidget.cpp
+++ b/sources/ui/shapegraphicsitempropertieswidget.cpp
@@ -504,7 +504,7 @@ void ShapeGraphicsItemPropertiesWidget::setUpEditConnection()
 
 void ShapeGraphicsItemPropertiesWidget::clearEditConnection()
 {
-	for (const auto &c : qAsConst(m_edit_connection)) {
+	for (const auto &c : std::as_const(m_edit_connection)) {
 		disconnect(c);
 	}
 	m_edit_connection.clear();

--- a/sources/undocommand/movegraphicsitemcommand.cpp
+++ b/sources/undocommand/movegraphicsitemcommand.cpp
@@ -172,7 +172,7 @@ void MoveGraphicsItemCommand::setupAnimation(QObject *target,
 void MoveGraphicsItemCommand::updateConductors(bool is_redo)
 {
 	//Recalculate the path of 'conductors_to_move'
-	for (const auto &conductor : qAsConst(m_content.m_conductors_to_move)) {
+	for (const auto &conductor : std::as_const(m_content.m_conductors_to_move)) {
 		conductor->updatePath();
 		if(conductor->textItem()->wasMovedByUser() == true){
 			if(is_redo)
@@ -184,7 +184,7 @@ void MoveGraphicsItemCommand::updateConductors(bool is_redo)
 	}
 
 	// Recalculate the path of 'conductors_to_update'
-	for (const auto &conductor : qAsConst(m_content.m_conductors_to_update)) {
+	for (const auto &conductor : std::as_const(m_content.m_conductors_to_update)) {
 		conductor->updatePath();
 	}
 }


### PR DESCRIPTION
Clears every deprecation warning a clean Qt 6.11 build produced, in 6 focused commits (qAsConst→std::as_const ×46, QVariant::Type→QMetaType, QSqlDatabase::exec→QSqlQuery, QString::count/QColor::setNamedColor, QVariant::canConvert, and three QT_VERSION-guarded ones: nativeTerritoryName / setContent-ParseResult / QNtfsPermissionCheckGuard). All replacements are valid on Qt5 too or guarded, so the Qt5 build is untouched. Verified warning-clean by a full clean rebuild on the Qt6 line (Windows 6.11 / Ubuntu 6.9.2 / 6.10.2); the commits cherry-picked onto master without conflicts.