### PR TITLE
Install the log message handler before the application starts

### DIFF
--- a/sources/main.cpp
+++ b/sources/main.cpp
@@ -246,6 +246,14 @@ QGuiApplication::setHighDpiScaleFactorRoundingPolicy(QetSettings::hdpiScaleFacto
 		}
 	}
 
+	// Install the log-file message handler BEFORE the application starts:
+	// QETApp's constructor does the whole startup (collections, editor,
+	// opening the projects given on the command line), so installing the
+	// handler afterwards - as was done in the startup worker below - meant
+	// exactly the interesting lines (collection and project load timers)
+	// went to stderr, which is invisible in a Windows GUI session.
+	qInstallMessageHandler(myMessageOutput);
+
 	SingleApplication app(argc, argv, true);
 #ifdef Q_OS_MACOS
 	app.setStyle(QStyleFactory::create("Fusion"));
@@ -291,8 +299,6 @@ QGuiApplication::setHighDpiScaleFactorRoundingPolicy(QetSettings::hdpiScaleFacto
 
 	[[maybe_unused]] auto startup_future = QtConcurrent::run([=]()
 	{
-		// for debugging
-		qInstallMessageHandler(myMessageOutput);
 		qInfo("Start-up");
 		// delete old log files of max 7 days old.
 		delete_old_log_files(7);


### PR DESCRIPTION
Follow-up to #560, discussed in #553: `qInstallMessageHandler()` currently runs inside the startup worker, which is scheduled after QETApp's constructor — but that constructor performs the whole startup (collections, editor, opening projects passed on the command line). Everything logged in that window goes to the default handler, i.e. stderr, which is invisible in a Windows GUI session. Concretely: the elements-collection timer and the new #560 project-load timer never reach the daily log file on Windows, so the freshly shipped CI builds cannot produce the load-time data this timer exists for.

Install the handler synchronously before `SingleApplication`; the worker keeps the old-log cleanup and machine-info dump. The CLI path returns earlier and intentionally keeps plain stderr logging.

Verified on Windows/Qt 6.11.1: a GUI session now logs the full timeline (collection reload, collection finished, project opened with phase split).