### PR TITLE
edz: make EdzArchive error strings translatable (+ German and French)

### DIFF
--- a/lang/qet_de.ts
+++ b/lang/qet_de.ts
@@ -15343,4 +15343,37 @@ Maximale Länge: %2px
         <translation>Was:</translation>
     </message>
 </context>
+<context>
+    <name>EdzArchive</name>
+    <message>
+        <location filename="../sources/import/edz/edzarchive.cpp" line="41"/>
+        <source>File not found: %1</source>
+        <translation>Datei nicht gefunden: %1</translation>
+    </message>
+    <message>
+        <location filename="../sources/import/edz/edzarchive.cpp" line="50"/>
+        <source>Cannot read %1</source>
+        <translation>Kann %1 nicht lesen.</translation>
+    </message>
+    <message>
+        <location filename="../sources/import/edz/edzarchive.cpp" line="58"/>
+        <source>This .edz is a zip-format package, which is not yet supported (only 7-Zip .edz files can be imported).</source>
+        <translation>Diese .edz-Datei ist ein Paket im ZIP-Format, das noch nicht unterstützt wird (es können nur .edz-Dateien im 7-Zip-Format importiert werden).</translation>
+    </message>
+    <message>
+        <location filename="../sources/import/edz/edzarchive.cpp" line="62"/>
+        <source>Not a valid .edz package (unrecognised archive format).</source>
+        <translation>Kein gültiges .edz-Paket (unbekanntes Archivformat).</translation>
+    </message>
+    <message>
+        <location filename="../sources/import/edz/edzarchive.cpp" line="70"/>
+        <source>Could not create a temporary directory: %1</source>
+        <translation>Temporäres Verzeichnis konnte nicht erstellt werden: %1</translation>
+    </message>
+    <message>
+        <location filename="../sources/import/edz/edzarchive.cpp" line="80"/>
+        <source>No *.part.xml found inside the .edz</source>
+        <translation>Keine *.part.xml in der .edz-Datei gefunden</translation>
+    </message>
+</context>
 </TS>

--- a/lang/qet_fr.ts
+++ b/lang/qet_fr.ts
@@ -15181,4 +15181,37 @@ Longueur maximale : %2px
         <translation></translation>
     </message>
 </context>
+<context>
+    <name>EdzArchive</name>
+    <message>
+        <location filename="../sources/import/edz/edzarchive.cpp" line="41"/>
+        <source>File not found: %1</source>
+        <translation>Fichier introuvable : %1</translation>
+    </message>
+    <message>
+        <location filename="../sources/import/edz/edzarchive.cpp" line="50"/>
+        <source>Cannot read %1</source>
+        <translation>Impossible de lire %1</translation>
+    </message>
+    <message>
+        <location filename="../sources/import/edz/edzarchive.cpp" line="58"/>
+        <source>This .edz is a zip-format package, which is not yet supported (only 7-Zip .edz files can be imported).</source>
+        <translation>Ce fichier .edz est un paquet au format zip, qui n&apos;est pas encore pris en charge (seuls les fichiers .edz au format 7-Zip peuvent être importés).</translation>
+    </message>
+    <message>
+        <location filename="../sources/import/edz/edzarchive.cpp" line="62"/>
+        <source>Not a valid .edz package (unrecognised archive format).</source>
+        <translation>Paquet .edz non valide (format d&apos;archive non reconnu).</translation>
+    </message>
+    <message>
+        <location filename="../sources/import/edz/edzarchive.cpp" line="70"/>
+        <source>Could not create a temporary directory: %1</source>
+        <translation>Impossible de créer un répertoire temporaire : %1</translation>
+    </message>
+    <message>
+        <location filename="../sources/import/edz/edzarchive.cpp" line="80"/>
+        <source>No *.part.xml found inside the .edz</source>
+        <translation>Aucun fichier *.part.xml trouvé dans le .edz</translation>
+    </message>
+</context>
 </TS>

--- a/sources/import/edz/edzarchive.cpp
+++ b/sources/import/edz/edzarchive.cpp
@@ -38,7 +38,7 @@ bool EdzArchive::extract(const QString &edz_path)
 
 	const QFileInfo fi(edz_path);
 	if (!fi.exists() || !fi.isFile()) {
-		m_error = QStringLiteral("File not found: %1").arg(edz_path);
+		m_error = tr("File not found: %1").arg(edz_path);
 		return false;
 	}
 
@@ -47,7 +47,7 @@ bool EdzArchive::extract(const QString &edz_path)
 	// detect that up front and say so clearly rather than failing opaquely.
 	QFile probe(fi.absoluteFilePath());
 	if (!probe.open(QIODevice::ReadOnly)) {
-		m_error = QStringLiteral("Cannot read %1").arg(edz_path);
+		m_error = tr("Cannot read %1").arg(edz_path);
 		return false;
 	}
 	const QByteArray magic = probe.read(6);
@@ -55,11 +55,11 @@ bool EdzArchive::extract(const QString &edz_path)
 	static const QByteArray k7z("7z\xBC\xAF\x27\x1C", 6);
 	if (!magic.startsWith(k7z)) {
 		if (magic.startsWith(QByteArray("PK\x03\x04", 4))) {
-			m_error = QStringLiteral(
+			m_error = tr(
 				"This .edz is a zip-format package, which is not yet "
 				"supported (only 7-Zip .edz files can be imported).");
 		} else {
-			m_error = QStringLiteral(
+			m_error = tr(
 				"Not a valid .edz package (unrecognised archive format).");
 		}
 		return false;
@@ -67,7 +67,7 @@ bool EdzArchive::extract(const QString &edz_path)
 
 	m_dir.reset(new QTemporaryDir);
 	if (!m_dir->isValid()) {
-		m_error = QStringLiteral("Could not create a temporary directory: %1")
+		m_error = tr("Could not create a temporary directory: %1")
 				  .arg(m_dir->errorString());
 		return false;
 	}
@@ -77,7 +77,7 @@ bool EdzArchive::extract(const QString &edz_path)
 	}
 
 	if (partXmlPath().isEmpty()) {
-		m_error = QStringLiteral("No *.part.xml found inside the .edz");
+		m_error = tr("No *.part.xml found inside the .edz");
 		return false;
 	}
 	return true;

--- a/sources/import/edz/edzarchive.h
+++ b/sources/import/edz/edzarchive.h
@@ -18,6 +18,7 @@
 #ifndef EDZARCHIVE_H
 #define EDZARCHIVE_H
 
+#include <QCoreApplication>
 #include <QString>
 #include <QScopedPointer>
 
@@ -38,6 +39,8 @@ class QTemporaryDir;
 */
 class EdzArchive
 {
+	Q_DECLARE_TR_FUNCTIONS(EdzArchive)
+
 	public:
 		EdzArchive();
 		~EdzArchive();


### PR DESCRIPTION
Follow-up to #513, addressing @plc-user's report that the EDZ importer's error messages could not be translated:

> Something I just noticed: In `sources/import/edz/edzarchive.cpp`, some texts cannot be translated because they are statically implemented.

## What this changes

The six user-facing error strings in `EdzArchive::extract()` were hard-coded `QStringLiteral`, so they never reached the `.ts` files. This wraps them in `tr()` and supplies German and French.

`EdzArchive` is not a `QObject`, so it uses `Q_DECLARE_TR_FUNCTIONS(EdzArchive)` — that gives the class its own translation context without pulling in a moc dependency.

The `*.part.xml` glob stays a `QStringLiteral`: it's a filename pattern, not user-facing text.

| # | Source | Deutsch | Français |
|---|---|---|---|
| 1 | `File not found: %1` | `Datei nicht gefunden: %1` | `Fichier introuvable : %1` |
| 2 | `Cannot read %1` | `Kann %1 nicht lesen.` | `Impossible de lire %1` |
| 3 | `This .edz is a zip-format package, which is not yet supported (only 7-Zip .edz files can be imported).` | `Diese .edz-Datei ist ein Paket im ZIP-Format, das noch nicht unterstützt wird (es können nur .edz-Dateien im 7-Zip-Format importiert werden).` | `Ce fichier .edz est un paquet au format zip, qui n'est pas encore pris en charge (seuls les fichiers .edz au format 7-Zip peuvent être importés).` |
| 4 | `Not a valid .edz package (unrecognised archive format).` | `Kein gültiges .edz-Paket (unbekanntes Archivformat).` | `Paquet .edz non valide (format d'archive non reconnu).` |
| 5 | `Could not create a temporary directory: %1` | `Temporäres Verzeichnis konnte nicht erstellt werden: %1` | `Impossible de créer un répertoire temporaire : %1` |
| 6 | `No *.part.xml found inside the .edz` | `Keine *.part.xml in der .edz-Datei gefunden` | `Aucun fichier *.part.xml trouvé dans le .edz` |

German #2 is @plc-user's wording — shorter and more readable than the passive form I first drafted. If any of the other five German strings read awkwardly, say so and I'll amend.

Other languages are left for native speakers, per @plc-user:

> For other languages, it’s best if native speakers contribute to this.

## One question for @scorpio810

While adding the `.ts` entries I noticed the rest of QET uses **French source strings** translated to en/de — e.g. `<source>Importer une pièce EPLAN (.edz)…</source>` → `<translation>Import an EPLAN part (.edz)…</translation>`. These EDZ error strings are English in the source (as merged in #513), so they're inconsistent with the other ~2,600 entries.

Converting them to French sources would be tidier, but it means rewriting strings that were already reviewed and merged, so I've left them as-is here rather than widening the diff unasked. **Happy to flip them to French sources if you'd prefer** — say so and I'll amend this PR.

## Testing

- `sources/import/edz/edzarchive.cpp` compiles clean (`g++ -fsyntax-only -std=c++17`), no new warnings
- `lang/qet_de.ts` and `lang/qet_fr.ts` are well-formed XML
- `lrelease` processes both, with all six new strings counted as finished

## Not included

The other follow-up items from the #513 thread — the LZMA SDK 23.01 → 26.02 bump, the `edzsevenzip.cpp` NULL guard, and the unpack-size bound — are deliberately **not** in this PR. They're still waiting on the vendored-vs-submodule decision, and the translation fix shouldn't be blocked behind it. Happy to combine them if you'd rather review one PR.
