### PR TITLE
Fix-PLC-Manager

### DIFF
--- a/sources/autoNum/assignvariables.cpp
+++ b/sources/autoNum/assignvariables.cpp
@@ -280,6 +280,11 @@ namespace autonum
 		str.replace("%{plc_function}", dc.value("plc_function").toString());
 		str.replace("%{plc_comment}", dc.value("plc_comment").toString());
 		str.replace("%{plc_crossref}", dc.value("plc_crossref").toString());
+		str.replace("%{plc_tc}", dc.value("plc_tc").toString());
+		str.replace("%{plc_t1}", dc.value("plc_t1").toString());
+		str.replace("%{plc_t2}", dc.value("plc_t2").toString());
+		str.replace("%{plc_t3}", dc.value("plc_t3").toString());
+		str.replace("%{plc_t4}", dc.value("plc_t4").toString());
 
 		return str;
 	}

--- a/sources/dataBase/projectdatabase.cpp
+++ b/sources/dataBase/projectdatabase.cpp
@@ -388,9 +388,15 @@ void projectDataBase::createElementNomenclatureView()
 						 "ei.supplier_auxiliary4 AS supplier_auxiliary4,"
 						 "ei.quantity_auxiliary4 AS quantity_auxiliary4,"
 						 "ei.unity_auxiliary4 AS unity_auxiliary4,"
-						 "ei.exclude_from_bom AS exclude_from_bom,"
-						
-						 "d.pos AS diagram_position,"
+					 "ei.exclude_from_bom AS exclude_from_bom,"
+					 
+					 "ei.plc_type AS plc_type,"
+					 "ei.plc_address AS plc_address,"
+					 "ei.plc_function AS plc_function,"
+					 "ei.plc_comment AS plc_comment,"
+					 "ei.plc_crossref AS plc_crossref,"
+					
+					 "d.pos AS diagram_position,"
 						 "e.type AS element_type,"
 						 "e.sub_type AS element_sub_type,"
 						 "di.title AS title,"

--- a/sources/dataBase/ui/elementquerywidget.cpp
+++ b/sources/dataBase/ui/elementquerywidget.cpp
@@ -47,6 +47,7 @@ ElementQueryWidget::ElementQueryWidget(QWidget *parent) :
 	m_button_group.addButton(ui->m_coil_cb, 4);
 	m_button_group.addButton(ui->m_protection_cb, 5);
 	m_button_group.addButton(ui->m_thumbnail_cb, 6);
+	m_button_group.addButton(ui->m_plc_cb, 7);
 #if QT_VERSION < QT_VERSION_CHECK(5, 15, 0)	// ### Qt 6: remove
 	connect(&m_button_group, static_cast<void (QButtonGroup::*)(int)>(&QButtonGroup::buttonClicked), [this](int id)
 #else
@@ -76,7 +77,7 @@ ElementQueryWidget::ElementQueryWidget(QWidget *parent) :
 		else
 		{
 			int checked = 0;
-			for (int i=1 ; i<7 ; ++i) {
+			for (int i=1 ; i<8 ; ++i) {
 				if (m_button_group.button(i)->isChecked()) {++checked;}
 			}
 
@@ -85,7 +86,7 @@ ElementQueryWidget::ElementQueryWidget(QWidget *parent) :
 				case 0 :
 					check_box->setCheckState(Qt::Unchecked);
 					break;
-				case 6:
+				case 7:
 					check_box->setCheckState(Qt::Checked);
 					break;
 				default:
@@ -187,12 +188,16 @@ void ElementQueryWidget::setQuery(const QString &query)
 				if (ui->m_protection_cb) {
 					++c;
 				}
-				ui->m_thumbnail_cb->setChecked  (str_type.contains(ElementData::typeToString(ElementData::Thumbnail)) ? true : false);
-				if (ui->m_thumbnail_cb->isChecked()) {
-					++c;
-				}
+			ui->m_thumbnail_cb->setChecked  (str_type.contains(ElementData::typeToString(ElementData::Thumbnail)) ? true : false);
+			if (ui->m_thumbnail_cb->isChecked()) {
+				++c;
+			}
+			ui->m_plc_cb->setChecked       (str_type.contains(ElementData::masterTypeToString(ElementData::PLC)) ? true : false);
+			if (ui->m_plc_cb->isChecked()) {
+				++c;
+			}
 
-				if (c == 6) {
+			if (c == 7) {
 					ui->m_all_cb->setCheckState(Qt::Checked);
 				} else if (c > 0) {
 					ui->m_all_cb->setCheckState(Qt::PartiallyChecked);
@@ -366,6 +371,11 @@ QString ElementQueryWidget::queryStr() const
 	if (ui->m_protection_cb->isChecked()) {
 		if (b) where +=" OR";
 		where +=  QStringLiteral(" element_sub_type = '") += ElementData::masterTypeToString(ElementData::Protection) += "'";
+		b = true;
+	}
+	if (ui->m_plc_cb->isChecked()) {
+		if (b) where +=" OR";
+		where +=  QStringLiteral(" element_sub_type = '") += ElementData::masterTypeToString(ElementData::PLC) += "'";
 	}
 	where.append(")");
 

--- a/sources/dataBase/ui/elementquerywidget.ui
+++ b/sources/dataBase/ui/elementquerywidget.ui
@@ -234,86 +234,96 @@
        <number>0</number>
       </property>
       <item>
-       <widget class="QGroupBox" name="groupBox_3">
-        <property name="title">
-         <string>Type d'éléments</string>
-        </property>
-        <property name="alignment">
-         <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
-        </property>
-        <layout class="QGridLayout" name="gridLayout_4">
-         <item row="5" column="0">
-          <widget class="QCheckBox" name="m_simple_cb">
-           <property name="text">
-            <string>Simples</string>
-           </property>
-           <property name="checked">
-            <bool>true</bool>
-           </property>
-          </widget>
-         </item>
-         <item row="5" column="1">
-          <widget class="QCheckBox" name="m_protection_cb">
-           <property name="text">
-            <string>Organes de protection</string>
-           </property>
-           <property name="checked">
-            <bool>true</bool>
-           </property>
-          </widget>
-         </item>
-         <item row="0" column="0">
-          <widget class="QCheckBox" name="m_all_cb">
-           <property name="text">
-            <string>Tous</string>
-           </property>
-           <property name="checked">
-            <bool>true</bool>
-           </property>
-          </widget>
-         </item>
-         <item row="2" column="1">
-          <widget class="QCheckBox" name="m_button_cb">
-           <property name="text">
-            <string>Boutons et commutateurs</string>
-           </property>
-           <property name="checked">
-            <bool>true</bool>
-           </property>
-          </widget>
-         </item>
-         <item row="2" column="0">
-          <widget class="QCheckBox" name="m_terminal_cb">
-           <property name="text">
-            <string>Borniers</string>
-           </property>
-           <property name="checked">
-            <bool>true</bool>
-           </property>
-          </widget>
-         </item>
-         <item row="1" column="0">
-          <widget class="QCheckBox" name="m_thumbnail_cb">
-           <property name="text">
-            <string>Vignettes</string>
-           </property>
-           <property name="checked">
-            <bool>true</bool>
-           </property>
-          </widget>
-         </item>
-         <item row="1" column="1">
-          <widget class="QCheckBox" name="m_coil_cb">
-           <property name="text">
-            <string>Contacteurs et relais</string>
-           </property>
-           <property name="checked">
-            <bool>true</bool>
-           </property>
-          </widget>
-         </item>
-        </layout>
-       </widget>
+        <widget class="QGroupBox" name="groupBox_3">
+         <property name="title">
+          <string>Type d'éléments</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+         </property>
+         <layout class="QGridLayout" name="gridLayout_4">
+          <item row="0" column="0">
+           <widget class="QCheckBox" name="m_all_cb">
+            <property name="text">
+             <string>Tous</string>
+            </property>
+            <property name="checked">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="1">
+           <widget class="QCheckBox" name="m_simple_cb">
+            <property name="text">
+             <string>Simples</string>
+            </property>
+            <property name="checked">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="0">
+           <widget class="QCheckBox" name="m_terminal_cb">
+            <property name="text">
+             <string>Borniers</string>
+            </property>
+            <property name="checked">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="1">
+           <widget class="QCheckBox" name="m_protection_cb">
+            <property name="text">
+             <string>Organes de protection</string>
+            </property>
+            <property name="checked">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="0">
+           <widget class="QCheckBox" name="m_coil_cb">
+            <property name="text">
+             <string>Contacteurs et relais</string>
+            </property>
+            <property name="checked">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="1">
+           <widget class="QCheckBox" name="m_thumbnail_cb">
+            <property name="text">
+             <string>Vignettes</string>
+            </property>
+            <property name="checked">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="0">
+           <widget class="QCheckBox" name="m_button_cb">
+            <property name="text">
+             <string>Boutons et commutateurs</string>
+            </property>
+            <property name="checked">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="1">
+           <widget class="QCheckBox" name="m_plc_cb">
+            <property name="text">
+             <string>Automates (MAE/SPS)</string>
+            </property>
+            <property name="checked">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
       </item>
      </layout>
     </widget>

--- a/sources/editor/ui/dynamictextfieldeditor.cpp
+++ b/sources/editor/ui/dynamictextfieldeditor.cpp
@@ -240,7 +240,12 @@ void DynamicTextFieldEditor::fillInfoComboBox()
 				QETInformation::ELMT_PLC_ADDRESS,
 				QETInformation::ELMT_PLC_FUNCTION,
 				QETInformation::ELMT_PLC_COMMENT,
-				QETInformation::ELMT_PLC_CROSSREF
+				QETInformation::ELMT_PLC_CROSSREF,
+				QETInformation::ELMT_PLC_TC,
+				QETInformation::ELMT_PLC_T1,
+				QETInformation::ELMT_PLC_T2,
+				QETInformation::ELMT_PLC_T3,
+				QETInformation::ELMT_PLC_T4
 			};
 			strl = plc_keys + strl;
 		} else {
@@ -249,6 +254,11 @@ void DynamicTextFieldEditor::fillInfoComboBox()
 			strl.removeAll(QETInformation::ELMT_PLC_FUNCTION);
 			strl.removeAll(QETInformation::ELMT_PLC_COMMENT);
 			strl.removeAll(QETInformation::ELMT_PLC_CROSSREF);
+			strl.removeAll(QETInformation::ELMT_PLC_TC);
+			strl.removeAll(QETInformation::ELMT_PLC_T1);
+			strl.removeAll(QETInformation::ELMT_PLC_T2);
+			strl.removeAll(QETInformation::ELMT_PLC_T3);
+			strl.removeAll(QETInformation::ELMT_PLC_T4);
 		}
 	}
 

--- a/sources/editor/ui/elementpropertieseditorwidget.cpp
+++ b/sources/editor/ui/elementpropertieseditorwidget.cpp
@@ -780,7 +780,7 @@ void ElementPropertiesEditorWidget::createPlcConfigWidgets()
 
 		auto *sb = new QSpinBox(m_plc_gb);
 		sb->setMinimum(10);
-		sb->setMaximum(200);
+		sb->setMaximum(500);
 		sb->setValue(40);
 		sb->setSuffix(tr(" mm"));
 		m_plc_col_width_spinboxes.append(sb);

--- a/sources/editor/ui/elementpropertieseditorwidget.cpp
+++ b/sources/editor/ui/elementpropertieseditorwidget.cpp
@@ -683,7 +683,7 @@ void ElementPropertiesEditorWidget::createPlcConfigWidgets()
 	m_plc_table->horizontalHeader()->resizeSection(2, 150);
 	m_plc_table->horizontalHeader()->resizeSection(3, 150);
 	m_plc_table->horizontalHeader()->resizeSection(4, 100);
-	m_plc_table->setSelectionBehavior(QAbstractItemView::SelectRows);
+	m_plc_table->setSelectionBehavior(QAbstractItemView::SelectItems);
 	m_plc_table->setSelectionMode(QAbstractItemView::ExtendedSelection);
 	m_plc_table->setMinimumHeight(200);
 	tables_splitter->addWidget(m_plc_table);
@@ -697,7 +697,7 @@ void ElementPropertiesEditorWidget::createPlcConfigWidgets()
 	m_plc_terminal_table->horizontalHeader()->setSectionResizeMode(QHeaderView::Interactive);
 	m_plc_terminal_table->horizontalHeader()->resizeSection(0, 50);
 	m_plc_terminal_table->horizontalHeader()->resizeSection(1, 80);
-	m_plc_terminal_table->setSelectionBehavior(QAbstractItemView::SelectRows);
+	m_plc_terminal_table->setSelectionBehavior(QAbstractItemView::SelectItems);
 	m_plc_terminal_table->setSelectionMode(QAbstractItemView::ExtendedSelection);
 	m_plc_terminal_table->setMinimumHeight(200);
 	tables_splitter->addWidget(m_plc_terminal_table);

--- a/sources/qetgraphicsitem/element.cpp
+++ b/sources/qetgraphicsitem/element.cpp
@@ -1397,15 +1397,19 @@ void Element::setElementInformations(DiagramContext dc)
 	}
 	emit elementInfoChange(old_info, m_data.m_informations);
 
-	// Propagate label change to linked PLC slaves
+	// Propagate label change to linked PLC slaves (label is changed via
+	// setElementInformations through the undo stack, not via setElementData)
 	if (m_data.m_type == ElementData::Master && m_data.m_master_type == ElementData::PLC)
 	{
-		if (!m_group_index_map.isEmpty()) {
+		if (!m_group_index_map.isEmpty())
+		{
 			const QString new_label = actualLabel();
 			for (auto it = m_group_index_map.constBegin(); it != m_group_index_map.constEnd(); ++it)
 			{
 				Element *slave = it.key();
 				if (!slave)
+					continue;
+				if (slave->elementInformations().value(QETInformation::ELMT_LABEL).toString() == new_label)
 					continue;
 				DiagramContext ctx = slave->elementInformations();
 				ctx.addValue(QETInformation::ELMT_LABEL, new_label);
@@ -1480,6 +1484,7 @@ void Element::setElementData(ElementData data)
 							return autonum::AssignVariables::formulaToLabel(
 								xrp.slaveLabel(), seq, diagram(), this);
 						}());
+					ctx.addValue(QETInformation::ELMT_LABEL, actualLabel());
 					ctx.addValue(QETInformation::ELMT_PLC_TC,
 						QString::number(io.terminalCount));
 					for (int t = 0; t < io.terminalCount && t < 4; ++t)
@@ -1511,7 +1516,7 @@ void Element::setElementData(ElementData data)
 						}
 					}
 				}
-				else if (label_changed)
+				if (label_changed)
 				{
 					// Only label changed, update the label on the slave
 					DiagramContext ctx = slave->elementInformations();
@@ -1958,7 +1963,10 @@ void Element::drawPlcTable(QPainter *painter)
 					}
 
 					QRectF text_rect = cr.adjusted(1, 0, -1, 0);
+					painter->save();
+					painter->setClipRect(text_rect, Qt::IntersectClip);
 					painter->drawText(text_rect, Qt::AlignLeft | Qt::AlignVCenter | Qt::TextWordWrap, cell_text);
+					painter->restore();
 
 					cx += col_widths[col];
 				}

--- a/sources/qetgraphicsitem/element.cpp
+++ b/sources/qetgraphicsitem/element.cpp
@@ -1396,6 +1396,23 @@ void Element::setElementInformations(DiagramContext dc)
 		m_data.m_informations.addValue(QStringLiteral("label"), actual_label); //Update the label if there is a formula
 	}
 	emit elementInfoChange(old_info, m_data.m_informations);
+
+	// Propagate label change to linked PLC slaves
+	if (m_data.m_type == ElementData::Master && m_data.m_master_type == ElementData::PLC)
+	{
+		if (!m_group_index_map.isEmpty()) {
+			const QString new_label = actualLabel();
+			for (auto it = m_group_index_map.constBegin(); it != m_group_index_map.constEnd(); ++it)
+			{
+				Element *slave = it.key();
+				if (!slave)
+					continue;
+				DiagramContext ctx = slave->elementInformations();
+				ctx.addValue(QETInformation::ELMT_LABEL, new_label);
+				slave->setElementInformations(ctx);
+			}
+		}
+	}
 }
 
 /**
@@ -1433,7 +1450,9 @@ void Element::setElementData(ElementData data)
 	{
 		const auto &new_plc = m_data.plcMasterData();
 		bool plc_changed = (old_plc.ios != new_plc.ios);
-		if (plc_changed && !m_group_index_map.isEmpty())
+		bool label_changed = (old_info.value(QStringLiteral("label")) !=
+			m_data.m_informations.value(QStringLiteral("label")));
+		if (!m_group_index_map.isEmpty() && (plc_changed || label_changed))
 		{
 			for (auto it = m_group_index_map.constBegin(); it != m_group_index_map.constEnd(); ++it)
 			{
@@ -1442,24 +1461,63 @@ void Element::setElementData(ElementData data)
 				if (!slave || io_idx < 0 || io_idx >= new_plc.ios.size())
 					continue;
 				const auto &io = new_plc.ios.at(io_idx);
-				DiagramContext ctx = slave->elementInformations();
-				ctx.addValue(QETInformation::ELMT_PLC_TYPE,
-					ElementData::translatedPlcIOType(io.type));
-				ctx.addValue(QETInformation::ELMT_PLC_ADDRESS, io.address);
-				ctx.addValue(QETInformation::ELMT_PLC_FUNCTION, io.functionText);
-				ctx.addValue(QETInformation::ELMT_PLC_COMMENT, io.comment);
-				ctx.addValue(QETInformation::ELMT_PLC_CROSSREF,
-					[&]() -> QString {
-						if (!diagram() || !diagram()->project())
-							return QString();
-						XRefProperties xrp = diagram()->project()
-							->defaultXRefProperties("plc");
-						autonum::sequentialNumbers seq;
-						return autonum::AssignVariables::formulaToLabel(
-							xrp.slaveLabel(), seq, diagram(), this);
-					}());
-				ctx.addValue(QETInformation::ELMT_LABEL, actualLabel());
-				slave->setElementInformations(ctx);
+
+				if (plc_changed)
+				{
+					DiagramContext ctx = slave->elementInformations();
+					ctx.addValue(QETInformation::ELMT_PLC_TYPE,
+						ElementData::translatedPlcIOType(io.type));
+					ctx.addValue(QETInformation::ELMT_PLC_ADDRESS, io.address);
+					ctx.addValue(QETInformation::ELMT_PLC_FUNCTION, io.functionText);
+					ctx.addValue(QETInformation::ELMT_PLC_COMMENT, io.comment);
+					ctx.addValue(QETInformation::ELMT_PLC_CROSSREF,
+						[&]() -> QString {
+							if (!diagram() || !diagram()->project())
+								return QString();
+							XRefProperties xrp = diagram()->project()
+								->defaultXRefProperties("plc");
+							autonum::sequentialNumbers seq;
+							return autonum::AssignVariables::formulaToLabel(
+								xrp.slaveLabel(), seq, diagram(), this);
+						}());
+					ctx.addValue(QETInformation::ELMT_PLC_TC,
+						QString::number(io.terminalCount));
+					for (int t = 0; t < io.terminalCount && t < 4; ++t)
+					{
+						QString val = (t < io.terminals.size())
+							? io.terminals.at(t) : QString();
+						ctx.addValue(
+							QStringList({
+								QETInformation::ELMT_PLC_T1,
+								QETInformation::ELMT_PLC_T2,
+								QETInformation::ELMT_PLC_T3,
+								QETInformation::ELMT_PLC_T4
+							}).at(t), val);
+					}
+					slave->setElementInformations(ctx);
+
+					// Update master labels on slave terminals
+					QList<Terminal *> slave_terms = slave->terminals();
+					for (int t = 0; t < slave_terms.size(); ++t)
+					{
+						if (t < io.terminals.size())
+						{
+							slave_terms.at(t)->setUseMasterLabel(true);
+							slave_terms.at(t)->setMasterLabelIndex(t);
+						}
+						else
+						{
+							slave_terms.at(t)->setUseMasterLabel(false);
+						}
+					}
+				}
+				else if (label_changed)
+				{
+					// Only label changed, update the label on the slave
+					DiagramContext ctx = slave->elementInformations();
+					ctx.addValue(QETInformation::ELMT_LABEL, actualLabel());
+					slave->setElementInformations(ctx);
+				}
 			}
 		}
 	}
@@ -1900,7 +1958,7 @@ void Element::drawPlcTable(QPainter *painter)
 					}
 
 					QRectF text_rect = cr.adjusted(1, 0, -1, 0);
-					painter->drawText(text_rect, Qt::AlignLeft | Qt::AlignVCenter, cell_text);
+					painter->drawText(text_rect, Qt::AlignLeft | Qt::AlignVCenter | Qt::TextWordWrap, cell_text);
 
 					cx += col_widths[col];
 				}

--- a/sources/qetgraphicsitem/terminal.cpp
+++ b/sources/qetgraphicsitem/terminal.cpp
@@ -289,8 +289,17 @@ void Terminal::paint(
 			painter->save();
 			painter->translate(label_pos);
 			painter->rotate(d->m_label_rotation);
-			QRectF text_rect(-text_size.width()/2.0, -text_size.height()/2.0,
-							 text_size.width(), text_size.height());
+
+			qreal rx = 0, ry = 0;
+			if (d->m_label_halignment & Qt::AlignLeft) rx = 0;
+			else if (d->m_label_halignment & Qt::AlignHCenter) rx = -text_size.width() / 2.0;
+			else if (d->m_label_halignment & Qt::AlignRight) rx = -text_size.width();
+
+			if (d->m_label_valignment & Qt::AlignTop) ry = 0;
+			else if (d->m_label_valignment & Qt::AlignVCenter) ry = -text_size.height() / 2.0;
+			else if (d->m_label_valignment & Qt::AlignBottom) ry = -text_size.height();
+
+			QRectF text_rect(QPointF(rx, ry), text_size);
 			painter->drawText(text_rect, static_cast<int>(d->m_label_halignment | d->m_label_valignment), display_name);
 			painter->restore();
 		} else {
@@ -307,7 +316,7 @@ void Terminal::paint(
 			if (d->m_label_frame) {
 				painter->drawRect(text_rect.adjusted(-1, -1, 1, 1));
 			}
-			painter->drawText(text_rect, static_cast<int>(Qt::AlignLeft | Qt::AlignTop), display_name);
+			painter->drawText(text_rect, static_cast<int>(d->m_label_halignment | d->m_label_valignment), display_name);
 		}
 	}
 
@@ -816,12 +825,24 @@ QString Terminal::name() const
 			if (elmt->linkType() == Element::Master) {
 				int group_idx = elmt->groupIndexForElement(parent_element_);
 				if (group_idx >= 0) {
-					const auto &groups = elmt->elementData().m_slave_contact_groups;
-					if (group_idx < groups.size()) {
-						int label_idx = d->m_master_label_index;
-						const QStringList &labels = groups.at(group_idx).labels;
-						if (label_idx >= 0 && label_idx < labels.size()) {
-							return labels.at(label_idx);
+					// For PLC masters, use io.terminals as labels
+					if (elmt->elementData().m_master_type == ElementData::PLC) {
+						const auto &plc_data = elmt->elementData().plcMasterData();
+						if (group_idx < plc_data.ios.size()) {
+							int label_idx = d->m_master_label_index;
+							const QStringList &labels = plc_data.ios.at(group_idx).terminals;
+							if (label_idx >= 0 && label_idx < labels.size()) {
+								return labels.at(label_idx);
+							}
+						}
+					} else {
+						const auto &groups = elmt->elementData().m_slave_contact_groups;
+						if (group_idx < groups.size()) {
+							int label_idx = d->m_master_label_index;
+							const QStringList &labels = groups.at(group_idx).labels;
+							if (label_idx >= 0 && label_idx < labels.size()) {
+								return labels.at(label_idx);
+							}
 						}
 					}
 				}
@@ -829,6 +850,16 @@ QString Terminal::name() const
 			}
 		}
 	}
+	return d->m_name;
+}
+
+/**
+	@brief Terminal::baseName
+	Return the original terminal name (T1, T2...) without master label override.
+	Used for sorting when linking.
+*/
+QString Terminal::baseName() const
+{
 	return d->m_name;
 }
 

--- a/sources/qetgraphicsitem/terminal.h
+++ b/sources/qetgraphicsitem/terminal.h
@@ -76,6 +76,7 @@ class Terminal : public QGraphicsObject
 		Element  *parentElement       () const;
 		QUuid     uuid                () const;
 		QString   name                () const;
+		QString   baseName            () const;
 		TerminalData::Type terminalType() const;
 		bool useMasterLabel() const { return d->m_use_master_label; }
 		void setUseMasterLabel(bool use);

--- a/sources/qetinformation.h
+++ b/sources/qetinformation.h
@@ -130,6 +130,11 @@ namespace QETInformation
 	static QString ELMT_PLC_FUNCTION    = "plc_function";
 	static QString ELMT_PLC_COMMENT     = "plc_comment";
 	static QString ELMT_PLC_CROSSREF    = "plc_crossref";
+	static QString ELMT_PLC_TC          = "plc_tc";
+	static QString ELMT_PLC_T1          = "plc_t1";
+	static QString ELMT_PLC_T2          = "plc_t2";
+	static QString ELMT_PLC_T3          = "plc_t3";
+	static QString ELMT_PLC_T4          = "plc_t4";
 
 
 

--- a/sources/ui/masterpropertieswidget.cpp
+++ b/sources/ui/masterpropertieswidget.cpp
@@ -216,6 +216,16 @@ void MasterPropertiesWidget::reset()
  */
 QUndoCommand* MasterPropertiesWidget::associatedUndo() const
 {
+	// PLC masters manage their slave links via the IO table (setElementData),
+	// not via the link tree widget. The link tree is always empty for PLC
+	// masters, so we must not create an unlinkAll command.
+	if (m_element &&
+		m_element->elementData().m_type == ElementData::Master &&
+		m_element->elementData().m_master_type == ElementData::PLC)
+	{
+		return nullptr;
+	}
+
 	QList <Element *> to_link;
 	QList <Element *> linked_ = m_element->linkedElements();
 
@@ -880,6 +890,8 @@ void MasterPropertiesWidget::plcRemoveRow()
 	if (selected.isEmpty())
 		return;
 
+	m_plc_updating = true;
+
 	// Remove from bottom to top to preserve indices
 	std::sort(selected.begin(), selected.end(),
 		[](const QModelIndex &a, const QModelIndex &b) { return a.row() > b.row(); });
@@ -887,6 +899,9 @@ void MasterPropertiesWidget::plcRemoveRow()
 	for (const QModelIndex &idx : selected) {
 		m_plc_table->removeRow(idx.row());
 	}
+
+	m_plc_updating = false;
+	plcUpdateDisplaySettings();
 }
 
 /**
@@ -902,6 +917,8 @@ void MasterPropertiesWidget::plcMoveRowUp()
 	if (row <= 0)
 		return;
 
+	m_plc_updating = true;
+
 	// Swap with row above
 	for (int col = 0; col < m_plc_table->columnCount(); ++col) {
 		QWidget *w1 = m_plc_table->cellWidget(row, col);
@@ -916,6 +933,8 @@ void MasterPropertiesWidget::plcMoveRowUp()
 	}
 
 	m_plc_table->setCurrentCell(row - 1, m_plc_table->currentColumn());
+	m_plc_updating = false;
+	plcUpdateDisplaySettings();
 }
 
 /**
@@ -931,6 +950,8 @@ void MasterPropertiesWidget::plcMoveRowDown()
 	if (row < 0 || row >= m_plc_table->rowCount() - 1)
 		return;
 
+	m_plc_updating = true;
+
 	// Swap with row below
 	for (int col = 0; col < m_plc_table->columnCount(); ++col) {
 		QWidget *w1 = m_plc_table->cellWidget(row, col);
@@ -945,6 +966,8 @@ void MasterPropertiesWidget::plcMoveRowDown()
 	}
 
 	m_plc_table->setCurrentCell(row + 1, m_plc_table->currentColumn());
+	m_plc_updating = false;
+	plcUpdateDisplaySettings();
 }
 
 /**
@@ -978,6 +1001,13 @@ void MasterPropertiesWidget::plcUpdateDisplaySettings()
 	ElementData::PlcMasterData plc_data = ed.plcMasterData();
 	plc_data.ios.clear();
 
+	// Build address -> original IO lookup to correctly reattach terminal data
+	// after row reorder (move up/down) or row removal
+	QHash<QString, int> addr_to_orig_idx;
+	for (int i = 0; i < ed.plcMasterData().ios.size(); ++i) {
+		addr_to_orig_idx[ed.plcMasterData().ios.at(i).address] = i;
+	}
+
 	// Read IOs from table, preserving terminal data from original IOs
 	for (int row = 0; row < m_plc_table->rowCount(); ++row) {
 		ElementData::PlcIO io;
@@ -1002,9 +1032,9 @@ void MasterPropertiesWidget::plcUpdateDisplaySettings()
 		if (crossref_item)
 			io.crossRef = crossref_item->text();
 
-		// Preserve terminal data from the original IO
-		if (row < ed.plcMasterData().ios.size()) {
-			const auto &orig_io = ed.plcMasterData().ios.at(row);
+		// Preserve terminal data by looking up original IO via address
+		if (addr_to_orig_idx.contains(io.address)) {
+			const auto &orig_io = ed.plcMasterData().ios.at(addr_to_orig_idx.value(io.address));
 			io.terminalCount = orig_io.terminalCount;
 			io.terminals = orig_io.terminals;
 		}

--- a/sources/ui/masterpropertieswidget.cpp
+++ b/sources/ui/masterpropertieswidget.cpp
@@ -978,7 +978,7 @@ void MasterPropertiesWidget::plcUpdateDisplaySettings()
 	ElementData::PlcMasterData plc_data = ed.plcMasterData();
 	plc_data.ios.clear();
 
-	// Read IOs from table
+	// Read IOs from table, preserving terminal data from original IOs
 	for (int row = 0; row < m_plc_table->rowCount(); ++row) {
 		ElementData::PlcIO io;
 
@@ -1001,6 +1001,13 @@ void MasterPropertiesWidget::plcUpdateDisplaySettings()
 		auto *crossref_item = m_plc_table->item(row, 4);
 		if (crossref_item)
 			io.crossRef = crossref_item->text();
+
+		// Preserve terminal data from the original IO
+		if (row < ed.plcMasterData().ios.size()) {
+			const auto &orig_io = ed.plcMasterData().ios.at(row);
+			io.terminalCount = orig_io.terminalCount;
+			io.terminals = orig_io.terminals;
+		}
 
 		plc_data.ios.append(io);
 	}

--- a/sources/undocommand/linkelementcommand.cpp
+++ b/sources/undocommand/linkelementcommand.cpp
@@ -406,22 +406,46 @@ void LinkElementCommand::makeLink(const QList<Element *> &element_list)
 					elmt->setGroupIndexForElement(m_element, group_idx);
 
 					// Set master labels on slave terminals
-					const auto &groups = elmt->elementData().m_slave_contact_groups;
-					if (group_idx < groups.size())
+					if (elmt->elementData().m_master_type == ElementData::PLC)
 					{
-						const QStringList &labels = groups.at(group_idx).labels;
-						QList<Terminal *> slave_terms = m_element->terminals();
-						// Sort terminals by name (T1, T2, T3...) to match label order
-						std::sort(slave_terms.begin(), slave_terms.end(),
-							[](Terminal *a, Terminal *b) {
-								return a->name() < b->name();
-							});
-						for (int i = 0; i < slave_terms.size(); ++i)
+						// For PLC masters, use io.terminals as labels
+						const auto &plc_data = elmt->elementData().plcMasterData();
+						if (group_idx < plc_data.ios.size())
 						{
-							if (i < labels.size())
+							const QStringList &labels = plc_data.ios.at(group_idx).terminals;
+							QList<Terminal *> slave_terms = m_element->terminals();
+							std::sort(slave_terms.begin(), slave_terms.end(),
+								[](Terminal *a, Terminal *b) {
+									return a->baseName() < b->baseName();
+								});
+							for (int i = 0; i < slave_terms.size(); ++i)
 							{
-								slave_terms.at(i)->setUseMasterLabel(true);
-								slave_terms.at(i)->setMasterLabelIndex(i);
+								if (i < labels.size())
+								{
+									slave_terms.at(i)->setUseMasterLabel(true);
+									slave_terms.at(i)->setMasterLabelIndex(i);
+								}
+							}
+						}
+					}
+					else
+					{
+						const auto &groups = elmt->elementData().m_slave_contact_groups;
+						if (group_idx < groups.size())
+						{
+							const QStringList &labels = groups.at(group_idx).labels;
+							QList<Terminal *> slave_terms = m_element->terminals();
+							std::sort(slave_terms.begin(), slave_terms.end(),
+								[](Terminal *a, Terminal *b) {
+									return a->baseName() < b->baseName();
+								});
+							for (int i = 0; i < slave_terms.size(); ++i)
+							{
+								if (i < labels.size())
+								{
+									slave_terms.at(i)->setUseMasterLabel(true);
+									slave_terms.at(i)->setMasterLabelIndex(i);
+								}
 							}
 						}
 					}
@@ -443,6 +467,20 @@ void LinkElementCommand::makeLink(const QList<Element *> &element_list)
 							plcCrossRefText(elmt, m_element));
 						ctx.addValue(QETInformation::ELMT_LABEL,
 							elmt->actualLabel());
+						ctx.addValue(QETInformation::ELMT_PLC_TC,
+							QString::number(io.terminalCount));
+						for (int t = 0; t < io.terminalCount && t < 4; ++t)
+						{
+							QString val = (t < io.terminals.size())
+								? io.terminals.at(t) : QString();
+							ctx.addValue(
+								QStringList({
+									QETInformation::ELMT_PLC_T1,
+									QETInformation::ELMT_PLC_T2,
+									QETInformation::ELMT_PLC_T3,
+									QETInformation::ELMT_PLC_T4
+								}).at(t), val);
+						}
 						m_element->setElementInformations(ctx);
 						}
 					}


### PR DESCRIPTION
Summary of 5 Fixes
1. Terminal count and values not propagated to slave
Problem: terminalCount and terminals (T1/T2/T3/T4) were not transferred from PLC-Master to PLC-Slave.

Fix (5 files):

qetinformation.h — New constants ELMT_PLC_TC, ELMT_PLC_T1–T4
assignvariables.cpp — Variables %{plc_tc}, %{plc_t1}–%{plc_t4} available
dynamictextfieldeditor.cpp — New keys in PLC-Slave dropdown
linkelementcommand.cpp — Propagate terminal values to slave when linking
element.cpp — Propagate terminal values to slaves on master update
2. Terminal name resets when editing master
Problem: MasterPropertiesWidget::plcUpdateDisplaySettings() rebuilt IOs from the table, but the table had no terminalCount or terminals columns. New PlcIO objects got terminalCount=0 and empty terminals → all terminal data was lost on every edit.

Fix:

masterpropertieswidget.cpp — Preserve terminalCount and terminals from the original IO before reading from table
3. BMK/label not updating on slave
Problem: setElementInformations() had no PLC-slave propagation. When the user only changed the label (not IOs), setElementData() was not called and the change never reached the slave. Also, sorting by name() broke after linking because it returned master labels instead of terminal names.

Fix (3 files):

element.cpp::setElementInformations() — Propagate label to all linked PLC-slaves
linkelementcommand.cpp — Sort using baseName() instead of name() to avoid master-label conflict
terminal.h/.cpp — New baseName() method always returns the original name regardless of master label
4. Column width limited and no text wrapping
Problem: Column width capped at 200mm, long text disappeared instead of wrapping.

Fix (2 files):

elementpropertieseditorwidget.cpp — Increased maximum from 200 to 500
element.cpp::drawPlcTable() — Added Qt::TextWordWrap to drawText() call
5. Terminal label alignment not working
Problem: In Terminal::paint(), alignment was hardcoded: non-rotated path used AlignLeft|AlignTop, rotated path centered the text rect regardless of alignment. Since most PLC-slave terminals are rotated 270°, alignment never worked.

Fix:

terminal.cpp — Both paths (rotated + non-rotated) now calculate text rect position based on m_label_halignment / m_label_valignment