### PR TITLE
Restore crash-recovery autosave on Qt6

### DIFF
--- a/sources/qetproject.cpp
+++ b/sources/qetproject.cpp
@@ -1914,21 +1914,17 @@ void QETProject::writeBackup()
 {
 	if (!m_backup_enabled)
 		return;
-#	if QT_VERSION < QT_VERSION_CHECK(6, 0, 0) // ### Qt 6: remove
 		//Don't launch a new backup while the previous one is still writing:
 		//both would write through &m_backup_file on different threads.
 	if (m_backup_future.isRunning())
 		return;
+		//Capture the document by value (implicitly shared, so cheap): the
+		//Qt5-style QtConcurrent::run(function, reference-args) call did not
+		//survive the Qt6 API change, a lambda behaves identically on both.
 	QDomDocument xml_project(toXml());
-	m_backup_future = QtConcurrent::run(
-				QET::writeToFile,xml_project,&m_backup_file,nullptr);
-#	else
-#		if TODO_LIST
-#			pragma message("@TODO remove code for QT 6 or later")
-#		endif
-	qDebug() << "Help code for QT 6 or later"
-			 << "QtConcurrent::run its backwards now...function, object, args";
-#	endif
+	m_backup_future = QtConcurrent::run([this, xml_project]() mutable {
+		return QET::writeToFile(xml_project, &m_backup_file, nullptr);
+	});
 }
 
 /**


### PR DESCRIPTION
Fixes the most serious of the three empty-Qt6-guard gaps found by @ispyisail in #553: `QETProject::writeBackup()` was Qt5-only — on Qt6 the guard body was a placeholder, so no crash-recovery backup was ever written. A Qt6 user who crashes silently loses everything since the last manual save.

The Qt5-style `QtConcurrent::run(function, reference-args)` call did not survive the Qt6 API change; a lambda capturing the (implicitly shared) document copy behaves identically on both majors, so the version guard disappears entirely.

Verified at runtime on Windows/Qt 6.11.1: opening a project creates the autosave triple (`.qetautosave` + `.lock` + `.path`) with valid XML content, and a clean exit removes it again. The CLI keeps backups disabled via `setBackupEnabled(false)` (19e99aab0), unchanged.

Given the momentum toward a Qt6 default, I would merge this one before any switch.