### PR TITLE
Request the GuiPrivate component only on Qt6

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,6 +78,14 @@ find_package(
     ${QET_COMPONENTS}
     REQUIRED)
 
+# Qt6 only creates the Qt::GuiPrivate target (used for QPdfEngine::drawHyperlink)
+# when the GuiPrivate component is explicitly requested. Qt5 has no such
+# component package and creates the target implicitly with Gui, so only
+# request it on Qt6 - requesting it on Qt5 fails the whole configure.
+if(QT_VERSION_MAJOR GREATER_EQUAL 6)
+    find_package(Qt${QT_VERSION_MAJOR} REQUIRED COMPONENTS GuiPrivate)
+endif()
+
 find_package(SQLite3 REQUIRED)
 
 set(CMAKE_AUTOUIC_SEARCH_PATHS ${QET_DIR}/sources/ui)

--- a/cmake/qet_compilation_vars.cmake
+++ b/cmake/qet_compilation_vars.cmake
@@ -16,6 +16,13 @@
 
 message(" - qet_compilation_vars")
 
+# Note: GuiPrivate is intentionally NOT in this list. Qt6's CMake config only
+# creates the Qt::GuiPrivate target when "GuiPrivate" is explicitly requested
+# as a component, but Qt5 has no Qt5GuiPrivate package at all (the target is
+# created implicitly with Gui), so requesting it as a component breaks the
+# whole Qt5 configure. It is requested separately, guarded by
+# QT_VERSION_MAJOR, after the main find_package.
+# (Needed for QPdfEngine::drawHyperlink, the PDF internal links.)
 set(QET_COMPONENTS
   LinguistTools
   PrintSupport
@@ -24,11 +31,7 @@ set(QET_COMPONENTS
   Sql
   Network
   Widgets
-  Concurrent
-  GuiPrivate) # Qt6 CMake config only creates the Qt::GuiPrivate target when
-              # "GuiPrivate" is explicitly requested as a component (unlike
-              # Qt5, which created it implicitly via Gui/PrintSupport/Widgets).
-              # Required for QPdfEngine::drawHyperlink (PDF internal links).
+  Concurrent)
 
 set(QET_PRIVATE_LIBRARIES
   Qt::PrintSupport

--- a/tests/catch/CMakeLists.txt
+++ b/tests/catch/CMakeLists.txt
@@ -59,6 +59,13 @@ find_package(
  ${QET_COMPONENTS}
  REQUIRED)
 
+# Qt6-only: the tests link ${QET_PRIVATE_LIBRARIES}, which contains
+# Qt::GuiPrivate; Qt6 only creates that target when the component is
+# explicitly requested (Qt5 creates it implicitly and has no such package).
+if(QT_VERSION_MAJOR GREATER_EQUAL 6)
+  find_package(Qt${QT_VERSION_MAJOR} REQUIRED COMPONENTS GuiPrivate)
+endif()
+
 Include(FetchContent)
 
 FetchContent_Declare(


### PR DESCRIPTION
Listing GuiPrivate unconditionally in QET_COMPONENTS breaks the whole Qt5 configure: find_package(Qt5 COMPONENTS GuiPrivate) looks for a Qt5GuiPrivateConfig.cmake that has never existed - Qt5 creates the Qt5::GuiPrivate target implicitly together with Gui. Only Qt6 requires (and provides) the explicit component.

Move the request into a QT_VERSION_MAJOR-guarded find_package after the main one, both for the application and for tests/catch (whose targets link Qt::GuiPrivate via QET_PRIVATE_LIBRARIES). Fixes the msys2/Qt5 Windows CI configure failure:
"Could not find a package configuration file provided by Qt5GuiPrivate".

Verified: Qt 6.11 configure passes and the Qt6::GuiPrivate target is created (the private-module warning now fires from the guarded call). The Qt5 path simply no longer requests the component, restoring the pre-existing implicit behaviour.