### PR TITLE
Make system pugixml (BUILD_PUGIXML=OFF) actually usable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -185,7 +185,6 @@ target_include_directories(
     ${QET_DIR}/sources/NameList
     ${QET_DIR}/sources/NameList/ui
     ${QET_DIR}/sources/utils
-    ${QET_DIR}/pugixml/src
     ${QET_DIR}/sources/dataBase
     ${QET_DIR}/sources/dataBase/ui
     ${QET_DIR}/sources/factory/ui

--- a/sources/ElementsCollection/elementslocation.h
+++ b/sources/ElementsCollection/elementslocation.h
@@ -20,7 +20,7 @@
 
 #include "../NameList/nameslist.h"
 #include "../diagramcontext.h"
-#include "pugixml/src/pugixml.hpp"
+#include <pugixml.hpp>
 
 #include <QIcon>
 #include <QString>

--- a/sources/NameList/nameslist.h
+++ b/sources/NameList/nameslist.h
@@ -17,7 +17,7 @@
 */
 #ifndef NAMES_LIST_H
 #define NAMES_LIST_H
-#include "pugixml/src/pugixml.hpp"
+#include <pugixml.hpp>
 
 #include <QtXml>
 /**

--- a/sources/diagramcontext.h
+++ b/sources/diagramcontext.h
@@ -17,7 +17,7 @@
 */
 #ifndef DIAGRAM_CONTEXT_H
 #define DIAGRAM_CONTEXT_H
-#include "pugixml/src/pugixml.hpp"
+#include <pugixml.hpp>
 
 #include <QDomElement>
 #include <QHash>


### PR DESCRIPTION
Fixes https://qelectrotech.org/bugtracker/view.php?id=337

## Problem

`fetch_pugixml.cmake`'s `BUILD_PUGIXML` option (`"Build pugixml library, use system one otherwise"`) correctly branches between `FetchContent` (bundled) and `find_package(pugixml REQUIRED)` (system) — and both paths already resolve to the same `pugixml::pugixml` CMake target that QET links against, so `target_link_libraries` needed no change at all. But two other things silently broke the system-package path regardless of that option:

- `CMakeLists.txt` unconditionally added `${QET_DIR}/pugixml/src` to QET's own `target_include_directories` — a directory that simply doesn't exist unless the bundled copy was actually fetched, i.e. it's never present when `BUILD_PUGIXML=OFF`.
- `sources/ElementsCollection/elementslocation.h`, `sources/NameList/nameslist.h` and `sources/diagramcontext.h` each hardcoded `#include "pugixml/src/pugixml.hpp"` — the bundled-tree-relative path — instead of the portable `<pugixml.hpp>` form a system package installs under.

So setting `BUILD_PUGIXML=OFF` (as documented) failed to build regardless of whether a system pugixml was actually present.

## Fix

Checked pugixml's own upstream `CMakeLists.txt` directly (via the vendored submodule) to confirm it already sets a correct `$<BUILD_INTERFACE:.../src>` include directory on the `pugixml::pugixml` target for *both* the `FetchContent` and installed-package cases — QET doesn't need (and per this bug, must not add) its own manual include path on top of that. So the fix is just:

- Drop the redundant `${QET_DIR}/pugixml/src` line from `target_include_directories`.
- Switch the three `#include`s to the plain `<pugixml.hpp>` form, which now resolves correctly via the `pugixml::pugixml` link in either configuration.

## Testing

Configured and built the full `qelectrotech` target end-to-end with the default `BUILD_PUGIXML=ON` (Qt6, `PACKAGE_TESTS=OFF`/`BUILD_WITH_KF5=OFF` to skip unrelated heavy fetches) after this change — clean configure, clean build, links successfully. Didn't have a system-installed pugixml package available in this environment to also exercise `BUILD_PUGIXML=OFF` end-to-end, but the fix is verified directly against pugixml's own exported target properties rather than assumed, and the change is minimal/mechanical enough that the `=ON` path succeeding gives good confidence in the `=OFF` path too — happy to have a maintainer or the original reporter (running ArchLinux, which packages pugixml) confirm `-DBUILD_PUGIXML=OFF` on their end.