### PR TITLE
Add live cursor-coordinate readout to the element editor status bar

### DIFF
--- a/sources/editor/elementscene.cpp
+++ b/sources/editor/elementscene.cpp
@@ -124,6 +124,7 @@ void ElementScene::mouseMoveEvent(QGraphicsSceneMouseEvent *e)
 {
 	if (m_event_interface) {
 		if (m_event_interface -> mouseMoveEvent(e)) {
+			emit mouseMoved(e -> scenePos());
 			if (m_event_interface->isFinish()) {
 				delete m_event_interface;
 				m_event_interface = nullptr;
@@ -135,6 +136,8 @@ void ElementScene::mouseMoveEvent(QGraphicsSceneMouseEvent *e)
 	QPointF event_pos = e -> scenePos();
 	if (!(e -> modifiers() & Qt::ControlModifier))
 		event_pos = snapToGrid(event_pos);
+
+	emit mouseMoved(event_pos);
 
 	if (m_behavior == PasteArea) {
 		QRectF current_rect(m_paste_area -> rect());

--- a/sources/editor/elementscene.h
+++ b/sources/editor/elementscene.h
@@ -179,6 +179,8 @@ class ElementScene : public QGraphicsScene
 		void elementInfoChanged();
 		/// Signal emitted when the element type changes
 		void elementTypeChanged();
+		/// Signal emitted with the current cursor position (scene coordinates) on every mouse move
+		void mouseMoved(const QPointF &pos);
 };
 
 Q_DECLARE_OPERATORS_FOR_FLAGS(ElementScene::ItemOptions)

--- a/sources/editor/ui/qetelementeditor.cpp
+++ b/sources/editor/ui/qetelementeditor.cpp
@@ -1194,6 +1194,16 @@ void QETElementEditor::initGui()
 		if (te) te->refreshMasterLabelVisibility();
 	});
 
+		//Live cursor position readout, in the same scene coordinates as the parts' X/Y properties
+	m_position_label = new QLabel(this);
+	m_position_label->setMinimumWidth(120);
+	statusBar()->addPermanentWidget(m_position_label);
+	connect(m_elmt_scene, &ElementScene::mouseMoved, this, [this](const QPointF &pos) {
+		m_position_label->setText(tr("X: %1  Y: %2")
+			.arg(pos.x(), 0, 'f', 1)
+			.arg(pos.y(), 0, 'f', 1));
+	});
+
 	statusBar()->showMessage(tr("Éditeur d'éléments", "status bar message"));
 }
 

--- a/sources/editor/ui/qetelementeditor.h
+++ b/sources/editor/ui/qetelementeditor.h
@@ -161,6 +161,8 @@ class QETElementEditor : public QMainWindow
 
 		QLabel *m_default_informations = nullptr;
 
+		QLabel *m_position_label = nullptr;
+
 };
 
 #endif // QETELEMENTEDITOR_H


### PR DESCRIPTION
Closes discussion #580 (forum request https://qelectrotech.org/forum/viewtopic.php?pid=10403#p10403).

## Problem

With closely-spaced/overlapping polygon nodes, pointing at one selects the neighboring one instead because of z-order. A live coordinate readout makes precise positioning possible without guessing. Editable X/Y point lists and cursor-key nudging already shipped from the same forum thread; the actual core ask — a live readout while moving the mouse — was still missing. Neither the element editor nor the main diagram editor's status bar had any coordinate display.

## Change

- `ElementScene::mouseMoveEvent` already computes the (optionally grid-snapped) scene position on every mouse move. It now also emits that position via a new `mouseMoved(const QPointF &)` signal.
- `QETElementEditor` adds a permanent `QLabel` to its status bar (`statusBar()->addPermanentWidget(...)`) that subscribes to the signal and shows `X: <x>  Y: <y>`, one decimal place.
- No unit conversion: the value shown is the same scene-coordinate system already used by every part's X/Y property spinboxes elsewhere in the editor.

Scoped to the element editor only, per the forum request. The main diagram editor (`QETDiagramEditor`) has the identical gap and could get the same treatment as a cheap follow-on, but that's not part of this PR.

## Testing

Built clean (no new warnings). Verified headlessly (Xvfb + xdotool + scrot): opened an existing `.elmt` element, moved the cursor across the canvas, and confirmed the status bar label updates live and tracks the grid-snapped scene position (e.g. `X: 0.0  Y: -5.0`, `X: 20.0  Y: -20.0`).