### PR TITLE
Add alphabetical auto-numbering (a, b, ... z, aa, ab, ...)

### DIFF
--- a/sources/autoNum/assignvariables.cpp
+++ b/sources/autoNum/assignvariables.cpp
@@ -44,6 +44,7 @@ namespace autonum
 		ten_folio     = other.ten_folio;
 		hundred       = other.hundred;
 		hundred_folio = other.hundred_folio;
+		alpha         = other.alpha;
 	}
 
 	sequentialNumbers::~sequentialNumbers()
@@ -61,6 +62,7 @@ namespace autonum
 		ten_folio     = other.ten_folio;
 		hundred       = other.hundred;
 		hundred_folio = other.hundred_folio;
+		alpha         = other.alpha;
 
 		return (*this);
 	}
@@ -72,7 +74,8 @@ namespace autonum
 			ten           == other.ten && \
 			ten_folio     == other.ten_folio && \
 			hundred       == other.hundred && \
-			hundred_folio == other.hundred_folio)
+			hundred_folio == other.hundred_folio && \
+			alpha         == other.alpha)
 			return true;
 		else
 			return false;
@@ -129,6 +132,11 @@ namespace autonum
 						    document,
 						    "hundredFolio",
 						    hundred_folio.join(";")));
+		if(!alpha.isEmpty())
+			element.appendChild(QETXML::textToDomElement(
+						    document,
+						    "alpha",
+						    alpha.join(";")));
 
 		return element;
 	}
@@ -162,6 +170,9 @@ namespace autonum
 
 		from = element.firstChildElement("hundredFolio");
 		hundred_folio = from.text().split(";");
+
+		from = element.firstChildElement("alpha");
+		alpha = from.text().split(";");
 	}
 	
 		//Clear this sequence
@@ -173,6 +184,7 @@ namespace autonum
 		ten_folio.clear();
 		hundred.clear();
 		hundred_folio.clear();
+		alpha.clear();
 	}
 
 	/**
@@ -414,8 +426,10 @@ namespace autonum
 								 m_seq_struct.ten_folio.size()),
 							qMax(m_seq_struct.hundred_folio.size(),
 								 m_seq_struct.unit.size())),
-						qMax(m_seq_struct.hundred.size(),
-							 m_seq_struct.ten.size())
+						qMax(
+							qMax(m_seq_struct.hundred.size(),
+								 m_seq_struct.ten.size()),
+							m_seq_struct.alpha.size())
 					);
 
 		for (int i=1; i<=max ; i++)
@@ -437,6 +451,9 @@ namespace autonum
 			}
 			if (m_assigned_label.contains("%seqhf_" + QString::number(i)) && m_seq_struct.hundred_folio.size() >= i) {
 				m_assigned_label.replace("%seqhf_" + QString::number(i),m_seq_struct.hundred_folio.at(i-1));
+			}
+			if (m_assigned_label.contains("%seqa_" + QString::number(i)) && m_seq_struct.alpha.size() >= i) {
+				m_assigned_label.replace("%seqa_" + QString::number(i),m_seq_struct.alpha.at(i-1));
 			}
 		}
 	}
@@ -462,6 +479,9 @@ namespace autonum
 					number = QString("%1").arg(context.itemAt(i).at(1).toInt(), 2, 10, QChar('0'));
 				else if (type == "hundred" || type == "hundredfolio")
 					number = QString("%1").arg(context.itemAt(i).at(1).toInt(), 3, 10, QChar('0'));
+				else if (type == "alpha")
+						//Alphabetic value, not an integer -- used as-is.
+					number = context.itemAt(i).at(1);
 				else number = QString::number(context.itemAt(i).at(1).toInt());
 					list.append(number);
 			}
@@ -551,6 +571,10 @@ namespace autonum
 				autonum::setSequentialToList(seqStruct.hundred_folio, context,"hundredfolio");
 				autonum::setFolioSequentialToHash(seqStruct.hundred_folio, diagram->m_elmt_hundredfolio_max, hashKey);
 			}
+			if (label.contains("%seqa_"))
+			{
+				autonum::setSequentialToList(seqStruct.alpha, context,"alpha");
+			}
 		}
 	}
 
@@ -570,6 +594,7 @@ namespace autonum
 		int count_tenf = 0;
 		int count_hundred = 0;
 		int count_hundredf = 0;
+		int count_alpha = 0;
 
 		for(int i=0 ; i<nc.size() ; i++)
 		{
@@ -625,6 +650,10 @@ namespace autonum
 			else if (type == "hundredfolio") {
 				count_hundredf++;
 				formula.append("%seqhf_" + QString::number(count_hundredf));
+			}
+			else if (type == "alpha") {
+				count_alpha++;
+				formula.append("%seqa_" + QString::number(count_alpha));
 			}
 		}
 

--- a/sources/autoNum/assignvariables.h
+++ b/sources/autoNum/assignvariables.h
@@ -52,6 +52,7 @@ namespace autonum
 			QStringList ten_folio;
 			QStringList hundred;
 			QStringList hundred_folio;
+			QStringList alpha;
 	};
 
 	/**

--- a/sources/autoNum/numerotationcontext.cpp
+++ b/sources/autoNum/numerotationcontext.cpp
@@ -129,7 +129,7 @@ QStringList NumerotationContext::itemAt(const int i) const
 */
 QString NumerotationContext::validRegExpNum () const
 {
-	return ("unit|unitfolio|ten|tenfolio|hundred|hundredfolio|wrap|string|idfolio|folio|plant|locmach|elementline|elementcolumn|elementprefix");
+	return ("unit|unitfolio|ten|tenfolio|hundred|hundredfolio|wrap|alpha|string|idfolio|folio|plant|locmach|elementline|elementcolumn|elementprefix");
 }
 
 /**

--- a/sources/autoNum/numerotationcontextcommands.cpp
+++ b/sources/autoNum/numerotationcontextcommands.cpp
@@ -204,6 +204,10 @@ void NumerotationContextCommands::setNumStrategy(const QString &str) {
 		strategy_ = new StringNum (diagram_);
 		return;
 	}
+	else if (str == "alpha") {
+		strategy_ = new AlphaNum (diagram_);
+		return;
+	}
 	else if (str == "idfolio") {
 		strategy_ = new IdFolioNum (diagram_);
 		return;
@@ -602,6 +606,120 @@ NumerotationContext StringNum::next (const NumerotationContext &nc, const int i)
 NumerotationContext StringNum::previous(const NumerotationContext &nc, const int i) const
 {
 	return (nextString(nc, i));
+}
+
+namespace
+{
+	/**
+	 * @brief incrementAlpha
+	 * Base-26 letter increment (a, b, ... z, aa, ab, ... az, ba, ...),
+	 * the same algorithm as incrementing a spreadsheet column name.
+	 * Carries right-to-left on 'z'/'Z' overflow; if the whole string
+	 * overflows, a new leading letter is prepended (lowercase 'a').
+	 * @param value : current alphabetic value; treated as "a" if empty.
+	 * @return the next value.
+	 */
+	QString incrementAlpha(QString value)
+	{
+		if (value.isEmpty()) {
+			return QStringLiteral("a");
+		}
+
+		int i = value.length() - 1;
+		while (i >= 0 && (value.at(i) == QLatin1Char('z') || value.at(i) == QLatin1Char('Z'))) {
+			value[i] = value.at(i).isUpper() ? QLatin1Char('A') : QLatin1Char('a');
+			--i;
+		}
+		if (i < 0) {
+			value.prepend(QLatin1Char('a'));
+		} else {
+			value[i] = QChar(value.at(i).unicode() + 1);
+		}
+		return value;
+	}
+
+	/**
+	 * @brief decrementAlpha
+	 * Inverse of incrementAlpha(): borrows right-to-left on 'a'/'A'
+	 * underflow. Symmetric shrink case (e.g. "aa" -> "z"): once every
+	 * position has borrowed, the leading letter is dropped rather than
+	 * left as an extra 'z'. A single-letter value already at "a"/"A" has
+	 * no representable predecessor and is left unchanged, the same way
+	 * the numeric parts don't clamp but a blank label would be worse
+	 * here than a value that stops decreasing.
+	 * @param value : current alphabetic value; treated as "a" if empty.
+	 * @return the previous value.
+	 */
+	QString decrementAlpha(QString value)
+	{
+		if (value.isEmpty()) {
+			return QStringLiteral("a");
+		}
+		if (value.length() == 1) {
+				//A single letter has no representable predecessor once it
+				//reaches "a"/"A" -- clamp rather than mutate, since the loop
+				//below would otherwise turn it into "z"/"Z" (borrowing past
+				//the only position there is).
+			if (value.at(0) == QLatin1Char('a') || value.at(0) == QLatin1Char('A')) {
+				return value;
+			}
+			return QChar(value.at(0).unicode() - 1);
+		}
+
+		int i = value.length() - 1;
+		while (i >= 0 && (value.at(i) == QLatin1Char('a') || value.at(i) == QLatin1Char('A'))) {
+			value[i] = value.at(i).isUpper() ? QLatin1Char('Z') : QLatin1Char('z');
+			--i;
+		}
+		if (i < 0) {
+				//Every position borrowed: the whole value was "a...a", whose
+				//predecessor is one fewer "z" (e.g. "aa" -> "z").
+			value.remove(0, 1);
+		} else {
+			value[i] = QChar(value.at(i).unicode() - 1);
+		}
+		return value;
+	}
+}
+
+/**
+	Constructor
+*/
+AlphaNum::AlphaNum (Diagram *d):
+	NumStrategy (d)
+{}
+
+/**
+	@brief AlphaNum::toRepresentedString
+	@return the represented string of str
+*/
+QString AlphaNum::toRepresentedString(const QString str) const
+{
+	return (str);
+}
+
+/**
+	@brief AlphaNum::next
+	@return the next NumerotationContext nc at position i
+*/
+NumerotationContext AlphaNum::next (const NumerotationContext &nc, const int i) const
+{
+	QStringList strl = nc.itemAt(i);
+	NumerotationContext newnc;
+	newnc.addValue(strl.at(0), incrementAlpha(strl.at(1)), strl.at(2).toInt());
+	return (newnc);
+}
+
+/**
+	@brief AlphaNum::previous
+	@return the previous NumerotationContext nc at posiiton i
+*/
+NumerotationContext AlphaNum::previous(const NumerotationContext &nc, const int i) const
+{
+	QStringList strl = nc.itemAt(i);
+	NumerotationContext newnc;
+	newnc.addValue(strl.at(0), decrementAlpha(strl.at(1)), strl.at(2).toInt());
+	return (newnc);
 }
 
 /**

--- a/sources/autoNum/numerotationcontextcommands.h
+++ b/sources/autoNum/numerotationcontextcommands.h
@@ -144,6 +144,23 @@ class StringNum: public NumStrategy
 	NumerotationContext previous (const NumerotationContext &, const int) const override;
 };
 
+/**
+	@brief The AlphaNum class
+	Alphabetic auto-numbering (a, b, ... z, aa, ab, ...). Unlike StringNum
+	(a fixed, non-incrementing text segment), this is a real base-26
+	counter: next()/previous() carry/borrow entirely within this part's
+	own value, the same self-contained shape every other incrementing
+	NumStrategy already has.
+*/
+class AlphaNum: public NumStrategy
+{
+	public:
+	AlphaNum (Diagram *);
+	QString toRepresentedString(const QString) const override;
+	NumerotationContext next     (const NumerotationContext &, const int) const override;
+	NumerotationContext previous (const NumerotationContext &, const int) const override;
+};
+
 class IdFolioNum: public NumStrategy
 {
 	public:

--- a/sources/autoNum/ui/numparteditorw.cpp
+++ b/sources/autoNum/ui/numparteditorw.cpp
@@ -18,6 +18,8 @@
 #include "numparteditorw.h"
 #include "ui_numparteditorw.h"
 
+#include <QRegularExpressionValidator>
+
 /**
 	@brief NumPartEditorW::NumPartEditorW
 	Constructor
@@ -28,6 +30,7 @@ NumPartEditorW::NumPartEditorW(int type, QWidget *parent) :
 	QWidget(parent),
 	ui(new Ui::NumPartEditorW),
 	intValidator (new QIntValidator(0,99999,this)),
+	alphaValidator (new QRegularExpressionValidator(QRegularExpression("[A-Za-z]+"), this)),
 	m_edited_type(type)
 {
 	ui -> setupUi(this);
@@ -51,6 +54,7 @@ NumPartEditorW::NumPartEditorW (NumerotationContext &context,
 	QWidget(parent),
 	ui(new Ui::NumPartEditorW),
 	intValidator (new QIntValidator(0,99999,this)),
+	alphaValidator (new QRegularExpressionValidator(QRegularExpression("[A-Za-z]+"), this)),
 	m_edited_type(type)
 {
 	ui -> setupUi(this);
@@ -73,6 +77,8 @@ NumPartEditorW::NumPartEditorW (NumerotationContext &context,
 			setType(NumPartEditorW::hundredfolio, true);
 		else if (strl.at(0)=="wrap")
 			setType(NumPartEditorW::wrap, true);
+		else if (strl.at(0)=="alpha")
+			setType(NumPartEditorW::alpha);
 		else if (strl.at(0)=="string")
 			setType(NumPartEditorW::string);
 		else if (strl.at(0)=="idfolio")
@@ -102,6 +108,7 @@ NumPartEditorW::NumPartEditorW (NumerotationContext &context,
 NumPartEditorW::~NumPartEditorW()
 {
 	delete intValidator;
+	delete alphaValidator;
 	delete ui;
 }
 
@@ -115,6 +122,7 @@ void NumPartEditorW::setVisibleItems()
 			<< tr("Chiffre 01")
 			<< tr("Chiffre 001")
 			<< tr("Cyclique (modulo)")
+			<< tr("Alphabétique")
 			<< tr("Texte");
 	}
 	else if (m_edited_type == 1)
@@ -126,6 +134,7 @@ void NumPartEditorW::setVisibleItems()
 			<< tr("Chiffre 001")
 			<< tr("Chiffre 001 - Folio")
 			<< tr("Cyclique (modulo)")
+			<< tr("Alphabétique")
 			<< tr("Texte")
 			<< tr("N° folio")
 			<< tr("Folio")
@@ -140,6 +149,7 @@ void NumPartEditorW::setVisibleItems()
 		      << tr("Chiffre 001")
 		      << tr("Chiffre 001 - Folio")
 		      << tr("Cyclique (modulo)")
+		      << tr("Alphabétique")
 		      << tr("Texte")
 		      << tr("N° folio")
 		      << tr("Folio")
@@ -204,6 +214,9 @@ NumerotationContext NumPartEditorW::toNumContext()
 			break;
 		case wrap:
 			type_str = "wrap";
+			break;
+		case alpha:
+			type_str = "alpha";
 			break;
 	}
 	if (type_str == "unitfolio"
@@ -278,6 +291,8 @@ void NumPartEditorW::on_type_cb_activated(int) {
 		setType(elementprefix);
 	else if (ui->type_cb->currentText() == tr("Cyclique (modulo)"))
 		setType(wrap);
+	else if (ui->type_cb->currentText() == tr("Alphabétique"))
+		setType(alpha);
 	emit changed();
 }
 
@@ -349,6 +364,7 @@ void NumPartEditorW::setType(NumPartEditorW::type t, bool fnum) {
 	}
 	//@t isn't a numeric type
 	else if (t == string
+		 || t == alpha
 		 || t == folio
 		 || t == idfolio
 		 || t == elementline
@@ -360,6 +376,13 @@ void NumPartEditorW::setType(NumPartEditorW::type t, bool fnum) {
 		ui -> increase_spinBox -> setDisabled(true);
 		if (t==string) {
 			ui -> value_field -> setValidator(nullptr);
+			ui -> value_field -> setEnabled(true);
+		}
+		else if (t==alpha) {
+				//Alphabetic step is always exactly one letter (a, b, ...);
+				//there is no numeric "increase" to configure, unlike the
+				//digit-based part types.
+			ui -> value_field -> setValidator(alphaValidator);
 			ui -> value_field -> setEnabled(true);
 		}
 		else if (t==folio) {
@@ -414,6 +437,8 @@ void NumPartEditorW::setCurrentIndex(NumPartEditorW::type t) {
 		i = ui->type_cb->findText(tr("Chiffre 001"));
 	else if (t == hundredfolio)
 		i = ui->type_cb->findText(tr("Chiffre 001 - Folio"));
+	else if (t == alpha)
+		i = ui->type_cb->findText(tr("Alphabétique"));
 	else if (t == string)
 		i = ui->type_cb->findText(tr("Texte"));
 	else if (t == idfolio)

--- a/sources/autoNum/ui/numparteditorw.h
+++ b/sources/autoNum/ui/numparteditorw.h
@@ -47,6 +47,7 @@ class NumPartEditorW : public QWidget
 		~NumPartEditorW() override;
 
 		enum type {unit,unitfolio,ten,tenfolio, hundred, hundredfolio,
+				   alpha,
 				   string,idfolio,folio,plant,locmach,
 				   elementline,elementcolumn,elementprefix,
 				   wrap,
@@ -73,6 +74,7 @@ class NumPartEditorW : public QWidget
 	private:
 		Ui::NumPartEditorW *ui;
 		QValidator *intValidator;
+		QValidator *alphaValidator;
 		int m_edited_type = -1; ///<0 == element : 1 == conductor : 2 == folio
 	
 


### PR DESCRIPTION
Closes discussion #579.

## Problem

There's no way to auto-number elements/conductors alphabetically (`a`, `b`, ... `z`, `aa`, `ab`, ...) — only numerically via `unit`/`ten`/`hundred`. `StringNum`, the closest existing part type, is a fixed/constant text segment (`nextString()` just re-adds the current value unchanged); there's no letter-incrementing anywhere in the codebase.

## Change

A new `AlphaNum` leaf strategy (`sources/autoNum/numerotationcontextcommands.{h,cpp}`), the 15th `NumStrategy` subclass:

- `incrementAlpha()`/`decrementAlpha()` implement the spreadsheet-column-name algorithm: increment carries right-to-left on `z`/`Z` overflow, prepending a new leading letter if the whole value overflows (`z → aa`, `az → ba`). Decrement is the exact inverse, including the symmetric shrink case (`aa → z`) once every position has borrowed.
- As the discussion correctly predicted, this is genuinely smaller than #578 (wrap-and-carry) — the carrying happens entirely within one part's own value, so `NumerotationContextCommands`'s composition loop needed zero changes.
- Registered in `NumerotationContext::validRegExpNum()` but deliberately **not** in `validRegExpNumber()`, so `addValue()` doesn't force alphabetic values through int conversion — exactly as scoped in the discussion.
- New "Alphabétique" entry in `numparteditorw`'s type dropdown, with its own letters-only `QRegularExpressionValidator`. The increase spinbox is disabled since the step is always exactly one letter, not a configurable amount (its minimum was already `1`, which doesn't apply here since there's no numeric step to configure).

## One thing the discussion didn't cover: this needed a second layer to actually reach labels

Folio numbering applies a `NumerotationContext`'s represented string directly, so `AlphaNum` works there with zero extra plumbing. But **element and conductor numbering** — the discussion's explicit primary use case — go through a separate formula-substitution layer: `autonum::sequentialNumbers` + `%sequ_N`/`%seqt_N`/`%seqh_N`-style placeholders resolved in `AssignVariables::assignSequence()`, auto-populated by `numerotationContextToFormula()`. Without a matching placeholder, an `alpha` part would silently disappear from the generated formula and never reach the actual label — the counter would advance correctly in the background while the UI looked complete, but element/conductor labels would just never show a letter.

So this PR also:
- Adds an `alpha` `QStringList` member to `sequentialNumbers` (copy ctor, `operator=`, `operator==`, `toXml`/`fromXml`, `clear()`).
- Adds a `%seqa_N` placeholder, emitted by `numerotationContextToFormula()` for `alpha` parts the same way `%sequ_N` is emitted for `unit`.
- `setSequential()`/`setSequentialToList()` populate `seqStruct.alpha`, passing the raw string through as-is (not the `.toInt()`-based formatting the numeric types use).
- `AssignVariables::assignSequence()` substitutes `%seqa_N`, mirroring the existing numeric substitutions.

No `alphafolio` variant was added, matching scope — only `unit`/`ten`/`hundred` have folio-anchored variants today.

## Testing

Built clean (no new warnings). Verified against production code via the numbering config dialog's own Suivant/Précédent buttons:
- `a` + 25 clicks → `z`; one more → `aa`; 25 more → `az`; one more → `ba` (carry).
- Reversed: `ba → az` → (25 clicks) → `aa` → `z` (shrink) → (25 clicks) → `a`.
- One more "previous" at `a` correctly **stays** at `a` (see below).
- The Formule field auto-updates to `%seqa_1` the instant the type is switched to "Alphabétique", confirming the formula-generation wiring works live, not just at the engine level.

**Bug caught and fixed during this testing**: the initial `decrementAlpha()` mutated the string in the borrow loop *before* checking whether to clamp a single letter at its minimum, so `a` → previous incorrectly produced `z` instead of staying at `a`. Fixed by handling the single-letter case up front, before any mutation.