### PR TITLE
Restore two more Qt5-only code paths on Qt6 (parts list, print dialog)

### DIFF
--- a/sources/editor/ui/qetelementeditor.cpp
+++ b/sources/editor/ui/qetelementeditor.cpp
@@ -480,15 +480,11 @@ void QETElementEditor::fillPartsList()
 					}
 				}
 				QListWidgetItem *qlwi = new QListWidgetItem(part_desc);
-				QVariant v;
-#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)	// ### Qt 6: remove
-				v.setValue<QGraphicsItem *>(qgi);
-#else
-#if TODO_LIST
-#pragma message("@TODO remove code for QT 6 or later")
-#endif
-				qDebug()<<"Help code for QT 6 or later";
-#endif
+					// Qt declares the QGraphicsItem* metatype itself, so this
+					// works on Qt 5 and Qt 6 alike. Without the stored pointer
+					// the parts list loses its item association and selecting
+					// a part no longer selects it on the canvas.
+				QVariant v = QVariant::fromValue(qgi);
 				qlwi -> setData(42, v);
 				m_parts_list -> addItem(qlwi);
 				qlwi -> setSelected(qgi -> isSelected());

--- a/sources/print/projectprintwindow.cpp
+++ b/sources/print/projectprintwindow.cpp
@@ -79,14 +79,10 @@ void ProjectPrintWindow::launchDialog(QETProject *project, QPrinter::OutputForma
 		print_dialog.setWindowFlags(Qt::Sheet);
 #endif
 		print_dialog.setWindowTitle(tr("Options d'impression", "window title"));
-#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)	// ### Qt 6: remove
-		print_dialog.setEnabledOptions(QAbstractPrintDialog::PrintShowPageSize);
-#else
-#if TODO_LIST
-#pragma message("@TODO remove code for QT 6 or later")
-#endif
-		qDebug()<<"Help code for QT 6 or later";
-#endif
+		// setOptions() is the modern spelling of the Qt4-era
+		// setEnabledOptions() (removed in Qt 6): replace the enabled
+		// option set with just PrintShowPageSize, on Qt 5 and 6 alike.
+		print_dialog.setOptions(QAbstractPrintDialog::PrintShowPageSize);
 		if (print_dialog.exec() == QDialog::Rejected) {
 			delete  printer_;
 			return;


### PR DESCRIPTION
The two remaining empty-Qt6-guard gaps from @ispyisail's list in #553:

- **Element editor parts list**: the `QGraphicsItem*` was only stored into the list item on Qt5, so on Qt6 selecting a part in the list silently stopped selecting it on the canvas. `QVariant::fromValue()` works on both majors (Qt itself declares the metatype), guard removed.
- **Print dialog**: `setEnabledOptions()` is a Qt4-era API removed in Qt6; `setOptions()` is the modern spelling with the same replace-the-set semantics and exists on both, guard removed.

Both builds (Qt 5.15.2 / Qt 6.11.1, MinGW) compile clean.