### PR TITLE
Fix folders showing with no name in the elements panel

### DIFF
--- a/sources/ElementsCollection/fileelementcollectionitem.cpp
+++ b/sources/ElementsCollection/fileelementcollectionitem.cpp
@@ -136,18 +136,26 @@ QString FileElementCollectionItem::localName()
 		}
 		else
 		{
+			// Fall back to the raw directory name (m_path) whenever the
+			// translated name can't be obtained -- qet_directory missing,
+			// unreadable (e.g. a Windows path-encoding issue with special
+			// characters, see bugtracker #332), malformed, or present but
+			// without a usable name entry -- rather than leaving the item
+			// blank.
+			QString display_name;
 			QString str(fileSystemPath() % "/qet_directory");
 			pugi::xml_document docu;
-			if(docu.load_file(str.toStdWString().c_str()))
+			if (docu.load_file(str.toStdWString().c_str()))
 			{
 				if (QString(docu.document_element().name())
 					== "qet-directory")
 				{
 					NamesList nl;
 					nl.fromXml(docu.document_element());
-					setText(nl.name());
+					display_name = nl.name(m_path);
 				}
 			}
+			setText(display_name.isEmpty() ? m_path : display_name);
 		}
 	}
 	else if (isElement()) {


### PR DESCRIPTION
Fixes https://qelectrotech.org/bugtracker/view.php?id=332

## Root cause

`FileElementCollectionItem::localName()` sets a non-root directory item's displayed text by loading its `qet_directory` metadata file and reading the translated name out of it:

```cpp
QString str(fileSystemPath() % "/qet_directory");
pugi::xml_document docu;
if(docu.load_file(str.toStdWString().c_str()))
{
    if (QString(docu.document_element().name()) == "qet-directory")
    {
        NamesList nl;
        nl.fromXml(docu.document_element());
        setText(nl.name());
    }
}
```

`setText()` is only ever called inside the success path. If `docu.load_file()` fails for any reason — the file is missing, malformed, or (per the Windows + special/accented-character reports on the bug) can't be opened at all due to a path-encoding issue — the whole branch does nothing. Since a freshly created tree item's `text()` starts null, that leaves the folder with a completely blank label — exactly the reported "folders without names."

## Fix

Track the resolved name in a local instead of calling `setText()` inline, and always fall back to something rather than nothing:
- Pass the item's own raw name (`m_path`) as the fallback argument to `NamesList::name()` — the same fallback-chain convention `ElementsLocation::name()` already uses elsewhere (system language → English → provided fallback → first available → empty).
- If `qet_directory` couldn't be loaded or parsed at all, fall back to `m_path` directly.

Either way the folder now always displays *something* — its own directory name at worst — instead of silently going blank.

## What this doesn't do

This doesn't chase down the exact platform-specific reason `qet_directory` fails to open on Windows with accented/special characters in the path — I don't have a Windows environment available to reproduce that specific trigger. What it does is make the app robust to that failure regardless of its root cause, which is what actually resolves the reported symptom (a permanently blank folder name) rather than papering over the underlying I/O issue.

## Testing

Built the full `qelectrotech` target end-to-end (Qt6, `PACKAGE_TESTS=OFF`/`BUILD_WITH_KF5=OFF` to skip unrelated heavy fetches) — clean build, no warnings from the changed file. Didn't have a way to reproduce the original special-character/Windows trigger in this sandbox to get a direct before/after; would appreciate the original reporter confirming their previously-blank folders now show a name.