### PR TITLE
qmake: allow building without KDE Frameworks 5 (CONFIG+=no_kf5)

### DIFF
--- a/qelectrotech.pro
+++ b/qelectrotech.pro
@@ -238,7 +238,26 @@ RESOURCES += qelectrotech.qrc
 TRANSLATIONS += lang/*.ts
 
 # Modules Qt utilises par l'application
-QT += xml svg network sql widgets printsupport concurrent KWidgetsAddons KCoreAddons gui-private
+QT += xml svg network sql widgets printsupport concurrent gui-private
+
+# KDE Frameworks 5 (KWidgetsAddons, KCoreAddons) are optional.
+#
+# Pass CONFIG+=no_kf5 to qmake to build against the Qt-only replacements in
+# sources/ui/nokde instead. This mirrors the CMake option BUILD_WITH_KF5=OFF
+# and is the easiest route on Windows/MinGW, where KF5 is awkward to obtain.
+#
+#     qmake CONFIG+=no_kf5 qelectrotech.pro
+#
+# sources/ui/nokde is only added to the include path in that configuration, so
+# a normal KF5 build is unaffected.
+no_kf5 {
+    DEFINES     += BUILD_WITHOUT_KF5
+    INCLUDEPATH += sources/ui/nokde
+    HEADERS     += $$files(sources/ui/nokde/*.h)
+    SOURCES     += $$files(sources/ui/nokde/*.cpp)
+} else {
+    QT += KWidgetsAddons KCoreAddons
+}
 
 # Private Qt GUI headers (needed for QPdfEngine::drawHyperlink)
 # gui-private should add this automatically, but some distros need it explicit


### PR DESCRIPTION
Fixes the build failure reported in #393, which has been open and unanswered since August 2025.

## The problem

The CMake build has been able to build without KDE Frameworks 5 since the Qt-only replacements landed in `sources/ui/nokde/`. Passing `-DBUILD_WITH_KF5=OFF` does four things:

1. defines `BUILD_WITHOUT_KF5` (`cmake/define_definitions.cmake:68`)
2. adds `sources/ui/nokde` to the include path (`CMakeLists.txt:196`)
3. compiles the three replacements — `KAutoSaveFile`, `KColorButton`, `KColorCombo` (`cmake/qet_compilation_vars.cmake:768`)
4. skips the KF5 packages

**The qmake build never got the equivalent.** `qelectrotech.pro` hard-coded the KF5 modules with no conditional:

```
QT += xml svg network sql widgets printsupport concurrent KWidgetsAddons KCoreAddons gui-private
```

so on a machine without KF5, qmake fails at configure time:

```
Project ERROR: Unknown module(s) in QT: KWidgetsAddons KCoreAddons
```

That is exactly what @freestyle12358 hit. It also explains the second half of that report: deleting the two modules by hand — the obvious workaround, which they tried — gets past configure and then fails at **link** time with `undefined reference to __imp__ZN13KAutoSaveFile13allStaleFilesERK7QString`, because the `nokde` sources are never compiled and nothing defines `BUILD_WITHOUT_KF5`.

## The change

One `no_kf5` scope in `qelectrotech.pro` mirroring what CMake already does (+20/−1):

```qmake
QT += xml svg network sql widgets printsupport concurrent gui-private

no_kf5 {
    DEFINES     += BUILD_WITHOUT_KF5
    INCLUDEPATH += sources/ui/nokde
    HEADERS     += $$files(sources/ui/nokde/*.h)
    SOURCES     += $$files(sources/ui/nokde/*.cpp)
} else {
    QT += KWidgetsAddons KCoreAddons
}
```

```
qmake CONFIG+=no_kf5 qelectrotech.pro
```

**The default build is unchanged.** Without `CONFIG+=no_kf5` the KF5 modules are still required and `sources/ui/nokde` is not on the include path, so existing distro and CI builds behave exactly as before. `$$files(sources/ui/*.cpp)` is non-recursive, so `nokde/` is never picked up accidentally.

## Testing

On a host with Qt 5.15.18 and **no KF5 installed**:

- stock `master` reproduces the reported failure exactly — `Project ERROR: Unknown module(s) in QT: KWidgetsAddons KCoreAddons`
- with `CONFIG+=no_kf5`, qmake configures cleanly
- generated Makefile verified to contain `-DBUILD_WITHOUT_KF5`, all three `nokde` sources, the `nokde` include path, and **zero** KF5 libraries
- **full build succeeds: 502 objects, 0 errors**
- `ldd` on the resulting binary shows no KF5 linkage; `./qelectrotech --help` runs
- 9 compiler warnings in the build, all in pre-existing QET sources, none from this change or from `sources/ui/nokde`

## Caveat

Verified on Linux/GCC. The original report is Windows/MinGW, and I have not been able to test there. The change is a qmake scope with no toolchain-specific content, so I would expect it to behave identically, but **someone on Windows should confirm before #393 is considered closed.**

## Note on the CI workflow

While tracing this I noticed `.github/workflows/windows-build.yml` passes `-DBUILD_TESTING=OFF` in the Qt5 job (line 116), but the project gates its tests on `PACKAGE_TESTS` (`CMakeLists.txt:52`, default `ON`). The Qt6 job (line 460) correctly passes `-DPACKAGE_TESTS=OFF`. So the Qt5 job is likely building the tests it intends to skip. Not touched here — mentioning it in case it is unintentional.
