### PR TITLE
Element editor: optional alignment for static texts

### DIFF
--- a/sources/editor/graphicspart/parttext.cpp
+++ b/sources/editor/graphicspart/parttext.cpp
@@ -131,6 +131,20 @@ void PartText::fromXml(const QDomElement &xml_element) {
 
 	setDefaultTextColor(QColor(xml_element.attribute("color", "#000000")));
 	setPlainText(xml_element.attribute("text"));
+
+		// Optional alignment (absent = historical behaviour: top-left anchor,
+		// left-aligned lines), same attributes as the dynamic text fields.
+	Qt::Alignment alignment_ = Qt::AlignTop | Qt::AlignLeft;
+	QMetaEnum me = QMetaEnum::fromType<Qt::Alignment>();
+	if (xml_element.hasAttribute("Halignment"))
+		alignment_ = Qt::Alignment(
+			me.keyToValue(xml_element.attribute("Halignment").toStdString().data()));
+	if (xml_element.hasAttribute("Valignment"))
+		alignment_ = Qt::Alignment(
+			me.keyToValue(xml_element.attribute("Valignment").toStdString().data()))
+			| (alignment_ & Qt::AlignHorizontal_Mask);
+	setAlignment(alignment_);
+
 	setPos(xml_element.attribute("x").toDouble(),
 			xml_element.attribute("y").toDouble());
 	QGraphicsObject::setRotation(QET::correctAngle(xml_element.attribute("rotation", QString::number(0)).toDouble()));
@@ -154,6 +168,18 @@ const QDomElement PartText::toXml(QDomDocument &xml_document) const
 	xml_element.setAttribute("font", font().toString());
 	xml_element.setAttribute("rotation", QString::number(rot));
 	xml_element.setAttribute("color", defaultTextColor().name());
+
+		// Only written when different from the historical behaviour, so
+		// existing .elmt files round-trip byte-identical.
+	QMetaEnum me = QMetaEnum::fromType<Qt::Alignment>();
+	if (m_alignment & Qt::AlignRight)
+		xml_element.setAttribute("Halignment", me.valueToKey(Qt::AlignRight));
+	else if (m_alignment & Qt::AlignHCenter)
+		xml_element.setAttribute("Halignment", me.valueToKey(Qt::AlignHCenter));
+	if (m_alignment & Qt::AlignBottom)
+		xml_element.setAttribute("Valignment", me.valueToKey(Qt::AlignBottom));
+	else if (m_alignment & Qt::AlignVCenter)
+		xml_element.setAttribute("Valignment", me.valueToKey(Qt::AlignVCenter));
 
 	return(xml_element);
 }
@@ -306,14 +332,107 @@ void PartText::setDefaultTextColor(const QColor &color) {
 
 void PartText::setPlainText(const QString &text) {
 	if (text != this -> toPlainText()) {
+		prepareAlignment();
 		QGraphicsTextItem::setPlainText(text);
+		applyLineAlignment();
+		finishAlignment();
 		emit plainTextChanged(text);
 	}
 }
 
+/**
+	@brief PartText::setAlignment
+	Set how this text is anchored to its position: when the content later
+	changes, the given corner/center of the bounding rect keeps its place
+	(the historical behaviour, and the default, is top-left). The
+	horizontal part also aligns the lines of a multi-line text relative
+	to each other. Changing the alignment never moves the text itself.
+	@param alignment
+*/
+void PartText::setAlignment(const Qt::Alignment &alignment)
+{
+	if (alignment == m_alignment)
+		return;
+	m_alignment = alignment;
+	applyLineAlignment();
+	emit alignmentChanged(m_alignment);
+}
+
+/**
+	@brief PartText::applyLineAlignment
+	Align the lines of a multi-line text relative to each other according
+	to the horizontal part of the alignment property. QGraphicsTextItem
+	only honors the document text option when a text width is set, hence
+	the idealWidth() dance; -1 restores the free (historical) layout.
+*/
+void PartText::applyLineAlignment()
+{
+	QTextOption option = document()->defaultTextOption();
+	option.setAlignment(m_alignment & Qt::AlignHorizontal_Mask);
+	document()->setDefaultTextOption(option);
+
+	setTextWidth(-1);
+	if (m_alignment & (Qt::AlignHCenter | Qt::AlignRight))
+		setTextWidth(document()->idealWidth());
+}
+
+/**
+	@brief PartText::prepareAlignment
+	Call before a change of the bounding rect (see finishAlignment).
+*/
+void PartText::prepareAlignment()
+{
+	m_alignment_rect = boundingRect();
+}
+
+/**
+	@brief PartText::finishAlignment
+	Call after a change of the bounding rect: moves the text so that the
+	point selected by the alignment property stays where it was (same
+	logic as DiagramTextItem::finishAlignment).
+*/
+void PartText::finishAlignment()
+{
+	QTransform transform;
+	transform.rotate(rotation());
+	qreal x, xa, y, ya;
+	x = xa = 0;
+	y = ya = 0;
+
+	if (m_alignment & Qt::AlignRight)
+	{
+		x = m_alignment_rect.right();
+		xa = boundingRect().right();
+	}
+	else if (m_alignment & Qt::AlignHCenter)
+	{
+		x = m_alignment_rect.center().x();
+		xa = boundingRect().center().x();
+	}
+
+	if (m_alignment & Qt::AlignBottom)
+	{
+		y = m_alignment_rect.bottom();
+		ya = boundingRect().bottom();
+	}
+	else if (m_alignment & Qt::AlignVCenter)
+	{
+		y = m_alignment_rect.center().y();
+		ya = boundingRect().center().y();
+	}
+
+	QPointF p = transform.map(QPointF(x, y));
+	QPointF pa = transform.map(QPointF(xa, ya));
+
+	setPos(pos() - (pa - p));
+}
+
 void PartText::setFont(const QFont &font) {
 	if (font != this -> font()) {
+		prepareAlignment();
 		QGraphicsTextItem::setFont(font);
+		applyLineAlignment();
+		finishAlignment();
 		// Re-anchor: the item's position transform is -margin(), and margin()
 		// depends on the font ascent. Without re-running this on a font change,
 		// the transform keeps the previous font's ascent — so the text renders
@@ -397,6 +516,11 @@ void PartText::startEdition()
 {
 	// !previous_text.isNull() means the text is being edited
 	previous_text = toPlainText();
+
+	// Anchor the aligned point across the whole inline edition; free the
+	// text width so typing is not wrapped at the previous block width.
+	prepareAlignment();
+	setTextWidth(-1);
 }
 
 /**
@@ -405,7 +529,8 @@ void PartText::startEdition()
 */
 void PartText::endEdition()
 {
-	if (!previous_text.isNull()) {
+	const bool was_editing = !previous_text.isNull();
+	if (was_editing) {
 			// the text was being edited
 		QString new_text = toPlainText();
 		if (previous_text != new_text) {
@@ -422,4 +547,9 @@ void PartText::endEdition()
 	setTextCursor(qtc);
 
 	setEditable(false);
+
+	if (was_editing) {
+		applyLineAlignment();
+		finishAlignment();
+	}
 }

--- a/sources/editor/graphicspart/parttext.h
+++ b/sources/editor/graphicspart/parttext.h
@@ -34,11 +34,13 @@ class PartText : public QGraphicsTextItem, public CustomElementPart {
 	Q_PROPERTY(QColor color READ defaultTextColor WRITE setDefaultTextColor NOTIFY colorChanged)
 	Q_PROPERTY(QString text READ toPlainText WRITE setPlainText NOTIFY plainTextChanged)
 	Q_PROPERTY(QFont font READ font WRITE setFont NOTIFY fontChanged)
+	Q_PROPERTY(Qt::Alignment alignment READ alignment WRITE setAlignment NOTIFY alignmentChanged)
 
 	signals:
 		void fontChanged(const QFont &font);
 		void colorChanged(const QColor &color);
 		void plainTextChanged(const QString &text);
+		void alignmentChanged(Qt::Alignment alignment);
 
 		// constructors, destructor
 	public:
@@ -77,6 +79,8 @@ class PartText : public QGraphicsTextItem, public CustomElementPart {
 		void setDefaultTextColor(const QColor &color);
 		void setPlainText(const QString &text);
 		void setFont(const QFont &font);
+		void setAlignment(const Qt::Alignment &alignment);
+		Qt::Alignment alignment() const {return m_alignment;}
 
 	public slots:
 		void adjustItemPosition(int = 0);
@@ -97,11 +101,16 @@ class PartText : public QGraphicsTextItem, public CustomElementPart {
 
 	private:
 		QPointF margin() const;
+		void applyLineAlignment();
+		void prepareAlignment();
+		void finishAlignment();
 		QString previous_text;
 		qreal real_font_size_;
 		QPointF saved_point_;
 		qreal saved_font_size_;
 		QGraphicsItem *decorator_;
 		QPointF m_origin_pos;
+		Qt::Alignment m_alignment = (Qt::AlignTop | Qt::AlignLeft);
+		QRectF m_alignment_rect;
 };
 #endif

--- a/sources/editor/ui/texteditor.cpp
+++ b/sources/editor/ui/texteditor.cpp
@@ -18,6 +18,7 @@
 #include "texteditor.h"
 
 #include "../../QPropertyUndoCommand/qpropertyundocommand.h"
+#include "../../ui/alignmenttextdialog.h"
 #include "../graphicspart/parttext.h"
 
 #include <cassert>
@@ -371,8 +372,34 @@ void TextEditor::setUpWidget(QWidget *parent)
 
 	gridLayout->addWidget(m_font_pb, 2, 2, 1, 2);
 
+	QPushButton *alignment_pb = new QPushButton(tr("Alignement"), parent);
+	alignment_pb->setToolTip(tr("Point d'ancrage du texte et alignement"
+								" des lignes entre elles"));
+	connect(alignment_pb, &QPushButton::clicked, [this]() {
+		if (m_text.isNull()) {
+			return;
+		}
+		AlignmentTextDialog atd(m_text->alignment(), this);
+		if (atd.exec() != QDialog::Accepted) {
+			return;
+		}
+		for (int i = 0; i < m_parts.length(); i++) {
+			PartText *part_text = m_parts[i];
+			if (atd.alignment() != part_text->alignment()) {
+				QPropertyUndoCommand *undo = new QPropertyUndoCommand(
+					part_text, "alignment",
+					QVariant(part_text->alignment()),
+					QVariant(atd.alignment()));
+				undo->setText(tr("Modifier l'alignement d'un champ texte"));
+				undoStack().push(undo);
+			}
+		}
+	});
+
+	gridLayout->addWidget(alignment_pb, 3, 0, 1, 2);
+
 	QSpacerItem *verticalSpacer = new QSpacerItem(20, 40, QSizePolicy::Minimum, QSizePolicy::Expanding);
 
-	gridLayout->addItem(verticalSpacer, 3, 2, 1, 1);
+	gridLayout->addItem(verticalSpacer, 4, 2, 1, 1);
 	setLayout(gridLayout);
 }

--- a/sources/factory/elementpicturefactory.cpp
+++ b/sources/factory/elementpicturefactory.cpp
@@ -534,6 +534,22 @@ void ElementPictureFactory::parseText(const QDomElement &dom, QPainter &painter,
 		//adjusts the offset by the margin of the text document
 	text_document.setDocumentMargin(0.0);
 
+		//Optional line alignment of multi-line texts (the anchor behaviour
+		//of the alignment is handled in the element editor; the saved x/y
+		//always stay the baseline-left of the text block). The document
+		//only honors the text option once a text width is set.
+	if (dom.hasAttribute("Halignment")) {
+		const QMetaEnum me = QMetaEnum::fromType<Qt::Alignment>();
+		const Qt::Alignment h_alignment = Qt::Alignment(
+			me.keyToValue(dom.attribute("Halignment").toStdString().data()));
+		if (h_alignment & (Qt::AlignHCenter | Qt::AlignRight)) {
+			QTextOption option = text_document.defaultTextOption();
+			option.setAlignment(h_alignment & Qt::AlignHorizontal_Mask);
+			text_document.setDefaultTextOption(option);
+			text_document.setTextWidth(text_document.idealWidth());
+		}
+	}
+
 	painter.translate(qpainter_offset);
 
 		// force the palette used to render the QTextDocument


### PR DESCRIPTION
Implements #549. Static texts (PartText) gain an optional alignment, exposed via the existing `AlignmentTextDialog` behind a new button in the static text editor:

- The horizontal part aligns the lines of a multi-line text relative to each other — centered block labels no longer need one hand-placed text per line.
- The full alignment defines the anchor: when the content or font changes later, the selected corner/center of the bounding rect keeps its place instead of always growing right/down from the top-left (same `prepareAlignment()`/`finishAlignment()` logic as the dynamic texts).

Format: the `<text>` node takes the same optional `Halignment`/`Valignment` attributes as `dynamic_text`, written only when they differ from the historical top-left behaviour — existing `.elmt` files are untouched and round-trip byte-identical. The saved x/y stay the baseline-left of the text block in all cases, so `ElementPictureFactory` only needs the line alignment and rendered elements match the editor exactly.

Verified headless: a project embedding a two-line text once with `Halignment="AlignHCenter"` and once without exports to SVG with the short line centered under the long one in the aligned block, and identical positions in the legacy block. (Translation updates for the three new strings are kept out of this PR to avoid churn in the .ts files.)