### PR TITLE
Find translations relative to the binary and in the build dir

### DIFF
--- a/sources/qetapp.cpp
+++ b/sources/qetapp.cpp
@@ -1295,6 +1295,13 @@ QString QETApp::languagesPath()
 			if (QDir(sibling_of_bin).exists())
 				return(sibling_of_bin);
 		}
+		// Running straight from a build directory: the build emits the
+		// qet_*.qm right next to the binary (no "lang" subfolder). Use the
+		// binary's own folder when the compiled translations sit there, so
+		// a dev build runs localized without first assembling a lang/
+		// folder.
+		if (QDir(bin_dir).exists(QStringLiteral("qet_en.qm")))
+			return(bin_dir + "/");
 		return(next_to_bin);
 	}
 #else
@@ -1304,7 +1311,18 @@ QString QETApp::languagesPath()
 		 * l'option de compilation represente
 		 *  un chemin absolu ou relatif classique
 		 */
-		return(resolveConfiguredDataPath(QUOTE(QET_LANG_PATH)));
+	{
+		const QString configured =
+			resolveConfiguredDataPath(QUOTE(QET_LANG_PATH));
+		if (QDir(configured).exists())
+			return(configured);
+		// Same build-directory fallback as above: nothing configured
+		// exists, but the freshly compiled qet_*.qm sit beside the binary.
+		const QString bin_dir = QCoreApplication::applicationDirPath();
+		if (QDir(bin_dir).exists(QStringLiteral("qet_en.qm")))
+			return(bin_dir + "/");
+		return(configured);
+	}
 	#else
 		/* the compilation option represents a path relative
 		 *  to the folder containing the executable binary


### PR DESCRIPTION
On Windows QET_LANG_PATH is "./l10n/", which languagesPath() returned verbatim: a path relative to the current working directory, so the binary only found its translations when launched from the right folder (the UI silently fell back to the French source language otherwise). Anchor a relative configured path to the executable's directory instead (absolute paths, as on Linux installs, stay unchanged), and add a fallback to the executable's own folder where qt_add_translation drops the qet_*.qm, so a build run straight from the build directory is localized too.