### PR TITLE
Harden QDom serialization against invalid data (CVE-2026-15037)

### DIFF
--- a/sources/main.cpp
+++ b/sources/main.cpp
@@ -24,6 +24,7 @@
 #include "utils/qetsettings.h"
 
 #include <QApplication>
+#include <QDomImplementation>
 
 #include <QStyleFactory>
 #include <QtConcurrentRun>
@@ -207,6 +208,12 @@ int main(int argc, char **argv)
 	QCoreApplication::setOrganizationName("QElectroTech");
 	QCoreApplication::setOrganizationDomain("qelectrotech.org");
 	QCoreApplication::setApplicationName("QElectroTech");
+
+	// Refuse invalid data when building QDom documents instead of
+	// serializing malformed XML (CVE-2026-15037). This is the default
+	// from Qt 6.12 on; opt in explicitly for older Qt 5/6.
+	QDomImplementation::setInvalidDataPolicy(
+		QDomImplementation::ReturnNullNode);
 	//Creation and execution of the application
 	//HighDPI
 #if QT_VERSION < QT_VERSION_CHECK(5, 14, 0)	// ### Qt 6: remove


### PR DESCRIPTION
As discussed in #553: Qt before 6.12 defaults to accepting invalid data when building QDom nodes, so untrusted text inserted into comments, CDATA sections or processing instructions could break out of its node on serialization (CVE-2026-15037, low severity). Qt 6.12 flips the default to `ReturnNullNode`; setting `QDomImplementation::setInvalidDataPolicy(ReturnNullNode)` at startup gives the same hardened behavior on any Qt 5/6 version, so no version guard is needed.

Verified: `--resave` of a 5-folio project produces valid XML with all folios intact, and `--export-pdf` still works on the result.