### PR TITLE
Log project load times, split by phase

### DIFF
--- a/sources/qetproject.cpp
+++ b/sources/qetproject.cpp
@@ -35,6 +35,7 @@
 #include "qetxml.h"
 #include "qetversion.h"
 
+#include <QElapsedTimer>
 #include <QHash>
 #include <QTimer>
 #include <QtConcurrentRun>
@@ -227,6 +228,9 @@ void QETProject::init()
 */
 QETProject::ProjectState QETProject::openFile(QFile *file)
 {
+	QElapsedTimer load_timer;
+	load_timer.start();
+
 	bool opened_here = file->isOpen() ? false : true;
 	if (!file->isOpen()
 			&& !file->open(QIODevice::ReadOnly
@@ -245,9 +249,18 @@ QETProject::ProjectState QETProject::openFile(QFile *file)
 		}
 		return XmlParsingFailed;
 	}
+	const qint64 xml_parse_ms = load_timer.elapsed();
 
 		//Build the project from the xml
 	readProjectXml(xml_project);
+
+	const qint64 total_ms = load_timer.elapsed();
+	qInfo().nospace().noquote()
+			<< "Project \"" << fi.fileName() << "\" ("
+			<< fi.size() / 1024 << " KiB) opened in "
+			<< total_ms / 1000.0 << " seconds (xml parsing "
+			<< xml_parse_ms / 1000.0 << ", content "
+			<< (total_ms - xml_parse_ms) / 1000.0 << ")";
 
 	if (!fi.isWritable()) {
 		setReadOnly(true);
@@ -1489,21 +1502,44 @@ void QETProject::readProjectXml(QDomDocument &xml_project)
 		//load the embedded titleblock templates
 	m_titleblocks_collection.fromXml(xml_project.documentElement());
 
+		/* Timings of the phases below are logged so the cost of opening a
+		 * project can be attributed. Reading the XML and building the objects
+		 * is mostly independent of the Qt version, while refreshing the
+		 * diagrams is graphics-scene work -- keeping them apart is what makes
+		 * the numbers comparable between builds.
+		 */
+	QElapsedTimer phase_timer;
+	phase_timer.start();
+
 		//Load the embedded elements collection
 	readElementsCollectionXml(xml_project);
+	const qint64 elements_ms = phase_timer.restart();
 
 		//Load the diagrams
 	readDiagramsXml(xml_project);
+	const qint64 diagrams_ms = phase_timer.restart();
 
 		//Load the terminal strip
 	readTerminalStripXml(xml_project);
+	const qint64 strips_ms = phase_timer.restart();
 
 		//Now that all are loaded we refresh content of the project.
 	refresh();
-
+	const qint64 refresh_ms = phase_timer.restart();
 
 	m_data_base.blockSignals(false);
 	m_data_base.updateDB();
+	const qint64 database_ms = phase_timer.elapsed();
+
+	qInfo().nospace()
+			<< "Project content built in "
+			<< (elements_ms + diagrams_ms + strips_ms
+				+ refresh_ms + database_ms) / 1000.0
+			<< " seconds (elements collection " << elements_ms / 1000.0
+			<< ", diagrams " << diagrams_ms / 1000.0
+			<< ", terminal strips " << strips_ms / 1000.0
+			<< ", refresh " << refresh_ms / 1000.0
+			<< ", database " << database_ms / 1000.0 << ")";
 
 	m_state = Ok;
 }


### PR DESCRIPTION
Picks up @scorpio810's request in #553:

> A new timer in the logs to measure project load times would be useful for comparing the improvements made by Qt6 compared to Qt5. If anyone fancies coding it and taking it on?

QET already reports how long the *elements collection* takes to load (`ElementsCollectionWidget::reload`, the line that produces the "1.3s to load 9000 elements" figure). This adds the equivalent for opening a *project*, following the same `QElapsedTimer` + `qInfo()` idiom so it appears in the normal log without a debug build.

## Why it reports phases and not just a total

This is the part worth a second of review. A single total would have been less useful and possibly misleading: reading the XML and constructing the objects is largely Qt-version-independent (QDom is QDom), whereas refreshing the diagrams is graphics-scene work. Mixed into one number, a real improvement in the graphics path could be diluted to invisibility — or a Qt version could look like it "made no difference" when the difference simply isn't in the phase being measured.

Measured on the bundled example projects, the split is lopsided enough to matter:

| Project | Size | Total | XML parse | Diagrams | Refresh | Database |
|---|---|---|---|---|---|---|
| `741.qet` | 123 KiB | 0.213 s | 0.007 | 0.192 | 0.006 | 0.006 |
| `Habitat-Schemas_developpes.qet` | 209 KiB | 0.619 s | 0.013 | 0.499 | 0.097 | 0.008 |
| `weneedpolonez-…_wiring_diagram.qet` | 3399 KiB | 1.505 s | 0.110 | 1.153 | 0.196 | 0.033 |

XML parsing is 3–7 % of the time; diagram construction is 77–83 %. So a timer wrapped only around the parse — the intuitive place to put one — would have reported almost nothing useful.

## What it logs

```
Project content built in 1.391 seconds (elements collection 0.009, diagrams 1.153,
  terminal strips 0, refresh 0.196, database 0.033)
Project "weneedpolonez-Polonez_MR89_wiring_diagram.qet" (3399 KiB) opened in 1.505 seconds
  (xml parsing 0.11, content 1.395)
```

Two lines: `QETProject::openFile()` reports the total with the parse/build split, and `readProjectXml()` reports the build phases. The file size is included so numbers are comparable between machines and projects.

## Scope

`readProjectXml()` has exactly one caller, and `openFile()` runs only from the two project-opening constructors, so this fires on project open (including backup recovery) and nowhere else — no extra output on save, import or export.

## Testing

Built and run against three example projects of increasing size, output as in the table above. Full build clean, no new warnings.

Verified on Linux/Qt 5.15.18. The point of the change is a Qt5-vs-Qt6 comparison, so the interesting numbers are the ones @scorpio810 or @DieterMayerOSS can now produce from a Qt6 Windows build against the same file — that comparison is what this is for, and I can't run it here.
