### PR TITLE
Renew element uuids when duplicating a folio

### DIFF
--- a/sources/elementspanelwidget.cpp
+++ b/sources/elementspanelwidget.cpp
@@ -643,6 +643,12 @@ void ElementsPanelWidget::duplicateDiagram()
 
 		for (QGraphicsItem *item : new_diagram->items()) {
 			if (Element *elmt = dynamic_cast<Element *>(item)) {
+				// The XML round-trip kept the source elements' uuids. Give the
+				// copies their own identity (as PasteDiagramCommand::redo()
+				// does for on-diagram paste): element.uuid is the PRIMARY KEY
+				// of the project database, so duplicates fail to insert and
+				// silently vanish from nomenclature/summary tables.
+				elmt->newUuid();
 				new_diagram->restoreText(elmt);
 			}
 		}


### PR DESCRIPTION
Fixes #532

The project panel's "copy and paste" action duplicates a folio through an XML round-trip (toXml/fromXml), and Element::fromXml adopts the uuid stored in the XML - so every element on the duplicated folio kept the uuid of its source element. On-diagram copy/paste already handles this (PasteDiagramCommand::redo() calls newUuid()), but the folio-duplicate path bypasses that command.

Since element.uuid is the PRIMARY KEY of the project database, the duplicated elements failed to insert ("UNIQUE constraint failed: element.uuid" spam in the log) and silently disappeared from nomenclature/summary tables, even though they are valid on the folio.

Renew the uuid of every element on the freshly duplicated folio, exactly as the paste command does. In-memory links established during fromXml are pointer-based and unaffected; the new uuids are written on save.
