### PR TITLE
Fix remaining Qt6 build warnings (narrowing, nodiscard, qHash)

### DIFF
--- a/sources/TerminalStrip/terminalstrip.cpp
+++ b/sources/TerminalStrip/terminalstrip.cpp
@@ -639,7 +639,7 @@ bool TerminalStrip::isBridgeable(const QVector<QSharedPointer<RealTerminal>> &re
 		// Get the physical terminal and pos
 	auto first_physical_terminal = first_real_terminal->physicalTerminal();
 	QVector<shared_physical_terminal> physical_vector{first_physical_terminal};
-	QVector<int> pos_vector{m_physical_terminals.indexOf(first_physical_terminal)};
+	QVector<int> pos_vector{static_cast<int>(m_physical_terminals.indexOf(first_physical_terminal))};
 
 	auto bridge_ = isBridged(first_real_terminal);
 		//bool to know at the end of this function if at least one terminal is not bridged

--- a/sources/TerminalStrip/ui/terminalstripmodel.h
+++ b/sources/TerminalStrip/ui/terminalstripmodel.h
@@ -29,9 +29,15 @@
 #include "modelTerminalData.h"
 
 //Code to use QColor as key for QHash
-inline uint qHash(const QColor &key, uint seed) {
-	return qHash(key.name(), seed);
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+inline size_t qHash(const QColor &key, size_t seed = 0) {
+	return qHash(key.rgba(), seed);
 }
+#else
+inline uint qHash(const QColor &key, uint seed) {
+	return qHash(key.rgba(), seed);
+}
+#endif
 
 //needed to use QPointer<Element> as key of QHash
 inline uint qHash(const QPointer<Element> &key, uint seed) {

--- a/sources/editor/elementscene.cpp
+++ b/sources/editor/elementscene.cpp
@@ -748,7 +748,7 @@ void ElementScene::addItems(QVector<QGraphicsItem *> items)
  */
 void ElementScene::removeItems(QVector<QGraphicsItem *> items)
 {
-	const int previous_selected_count{selectedItems().size()};
+	const int previous_selected_count = static_cast<int>(selectedItems().size());
 
 		//block signal to avoid multiple emit of selection changed,
 		//we emit this signal only once at the end of this function.

--- a/sources/main.cpp
+++ b/sources/main.cpp
@@ -289,7 +289,7 @@ QGuiApplication::setHighDpiScaleFactorRoundingPolicy(QetSettings::hdpiScaleFacto
 	// here guarantees the singleton is fully built before the worker runs.
 	MachineInfo::instance();
 
-	QtConcurrent::run([=]()
+	[[maybe_unused]] auto startup_future = QtConcurrent::run([=]()
 	{
 		// for debugging
 		qInstallMessageHandler(myMessageOutput);

--- a/sources/qetapp.cpp
+++ b/sources/qetapp.cpp
@@ -1697,10 +1697,11 @@ void QETApp::useSystemPalette(bool use) {
 				);
 	} else {
 		QFile file(configDir() + "/style.css");
-		file.open(QFile::ReadOnly);
-		QString styleSheet = QLatin1String(file.readAll());
-		qApp->setStyleSheet(styleSheet);
-		file.close();
+		if (file.open(QFile::ReadOnly)) {
+			QString styleSheet = QLatin1String(file.readAll());
+			qApp->setStyleSheet(styleSheet);
+			file.close();
+		}
 	}
 }
 


### PR DESCRIPTION
Clears the 9 non-deprecation warnings from the Qt6 build:
- qHash(QColor): hash rgba() (unambiguous QRgb) instead of name(), and use the size_t seed signature on Qt6 (guarded for Qt5). Fixes the ambiguous-overload warning in terminalstripmodel.h.
- Two qsizetype->int narrowings in brace-init: explicit static_cast<int>
  (elementscene.cpp, terminalstrip.cpp).
- main.cpp: keep the QtConcurrent::run QFuture in a [[maybe_unused]] variable (nodiscard).
- qetapp.cpp: guard the stylesheet load on QFile::open() succeeding (nodiscard) instead of ignoring the result.