### PR TITLE
ElementFactory: read link_type from the cached QDom, drop the pugixml pass

### DIFF
--- a/sources/factory/elementfactory.cpp
+++ b/sources/factory/elementfactory.cpp
@@ -42,10 +42,14 @@ Element * ElementFactory::createElement(const ElementsLocation &location, QGraph
 		return nullptr;
 	}
 
-	auto doc = location.pugiXml();
-	if (doc.document_element().attribute("link_type"))
+		//Read the link_type from the (cached) QDom definition instead of
+		//running a second, pugixml parse of the same definition: this
+		//dispatch runs once per element instance on project load, and the
+		//pugixml detour was ~4 % of the whole load time of a big project.
+	const QString link_type =
+		location.xml().attribute(QStringLiteral("link_type"));
+	if (!link_type.isEmpty())
 	{
-		QString link_type(doc.document_element().attribute("link_type").as_string());
 		if (link_type == QLatin1String("next_report") || link_type == QLatin1String("previous_report"))
 			return (new ReportElement(location, link_type, qgi, state));
 		if (link_type == QLatin1String("master"))
@@ -55,7 +59,7 @@ Element * ElementFactory::createElement(const ElementsLocation &location, QGraph
 		if (link_type == QLatin1String("terminal"))
 			return (new TerminalElement (location, qgi, state));
 	}
-	
+
 		//default if nothing match for link_type
 	return (new SimpleElement(location, qgi, state));
 }


### PR DESCRIPTION
Second finding from the #553 load profiling: `createElement()` ran a full pugixml parse of the element definition for every instance, only to read the `link_type` attribute for the subclass dispatch — measured at ~49 ms on a 3.4 MB project (191 instances). The QDom definition is already cached and the constructor uses it anyway; reading the attribute there costs ~17 ms in total, so the net win is ~30 ms and one entire redundant parser pass per element goes away.

Behavior unchanged: an absent and an empty `link_type` both fell through to `SimpleElement` before and still do.