### PR TITLE
Fix #531: page-level empty title block variable no longer shadows project-level value

### DIFF
--- a/sources/bordertitleblock.cpp
+++ b/sources/bordertitleblock.cpp
@@ -898,9 +898,13 @@ void BorderTitleBlock::updateDiagramContextForTitleBlock(
 		const DiagramContext &initial_context) {
 	// Our final DiagramContext is the initial one (which is supposed to bring
 	// project-wide properties), overridden by the "additional fields" one...
+	// An empty page-level value means the variable was auto-added to the
+	// folio's Custom tab (#495) but never actually set by the user, so it
+	// must not shadow a real project-level value of the same name (#531).
 	DiagramContext context = initial_context;
 	foreach (QString key, additional_fields_.keys()) {
-		context.addValue(key, additional_fields_[key]);
+		if (!additional_fields_[key].toString().isEmpty())
+			context.addValue(key, additional_fields_[key]);
 	}
 
 	// ... overridden by the historical and/or dynamically generated fields


### PR DESCRIPTION
Fixes #531, a regression introduced by my own #495.

**Root cause**

#495 auto-adds every title block template custom variable to the folio's Custom tab with an empty value, so the user only has to fill in what's missing (per #271). But `BorderTitleBlock::updateDiagramContextForTitleBlock()` merges the page-level "additional fields" over the project-level context unconditionally:

```cpp
DiagramContext context = initial_context;   // project-level
foreach (QString key, additional_fields_.keys()) {
    context.addValue(key, additional_fields_[key]);   // page-level always wins, even when empty
}
```

So simply opening/confirming the Folio Properties dialog permanently blanks out any project-level custom variable of the same name — and it's self-perpetuating, since the dialog re-adds the empty entry every time it's reopened, so deleting it by hand doesn't stick.

**Fix**

Skip page-level values that are empty when merging, so the real project-level value shows through instead:

```cpp
foreach (QString key, additional_fields_.keys()) {
    if (!additional_fields_[key].toString().isEmpty())
        context.addValue(key, additional_fields_[key]);
}
```

An explicit non-empty page-level override still takes precedence, unchanged. `additional_fields_`/`updateDiagramContextForTitleBlock` aren't used anywhere else in the codebase, so the change is fully contained to this one merge.

**Testing**

- `bordertitleblock.cpp` compiles clean (`-fsyntax-only` against Qt5) with the change.
- Built a standalone test linking the actual `DiagramContext` class (not a reimplementation) and replicated both the old and new merge loops:
  - Old loop, project `department = "Engineering"` + page auto-added empty `department` → merged result `""` (reproduces the bug).
  - New loop, same inputs → merged result `"Engineering"` (fixed).
  - Sanity check: an intentional non-empty page-level override (`"Page-specific override"`) still wins with the new loop — confirms the fix doesn't remove the ability to override.

*Developed with assistance from Claude (Anthropic).*
