### PR TITLE
Add drag-to-resize for dynamic element text width (#577 phase 1)

### DIFF
--- a/sources/qetgraphicsitem/dynamicelementtextitem.cpp
+++ b/sources/qetgraphicsitem/dynamicelementtextitem.cpp
@@ -24,6 +24,7 @@
 #include "../qetgraphicsitem/terminal.h"
 #include "../qetinformation.h"
 #include "../utils/qetutils.h"
+#include "../QetGraphicsItemModeler/qetgraphicshandleritem.h"
 #include "crossrefitem.h"
 #include "element.h"
 #include "elementtextitemgroup.h"
@@ -66,7 +67,9 @@ DynamicElementTextItem::DynamicElementTextItem(Element *parent_element) :
 }
 
 DynamicElementTextItem::~DynamicElementTextItem()
-{}
+{
+	removeResizeHandles();
+}
 
 /**
 	@brief DynamicElementTextItem::textFromMetaEnum
@@ -688,7 +691,10 @@ void DynamicElementTextItem::hoverLeaveEvent(QGraphicsSceneHoverEvent *event)
 void DynamicElementTextItem::paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget)
 {
 	DiagramTextItem::paint(painter, option, widget);
-	
+
+	if (m_left_resize_handle || m_right_resize_handle)
+		updateResizeHandlesPos();
+
 	if (m_frame)
 	{
 		painter->save();
@@ -776,15 +782,44 @@ QVariant DynamicElementTextItem::itemChange(QGraphicsItem::GraphicsItemChange ch
 		updateXref();
 		updateXref();
 	}
-	
+	else if (change == QGraphicsItem::ItemSelectedHasChanged)
+	{
+		if (value.toBool())
+			addResizeHandles();
+		else
+			removeResizeHandles();
+	}
+	else if (change == QGraphicsItem::ItemSceneHasChanged && !scene())
+	{
+		removeResizeHandles();
+	}
+
 	return QGraphicsObject::itemChange(change, value);
 }
 
 bool DynamicElementTextItem::sceneEventFilter(QGraphicsItem *watched, QEvent *event)
 {
+	if (watched == m_left_resize_handle || watched == m_right_resize_handle)
+	{
+		auto *handle = static_cast<QetGraphicsHandlerItem *>(watched);
+		if (event->type() == QEvent::GraphicsSceneMousePress) {
+			handlerMousePressEvent(handle, static_cast<QGraphicsSceneMouseEvent *>(event));
+			return true;
+		}
+		else if (event->type() == QEvent::GraphicsSceneMouseMove) {
+			handlerMouseMoveEvent(handle, static_cast<QGraphicsSceneMouseEvent *>(event));
+			return true;
+		}
+		else if (event->type() == QEvent::GraphicsSceneMouseRelease) {
+			handlerMouseReleaseEvent(handle, static_cast<QGraphicsSceneMouseEvent *>(event));
+			return true;
+		}
+		return false;
+	}
+
 	if(watched != m_slave_Xref_item)
 		return false;
-	
+
 	if(event->type() == QEvent::GraphicsSceneHoverEnter) {
 		m_slave_Xref_item->setDefaultTextColor(Qt::blue);
 		return true;
@@ -797,8 +832,127 @@ bool DynamicElementTextItem::sceneEventFilter(QGraphicsItem *watched, QEvent *ev
 		zoomToLinkedElement();
 		return true;
 	}
-	
+
 	return false;
+}
+
+/**
+	@brief DynamicElementTextItem::addResizeHandles
+	Create and show the two width-resize handles (left/right edge of
+	frameRect()), reusing QetGraphicsHandlerItem the same way QetShapeItem
+	does for its own resize handles.
+*/
+void DynamicElementTextItem::addResizeHandles()
+{
+	if (m_left_resize_handle || !scene())
+		return;
+
+	qreal size = QETUtils::graphicsHandlerSize(this);
+	m_left_resize_handle = new QetGraphicsHandlerItem(size);
+	m_right_resize_handle = new QetGraphicsHandlerItem(size);
+
+	for (QetGraphicsHandlerItem *handle : {m_left_resize_handle, m_right_resize_handle})
+	{
+		scene()->addItem(handle);
+		handle->setColor(Qt::darkGreen);
+		handle->setZValue(zValue() + 1);
+		handle->installSceneEventFilter(this);
+	}
+
+	updateResizeHandlesPos();
+}
+
+/**
+	@brief DynamicElementTextItem::removeResizeHandles
+*/
+void DynamicElementTextItem::removeResizeHandles()
+{
+	delete m_left_resize_handle;
+	delete m_right_resize_handle;
+	m_left_resize_handle = nullptr;
+	m_right_resize_handle = nullptr;
+}
+
+/**
+	@brief DynamicElementTextItem::updateResizeHandlesPos
+	Keep the two resize handles at the vertical middle of frameRect()'s left
+	and right edges, in scene coordinates -- called on every paint() so it
+	stays correct across every kind of change that can move this item or
+	change its size (position, rotation, font, text, textWidth...) without
+	needing a dedicated hook for each one.
+*/
+void DynamicElementTextItem::updateResizeHandlesPos()
+{
+	if (!m_left_resize_handle || !m_right_resize_handle)
+		return;
+
+	QRectF fr = frameRect();
+	m_left_resize_handle->setPos(mapToScene(QPointF(fr.left(), fr.center().y())));
+	m_right_resize_handle->setPos(mapToScene(QPointF(fr.right(), fr.center().y())));
+}
+
+/**
+	@brief DynamicElementTextItem::handlerMousePressEvent
+	@param handle
+	@param event
+*/
+void DynamicElementTextItem::handlerMousePressEvent(QetGraphicsHandlerItem *handle, QGraphicsSceneMouseEvent *event)
+{
+	Q_UNUSED(handle)
+
+		//The actual property value, kept as-is (possibly -1, meaning "auto")
+		//so a later undo restores the exact original state rather than a
+		//synthesized fixed width.
+	m_resize_original_width = textWidth();
+		//A concrete baseline for the live drag's delta math, which can't
+		//start from -1.
+	m_resize_baseline_width = (m_resize_original_width < 0) ? frameRect().width() : m_resize_original_width;
+	m_resize_start_local_x = mapFromScene(event->scenePos()).x();
+}
+
+/**
+	@brief DynamicElementTextItem::handlerMouseMoveEvent
+	Live-resize the text while dragging, exactly like the element editor's
+	resize handles live-update geometry during a drag (undo is only pushed
+	on release). The drag delta is resolved in this item's own local
+	coordinates (not scene coordinates) so a rotated text box still resizes
+	along its own baseline.
+	@param handle
+	@param event
+*/
+void DynamicElementTextItem::handlerMouseMoveEvent(QetGraphicsHandlerItem *handle, QGraphicsSceneMouseEvent *event)
+{
+	qreal local_x = mapFromScene(event->scenePos()).x();
+	qreal delta = local_x - m_resize_start_local_x;
+	if (handle == m_left_resize_handle)
+		delta = -delta;
+
+	qreal new_width = qMax(m_resize_baseline_width + delta, qreal(10));
+	setTextWidth(new_width);
+	updateResizeHandlesPos();
+}
+
+/**
+	@brief DynamicElementTextItem::handlerMouseReleaseEvent
+	Push the same QPropertyUndoCommand the properties-panel width spinbox
+	already pushes (sources/ui/dynamicelementtextmodel.cpp) -- the value is
+	already applied live from the drag, so this only makes it undoable.
+	@param handle
+	@param event
+*/
+void DynamicElementTextItem::handlerMouseReleaseEvent(QetGraphicsHandlerItem *handle, QGraphicsSceneMouseEvent *event)
+{
+	Q_UNUSED(handle)
+	Q_UNUSED(event)
+
+	qreal new_width = textWidth();
+	if (!qFuzzyCompare(m_resize_original_width, new_width) && m_parent_element && m_parent_element->diagram())
+	{
+		auto *undo = new QPropertyUndoCommand(this, "textWidth", QVariant(m_resize_original_width), QVariant(new_width));
+		undo->setAnimated(true, false);
+		undo->setText(tr("Redimensionner un texte d'élément"));
+		m_parent_element->diagram()->undoStack().push(undo);
+	}
 }
 
 void DynamicElementTextItem::elementInfoChanged()

--- a/sources/qetgraphicsitem/dynamicelementtextitem.h
+++ b/sources/qetgraphicsitem/dynamicelementtextitem.h
@@ -29,6 +29,7 @@ class Element;
 class Conductor;
 class ElementTextItemGroup;
 class CrossRefItem;
+class QetGraphicsHandlerItem;
 
 /**
 	@brief The DynamicElementTextItem class
@@ -144,6 +145,12 @@ class DynamicElementTextItem : public DiagramTextItem
 		void zoomToLinkedElement();
 		void parentElementRotationChanged();
 		void thisRotationChanged();
+		void addResizeHandles();
+		void removeResizeHandles();
+		void updateResizeHandlesPos();
+		void handlerMousePressEvent(QetGraphicsHandlerItem *handle, QGraphicsSceneMouseEvent *event);
+		void handlerMouseMoveEvent(QetGraphicsHandlerItem *handle, QGraphicsSceneMouseEvent *event);
+		void handlerMouseReleaseEvent(QetGraphicsHandlerItem *handle, QGraphicsSceneMouseEvent *event);
 
 	private:
 		QPointer <Element>
@@ -174,6 +181,11 @@ class DynamicElementTextItem : public DiagramTextItem
 		bool m_keep_visual_rotation = true;
 		qreal m_visual_rotation_ref = 0;
 		bool m_move_parent = true;
+		QetGraphicsHandlerItem *m_left_resize_handle = nullptr;
+		QetGraphicsHandlerItem *m_right_resize_handle = nullptr;
+		qreal m_resize_original_width = -1;
+		qreal m_resize_baseline_width = -1;
+		qreal m_resize_start_local_x = 0;
 };
 
 #endif // DYNAMICELEMENTTEXTITEM_H


### PR DESCRIPTION
Closes discussion #577, phase 1 (forum #2168).

## Scope

Per the discussion's own analysis, "resize by dragging" only had an existing width property + XML round-trip to build on for `DynamicElementTextItem` (diagram-placed dynamic text: element labels, user text, element info, composite text). `IndependentTextItem` (free text boxes) and the element editor's `PartText`/`PartDynamicTextField` have no serialized width property at all yet, so they're left as explicit follow-ups — this PR is phase 1 only.

## Change

Two `QetGraphicsHandlerItem` grip handles appear at the left/right edges of a selected `DynamicElementTextItem`'s `frameRect()`, reusing the exact same handle class, `installSceneEventFilter`/`sceneEventFilter` wiring, and live-drag-then-undo-on-release pattern `QetShapeItem` already uses for its own diagram-level resize handles — not the element editor's `ElementPrimitiveDecorator` (that one is scene-space, multi-item, 8-point scaling; overkill for a single item's width-only resize).

- Handles are created/destroyed on `ItemSelectedHasChanged`, matching `QetShapeItem`'s own convention.
- Handle position is recomputed in `paint()` rather than hooked to specific mutators, since `textWidth`/font/text/rotation can all move `frameRect()` and there's no single `itemChange` notification covering all of them.
- The drag delta is resolved via `mapFromScene()` into the item's own local coordinates, so a rotated text box resizes along its own baseline, not the scene's x-axis.
- `setTextWidth()` is called live during the drag for immediate visual feedback; only on release is a `QPropertyUndoCommand` pushed — the same command the properties-panel width spinbox already uses (`sources/ui/dynamicelementtextmodel.cpp:590`). No new undo-command class, no new XML, no new data model.
- The original `textWidth()` value (which can be `-1`, the "auto" sentinel) is preserved separately from the concrete baseline used for the live drag's delta math, so undoing a resize restores actual auto-sizing rather than a synthesized fixed width that merely looks the same.

## Testing

Built clean (no new warnings). Verified headlessly (Xvfb + xdotool + scrot):
- Selecting an element's label text shows the two green handles.
- Dragging the right handle live-resizes the text (confirmed via the properties panel's width field updating in real time during the drag, e.g. `-1` → `86.4` → `94.17`).
- Handles clean up correctly on deselect.
- Undo restores the exact original state, including back to `-1` (auto) when that was the starting value — not a fixed width that happens to look the same.
- Redo reapplies the resized width.