### PR TITLE
Clear the application stylesheet when using system colors

### DIFF
--- a/sources/qetapp.cpp
+++ b/sources/qetapp.cpp
@@ -1690,11 +1690,15 @@ void QETApp::invertMainWindowVisibility(QWidget *window) {
 void QETApp::useSystemPalette(bool use) {
 	if (use) {
 		qApp->setPalette(initial_palette_);
-		qApp->setStyleSheet(
-				"QAbstractScrollArea#mdiarea {"
-				"background-color -> setPalette(initial_palette_);"
-				"}"
-				);
+		// Drop any stylesheet previously loaded from style.css: with system
+		// colors requested, the palette set just above is what provides them.
+		//
+		// This used to install a one-rule stylesheet whose only declaration
+		// was invalid CSS ("background-color -> setPalette(initial_palette_);",
+		// a note-to-self committed in e6c32bc0, 2014). It styled nothing, but
+		// a non-empty application stylesheet still wraps every widget in
+		// QStyleSheetStyle, which overrides per-widget QWidget::setStyle().
+		qApp->setStyleSheet(QString());
 	} else {
 		QFile file(configDir() + "/style.css");
 		if (file.open(QFile::ReadOnly)) {


### PR DESCRIPTION
Picks up the stylesheet finding reported by @DieterMayerOSS in #553, split out as a standalone one-line change so it can be reviewed independently of the Qt 6 discussion in that issue.

## The problem

`QETApp::useSystemPalette(true)` installs an application stylesheet whose only declaration is invalid CSS (`sources/qetapp.cpp:1693`):

```cpp
qApp->setStyleSheet(
        "QAbstractScrollArea#mdiarea {"
        "background-color -> setPalette(initial_palette_);"
        "}"
        );
```

## Where it came from

I traced it, because the history explains why nobody noticed. It is **not** a bad merge — it is an unfinished edit from 2014. Commit `e6c32bc0`, *"Background set to use System Palette"*:

```diff
-		"	background-color:#D5D2D1;"
+		"	background-color -> setPalette(initial_palette_);"
```

A hardcoded grey was replaced with a note-to-self describing the intended change, and the note was committed as if it were code.

It went unnoticed for twelve years for a good reason: Qt's CSS parser **silently skips invalid declarations**, and at the time the same rule still carried valid `background-image` / `background-repeat` / `background-position` properties. The block kept working, so nothing looked wrong. Those properties were dropped in a later restructure, leaving a rule with no valid declarations at all.

The selector itself is still live — `qetdiagrameditor.cpp:100` does `m_workspace.setObjectName("mdiarea")` — so the rule targets a real widget and does nothing to it.

## Why it is worth fixing

Mostly it is dead code, but not entirely inert: a **non-empty** application stylesheet wraps every widget in `QStyleSheetStyle`, which overrides per-widget `QWidget::setStyle()`.

To be precise about the impact, since #553 states it slightly more strongly: **QET does not call `QWidget::setStyle()` anywhere today** — every `setStyle(` call site in `sources/` is `QPen::setStyle` or `QBrush::setStyle` — so nothing is visibly broken right now. It does block that API for future work, which is how it was found (prototyping a palette-based dark mode).

## The change

```cpp
qApp->setStyleSheet(QString());
```

plus a comment recording the above so it does not get "restored" later.

**Behavior is unchanged.** The `use == true` branch already discarded whatever `style.css` had loaded — by overwriting it with the inert rule — and `qApp->setPalette(initial_palette_)` on the line above is what actually supplies the system colors, which is exactly what the 2014 note was asking for. The intent is already satisfied; the rule is vestigial.

**The `style.css` path (`use == false`) is untouched**, so existing custom themes behave exactly as before.

## Testing

- `sources/qetapp.cpp` compiles clean, no new warnings
- full build relinks; resulting binary runs (`--version` → `0.100.1-dev`)

Verified on Linux / Qt 5.15.18 / GCC.
