### PR TITLE
Fix #487: drag-selecting dynamic text fields silently converts their text source

### DIFF
--- a/sources/editor/ui/dynamictextfieldeditor.cpp
+++ b/sources/editor/ui/dynamictextfieldeditor.cpp
@@ -163,7 +163,7 @@ void DynamicTextFieldEditor::updateForm()
 			}
 		}
 
-		on_m_text_from_cb_activated(ui -> m_text_from_cb -> currentIndex()); //For enable the good widget
+		updateTextFromWidgetsEnabled(ui -> m_text_from_cb -> currentIndex()); //For enable the good widget
 	}
 }
 
@@ -327,7 +327,16 @@ void DynamicTextFieldEditor::on_m_elmt_info_cb_activated(const QString &arg1) {
 	}
 }
 
-void DynamicTextFieldEditor::on_m_text_from_cb_activated(int index) {
+/**
+	@brief DynamicTextFieldEditor::updateTextFromWidgetsEnabled
+	Enable the widget matching @p index (the "text from" combo box's current
+	index) and disable the other two. Purely cosmetic: called both from the
+	real user-activated slot below and from updateForm() when the form is
+	(re)filled for a part/selection, so it must never touch m_parts's data —
+	see on_m_text_from_cb_activated() for the part-mutating counterpart.
+*/
+void DynamicTextFieldEditor::updateTextFromWidgetsEnabled(int index)
+{
 	ui -> m_user_text_le -> setDisabled(true);
 	ui -> m_elmt_info_cb -> setDisabled(true);
 	ui -> m_composite_text_pb -> setDisabled(true);
@@ -341,6 +350,10 @@ void DynamicTextFieldEditor::on_m_text_from_cb_activated(int index) {
 	else {
 		ui->m_composite_text_pb->setEnabled(true);
 	}
+}
+
+void DynamicTextFieldEditor::on_m_text_from_cb_activated(int index) {
+	updateTextFromWidgetsEnabled(index);
 
 	DynamicElementTextItem::TextFrom tf;
 	if(index == 0) {

--- a/sources/editor/ui/dynamictextfieldeditor.h
+++ b/sources/editor/ui/dynamictextfieldeditor.h
@@ -52,6 +52,7 @@ class DynamicTextFieldEditor : public ElementItemEditor {
 		void fillInfoComboBox();
 		void setUpConnections();
 		void disconnectConnections();
+			void updateTextFromWidgetsEnabled(int index);
 
 	private slots:
 		void on_m_x_sb_editingFinished();


### PR DESCRIPTION
Fixes #487.

**Root cause**

`DynamicTextFieldEditor::updateForm()` syncs the "text from" combo box to the representative part's `textFrom()`, then calls:
```cpp
on_m_text_from_cb_activated(ui -> m_text_from_cb -> currentIndex()); //For enable the good widget
```
The comment says this is only to enable the right sibling widget (user-text field / element-info combo / composite-text button). But `on_m_text_from_cb_activated()` also loops over every currently selected part and pushes an undo command overwriting `textFrom` on any part that doesn't match the combo's index:
```cpp
for (int i = 0; i < m_parts.length(); i++) {
    if(tf != m_parts[i] -> textFrom()) {
        QPropertyUndoCommand *undo = new QPropertyUndoCommand(m_parts[i], "textFrom", ..., tf);
        undoStack().push(undo);   // applies immediately via QUndoStack::push -> redo()
    }
}
```
This is normally safe because `QComboBox::activated(int)` (which this slot is auto-connected to by name) is only emitted on real user interaction, never by programmatic `setCurrentIndex()`. But `updateForm()` calls the slot directly, so the mutating loop runs every time the form is (re)filled — including on every selection change.

`ElementScene::selectionChanged` → `setParts()` → `updateForm()` fires as the selection grows during a rubber-band drag (Qt updates `QGraphicsScene::selectedItems()` live while dragging, which is why the dock panel visibly updates mid-drag). So dragging over a dynamic text field with `ElementInfo` source, then a second one with `UserText`, forces the second field's source to `ElementInfo` the moment both are selected — before the mouse is released or the combo box touched at all.

**Fix**

Split the cosmetic widget-enable logic out into its own method and have `updateForm()` call only that:
```cpp
void DynamicTextFieldEditor::updateTextFromWidgetsEnabled(int index)
{
    ui->m_user_text_le->setDisabled(true);
    ui->m_elmt_info_cb->setDisabled(true);
    ui->m_composite_text_pb->setDisabled(true);
    if (index == 0) ui->m_user_text_le->setEnabled(true);
    else if (index == 1) ui->m_elmt_info_cb->setEnabled(true);
    else ui->m_composite_text_pb->setEnabled(true);
}
```
`on_m_text_from_cb_activated()` now calls this helper first, then keeps the part-mutating loop — reached only via real combo-box activation. `updateForm()` calls the helper directly.

**Testing**

Built QET from source (cmake) and reproduced this headlessly (Xvfb + xdotool) against a minimal test element with one `ElementInfo` and one `UserText` dynamic text field:

- On the unpatched code: driving an actual mouse-down → multi-step drag → mouse-up over both fields, the undo history recorded a `"Modifier la source de texte, d'un texte"` entry, and the `UserText` field's source flipped to `ElementInfo` (its text content disappeared from the canvas, since it started rendering the empty `label` info instead) — reproducing the reported behavior exactly.
- On the patched code, the identical drag produced zero undo commands; the `UserText` field kept its own source and content untouched.
- `dynamictextfieldeditor.cpp`/`.h` compile clean; `nm` confirms `updateTextFromWidgetsEnabled` is present in the rebuilt binary.

*Developed with assistance from Claude (Anthropic).*
