### PR TITLE
Fix the Qt6 load-time regression: linear child lookup in XmlElementCollection

### DIFF
--- a/sources/ElementsCollection/xmlelementcollection.cpp
+++ b/sources/ElementsCollection/xmlelementcollection.cpp
@@ -186,22 +186,21 @@ QDomElement XmlElementCollection::child(const QDomElement &parent_element,
 	if (parent_element.ownerDocument() != m_dom_document)
 		return QDomElement();
 
-		//Get all childs element of parent_element
-	QDomNodeList child_list = parent_element.childNodes();
-	QString tag_name(child_name.endsWith(".elmt")? "element" : "category");
-	QList <QDomElement> found_dom_element;
-	for (int i=0 ; i<child_list.length() ; i++)
+		/* Walk the siblings directly instead of the previous
+		 * childNodes()+item(i) double pass: QDomNodeList::item(i) restarts
+		 * from the first child every call, which made this loop quadratic
+		 * in the number of children. This lookup runs several times per
+		 * element instance while loading a project, on the "import"
+		 * category that holds every embedded definition. */
+	const QString tag_name = child_name.endsWith(QLatin1String(".elmt"))
+			? QStringLiteral("element") : QStringLiteral("category");
+	for (QDomElement child_element = parent_element.firstChildElement(tag_name) ;
+		 !child_element.isNull() ;
+		 child_element = child_element.nextSiblingElement(tag_name))
 	{
-		QDomElement child_element = child_list.item(i).toElement();
-		if (child_element.tagName() == tag_name)
-			found_dom_element << child_element;
+		if (child_element.attribute(QStringLiteral("name")) == child_name)
+			return child_element;
 	}
-
-	if (found_dom_element.isEmpty()) return QDomElement();
-
-	foreach (QDomElement elmt, found_dom_element)
-		if (elmt.attribute("name") == child_name)
-			return elmt;
 
 	return QDomElement();
 }


### PR DESCRIPTION
This resolves the Qt6 load-time regression discussed in #553 — the one @ispyisail measured at +12 % on Linux and I reproduced at +31 % on Windows with @scorpio810''s Käfer reference project.

**Root cause:** `XmlElementCollection::child(parent, name)` iterated the children via `childNodes()` + `item(i)`, and `QDomNodeList::item()` walks the sibling chain from the start on every call — the loop is quadratic in the number of children, plus a QList allocation and a second pass. This lookup runs several times per element instance during project load, against the `import` category that holds every embedded definition, so the cost scales with instances × embedded definitions. Qt6''s QDom makes this pattern far more expensive than Qt5''s did, which is why the same code regressed only on Qt6 — and only on projects with a large embedded collection (which is exactly why my three example-project measurements showed Qt6 *faster*: they barely exercise this path).

**Fix:** a `firstChildElement()`/`nextSiblingElement()` walk with an early return. Same semantics — first tag+name match in document order.

**Measured** on Kaefer_1303_20260204-2.qet (3.9 MB, 23 folios, 432 instances; Windows/MinGW, same GCC 13.1 for both builds, headless CLI, median of 6 with warm-up discarded):

| | before | after |
|---|---|---|
| Qt5 | 5.116 s | 5.068 s |
| Qt6 | 6.683 s | **4.640 s (−31 %)** |

Qt6 goes from +31 % slower to 8 % **faster** than Qt5 on the very project that exposed the regression. The 3.4 MB example project also gains ~9 % on Qt6, and `--export-nets` output is unchanged. @ispyisail: your Linux numbers on this patch would complete the picture.