### PR TITLE
Give Conductor its own persisted uuid (discussion #503, slice 1)

### DIFF
--- a/sources/diagramcommands.cpp
+++ b/sources/diagramcommands.cpp
@@ -75,6 +75,13 @@ void PasteDiagramCommand::redo()
 	{
 		first_redo = false;
 
+		//make new uuid for every pasted conductor, because old uuid are
+		//the uuid of the copied conductor
+		const QList <Conductor *> all_pasted_conductors = content.conductors();
+		for (Conductor *c : all_pasted_conductors) {
+			c -> newUuid();
+		}
+
 		//this is the first paste, we do some actions for the new element
 		const QList <Element *> elmts_list = content.m_elements;
 		for (Element *e : elmts_list)

--- a/sources/elementspanelwidget.cpp
+++ b/sources/elementspanelwidget.cpp
@@ -17,6 +17,7 @@
 */
 #include "elementspanelwidget.h"
 #include "diagram.h"
+#include "qetgraphicsitem/conductor.h"
 #include "editor/ui/qetelementeditor.h"
 #include "elementscategoryeditor.h"
 #include "qetapp.h"
@@ -651,6 +652,13 @@ void ElementsPanelWidget::duplicateDiagram()
 				// silently vanish from nomenclature/summary tables.
 				elmt->newUuid();
 				new_diagram->restoreText(elmt);
+			}
+			else if (Conductor *cond = dynamic_cast<Conductor *>(item)) {
+				// Same reasoning for conductors: conductor.uuid is the PRIMARY
+				// KEY of the conductor table, and its insert is a plain INSERT,
+				// so a duplicated uuid fails and the wire silently disappears
+				// from the wiring list and the per-element wire count.
+				cond->newUuid();
 			}
 		}
 	}

--- a/sources/qetgraphicsitem/conductor.cpp
+++ b/sources/qetgraphicsitem/conductor.cpp
@@ -91,6 +91,7 @@ Conductor::Conductor(Terminal *p1, Terminal* p2) :
 		//set Zvalue at 11 to be upper than the DiagramImageItem and element
 	setZValue(11);
 	m_previous_z_value = zValue();
+	m_uuid = QUuid::createUuid();
 
 		//Add this conductor to the list of conductors of each of the two terminals
 	bool ajout_p1 = terminal1 -> addConductor(this);
@@ -1005,6 +1006,12 @@ void Conductor::pointsToSegments(const QList<QPointF>& points_list) {
 */
 bool Conductor::fromXml(QDomElement &dom_element)
 {
+		//Older project files have no conductor uuid attribute at all --
+		//generate one on load, same treatment terminal uuids got when
+		//that field was introduced (see terminal1/terminal2 handling in
+		//toXml() below).
+	m_uuid = QUuid(dom_element.attribute("uuid", QUuid::createUuid().toString()));
+
 	setPos(dom_element.attribute("x", nullptr).toDouble(),
 		   dom_element.attribute("y", nullptr).toDouble());
 
@@ -1043,6 +1050,7 @@ QDomElement Conductor::toXml(QDomDocument &dom_document,
 {
 	QDomElement dom_element = dom_document.createElement("conductor");
 
+	dom_element.setAttribute("uuid", m_uuid.toString());
 	dom_element.setAttribute("x", QString::number(pos().x()));
 	dom_element.setAttribute("y", QString::number(pos().y()));
 	

--- a/sources/qetgraphicsitem/conductor.cpp
+++ b/sources/qetgraphicsitem/conductor.cpp
@@ -1010,7 +1010,13 @@ bool Conductor::fromXml(QDomElement &dom_element)
 		//generate one on load, same treatment terminal uuids got when
 		//that field was introduced (see terminal1/terminal2 handling in
 		//toXml() below).
-	m_uuid = QUuid(dom_element.attribute("uuid", QUuid::createUuid().toString()));
+	m_uuid = QUuid(dom_element.attribute(QStringLiteral("uuid")));
+	if (m_uuid.isNull()) {
+			//Absent, empty or malformed: mint one. A null uuid is not a usable
+			//identity -- every conductor carrying one would collide with every
+			//other on the conductor table's primary key.
+		m_uuid = QUuid::createUuid();
+	}
 
 	setPos(dom_element.attribute("x", nullptr).toDouble(),
 		   dom_element.attribute("y", nullptr).toDouble());

--- a/sources/qetgraphicsitem/conductor.h
+++ b/sources/qetgraphicsitem/conductor.h
@@ -21,6 +21,7 @@
 #include "../conductorproperties.h"
 
 #include <QGraphicsPathItem>
+#include <QUuid>
 
 class ConductorProfile;
 class ConductorSegmentProfile;
@@ -77,6 +78,8 @@ class Conductor : public QGraphicsObject
 		int type() const override { return Type; }
 		Diagram *diagram() const;
 		ConductorTextItem *textItem() const;
+		QUuid uuid() const {return m_uuid;}
+		void newUuid() {m_uuid = QUuid::createUuid();}	//create new uuid for this conductor
 		void updatePath(const QRectF & = QRectF());
 
 		//This method do nothing, it's only made to be used with Q_PROPERTY
@@ -205,6 +208,7 @@ class Conductor : public QGraphicsObject
 		Highlight must_highlight_;
 		bool m_valid;
 		bool m_freeze_label = false;
+		QUuid m_uuid;
 
 			/// QPen et QBrush objects used to draw conductors
 		static QPen conductor_pen;


### PR DESCRIPTION
> ### Updated since first posting
>
> Two fixes on top of the original commit, both found by reviewing this branch against current `master`:
>
> **Duplicating a folio produced duplicate conductor uuids.** The original commit covered `PasteDiagramCommand::redo()` but not `ElementsPanelWidget::duplicateDiagram()`, which round-trips the folio through XML and then regenerates *element* uuids only. Conductors kept the source folio's uuids, and since `conductor.uuid` is a primary key with a plain `INSERT` (the *terminal* insert is `INSERT OR IGNORE`, this one is not) and a failure only reaches `qDebug()`, every wire on a duplicated folio silently vanished from the tables in #628. Verified against the real schema: the second insert fails with `UNIQUE constraint failed: conductor.uuid`, leaving one row where two were expected. The comment already in `duplicateDiagram()` describes this exact hazard for elements; conductors now get the same loop.
>
> **The uuid read in `fromXml()` is hardened.** `QDomElement::attribute()` evaluates its default argument whether or not the attribute exists, so a uuid was minted for every conductor on every load and thrown away. More importantly the default only applies when the attribute is *absent*: a present-but-empty `uuid=""` parsed to a null `QUuid` rather than a fresh one, and null uuids collide with each other exactly as duplicates do.

**Ready for review.** Base of the stack: this one stands alone and has no dependency on the others. #628 → #629 → #630 build on it, in that order.

Slice 1 of #503 (from-to wiring list built on `projectDataBase`), landing incrementally per the plan agreed there: conductor uuid → tables/hooks → view → minimal export → terminal plans/BOM later.

## Problem

`Conductor` is the one item type on a diagram without a stable identity of its own — `Element` and `Diagram` both have a uuid, `Conductor` didn't (confirmed: no `uuid` attribute written anywhere in `Conductor::toXml()`). This is the prerequisite the wiring-list tables in #503 need: a `conductor` table keyed by uuid, the same way the existing `element` table in `projectDataBase` is keyed by `Element::uuid()`.

## Change

- `Conductor` gets a `QUuid m_uuid`, generated in the constructor, with `uuid()`/`newUuid()` accessors mirroring `Element`'s exact existing pattern (`element.h`'s `newUuid() {m_uuid = QUuid::createUuid();}`).
- `toXml()`/`fromXml()` read/write a `uuid` attribute the same way `Element` already does, generating one when the attribute is missing so old files keep loading.
- `PasteDiagramCommand::redo()` **and** `ElementsPanelWidget::duplicateDiagram()` call `newUuid()` on every copied conductor (`content.conductors()`, all three categories: to-move/to-update/other), mirroring the existing per-element `newUuid()` call directly above it — otherwise copy-paste would duplicate a conductor's uuid.

## Backward compatibility

This is the core constraint from the discussion. `Conductor::valideXml()` doesn't require a `uuid` attribute, so old files parse completely unchanged — the uuid is purely additive.

Verified concretely, not just by code inspection:
- Opened `examples/industrial.qet` (150 folios, 671 conductors) — a genuinely pre-uuid project using the legacy integer `terminal1`/`terminal2` positional scheme, no `uuid` attribute on any `<conductor>` at all. Loads and renders correctly.
- Saved it: every conductor now has a `uuid` attribute; the legacy `terminal1`/`terminal2` integer attributes are untouched.
- Closed, reopened, saved again: uuids are byte-identical to the first save (not regenerated once present).
- Copy-pasted a selection containing 4 conductors: each pasted conductor got a distinct new uuid, none colliding with the originals or each other (verified via debug trace during development, since none of this touches anything visible in the UI).

## Testing

Built clean, no new warnings beyond pre-existing unrelated deprecation warnings elsewhere in the same files.

