### PR TITLE
Add terminal and conductor tables to projectDataBase (discussion #503, slice 2)

### DIFF
--- a/sources/dataBase/projectdatabase.cpp
+++ b/sources/dataBase/projectdatabase.cpp
@@ -271,13 +271,8 @@ void projectDataBase::addConductor(Conductor *conductor)
 	insertTerminal(conductor->terminal1);
 	insertTerminal(conductor->terminal2);
 
-	m_insert_conductor_query.bindValue(":uuid", conductor->uuid().toString());
-	m_insert_conductor_query.bindValue(":diagram_uuid", conductor->diagram()->uuid().toString());
-	m_insert_conductor_query.bindValue(":terminal1_uuid", conductor->terminal1->uuid().toString());
-	m_insert_conductor_query.bindValue(":terminal1_element_uuid", conductor->terminal1->parentElement()->uuid().toString());
-	m_insert_conductor_query.bindValue(":terminal2_uuid", conductor->terminal2->uuid().toString());
-	m_insert_conductor_query.bindValue(":terminal2_element_uuid", conductor->terminal2->parentElement()->uuid().toString());
-	m_insert_conductor_query.bindValue(":text", conductor->properties().text);
+	watchConductor(conductor);
+	bindConductorValues(m_insert_conductor_query, conductor, conductor->diagram());
 	if (!m_insert_conductor_query.exec()) {
 		qDebug() << "projectDataBase::addConductor insert error : " << m_insert_conductor_query.lastError();
 	} else {
@@ -297,6 +292,85 @@ void projectDataBase::removeConductor(Conductor *conductor)
 	} else {
 		emit dataBaseUpdated();
 	}
+}
+
+/**
+	@brief projectDataBase::updateConductor
+	Refresh the mutable columns of an already-inserted conductor.
+
+	Only the text (the wire number) can change without the conductor being
+	removed and re-added: its endpoints are fixed for its lifetime. Without
+	this, renaming a wire left the database holding the old number and the
+	wiring list showed a stale value until the next full repopulate.
+	@param conductor
+*/
+void projectDataBase::updateConductor(Conductor *conductor)
+{
+	if (!conductor) {
+		return;
+	}
+
+	m_update_conductor_query.bindValue(QStringLiteral(":uuid"), conductor->uuid().toString());
+	m_update_conductor_query.bindValue(QStringLiteral(":text"), conductor->properties().text);
+	if (!m_update_conductor_query.exec()) {
+		qDebug() << "projectDataBase::updateConductor update error : " << m_update_conductor_query.lastError();
+	}
+
+		//Deliberately no dataBaseUpdated() here, unlike add/remove. The only
+		//column this touches is the wire text, which no view watched by
+		//ProjectDBModel displays -- the nomenclature shows elements, and its
+		//wire_count changes when a conductor appears or disappears, not when
+		//it is renamed. Emitting would make every ProjectDBModel re-run its
+		//query, and auto-numbering renames every conductor in the project in
+		//one pass.
+}
+
+/**
+	@brief projectDataBase::watchConductor
+	Keep this conductor's row in step with its properties.
+
+	Conductor::setProperties() has a dozen call sites (auto-numbering, the
+	properties dialog, element moves, deletion re-links...), so listening to
+	the signal it already emits is the only way to catch them all -- and the
+	only way to catch the ones added later. Qt::UniqueConnection makes a
+	repeated insert or a full repopulate harmless.
+	@param conductor
+*/
+void projectDataBase::watchConductor(Conductor *conductor)
+{
+	connect(conductor, &Conductor::propertiesChange,
+			this, &projectDataBase::conductorPropertiesChanged,
+			Qt::UniqueConnection);
+}
+
+/**
+	@brief projectDataBase::conductorPropertiesChanged
+*/
+void projectDataBase::conductorPropertiesChanged()
+{
+	if (auto *conductor = qobject_cast<Conductor *>(sender())) {
+		updateConductor(conductor);
+	}
+}
+
+/**
+	@brief projectDataBase::bindConductorValues
+	One binder for both insert paths, so a conductor added to a live diagram
+	and one read from a file can never drift apart -- the same reason
+	bindElementValues() exists for elements.
+	@param query
+	@param conductor
+	@param diagram : the diagram the conductor belongs to
+*/
+void projectDataBase::bindConductorValues(QSqlQuery &query, Conductor *conductor, Diagram *diagram)
+{
+	query.bindValue(QStringLiteral(":uuid"), conductor->uuid().toString());
+	query.bindValue(QStringLiteral(":diagram_uuid"), diagram->uuid().toString());
+	query.bindValue(QStringLiteral(":terminal1_uuid"), conductor->terminal1->uuid().toString());
+	query.bindValue(QStringLiteral(":terminal1_element_uuid"), conductor->terminal1->parentElement()->uuid().toString());
+	query.bindValue(QStringLiteral(":terminal2_uuid"), conductor->terminal2->uuid().toString());
+	query.bindValue(QStringLiteral(":terminal2_element_uuid"), conductor->terminal2->parentElement()->uuid().toString());
+	query.bindValue(QStringLiteral(":text"), conductor->properties().text);
 }
 
 /**
@@ -411,6 +485,21 @@ bool projectDataBase::createDataBase()
 						  ")");
 	if (!query_.exec(conductor_table)) {
 		qDebug() << "conductor_table query : "<< query_.lastError();
+	}
+
+		//The element-facing columns are looked up per element row, not per
+		//conductor row: element_nomenclature_view carries a correlated
+		//subquery counting the wires touching each element. Without these
+		//indexes each element row full-scans the conductor table, which grows
+		//as elements x conductors.
+	for (const QString &index_ : {
+			QStringLiteral("CREATE INDEX idx_conductor_terminal1_element ON conductor (terminal1_element_uuid)"),
+			QStringLiteral("CREATE INDEX idx_conductor_terminal2_element ON conductor (terminal2_element_uuid)"),
+			QStringLiteral("CREATE INDEX idx_conductor_diagram ON conductor (diagram_uuid)") })
+	{
+		if (!query_.exec(index_)) {
+			qDebug() << "conductor index query : " << query_.lastError();
+		}
 	}
 
 	createElementNomenclatureView();
@@ -650,13 +739,8 @@ void projectDataBase::populateConductorTable()
 			insertTerminal(conductor->terminal1);
 			insertTerminal(conductor->terminal2);
 
-			m_insert_conductor_query.bindValue(":uuid", conductor->uuid().toString());
-			m_insert_conductor_query.bindValue(":diagram_uuid", diagram->uuid().toString());
-			m_insert_conductor_query.bindValue(":terminal1_uuid", conductor->terminal1->uuid().toString());
-			m_insert_conductor_query.bindValue(":terminal1_element_uuid", conductor->terminal1->parentElement()->uuid().toString());
-			m_insert_conductor_query.bindValue(":terminal2_uuid", conductor->terminal2->uuid().toString());
-			m_insert_conductor_query.bindValue(":terminal2_element_uuid", conductor->terminal2->parentElement()->uuid().toString());
-			m_insert_conductor_query.bindValue(":text", conductor->properties().text);
+			watchConductor(conductor);
+			bindConductorValues(m_insert_conductor_query, conductor, diagram);
 			if (!m_insert_conductor_query.exec()) {
 				qDebug() << "projectDataBase::populateConductorTable insert error : " << m_insert_conductor_query.lastError();
 			}
@@ -761,6 +845,10 @@ void projectDataBase::prepareQuery()
 	m_insert_conductor_query = QSqlQuery(m_data_base);
 	m_insert_conductor_query.prepare("INSERT INTO conductor (uuid, diagram_uuid, terminal1_uuid, terminal1_element_uuid, terminal2_uuid, terminal2_element_uuid, text) "
 					  "VALUES (:uuid, :diagram_uuid, :terminal1_uuid, :terminal1_element_uuid, :terminal2_uuid, :terminal2_element_uuid, :text)");
+
+		//UPDATE CONDUCTOR
+	m_update_conductor_query = QSqlQuery(m_data_base);
+	m_update_conductor_query.prepare(QStringLiteral("UPDATE conductor SET text = :text WHERE uuid = :uuid"));
 
 		//REMOVE CONDUCTOR
 	m_remove_conductor_query = QSqlQuery(m_data_base);

--- a/sources/dataBase/projectdatabase.cpp
+++ b/sources/dataBase/projectdatabase.cpp
@@ -21,7 +21,9 @@
 #include "../diagramposition.h"
 #include "../elementprovider.h"
 #include "../qetapp.h"
+#include "../qetgraphicsitem/conductor.h"
 #include "../qetgraphicsitem/element.h"
+#include "../qetgraphicsitem/terminal.h"
 #include "../qetinformation.h"
 #include "../qetproject.h"
 
@@ -87,6 +89,7 @@ void projectDataBase::updateDB()
 	populateDiagramInfoTable();
 	populateElementTable();
 	populateElementInfoTable();
+	populateConductorTable();
 	emit dataBaseUpdated();
 }
 
@@ -246,6 +249,57 @@ void projectDataBase::diagramOrderChanged()
 }
 
 /**
+	@brief projectDataBase::addConductor
+	@param conductor
+*/
+void projectDataBase::addConductor(Conductor *conductor)
+{
+	if (!conductor || !conductor->diagram()) {
+		qDebug() << "projectDataBase::addConductor: null conductor or diagram";
+		return;
+	}
+
+		//A conductor whose terminal(s) predate terminal uuids (legacy
+		//elements not yet re-saved by a uuid-aware element editor) can't
+		//be given a stable identity here -- omitted the same way
+		//element_nomenclature_view already omits exclude_from_bom elements,
+		//rather than fabricating one.
+	if (conductor->terminal1->uuid().isNull() || conductor->terminal2->uuid().isNull()) {
+		return;
+	}
+
+	insertTerminal(conductor->terminal1);
+	insertTerminal(conductor->terminal2);
+
+	m_insert_conductor_query.bindValue(":uuid", conductor->uuid().toString());
+	m_insert_conductor_query.bindValue(":diagram_uuid", conductor->diagram()->uuid().toString());
+	m_insert_conductor_query.bindValue(":terminal1_uuid", conductor->terminal1->uuid().toString());
+	m_insert_conductor_query.bindValue(":terminal1_element_uuid", conductor->terminal1->parentElement()->uuid().toString());
+	m_insert_conductor_query.bindValue(":terminal2_uuid", conductor->terminal2->uuid().toString());
+	m_insert_conductor_query.bindValue(":terminal2_element_uuid", conductor->terminal2->parentElement()->uuid().toString());
+	m_insert_conductor_query.bindValue(":text", conductor->properties().text);
+	if (!m_insert_conductor_query.exec()) {
+		qDebug() << "projectDataBase::addConductor insert error : " << m_insert_conductor_query.lastError();
+	} else {
+		emit dataBaseUpdated();
+	}
+}
+
+/**
+	@brief projectDataBase::removeConductor
+	@param conductor
+*/
+void projectDataBase::removeConductor(Conductor *conductor)
+{
+	m_remove_conductor_query.bindValue(":uuid", conductor->uuid().toString());
+	if (!m_remove_conductor_query.exec()) {
+		qDebug() << "projectDataBase::removeConductor delete error : " << m_remove_conductor_query.lastError();
+	} else {
+		emit dataBaseUpdated();
+	}
+}
+
+/**
 	@brief projectDataBase::createDataBase
 	Create the data base
 	@return : true if the data base was successfully created.
@@ -321,6 +375,42 @@ bool projectDataBase::createDataBase()
 
 	if (!query_.exec(element_info_table)) {
 		qDebug() << " element_info_table query : " << query_.lastError();
+	}
+
+	//Create the terminal table.
+	//Terminal::uuid() is the terminal-position id baked into the catalog
+	//.elmt definition (e.g. "the top terminal") -- identical across every
+	//placed instance of that catalog element, not a per-instance id. A
+	//terminal instance is only uniquely identified by (uuid, element_uuid)
+	//together, so that pair is the primary key here, not uuid alone.
+	QString terminal_table("CREATE TABLE terminal"
+						  "( "
+						  "uuid VARCHAR(50) NOT NULL, "
+						  "element_uuid VARCHAR(50) NOT NULL,"
+						  "name VARCHAR(50),"
+						  "PRIMARY KEY (uuid, element_uuid),"
+						  "FOREIGN KEY (element_uuid) REFERENCES element (uuid)"
+						  ")");
+	if (!query_.exec(terminal_table)) {
+		qDebug() << "terminal_table query : "<< query_.lastError();
+	}
+
+	//Create the conductor table
+	QString conductor_table("CREATE TABLE conductor"
+						  "( "
+						  "uuid VARCHAR(50) PRIMARY KEY NOT NULL, "
+						  "diagram_uuid VARCHAR(50) NOT NULL,"
+						  "terminal1_uuid VARCHAR(50) NOT NULL,"
+						  "terminal1_element_uuid VARCHAR(50) NOT NULL,"
+						  "terminal2_uuid VARCHAR(50) NOT NULL,"
+						  "terminal2_element_uuid VARCHAR(50) NOT NULL,"
+						  "text VARCHAR(100),"
+						  "FOREIGN KEY (diagram_uuid) REFERENCES diagram (uuid),"
+						  "FOREIGN KEY (terminal1_uuid, terminal1_element_uuid) REFERENCES terminal (uuid, element_uuid),"
+						  "FOREIGN KEY (terminal2_uuid, terminal2_element_uuid) REFERENCES terminal (uuid, element_uuid)"
+						  ")");
+	if (!query_.exec(conductor_table)) {
+		qDebug() << "conductor_table query : "<< query_.lastError();
 	}
 
 	createElementNomenclatureView();
@@ -534,6 +624,62 @@ void projectDataBase::populateDiagramInfoTable()
 	}
 }
 
+/**
+	@brief projectDataBase::populateConductorTable
+	Populate the terminal and conductor tables. Terminals only matter here
+	in the context of a conductor referencing them, so their population is
+	folded into this method rather than tracked independently.
+*/
+void projectDataBase::populateConductorTable()
+{
+	QSqlQuery query(m_data_base);
+	query.exec(QStringLiteral("DELETE FROM conductor"));
+	query.exec(QStringLiteral("DELETE FROM terminal"));
+
+	for (auto *diagram : m_project->diagrams())
+	{
+		const auto conductor_list = diagram->conductors();
+		for (auto *conductor : conductor_list)
+		{
+				//See addConductor() for why terminals without a uuid
+				//(legacy elements) are omitted rather than fabricating one.
+			if (conductor->terminal1->uuid().isNull() || conductor->terminal2->uuid().isNull()) {
+				continue;
+			}
+
+			insertTerminal(conductor->terminal1);
+			insertTerminal(conductor->terminal2);
+
+			m_insert_conductor_query.bindValue(":uuid", conductor->uuid().toString());
+			m_insert_conductor_query.bindValue(":diagram_uuid", diagram->uuid().toString());
+			m_insert_conductor_query.bindValue(":terminal1_uuid", conductor->terminal1->uuid().toString());
+			m_insert_conductor_query.bindValue(":terminal1_element_uuid", conductor->terminal1->parentElement()->uuid().toString());
+			m_insert_conductor_query.bindValue(":terminal2_uuid", conductor->terminal2->uuid().toString());
+			m_insert_conductor_query.bindValue(":terminal2_element_uuid", conductor->terminal2->parentElement()->uuid().toString());
+			m_insert_conductor_query.bindValue(":text", conductor->properties().text);
+			if (!m_insert_conductor_query.exec()) {
+				qDebug() << "projectDataBase::populateConductorTable insert error : " << m_insert_conductor_query.lastError();
+			}
+		}
+	}
+}
+
+/**
+	@brief projectDataBase::insertTerminal
+	Insert (or, if already present -- e.g. a junction shared by several
+	conductors -- silently keep) @terminal in the terminal table.
+	@param terminal
+*/
+void projectDataBase::insertTerminal(Terminal *terminal)
+{
+	m_insert_terminal_query.bindValue(":uuid", terminal->uuid().toString());
+	m_insert_terminal_query.bindValue(":element_uuid", terminal->parentElement()->uuid().toString());
+	m_insert_terminal_query.bindValue(":name", terminal->name());
+	if (!m_insert_terminal_query.exec()) {
+		qDebug() << "projectDataBase::insertTerminal insert error : " << m_insert_terminal_query.lastError();
+	}
+}
+
 void projectDataBase::prepareQuery()
 {
 		//INSERT DIAGRAM
@@ -606,6 +752,19 @@ void projectDataBase::prepareQuery()
 	update_str.append(" WHERE element_uuid = :uuid");
 	m_update_element_query = QSqlQuery(m_data_base);
 	m_update_element_query.prepare(update_str);
+
+		//INSERT TERMINAL
+	m_insert_terminal_query = QSqlQuery(m_data_base);
+	m_insert_terminal_query.prepare("INSERT OR IGNORE INTO terminal (uuid, element_uuid, name) VALUES (:uuid, :element_uuid, :name)");
+
+		//INSERT CONDUCTOR
+	m_insert_conductor_query = QSqlQuery(m_data_base);
+	m_insert_conductor_query.prepare("INSERT INTO conductor (uuid, diagram_uuid, terminal1_uuid, terminal1_element_uuid, terminal2_uuid, terminal2_element_uuid, text) "
+					  "VALUES (:uuid, :diagram_uuid, :terminal1_uuid, :terminal1_element_uuid, :terminal2_uuid, :terminal2_element_uuid, :text)");
+
+		//REMOVE CONDUCTOR
+	m_remove_conductor_query = QSqlQuery(m_data_base);
+	m_remove_conductor_query.prepare("DELETE FROM conductor WHERE uuid=:uuid");
 }
 
 /**

--- a/sources/dataBase/projectdatabase.cpp
+++ b/sources/dataBase/projectdatabase.cpp
@@ -259,12 +259,13 @@ void projectDataBase::addConductor(Conductor *conductor)
 		return;
 	}
 
-		//A conductor whose terminal(s) predate terminal uuids (legacy
-		//elements not yet re-saved by a uuid-aware element editor) can't
-		//be given a stable identity here -- omitted the same way
-		//element_nomenclature_view already omits exclude_from_bom elements,
-		//rather than fabricating one.
-	if (conductor->terminal1->uuid().isNull() || conductor->terminal2->uuid().isNull()) {
+		//Both endpoints must belong to an element: the terminal table is keyed
+		//on (terminal, element) and a terminal with no parent has no identity
+		//to key on. Terminals whose *definition* predates terminal uuids are
+		//fine -- Terminal::stableUuid() derives one from the terminal's local
+		//position, which is what the project format itself matches on.
+	if (!conductor->terminal1->parentElement()
+		|| !conductor->terminal2->parentElement()) {
 		return;
 	}
 
@@ -366,9 +367,9 @@ void projectDataBase::bindConductorValues(QSqlQuery &query, Conductor *conductor
 {
 	query.bindValue(QStringLiteral(":uuid"), conductor->uuid().toString());
 	query.bindValue(QStringLiteral(":diagram_uuid"), diagram->uuid().toString());
-	query.bindValue(QStringLiteral(":terminal1_uuid"), conductor->terminal1->uuid().toString());
+	query.bindValue(QStringLiteral(":terminal1_uuid"), conductor->terminal1->stableUuid().toString());
 	query.bindValue(QStringLiteral(":terminal1_element_uuid"), conductor->terminal1->parentElement()->uuid().toString());
-	query.bindValue(QStringLiteral(":terminal2_uuid"), conductor->terminal2->uuid().toString());
+	query.bindValue(QStringLiteral(":terminal2_uuid"), conductor->terminal2->stableUuid().toString());
 	query.bindValue(QStringLiteral(":terminal2_element_uuid"), conductor->terminal2->parentElement()->uuid().toString());
 	query.bindValue(QStringLiteral(":text"), conductor->properties().text);
 }
@@ -730,9 +731,10 @@ void projectDataBase::populateConductorTable()
 		const auto conductor_list = diagram->conductors();
 		for (auto *conductor : conductor_list)
 		{
-				//See addConductor() for why terminals without a uuid
-				//(legacy elements) are omitted rather than fabricating one.
-			if (conductor->terminal1->uuid().isNull() || conductor->terminal2->uuid().isNull()) {
+				//See addConductor(): only a terminal with no parent element is
+				//skipped. A missing terminal uuid is handled by stableUuid().
+			if (!conductor->terminal1->parentElement()
+				|| !conductor->terminal2->parentElement()) {
 				continue;
 			}
 
@@ -756,7 +758,7 @@ void projectDataBase::populateConductorTable()
 */
 void projectDataBase::insertTerminal(Terminal *terminal)
 {
-	m_insert_terminal_query.bindValue(":uuid", terminal->uuid().toString());
+	m_insert_terminal_query.bindValue(":uuid", terminal->stableUuid().toString());
 	m_insert_terminal_query.bindValue(":element_uuid", terminal->parentElement()->uuid().toString());
 	m_insert_terminal_query.bindValue(":name", terminal->name());
 	if (!m_insert_terminal_query.exec()) {

--- a/sources/dataBase/projectdatabase.h
+++ b/sources/dataBase/projectdatabase.h
@@ -27,6 +27,8 @@
 class Element;
 class QETProject;
 class Diagram;
+class Conductor;
+class Terminal;
 class sqlite3;
 
 /**
@@ -58,6 +60,9 @@ class projectDataBase : public QObject
 		void diagramInfoChanged (Diagram *diagram);
 		void diagramOrderChanged();
 
+		void addConductor       (Conductor *conductor);
+		void removeConductor    (Conductor *conductor);
+
 	signals:
 		void dataBaseUpdated();
 
@@ -69,6 +74,8 @@ class projectDataBase : public QObject
 		void populateElementTable();
 		void populateElementInfoTable();
 		void populateDiagramInfoTable();
+		void populateConductorTable();
+		void insertTerminal(Terminal *terminal);
 		void prepareQuery();
 		static QHash<QString, QString> elementInfoToString(
 				Element *elmt);
@@ -86,7 +93,10 @@ class projectDataBase : public QObject
 				  m_insert_diagram_info_query,
 				  m_update_diagram_info_query,
 				  m_diagram_order_changed,
-				  m_diagram_info_order_changed;
+				  m_diagram_info_order_changed,
+				  m_insert_terminal_query,
+				  m_insert_conductor_query,
+				  m_remove_conductor_query;
 
 #ifdef QET_EXPORT_PROJECT_DB
 	public:

--- a/sources/dataBase/projectdatabase.h
+++ b/sources/dataBase/projectdatabase.h
@@ -62,6 +62,13 @@ class projectDataBase : public QObject
 
 		void addConductor       (Conductor *conductor);
 		void removeConductor    (Conductor *conductor);
+		void updateConductor    (Conductor *conductor);
+
+	private slots:
+			//Refresh the sender()'s row after Conductor::setProperties().
+		void conductorPropertiesChanged();
+
+	public:
 
 	signals:
 		void dataBaseUpdated();
@@ -75,6 +82,8 @@ class projectDataBase : public QObject
 		void populateElementInfoTable();
 		void populateDiagramInfoTable();
 		void populateConductorTable();
+		void bindConductorValues(QSqlQuery &query, Conductor *conductor, Diagram *diagram);
+		void watchConductor(Conductor *conductor);
 		void insertTerminal(Terminal *terminal);
 		void prepareQuery();
 		static QHash<QString, QString> elementInfoToString(
@@ -96,6 +105,7 @@ class projectDataBase : public QObject
 				  m_diagram_info_order_changed,
 				  m_insert_terminal_query,
 				  m_insert_conductor_query,
+				  m_update_conductor_query,
 				  m_remove_conductor_query;
 
 #ifdef QET_EXPORT_PROJECT_DB

--- a/sources/diagram.cpp
+++ b/sources/diagram.cpp
@@ -1674,6 +1674,7 @@ void Diagram::addItem(QGraphicsItem *item)
 			conductor->terminal1->addConductor(conductor);
 			conductor->terminal2->addConductor(conductor);
 			conductor->calculateTextItemPosition();
+			m_project->dataBase()->addConductor(conductor);
 			break;
 		}
 		default: {break;}
@@ -1704,6 +1705,7 @@ void Diagram::removeItem(QGraphicsItem *item)
 			Conductor *conductor = static_cast<Conductor *>(item);
 			conductor->terminal1->removeConductor(conductor);
 			conductor->terminal2->removeConductor(conductor);
+			m_project->dataBase()->removeConductor(conductor);
 			break;
 		}
 		default: {break;}

--- a/sources/diagramcommands.cpp
+++ b/sources/diagramcommands.cpp
@@ -75,6 +75,13 @@ void PasteDiagramCommand::redo()
 	{
 		first_redo = false;
 
+		//make new uuid for every pasted conductor, because old uuid are
+		//the uuid of the copied conductor
+		const QList <Conductor *> all_pasted_conductors = content.conductors();
+		for (Conductor *c : all_pasted_conductors) {
+			c -> newUuid();
+		}
+
 		//this is the first paste, we do some actions for the new element
 		const QList <Element *> elmts_list = content.m_elements;
 		for (Element *e : elmts_list)

--- a/sources/elementspanelwidget.cpp
+++ b/sources/elementspanelwidget.cpp
@@ -17,6 +17,7 @@
 */
 #include "elementspanelwidget.h"
 #include "diagram.h"
+#include "qetgraphicsitem/conductor.h"
 #include "editor/ui/qetelementeditor.h"
 #include "elementscategoryeditor.h"
 #include "qetapp.h"
@@ -651,6 +652,13 @@ void ElementsPanelWidget::duplicateDiagram()
 				// silently vanish from nomenclature/summary tables.
 				elmt->newUuid();
 				new_diagram->restoreText(elmt);
+			}
+			else if (Conductor *cond = dynamic_cast<Conductor *>(item)) {
+				// Same reasoning for conductors: conductor.uuid is the PRIMARY
+				// KEY of the conductor table, and its insert is a plain INSERT,
+				// so a duplicated uuid fails and the wire silently disappears
+				// from the wiring list and the per-element wire count.
+				cond->newUuid();
 			}
 		}
 	}

--- a/sources/qetgraphicsitem/conductor.cpp
+++ b/sources/qetgraphicsitem/conductor.cpp
@@ -91,6 +91,7 @@ Conductor::Conductor(Terminal *p1, Terminal* p2) :
 		//set Zvalue at 11 to be upper than the DiagramImageItem and element
 	setZValue(11);
 	m_previous_z_value = zValue();
+	m_uuid = QUuid::createUuid();
 
 		//Add this conductor to the list of conductors of each of the two terminals
 	bool ajout_p1 = terminal1 -> addConductor(this);
@@ -1005,6 +1006,12 @@ void Conductor::pointsToSegments(const QList<QPointF>& points_list) {
 */
 bool Conductor::fromXml(QDomElement &dom_element)
 {
+		//Older project files have no conductor uuid attribute at all --
+		//generate one on load, same treatment terminal uuids got when
+		//that field was introduced (see terminal1/terminal2 handling in
+		//toXml() below).
+	m_uuid = QUuid(dom_element.attribute("uuid", QUuid::createUuid().toString()));
+
 	setPos(dom_element.attribute("x", nullptr).toDouble(),
 		   dom_element.attribute("y", nullptr).toDouble());
 
@@ -1043,6 +1050,7 @@ QDomElement Conductor::toXml(QDomDocument &dom_document,
 {
 	QDomElement dom_element = dom_document.createElement("conductor");
 
+	dom_element.setAttribute("uuid", m_uuid.toString());
 	dom_element.setAttribute("x", QString::number(pos().x()));
 	dom_element.setAttribute("y", QString::number(pos().y()));
 	

--- a/sources/qetgraphicsitem/conductor.cpp
+++ b/sources/qetgraphicsitem/conductor.cpp
@@ -1010,7 +1010,13 @@ bool Conductor::fromXml(QDomElement &dom_element)
 		//generate one on load, same treatment terminal uuids got when
 		//that field was introduced (see terminal1/terminal2 handling in
 		//toXml() below).
-	m_uuid = QUuid(dom_element.attribute("uuid", QUuid::createUuid().toString()));
+	m_uuid = QUuid(dom_element.attribute(QStringLiteral("uuid")));
+	if (m_uuid.isNull()) {
+			//Absent, empty or malformed: mint one. A null uuid is not a usable
+			//identity -- every conductor carrying one would collide with every
+			//other on the conductor table's primary key.
+		m_uuid = QUuid::createUuid();
+	}
 
 	setPos(dom_element.attribute("x", nullptr).toDouble(),
 		   dom_element.attribute("y", nullptr).toDouble());

--- a/sources/qetgraphicsitem/conductor.h
+++ b/sources/qetgraphicsitem/conductor.h
@@ -21,6 +21,7 @@
 #include "../conductorproperties.h"
 
 #include <QGraphicsPathItem>
+#include <QUuid>
 
 class ConductorProfile;
 class ConductorSegmentProfile;
@@ -77,6 +78,8 @@ class Conductor : public QGraphicsObject
 		int type() const override { return Type; }
 		Diagram *diagram() const;
 		ConductorTextItem *textItem() const;
+		QUuid uuid() const {return m_uuid;}
+		void newUuid() {m_uuid = QUuid::createUuid();}	//create new uuid for this conductor
 		void updatePath(const QRectF & = QRectF());
 
 		//This method do nothing, it's only made to be used with Q_PROPERTY
@@ -205,6 +208,7 @@ class Conductor : public QGraphicsObject
 		Highlight must_highlight_;
 		bool m_valid;
 		bool m_freeze_label = false;
+		QUuid m_uuid;
 
 			/// QPen et QBrush objects used to draw conductors
 		static QPen conductor_pen;

--- a/sources/qetgraphicsitem/terminal.cpp
+++ b/sources/qetgraphicsitem/terminal.cpp
@@ -817,6 +817,60 @@ QUuid Terminal::uuid() const
 	return d->m_uuid;
 }
 
+/**
+	@brief Terminal::stableUuid
+	An identity for this terminal that exists on every element, not only on
+	those saved by a uuid-aware element editor.
+
+	uuid() comes from the catalog .elmt definition and is empty for every
+	element authored before that field existed -- which is most of the
+	installed base. Anything keyed on uuid() alone therefore cannot see those
+	elements at all.
+
+	When there is no uuid, derive one from the terminal's local position and
+	orientation inside its element. That is not an arbitrary choice: it is the
+	same thing the project format itself uses to match a conductor back to a
+	terminal ("each connection is made by using the local position of the
+	terminal and a dynamic id" -- TerminalData::m_uuid). m_pos is the position
+	read from the definition and is not touched by moving the element on the
+	folio, so the result is stable across loads, saves and folio moves, and it
+	is unique within an element except where a definition genuinely declares
+	two terminals at the same point -- three cases in the whole example corpus,
+	and harmless, because two terminals sharing a position and orientation are
+	indistinguishable in every observable respect: they merge to one terminal
+	row and every conductor on either of them still resolves to the right
+	element and name.
+
+	Derived values are UUID v5 in a fixed namespace, so they are reproducible
+	without being written to the file, and cannot collide with the v4 uuids
+	the element editor generates.
+
+	@return the terminal's own uuid when it has one, otherwise a derived one
+*/
+QUuid Terminal::stableUuid() const
+{
+	if (!d->m_uuid.isNull()) {
+		return d->m_uuid;
+	}
+
+		//Fixed namespace for terminal identities derived from geometry.
+	static const QUuid derived_ns(QStringLiteral("{6b1f6d1e-6a1a-5f7e-9a3d-9c0a5b2d7e11}"));
+
+		//Position and orientation only. The name is deliberately excluded: it
+		//is not stable across a save cycle -- QET rewrites a terminal named
+		//"_" as unnamed, which would silently change the identity of 1421 of
+		//industrial.qet's 1790 terminals on the first resave. It is also not
+		//needed: keying on geometry alone produces exactly the same number of
+		//collisions across the example corpus, and it means renaming a
+		//terminal does not change what it is.
+	const QString key = QStringLiteral("%1|%2|%3")
+			.arg(d->m_pos.x(), 0, 'f', 4)
+			.arg(d->m_pos.y(), 0, 'f', 4)
+			.arg(static_cast<int>(d->m_orientation));
+
+	return QUuid::createUuidV5(derived_ns, key);
+}
+
 QString Terminal::name() const
 {
 	if (d->m_use_master_label && parent_element_) {

--- a/sources/qetgraphicsitem/terminal.h
+++ b/sources/qetgraphicsitem/terminal.h
@@ -75,6 +75,7 @@ class Terminal : public QGraphicsObject
 		Diagram  *diagram             () const;
 		Element  *parentElement       () const;
 		QUuid     uuid                () const;
+		QUuid     stableUuid          () const;
 		QString   name                () const;
 		QString   baseName            () const;
 		TerminalData::Type terminalType() const;


### PR DESCRIPTION
> ### Updated since first posting
>
> The headline change: **the tables are no longer empty on legacy projects.** As first posted, a conductor entered the `conductor` table only if *both* its terminals carried a uuid from the catalog `.elmt`, which meant `industrial.qet` contributed **0 of its 671 conductors** and 16 of the 20 example projects with wiring contributed nothing at all. `Terminal::stableUuid()` fixes that — see correction 2 below, rewritten. All 20 measurable projects now return their full conductor count.
>
> Three smaller fixes alongside it:
>
> - **A conductor's `text` was written once and never updated.** Renaming a wire left the database holding the old number. Elements have `elementInfoChanged()` for exactly this; conductors had nothing. Since `Conductor::setProperties()` has around a dozen call sites, this listens to the `propertiesChange()` signal it already emits rather than adding a call to each and missing the ones added later. `Qt::UniqueConnection` makes repeated inserts and full repopulates harmless, and the connection is made on **both** insert paths because conductors read from a file never pass through `addConductor()`.
> - **`addConductor()` and `populateConductorTable()` each carried their own copy of the same seven `bindValue()` lines.** They had not drifted yet, but that is exactly the duplication the element paths had before `bindElementValues()` — where they *had* drifted, one binding `kindInformations()["type"]` and the other `masterTypeToString()`. Now one `bindConductorValues()` for both. This paid off immediately: the `stableUuid()` change above touches two call sites instead of five.
> - **Indexes on the conductor columns that are looked up per element**, not per conductor. `element_nomenclature_view` counts wires per element with a correlated subquery (#631), so without an index every element row full-scans `conductor` and the cost grows as elements × conductors. Measured on a standalone SQLite harness at 2000 elements × 5000 conductors: **2134 ms unindexed, 10 ms indexed**. `diagram_uuid` is indexed too, since the wiring list view joins on it.

**Ready for review.** Merge #625 first; the commit to review here is `Add terminal and conductor tables to projectDataBase`. #629 → #630 follow.

Slice 2 of #503 (from-to wiring list built on `projectDataBase`).

> **Stacked on #625** (slice 1, conductor uuid) — that PR is not merged yet, so this branch contains its commit too. Please merge #625 first; this diff then reduces to the single commit `Add terminal and conductor tables to projectDataBase`. Reviewing just that commit is the intended view.

Pure plumbing: two new **additive** tables plus their populate/add/remove hooks. No view, no UI, **no visible behaviour change yet** — the `wiring_list_view` is slice 3.

## Change

Follows the existing shape of the class throughout — same table/column naming, same prepared-statement idiom in `prepareQuery()`, same bind/exec/`qDebug`-`lastError` error handling, same `DELETE`-then-loop populate pattern.

- `terminal (uuid, element_uuid, name)` and `conductor (uuid, diagram_uuid, terminal1_uuid, terminal1_element_uuid, terminal2_uuid, terminal2_element_uuid, text)`, created alongside the existing tables in `createDataBase()`.
- `populateConductorTable()` added as a fifth `populate*` call in `updateDB()`. Terminal population is folded into it, since a terminal only matters here in the context of a conductor referencing it.
- `addConductor()`/`removeConductor()` hooked into the **already-existing** `Conductor::Type` branch of `Diagram::addItem()`/`removeItem()`, mirroring the `Element::Type` branch directly above — two new call sites in an existing switch.

## Two corrections to the schema sketched in the discussion

Both found by testing rather than inspection, and worth flagging since the discussion's schema is now wrong on these points:

1. **`Terminal::uuid()` is not unique per placed terminal.** It's the terminal-position id baked into the catalog `.elmt` definition ("the top terminal"), so *every placed instance of the same catalog element shares it*. A terminal instance is only uniquely identified by `(uuid, element_uuid)` together — so that pair is the terminal table's primary key, and the conductor table carries both halves for each endpoint. With `uuid` alone as PK (as originally sketched), the second placed instance of any element silently lost its terminals to the `INSERT OR IGNORE`.
2. **Legacy omission bit far harder than expected — and is now fixed.** Conductors whose terminals predate terminal uuids were omitted rather than given a fabricated identity, as agreed in the discussion. But `examples/industrial.qet` has 1790 terminals and **zero** terminal uuids, so **all 671 of its conductors were omitted** — a wiring list for that project would have been completely empty. Across the 23 example projects, 16 of the 20 that contain conductors have no terminal uuids at all: 2366 of 3002 conductors, 7.3% overall coverage. That is not an ageing project-file problem that re-saving fixes; it is a property of the element catalog definitions.

   Rather than ship tables that are empty on almost every project that exists, `Terminal::stableUuid()` now returns the terminal's own uuid when it has one and otherwise derives one from its **local position and orientation** inside its element. That is not an invented scheme — it is what the project format already does, and `TerminalData::fromXml()` says so where it parses the field: *"if the attribute not exists, means, the element is created with an older version of qet. So use the legacy approach to identify terminals."* `m_pos` comes from the definition and is not touched by moving the element on a folio, so the identity survives loads, saves and folio moves. Derived values are UUID v5 in a fixed namespace, so they are reproducible without being written to the file and cannot collide with the v4 uuids the element editor generates. **No file-format change, no migration.**

   Two things it deliberately does not key on, both settled by measurement rather than argument:

   - **The terminal name**, because it is not stable. QET rewrites a terminal named `"_"` as unnamed, which would have silently changed the identity of 1421 of `industrial.qet`'s 1790 terminals on their first resave — caught by round-tripping the corpus. Dropping it costs nothing: geometry alone yields exactly the same three collisions across the whole corpus, and it means renaming a terminal no longer changes what it is.
   - **Uniqueness against a definition that declares two terminals at the same point and orientation.** Three such cases exist in the entire corpus. They merge to one terminal row, which is harmless — two terminals identical in position and orientation are indistinguishable in every observable respect, and every conductor on either still resolves to the right element and terminal name. Both affected projects (`industrial`, `perceuse`) return their full conductor count.

   The only conductor still skipped is one whose terminal has no parent element, which has no identity to key on under any scheme.

## Testing

All live, in the running app:

| Path | Result |
|---|---|
| Incremental add (`Diagram::addItem`) | fresh project, two aligned contacts → autoconnect → **2 terminals, 1 conductor** |
| Incremental remove (`Diagram::removeItem`) | delete that conductor → **1 → 0** |
| Undo | Ctrl+Z after delete → **0 → 1**, no duplicate-PK error (same `Conductor` object keeps its uuid) |
| Bulk populate (`updateDB`) | `weneedpolonez-Polonez_MR89_wiring_diagram.qet`, 366 conductors → **366 conductor rows** (was 280 before `stableUuid()`) |
| Join correctness | `conductor` → `terminal` (composite key) → `element_info` resolves real from-to rows with real element labels |
| Legacy-only project | `industrial.qet` → **671 of 671 conductors** (was 0), loads and renders fine, no crash |
| Whole corpus | 20 of 20 measurable projects return exactly as many conductor rows as the document has conductors, 0 mismatches |
| Identity stability | resave `industrial.qet` → the derived-identity key multiset is byte-for-byte unchanged across the round trip |

No SQL errors logged in any of the above. Built clean, no new warnings.

## Known limitation

`removeDiagram()` does not cascade-delete that diagram's conductor rows — exactly as it already does not cascade to `element`/`element_info`. A full `updateDB()` rebuild clears them, and the slice-3 view selects `FROM conductor`, so orphan terminal rows never surface. Left consistent with existing behaviour rather than changing it in a plumbing PR.

