### PR TITLE
Show unsaved-changes state in the main window title (macOS modified dot)

### DIFF
--- a/sources/qetdiagrameditor.cpp
+++ b/sources/qetdiagrameditor.cpp
@@ -1283,6 +1283,12 @@ bool QETDiagramEditor::addProject(QETProject *project, bool update_panel)
 
 	undo_group.addStack(project -> undoStack());
 
+	connect(project, &QETProject::projectModified, this, [this](QETProject *modified_project, bool) {
+		if (modified_project == currentProject()) {
+			updateWindowModifiedState();
+		}
+	});
+
 	m_element_collection_widget->addProject(project);
 
 	// met a jour le panel d'elements
@@ -2553,6 +2559,7 @@ void QETDiagramEditor::subWindowActivated(QMdiSubWindow *subWindows)
 	slot_updateWindowsMenu();
 	emit syncElementsPanel();
 	updateUsageTrackersActiveState();
+	updateWindowModifiedState();
 }
 
 /**
@@ -2575,6 +2582,32 @@ void QETDiagramEditor::updateUsageTrackersActiveState()
 		if (QETProject *project = project_view->project()) {
 			project->projectPropertiesHandler().usageTracker().setActive(project == active_project);
 		}
+	}
+}
+
+/**
+	@brief QETDiagramEditor::updateWindowModifiedState
+	Reflect the currently active project's unsaved-changes state in the
+	main window's title and native "document modified" indicator (e.g.
+	the dot in the close button on macOS). Called whenever the active
+	project changes, or whenever the active project's own modified state
+	changes.
+
+	The window title's "[*]" placeholder is Qt's own convention: combined
+	with setWindowModified(), it lets each platform render the modified
+	indicator its own way (or not at all, on platforms without one)
+	without QET having to draw anything itself.
+*/
+void QETDiagramEditor::updateWindowModifiedState()
+{
+	if (QETProject *project = currentProject()) {
+		setWindowTitle(QString("%1[*] - %2").arg(
+			project->pathNameTitle(),
+			tr("QElectroTech", "window title")));
+		setWindowModified(project->projectOptionsWereModified());
+	} else {
+		setWindowTitle(tr("QElectroTech", "window title"));
+		setWindowModified(false);
 	}
 }
 

--- a/sources/qetdiagrameditor.h
+++ b/sources/qetdiagrameditor.h
@@ -98,6 +98,7 @@ class QETDiagramEditor : public QETMainWindow
 		ProjectView *findProject(const QString &) const;
 		QMdiSubWindow *subWindowForWidget(QWidget *) const;
 		void updateUsageTrackersActiveState();
+		void updateWindowModifiedState();
 
 	signals:
 		void syncElementsPanel();


### PR DESCRIPTION
Implements discussion #596: https://github.com/qelectrotech/qelectrotech-source-mirror/discussions/596

## Problem

On macOS in particular, there's no way to tell from the window chrome alone whether the active project has unsaved changes — the request specifically points at the small dot Cocoa apps show inside the red traffic-light close button for a modified document. Qt exposes this natively via the \`windowModified\` property; QET didn't set it anywhere.

## What exists already (from the discussion's scoping)

- \`QETDiagramEditor\`'s title is set once in the constructor to a static string and never updated.
- Each project's own \`ProjectView\` already updates its own tab-label title on every \`QETProject::projectModified\` — but that's the tab label, not the OS-level window title.
- \`QETDiagramEditor::subWindowActivated(QMdiSubWindow*)\` is already the single choke point connected to \`QMdiArea\`'s native \`subWindowActivated\` signal, firing on every active-tab change regardless of trigger (programmatic activation, direct tab click, closing a window causing another to become active).
- \`QETProject::projectOptionsWereModified()\` is a public accessor for the same clean/dirty flag \`projectModified\` is emitted from.

## Change

- New \`QETDiagramEditor::updateWindowModifiedState()\`: sets the window title to \`\"<project>[*] - QElectroTech\"\` (Qt's own \`[*]\` placeholder convention) and calls \`setWindowModified()\` with the active project's own flag; reverts to the plain static title with no project open.
- Called from \`subWindowActivated()\` so switching the active project tab immediately reflects that project's own state.
- Called from a new per-project connection to \`QETProject::projectModified\`, added in \`addProject()\` right next to the existing undo-stack registration, filtered so it only acts when the modified project is the currently active one (multiple projects can be open at once, each with its own independent modified state).

Purely additive/cosmetic — platforms without a native \`windowModified\` rendering are unaffected.

## Testing

Built the full \`qelectrotech\` target end-to-end (Qt6, \`PACKAGE_TESTS=OFF\`/\`BUILD_WITH_KF5=OFF\` to skip unrelated heavy fetches) — clean build, no warnings from the changed files.

I attempted to also verify this live (launch the built binary and check the title bar / modified-asterisk behavior directly), but the only display available in this environment turned out to be a shared desktop with other concurrent sessions actively running their own QElectroTech instances — one had a genuinely modal dialog that wouldn't release focus. Rather than risk interfering with unrelated work, I stopped short of a live run and confirmed my own test process was cleanly isolated and terminated. So this is verified by code review and successful build, not a runtime screenshot — flagging that honestly, same as I did for #619/#620/#622.