### PR TITLE
Fix language (and data paths) when opening a .qet by double-click on Windows

### DIFF
--- a/build-aux/windows/QElectroTech.wxs
+++ b/build-aux/windows/QElectroTech.wxs
@@ -97,8 +97,13 @@
         <RegistryValue Root="HKCR" Key="QElectroTech.Document" Type="string" Value="QElectroTech Project" />
         <RegistryValue Root="HKCR" Key="QElectroTech.Document\DefaultIcon" Type="string"
                        Value="[INSTALLDIR]ico\qelectrotech.ico" />
+        <!-- Pass the same arguments as the shortcuts above: opening a .qet from
+             Explorer sets the working directory to the document's folder, so a
+             bare command line leaves QET unable to locate its data. Without the
+             lang-dir argument the UI falls back to the source language, which
+             is French. See issue #554. -->
         <RegistryValue Root="HKCR" Key="QElectroTech.Document\shell\open\command" Type="string"
-                       Value="&quot;[INSTALLDIR]bin\qelectrotech.exe&quot; &quot;%1&quot;" />
+                       Value="&quot;[INSTALLDIR]bin\qelectrotech.exe&quot; --common-elements-dir=&quot;[INSTALLDIR]elements/&quot; --common-tbt-dir=&quot;[INSTALLDIR]titleblocks/&quot; --lang-dir=&quot;[INSTALLDIR]lang/&quot; $(var.QtPlatformArgs) &quot;%1&quot;" />
       </Component>
     </ComponentGroup>
 

--- a/cmake/paths_compilation_installation.cmake
+++ b/cmake/paths_compilation_installation.cmake
@@ -58,7 +58,10 @@ if(WIN32)
   set(QET_BINARY_PATH             "./")
   set(QET_COMMON_COLLECTION_PATH  "elements/")
   set(QET_COMMON_TBT_PATH         "titleblocks/")
-  set(QET_LANG_PATH               "l10n/")
+  # "lang/" and not "l10n/": that is where every Windows packaging actually
+  # puts the .qm files (see build-aux/windows/QElectroTech.wxs and the
+  # windows-build workflow), and what the shortcuts pass as --lang-dir.
+  set(QET_LANG_PATH               "lang/")
   set(QET_LICENSE_PATH            "./")
   # Liste des ressources Windows
 #RC_FILE = qelectrotech.rc

--- a/sources/qetapp.cpp
+++ b/sources/qetapp.cpp
@@ -540,6 +540,48 @@ TitleBlockTemplatesCollection *QETApp::titleBlockTemplatesCollection(
 }
 
 /**
+	@brief resolveConfiguredDataPath
+	Resolve a data directory baked in at compile time.
+
+	An absolute path is returned unchanged. A relative one used to be
+	interpreted against the process working directory, which is only correct
+	when QET is started from its own installation folder: opening a document
+	from a file manager sets the working directory to the document's folder,
+	so the data was not found there. Resolve it against the executable
+	instead, trying the folder next to the binary and then its parent -- some
+	packagings put the binary in a "bin" subfolder with the data beside it
+	(see issue #86).
+
+	The working-directory interpretation is still attempted first, so any
+	setup that relied on it keeps working.
+
+	\~French Resout un dossier de donnees fixe a la compilation.
+	@param configured : the compile-time path
+	@return an existing directory if one is found, @a configured otherwise
+*/
+static QString resolveConfiguredDataPath(const QString &configured)
+{
+	if (configured.isEmpty() || QDir::isAbsolutePath(configured)) {
+		return(configured);
+	}
+	if (QDir(configured).exists()) {
+		return(configured);
+	}
+
+	const QString bin_dir = QCoreApplication::applicationDirPath();
+	const QStringList candidates = {
+		QDir::cleanPath(bin_dir + "/" + configured) + "/",
+		QDir::cleanPath(bin_dir + "/../" + configured) + "/"
+	};
+	for (const QString &candidate : candidates) {
+		if (QDir(candidate).exists()) {
+			return(candidate);
+		}
+	}
+	return(configured);
+}
+
+/**
 	@brief QETApp::commonElementsDir
 	@return the dir path of the common elements collection.
 */
@@ -586,7 +628,8 @@ QString QETApp::commonElementsDir()
 		/* the compilation option represents a classic absolute
 		 *  or relative path
 		 */
-		m_common_element_dir = QUOTE(QET_COMMON_COLLECTION_PATH);
+		m_common_element_dir =
+				resolveConfiguredDataPath(QUOTE(QET_COMMON_COLLECTION_PATH));
 		return m_common_element_dir;
 #else
 		/* the compilation option represents a path
@@ -754,7 +797,7 @@ QString QETApp::commonTitleBlockTemplatesDir()
 	#ifndef QET_COMMON_COLLECTION_PATH_RELATIVE_TO_BINARY_PATH
 		// the compile-time option represents a usual path
 		// (be it absolute or relative)
-		return(QUOTE(QET_COMMON_TBT_PATH));
+		return(resolveConfiguredDataPath(QUOTE(QET_COMMON_TBT_PATH)));
 	#else
 		/* the compile-time option represents a path relative
 		 * to the directory that contains the executable binary
@@ -1261,7 +1304,7 @@ QString QETApp::languagesPath()
 		 * l'option de compilation represente
 		 *  un chemin absolu ou relatif classique
 		 */
-		return(QUOTE(QET_LANG_PATH));
+		return(resolveConfiguredDataPath(QUOTE(QET_LANG_PATH)));
 	#else
 		/* the compilation option represents a path relative
 		 *  to the folder containing the executable binary


### PR DESCRIPTION
Fixes #554 — the interface always coming up in French when a `.qet` is opened by double-click, while the Start Menu shortcut works.

@mr-rfh diagnosed this correctly and the registry value he built by hand is exactly right. Three commits, smallest first, so the first can be taken on its own if you'd rather not touch the rest.

## What is happening

**The MSI contradicts itself.** `QElectroTech.wxs` registers both shortcuts with the arguments QET needs, under a comment reading *"Point directly to qelectrotech.exe with all required arguments"* (lines 64 and 79). The file association, ~20 lines further down, was written without them:

```xml
Value="&quot;[INSTALLDIR]bin\qelectrotech.exe&quot; &quot;%1&quot;"
```

**Why that matters:** on Windows the compiled-in data paths are *relative* (`./elements/`, `./titleblocks/`, `./lang/`), and `commonElementsDir()` / `commonTitleBlockTemplatesDir()` / `languagesPath()` return them verbatim — so they resolve against the **process working directory**. Explorer sets that to the folder holding the document, so QET looks for its data next to the user's file and finds nothing. The shortcuts hide this by passing the three paths explicitly; the file association didn't.

**Why French specifically:** no translation loads, and QET's source strings *are* French (`<source>Importer une pièce EPLAN…</source>` → `<translation>Import an EPLAN part…</translation>`). "No translation" and "French UI" are the same state.

Worth noting the common element collection and title blocks are resolved the same way, so they are very likely failing on double-click too — @mr-rfh, does the element panel look right when you open a project that way *without* your registry fix?

## The commits

**1. `QElectroTech.wxs` — give the file association the same arguments as the shortcuts.** Immediate fix, matches the reporter's verified workaround.

**2. `qetapp.cpp` — resolve relative compiled paths from the binary rather than the CWD.** Adds `resolveConfiguredDataPath()`: absolute paths pass through untouched; a relative one is tried against the working directory **first** (so anything relying on today's behaviour keeps working), then next to the executable, then in its parent — the packaging layout where the binary is in `bin/` with data beside it.

That last fallback already exists for issue #86, but only in the branch taken when the compile-time option is *absent* — it was unreachable whenever `QET_LANG_PATH` is set, which is always on Windows.

**3. `cmake/paths_compilation_installation.cmake` — `l10n/` → `lang/`.** `QET_LANG_PATH` was `"l10n/"` on WIN32, a string that appears nowhere else in the tree: the shortcuts pass `--lang-dir="[INSTALLDIR]lang/"` and the CI workflow copies the `.qm` files into `files/lang/`. The compiled default pointed at a directory no packaging creates, which is why commit 2 needs this to find anything on Windows.

## Testing

- Full build clean, no new warnings; binary runs (`--version` → `0.100.1-dev`)
- `QElectroTech.wxs` verified well-formed after the edit
- `resolveConfiguredDataPath()` exercised standalone from a **foreign working directory**, covering: absolute unchanged; empty unchanged; relative found in CWD (back-compat); relative found next to the binary; relative found as a sibling of `bin/` (the MSI layout, the case that was broken); unresolvable returned unchanged. All pass.

## Caveats

Verified on Linux/GCC — I can't build the MSI or test on Windows. Commit 1 is a literal transcription of the arguments already on lines 64/79 and of the registry value @mr-rfh confirmed working, but **someone with a Windows toolchain should confirm the built MSI before this is closed.**

Commits 2 and 3 change path resolution, so they deserve a look from whoever owns the packaging — particularly commit 3, in case any downstream build expects `l10n/`. Dropping commit 3 leaves commits 1 and 2 valid; commit 1 alone also stands on its own.
