### PR TITLE
Fix: potential-selector dialog can't actually be cancelled (#581)

### DIFF
--- a/sources/ui/potentialselectordialog.cpp
+++ b/sources/ui/potentialselectordialog.cpp
@@ -188,8 +188,11 @@ class LinkReportPotentialSelector : public AbstractPotentialSelector
 //### END PRIVATE CLASS ###//
 
 
-ConductorProperties PotentialSelectorDialog::chosenProperties(QList<ConductorProperties> list, QWidget *widget)
+ConductorProperties PotentialSelectorDialog::chosenProperties(QList<ConductorProperties> list, QWidget *widget, bool *cancelled)
 {
+	if (cancelled)
+		*cancelled = false;
+
 	if (list.isEmpty()) {
 		return ConductorProperties() ;
 	} else if (list.size() == 1) {
@@ -222,11 +225,25 @@ ConductorProperties PotentialSelectorDialog::chosenProperties(QList<ConductorPro
 		layout.addWidget(b);
 		H.insert(b, cp);
 	}
-	QDialogButtonBox *button_box = new QDialogButtonBox(QDialogButtonBox::Ok, &dialog);
+
+	// Pre-select the first entry: without this, accepting the dialog without
+	// ever touching a radio button silently returned blank properties too,
+	// the same failure mode as the missing Cancel button below.
+	if (!H.isEmpty())
+		H.constBegin().key()->setChecked(true);
+
+	QDialogButtonBox *button_box = new QDialogButtonBox(
+				QDialogButtonBox::Ok | QDialogButtonBox::Cancel, &dialog);
 	layout.addWidget(button_box);
 	connect(button_box, &QDialogButtonBox::accepted, &dialog, &QDialog::accept);
+	connect(button_box, &QDialogButtonBox::rejected, &dialog, &QDialog::reject);
 
-	dialog.exec();
+	if (dialog.exec() != QDialog::Accepted) {
+		if (cancelled)
+			*cancelled = true;
+		return ConductorProperties();
+	}
+
 	for (QRadioButton *b : H.keys()) {
 		if(b->isChecked()) {
 			return H.value(b);

--- a/sources/ui/potentialselectordialog.h
+++ b/sources/ui/potentialselectordialog.h
@@ -64,7 +64,11 @@ namespace Ui {
 
 	the static function chosenProperties,
 	open a dialog who ask user to make a choice between the given
-	properties
+	properties. If the dialog is cancelled (Cancel button, Escape, or the
+	window's close button) and @a cancelled is non-null, *cancelled is set
+	to true and an empty ConductorProperties() is returned; callers that
+	care about a real cancellation (as opposed to "no properties to choose
+	from") should check it rather than relying on the returned value alone.
 */
 class PotentialSelectorDialog : public QDialog
 {
@@ -73,7 +77,8 @@ class PotentialSelectorDialog : public QDialog
 	public:
 		static ConductorProperties chosenProperties(
 				QList<ConductorProperties> list,
-				QWidget *parent = nullptr);
+				QWidget *parent = nullptr,
+				bool *cancelled = nullptr);
 
 	public:
 		explicit PotentialSelectorDialog(

--- a/sources/ui/potentialselectordialog.ui
+++ b/sources/ui/potentialselectordialog.ui
@@ -55,7 +55,7 @@ Veuillez choisir les propriétées à appliquer au nouveau potentiel.</string>
       <enum>Qt::Horizontal</enum>
      </property>
      <property name="standardButtons">
-      <set>QDialogButtonBox::Ok</set>
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
      </property>
     </widget>
    </item>

--- a/sources/utils/conductorcreator.cpp
+++ b/sources/utils/conductorcreator.cpp
@@ -42,8 +42,10 @@ ConductorCreator::ConductorCreator(Diagram *d, QList<Terminal *> terminals_list)
 		return;
 	}
 	m_properties = m_terminals_list.first()->diagram()->defaultConductorProperties;
-	
-	setUpPropertieToUse();
+
+	if (!setUpPropertieToUse()) {
+		return;
+	}
 	Terminal *hub_terminal = hubTerminal();
 	
 	d->undoStack().beginMacro(QObject::tr("Création de conducteurs"));
@@ -95,12 +97,15 @@ void ConductorCreator::create(Diagram *d, const QPolygonF &polygon)
 
 /**
 	@brief ConductorCreator::propertieToUse
-	@return the conductor properties to use for the new conductors.
+	@return true if the caller should proceed with conductor creation,
+	false if the user cancelled the potential-selection dialog (in which
+	case no properties were chosen and creation must be aborted rather
+	than proceeding with blank/default properties).
 */
-void ConductorCreator::setUpPropertieToUse()
+bool ConductorCreator::setUpPropertieToUse()
 {
 	QList<Conductor *> potentials = existingPotential();
-	
+
 		//There is an existing potential
 		//we get one of them
 	if (!potentials.isEmpty())
@@ -111,8 +116,12 @@ void ConductorCreator::setUpPropertieToUse()
 			for(Conductor *c : potentials) {
 				cp_list.append(c->properties());
 			}
-			
-			m_properties = PotentialSelectorDialog::chosenProperties(cp_list);
+
+			bool cancelled = false;
+			m_properties = PotentialSelectorDialog::chosenProperties(cp_list, nullptr, &cancelled);
+			if (cancelled) {
+				return false;
+			}
 			for (Conductor *c : potentials) {
 				if (c->properties() == m_properties) {
 					m_sequential_number = c->sequenceNum();
@@ -124,11 +133,12 @@ void ConductorCreator::setUpPropertieToUse()
 			m_properties = potentials.first()->properties();
 			m_sequential_number = potentials.first()->sequenceNum();
 		}
-		return;
+		return true;
 	}
-	
+
 		//get a new properties
 	ConductorAutoNumerotation::newProperties(m_terminals_list.first()->diagram(), m_properties, m_sequential_number);
+	return true;
 }
 
 /**

--- a/sources/utils/conductorcreator.h
+++ b/sources/utils/conductorcreator.h
@@ -40,7 +40,7 @@ class ConductorCreator
 		static void create(Diagram *d, const QPolygonF &polygon);
 		
 	private:
-		void setUpPropertieToUse();
+		bool setUpPropertieToUse();
 		QList<Conductor *> existingPotential();
 		Terminal *hubTerminal();
 		


### PR DESCRIPTION
Fixes the bug in #581 (forum request: https://qelectrotech.org/forum/viewtopic.php?pid=10604#p10604).

**Root cause**

`PotentialSelectorDialog::chosenProperties()` builds an OK-only `QDialog` and discards `exec()`'s return value entirely:
```cpp
dialog.exec();
for (QRadioButton *b : H.keys()) {
    if (b->isChecked()) return H.value(b);
}
return ConductorProperties();
```
Escape / the window-close button already trigger `QDialog::reject()` on a plain `QDialog` — but since the result was never checked, dismissing the dialog without picking anything just silently returned blank `ConductorProperties()`, the exact same value returned when a real potential was chosen but happened to be empty. There was no way to tell "the user cancelled" apart from "the user chose an empty potential," so the caller (`ConductorCreator::setUpPropertieToUse()`) always proceeded as if a real choice had been made.

**Fix**

- Add a real Cancel button; check `dialog.exec() == QDialog::Accepted`.
- Report cancellation through a new optional `bool *cancelled` out-parameter on `chosenProperties()`.
- Pre-select the first entry — closes a related, same-shaped gap where clicking OK without ever touching a radio button hit the identical "silently returns blank properties" failure.
- Thread the result through `ConductorCreator::setUpPropertieToUse()` (now returning `bool`) so the calling constructor aborts and creates **no conductors at all** when the user cancels, instead of proceeding with blank properties.
- The sibling constructor-based `PotentialSelectorDialog` (conductor/report potential *linking*, a separate flow) already gates its side effects behind `on_buttonBox_accepted()`, so cancelling it was already safe — gave it a visible Cancel button too for UI consistency while touching this file; no behavior change there.

**Testing**

Built and compiled clean (CMake, full build, zero new warnings). Beyond that, verified the actual new dialog logic with real Qt event simulation (`QTest::mouseClick`/`keyClick`, not just reasoning about the diff) reproducing the exact new code verbatim in a standalone harness:
- Clicking the real Cancel button → `cancelled=true`, empty properties.
- Pressing Escape → `cancelled=true`, empty properties.
- Clicking OK without touching anything → returns the pre-selected first entry (confirms the robustness fix).
- Selecting the second option, then OK → returns that selection.

All four passed.

*Developed with assistance from Claude (Anthropic).*
