### PR TITLE
Element panel: show name and element information in the tooltip

### DIFF
--- a/sources/ElementsCollection/fileelementcollectionitem.cpp
+++ b/sources/ElementsCollection/fileelementcollectionitem.cpp
@@ -327,6 +327,26 @@ void FileElementCollectionItem::setUpData()
 			{ search_list.append(context.value(key).toString()); }
 			search_list.append(localName(loc));
 			setData(search_list.join(" "));
+
+			// Tooltip: show what a truncated tree label can't - the full
+			// localized name and the descriptive element information.
+			// Reuses the location/context already parsed for the search
+			// index above; the collection path stays as the last line
+			// (it used to be the whole tooltip).
+			QStringList tip;
+			tip << localName(loc);
+			for (const auto &key : { QStringLiteral("description"),
+									 QStringLiteral("manufacturer"),
+									 QStringLiteral("manufacturer_reference") })
+			{
+				const QString value = context.value(key).toString();
+				if (!value.isEmpty())
+					tip << value;
+			}
+			tip << collectionPath();
+			tip.removeDuplicates();
+			setToolTip(tip.join(QLatin1Char('\n')));
+			return;
 		}
 	}
 


### PR DESCRIPTION
Implements the tooltip fix from the discussion in #552 (thanks @ispyisail for the triage and the invitation to take it).

The element tooltip showed only the collection path — the least useful string exactly when a long descriptive name is truncated in the tree. It now shows the **localized name, description, manufacturer and manufacturer reference** (each only when set), with the collection path kept as the last line. Directories and `.qetmak` entries keep the plain path tooltip.

Implementation reuses the location/context that `setUpData()` already parses right above for the search index, so there is **no additional file access or parsing** — the concern about per-item cost at scale does not apply here.

GUI-verified against a library where every element carries these fields; hovering an element shows e.g.:

```
MEAN WELL HDR-100-24 - 1-reihig (Klemmenreihe)
MEAN WELL HDR-100-24 - Hutschienennetzteil 85-264VAC auf 24VDC, 92W, Schutzklasse II (kein PE)
MEAN WELL
HDR-100-24
custom://MeanWell/hdr_100_24/hdr_100_24_komplett_1reihig.elmt
```

Elements without the metadata degrade gracefully to name + path — which also makes the missing metadata visible, per the discussion.