### PR TITLE
Inherit text configuration from the last placed instance of the same element

### DIFF
--- a/sources/diagramevent/diagrameventaddelement.cpp
+++ b/sources/diagramevent/diagrameventaddelement.cpp
@@ -25,6 +25,8 @@
 #include "../qetdiagrameditor.h"
 #include "../qetgraphicsitem/element.h"
 #include "../qetgraphicsitem/conductor.h"
+#include "../qetgraphicsitem/elementtextitemgroup.h"
+#include "../qetgraphicsitem/dynamicelementtextitem.h"
 
 /**
 	@brief DiagramEventAddElement::DiagramEventAddElement
@@ -269,9 +271,90 @@ void DiagramEventAddElement::addElement()
 			conductor->setFreezeLabel(true);
 		}
 	}
+
+		//m_element (the placement preview/ghost) is temporarily out of the
+		//scene here, so Diagram::elements() below can't match against it --
+		//only real, previously placed instances are candidates.
+	applyInheritedTextConfiguration(element);
 	m_diagram->addItem(m_element);
 
 	m_diagram -> undoStack().push(undo_object);
 	element->setUpFormula();
 	element->freezeNewAddedElement();
+}
+
+/**
+	@brief DiagramEventAddElement::applyInheritedTextConfiguration
+	If another instance of the same catalog element already exists on the
+	diagram, copy its dynamic-text layout (group position/alignment/frame,
+	per-text font) onto @new_element instead of leaving it at the catalog
+	template's defaults. Matching is done via ElementsLocation::uuid() (the
+	catalog item's own identity), not Element::uuid() (assigned fresh on
+	every placement). Groups are matched by name and texts within a group
+	by their ordinal position, since a freshly placed instance's own
+	dynamic texts get brand new uuids that can't be cross-referenced
+	against another instance's.
+
+	Many catalog elements (e.g. a simple auxiliary contact) don't wrap
+	their dynamic text in a group at all -- textGroups() is empty and the
+	text sits directly under the element. Those are handled separately
+	below, matched by their ordinal position among the element's own
+	ungrouped texts.
+	@param new_element : the just-placed element to update
+*/
+void DiagramEventAddElement::applyInheritedTextConfiguration(Element *new_element) const
+{
+	Element *source = nullptr;
+	for (Element *elmt : m_diagram->elements())
+	{
+		if (elmt != new_element &&
+			elmt->location().uuid() == new_element->location().uuid())
+		{
+			source = elmt;
+			break;
+		}
+	}
+	if (!source) {
+		return;
+	}
+
+	for (ElementTextItemGroup *source_group : source->textGroups())
+	{
+		ElementTextItemGroup *target_group = new_element->textGroup(source_group->name());
+		if (!target_group) {
+			continue;
+		}
+
+		target_group->setPos(source_group->pos());
+		target_group->setRotation(source_group->rotation());
+		target_group->setAlignment(source_group->alignment());
+		target_group->setVerticalAdjustment(source_group->verticalAdjustment());
+		target_group->setFrame(source_group->frame());
+		target_group->setHoldToBottomPage(source_group->holdToBottomPage());
+
+		const QList<DynamicElementTextItem *> source_texts = source_group->texts();
+		const QList<DynamicElementTextItem *> target_texts = target_group->texts();
+		for (int i = 0; i < source_texts.size() && i < target_texts.size(); ++i) {
+			target_texts.at(i)->setFont(source_texts.at(i)->font());
+		}
+	}
+
+	QList<DynamicElementTextItem *> source_ungrouped;
+	for (DynamicElementTextItem *deti : source->dynamicTextItems()) {
+		if (!deti->parentGroup()) {
+			source_ungrouped << deti;
+		}
+	}
+	QList<DynamicElementTextItem *> target_ungrouped;
+	for (DynamicElementTextItem *deti : new_element->dynamicTextItems()) {
+		if (!deti->parentGroup()) {
+			target_ungrouped << deti;
+		}
+	}
+	for (int i = 0; i < source_ungrouped.size() && i < target_ungrouped.size(); ++i) {
+		target_ungrouped.at(i)->setPos(source_ungrouped.at(i)->pos());
+		target_ungrouped.at(i)->setRotation(source_ungrouped.at(i)->rotation());
+		target_ungrouped.at(i)->setFont(source_ungrouped.at(i)->font());
+		target_ungrouped.at(i)->setFrame(source_ungrouped.at(i)->frame());
+	}
 }

--- a/sources/diagramevent/diagrameventaddelement.h
+++ b/sources/diagramevent/diagrameventaddelement.h
@@ -47,6 +47,7 @@ class DiagramEventAddElement : public DiagramEventInterface
 	private:
 		bool buildElement();
 		void addElement();
+		void applyInheritedTextConfiguration(Element *new_element) const;
 
 	private:
 		ElementsLocation m_location;


### PR DESCRIPTION
Closes discussion #595.

## Problem

Users placing many instances of the same catalog element (coils, breakers, contacts) end up repeating the same manual text-field tweaks on each one — position/alignment/font/frame of the dynamic text items. Today the only way to reuse a tuned configuration is to open an element's text properties, locate the desired source config by hand, tick "overwrite others", and apply it after the fact.

## Change

`DiagramEventAddElement::applyInheritedTextConfiguration()` runs right after a new element is placed and committed to the diagram (`addElement()`, while the placement-preview ghost is temporarily out of the scene so it can't be matched against). It looks for another element on the diagram whose `ElementsLocation::uuid()` matches the newly placed one — catalog identity, not `Element::uuid()`, which is assigned fresh on every placement — and copies its dynamic-text layout onto the new instance:

- **Grouped texts** (`ElementTextItemGroup`): matched by group name; position/rotation/alignment/vertical-adjustment/frame/hold-to-bottom-of-page copied across. Texts within a matched group are paired by ordinal position to copy font (their own uuids can't be cross-referenced between instances, since each placement gets brand new ones).
- **Ungrouped texts**: many catalog elements (e.g. a simple auxiliary contact) don't wrap their dynamic text in a group at all — `textGroups()` is empty and the text sits directly under the element. Discovered this while testing: initially only handled the grouped case and the fix did nothing for `con_simple.elmt`. Ungrouped texts are now matched by ordinal position among the element's own ungrouped texts, copying position/rotation/font/frame.

If no matching instance exists yet on the diagram, behavior is unchanged — the new element keeps the catalog template's defaults.

## Not proposed here

Per the discussion, Joshua's suggested complementary feature — manually selecting one placed element and applying its configuration retroactively to every other matching instance already on the diagram — is a separate, batch-style operation and out of scope here.

## Testing

Built clean, no new warnings. Verified live in the running app: placed a "Simple contact" (`con_simple.elmt`), customized its label's position (2.75 → 55) and font size (9 → 20) via the element's own Textes properties dialog, then placed a second instance of the same catalog element elsewhere on the diagram — its label came in already at position 55 / size 20 instead of the template defaults. Confirmed via debug tracing during development that the very first placement (no prior instance) correctly finds no match and leaves the template defaults untouched.