### PR TITLE
Fix the remaining Qt6 compile blockers

### DIFF
--- a/sources/diagramview.cpp
+++ b/sources/diagramview.cpp
@@ -1355,7 +1355,9 @@ void DiagramView::createTemplateFromSelection()
 	QFile file(full_path);
 	if (file.open(QIODevice::WriteOnly | QIODevice::Text)) {
 		QTextStream out(&file);
-		out.setCodec("UTF-8");
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)	// ### Qt 6: remove
+		out.setCodec("UTF-8");	// Qt6 QTextStream defaults to UTF-8
+#endif
 		out << macro_doc.toString(4);
 		file.close();
 		qDebug() << "Template successfully saved to:" << full_path;

--- a/sources/print/projectprintwindow.cpp
+++ b/sources/print/projectprintwindow.cpp
@@ -208,10 +208,17 @@ void ProjectPrintWindow::requestPaint()
 			#ifdef QT_DEBUG
 			qDebug() << "--";
 			qDebug() << "DiagramPrintDialog::print  printer_->resolution() before " << m_printer->resolution();
+			#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
 			qDebug() << "DiagramPrintDialog::print  screennumber " << QApplication::desktop()->screenNumber();
 			#endif
+			#endif
 
+			// QApplication::desktop() was removed in Qt6; use QWidget::screen().
+			#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
 			QScreen *srn = QApplication::screens().at(QApplication::desktop()->screenNumber());
+			#else
+			QScreen *srn = screen();
+			#endif
 			qreal dotsPerInch = (qreal)srn->logicalDotsPerInch();
 			m_printer->setResolution(dotsPerInch);
 

--- a/sources/qgimanager.cpp
+++ b/sources/qgimanager.cpp
@@ -74,9 +74,11 @@ void QGIManager::release(QGraphicsItem *qgi) {
 	Demande au QGIManager de gerer plusieurs QGI
 	@param qgis QGraphicsItems a gerer
 */
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
 void QGIManager::manage(const QList<QGraphicsItem *> &qgis) {
 	foreach(QGraphicsItem *qgi, qgis) manage(qgi);
 }
+#endif
 
 /**
 	Indique au QGIManager que pour chaque QGI fourni, une reference vers celui-ci
@@ -85,9 +87,11 @@ void QGIManager::manage(const QList<QGraphicsItem *> &qgis) {
 	sur la scene de ce QGIManager, alors il sera detruit.
 	@param qgis QGraphicsItems a ne plus gerer
 */
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
 void QGIManager::release(const QList<QGraphicsItem *> &qgis) {
 	foreach(QGraphicsItem *qgi, qgis) release(qgi);
 }
+#endif
 
 void QGIManager::manage(const QVector<QGraphicsItem *> &items) {
 	for (const auto &qgi : items) {

--- a/sources/qgimanager.h
+++ b/sources/qgimanager.h
@@ -45,10 +45,14 @@ class QGIManager {
 	public:
 	void manage(QGraphicsItem *);
 	void release(QGraphicsItem *);
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+	// In Qt6 QVector is an alias for QList, so these overloads would collide
+	// with the QVector ones below (same signature). Keep them on Qt5 only.
 	QT_DEPRECATED_X("Use QGIManager::manage(const QVector<QGraphicsItem *> &) instead")
 		void manage(const QList<QGraphicsItem *> &);
 	QT_DEPRECATED_X("Use QGIManager::release(const QVector<QGraphicsItem *> &) instead")
 		void release(const QList<QGraphicsItem *> &);
+#endif
 	void manage(const QVector<QGraphicsItem *> &items);
 	void release(const QVector<QGraphicsItem *> &items);
 	void setDestroyQGIOnDelete(bool);

--- a/sources/titleblocktemplate.cpp
+++ b/sources/titleblocktemplate.cpp
@@ -103,7 +103,9 @@ bool TitleBlockTemplate::loadFromXmlFile(const QString &filepath) {
 
 	// parse its content as XML
 	QDomDocument xml_doc;
-	bool xml_parsing = xml_doc.setContent(&template_file);
+	// Qt6 QDomDocument::setContent() returns a ParseResult (explicit bool);
+	// static_cast keeps this working on both Qt5 (bool) and Qt6.
+	bool xml_parsing = static_cast<bool>(xml_doc.setContent(&template_file));
 	if (!xml_parsing) {
 		return(false);
 	}


### PR DESCRIPTION
Clears the last five spots that stop master from compiling against Qt6 (all mirrored from the proven qt6-build line):

- qgimanager.h/.cpp: in Qt6 QVector is an alias for QList, so the deprecated QList overloads of manage()/release() collide with the QVector ones (same signature). Keep them on Qt5 only.
- diagramview.cpp: one unguarded QTextStream::setCodec() call (removed in Qt6, which defaults to UTF-8).
- print/projectprintwindow.cpp: QApplication::desktop() was removed in Qt6; use QWidget::screen() there, keep the old path on Qt5.
- titleblocktemplate.cpp: QDomDocument::setContent() returns a ParseResult in Qt6 whose operator bool is explicit; static_cast keeps the bool initialization working on both.

With these, master configures and builds to a running binary with Qt 6.11 (mingw, BUILD_WITH_KF5=OFF); every change is guarded or dual-safe, the Qt5 build is unaffected.