### PR TITLE
Fix element library icons invisible on dark OS themes

### DIFF
--- a/sources/ElementsCollection/elementstreeview.cpp
+++ b/sources/ElementsCollection/elementstreeview.cpp
@@ -43,6 +43,14 @@ ElementsTreeView::ElementsTreeView(QWidget *parent) :
 {
 	// force du noir sur une alternance de blanc (comme le schema) et de gris
 	// clair, avec du blanc sur bleu pas trop fonce pour la selection
+	//
+	// Element icons are rendered with colors read directly from each .elmt
+	// file (almost always black linework, matching printed-schematic
+	// convention) onto a transparent background -- so this view must keep
+	// a light background regardless of the OS/desktop theme, or the icons
+	// become invisible on dark themes. QAbstractItemView paints its rows
+	// using the viewport's palette, not the view's own, so the palette
+	// must be applied to both to actually take effect under every style.
 	QPalette qp = palette();
 	qp.setColor(QPalette::Text,            Qt::black);
 	qp.setColor(QPalette::Base,            Qt::white);
@@ -50,6 +58,7 @@ ElementsTreeView::ElementsTreeView(QWidget *parent) :
 	qp.setColor(QPalette::Highlight,       QColor("#678db2"));
 	qp.setColor(QPalette::HighlightedText, Qt::black);
 	setPalette(qp);
+	viewport()->setPalette(qp);
 }
 
 /**

--- a/sources/elementspanel.cpp
+++ b/sources/elementspanel.cpp
@@ -56,6 +56,14 @@ ElementsPanel::ElementsPanel(QWidget *parent) :
 	
 	// force du noir sur une alternance de blanc (comme le schema) et de gris
 	// clair, avec du blanc sur bleu pas trop fonce pour la selection
+	//
+	// Element icons are rendered with colors read directly from each .elmt
+	// file (almost always black linework, matching printed-schematic
+	// convention) onto a transparent background -- so this view must keep
+	// a light background regardless of the OS/desktop theme, or the icons
+	// become invisible on dark themes. QAbstractItemView paints its rows
+	// using the viewport's palette, not the view's own, so the palette
+	// must be applied to both to actually take effect under every style.
 	QPalette qp = palette();
 	qp.setColor(QPalette::Text,            Qt::black);
 	qp.setColor(QPalette::Base,            Qt::white);
@@ -63,6 +71,7 @@ ElementsPanel::ElementsPanel(QWidget *parent) :
 	qp.setColor(QPalette::Highlight,       QColor("#678db2"));
 	qp.setColor(QPalette::HighlightedText, Qt::black);
 	setPalette(qp);
+	viewport()->setPalette(qp);
 	
 		// we handle double click on items ourselves
 	connect(this, &ElementsPanel::itemDoubleClicked, this, &ElementsPanel::slot_doubleClick);


### PR DESCRIPTION
Fixes https://qelectrotech.org/bugtracker/view.php?id=335

## Root cause

Element catalog icons (relays, breakers, terminals, etc.) are rendered by `ElementPictureFactory::pixmap()` onto a fully transparent background, using colors read literally from each `.elmt` file's own XML — almost always black linework, matching the printed-schematic convention these files were authored under. That's only legible if the row background behind it stays reliably light.

`ElementsPanel` and `ElementsTreeView` — the two widgets that display these icons — already know this: both constructors build an identical, deliberately hardcoded light `QPalette` (white base, black text) with a comment explaining exactly this intent ("force black on an alternation of white, like the schematic..."). Someone already anticipated and tried to fix this.

But both only call `setPalette(qp)` on the view widget itself. `QAbstractItemView` paints its row backgrounds using the *viewport's* palette, not the view's own — `setPalette()` on the outer widget doesn't propagate to `viewport()` in the general case. Under styles that actually honor the viewport's own (unset, therefore theme-inherited) palette — KDE Plasma's Breeze Dark being the reported case — the row background falls through to the app's dark palette while the element linework is still literal black, making icons and terminal symbols invisible.

## Fix

Apply the same `QPalette` to `viewport()` right after `setPalette()` in both constructors, so the light-background intent these two classes already clearly had actually takes effect under every style, not just ones that happen to read the view's own palette for background painting.

## Testing

Confirmed via `git grep` that these are the only two occurrences of this palette-forcing pattern in the codebase (identical comment text in both). Built the full `qelectrotech` target end-to-end (Qt6, `PACKAGE_TESTS=OFF`/`BUILD_WITH_KF5=OFF` to skip unrelated heavy fetches) — clean build, no warnings from the changed files.

I wasn't able to reproduce the actual dark-theme symptom directly, since this sandbox doesn't have a KDE Plasma / Breeze Dark desktop session to test against — the diagnosis and fix are based on tracing the exact rendering path (`ElementPictureFactory` → transparent+black-linework pixmap → `QIcon` → `ElementsPanel`/`ElementsTreeView`) plus `QAbstractItemView`'s well-documented viewport-palette-for-background-painting behavior, not a direct before/after screenshot. Would appreciate the original reporter (Fedora + KDE Plasma, dark theme) confirming this resolves it on their end.