### PR TITLE
Add wiring_list_view: from-to wiring list over the conductor tables (discussion #503, slice 3)

### DIFF
--- a/sources/cli_export.cpp
+++ b/sources/cli_export.cpp
@@ -70,6 +70,7 @@ const QHash<QString, QString> &exportFlags()
 		{"--export-cables", "cables"},
 		{"--export-wires", "wires"},
 		{"--export-bom", "bom"},
+		{"--export-wiring", "wiring"},
 		{"--export-nets", "nets"},
 		{"--export-links", "links"},
 		{"--info", "info"},
@@ -525,6 +526,54 @@ QHash<Element *, int> folioIndex(QETProject &project)
 	return folio;
 }
 
+/// From-to wiring list: one row per conductor, each endpoint resolved to its
+/// element label and terminal name.
+///
+/// Reads wiring_list_view out of the project database. --export-cables produces
+/// the same logical list from the document XML instead, and the two are meant
+/// to agree: running both and diffing them is a direct check that the database
+/// still describes the project, which is otherwise only observable through the
+/// GUI.
+int exportWiring(QETProject &project, const QString &output)
+{
+	// The project database is built lazily; force a (re)build before querying.
+	project.dataBase()->updateDB();
+
+	static const QStringList columns {
+		"wire_number", "from_element_label", "from_terminal",
+		"to_element_label", "to_terminal", "diagram_position", "conductor_uuid"
+	};
+
+	QSqlQuery query = project.dataBase()->newQuery(
+		"SELECT " % columns.join(", ") %
+		" FROM wiring_list_view ORDER BY diagram_position, wire_number");
+	if (!query.exec()) {
+		err << "Wiring list query failed: " << query.lastError().text() << "\n";
+		return 1;
+	}
+
+	QString csv = columns.join(";") % "\n";
+	int rows = 0;
+	while (query.next()) {
+		QStringList values;
+		for (int i = 0; i < columns.size(); ++i)
+			values << csvField(query.value(i).toString());
+		csv += values.join(";") % "\n";
+		++rows;
+	}
+
+	QFile file(output);
+	if (!file.open(QIODevice::WriteOnly | QIODevice::Text)) {
+		err << "Cannot open '" << output << "' for writing.\n";
+		return 1;
+	}
+	QTextStream fout(&file);
+	fout << csv;
+	file.close();
+	out << "Exported " << rows << " conductor(s) -> " << output << "\n";
+	return 0;
+}
+
 /// Electrical nets: groups of terminals joined into one potential.
 /// Walks QET's own potential graph, so each net is a connected component
 /// of terminals across all folios. The ground truth for connectivity.
@@ -823,6 +872,8 @@ int run(const QStringList &args)
 		return exportCsv(project, format, output);
 	if (format == "bom")
 		return exportBom(project, output);
+	if (format == "wiring")
+		return exportWiring(project, output);
 	if (format == "nets")
 		return exportNets(project, output);
 	if (format == "links")

--- a/sources/cli_export.h
+++ b/sources/cli_export.h
@@ -48,6 +48,7 @@ namespace CLIExport {
 		  qelectrotech --export-cables  <project.qet> <output.csv>
 		  qelectrotech --export-wires   <project.qet> <output.csv>
 		  qelectrotech --export-bom     <project.qet> <output.csv>
+		  qelectrotech --export-wiring  <project.qet> <output.csv>
 		  qelectrotech --export-nets    <project.qet> <output.json>
 		  qelectrotech --export-links   <project.qet> <output.csv>
 		  qelectrotech --info           <project.qet> [output.json]
@@ -60,6 +61,11 @@ namespace CLIExport {
 		cables: wiring list (one row per conductor) as CSV.
 		wires: list of distinct wire numbers as CSV.
 		bom: bill of materials (one row per element) as CSV.
+		wiring: from-to wiring list (one row per conductor) as CSV, read from
+		        the project database. Same logical list as `cables`, which
+		        reads the document XML instead; the two are meant to agree,
+		        so diffing them checks that the database still describes the
+		        project.
 		nets: electrical nets (connected-terminal groups) as JSON.
 		links: element cross-references (coil/contact) as CSV, with
 		       unresolved links flagged.

--- a/sources/dataBase/projectdatabase.cpp
+++ b/sources/dataBase/projectdatabase.cpp
@@ -271,13 +271,8 @@ void projectDataBase::addConductor(Conductor *conductor)
 	insertTerminal(conductor->terminal1);
 	insertTerminal(conductor->terminal2);
 
-	m_insert_conductor_query.bindValue(":uuid", conductor->uuid().toString());
-	m_insert_conductor_query.bindValue(":diagram_uuid", conductor->diagram()->uuid().toString());
-	m_insert_conductor_query.bindValue(":terminal1_uuid", conductor->terminal1->uuid().toString());
-	m_insert_conductor_query.bindValue(":terminal1_element_uuid", conductor->terminal1->parentElement()->uuid().toString());
-	m_insert_conductor_query.bindValue(":terminal2_uuid", conductor->terminal2->uuid().toString());
-	m_insert_conductor_query.bindValue(":terminal2_element_uuid", conductor->terminal2->parentElement()->uuid().toString());
-	m_insert_conductor_query.bindValue(":text", conductor->properties().text);
+	watchConductor(conductor);
+	bindConductorValues(m_insert_conductor_query, conductor, conductor->diagram());
 	if (!m_insert_conductor_query.exec()) {
 		qDebug() << "projectDataBase::addConductor insert error : " << m_insert_conductor_query.lastError();
 	} else {
@@ -297,6 +292,85 @@ void projectDataBase::removeConductor(Conductor *conductor)
 	} else {
 		emit dataBaseUpdated();
 	}
+}
+
+/**
+	@brief projectDataBase::updateConductor
+	Refresh the mutable columns of an already-inserted conductor.
+
+	Only the text (the wire number) can change without the conductor being
+	removed and re-added: its endpoints are fixed for its lifetime. Without
+	this, renaming a wire left the database holding the old number and the
+	wiring list showed a stale value until the next full repopulate.
+	@param conductor
+*/
+void projectDataBase::updateConductor(Conductor *conductor)
+{
+	if (!conductor) {
+		return;
+	}
+
+	m_update_conductor_query.bindValue(QStringLiteral(":uuid"), conductor->uuid().toString());
+	m_update_conductor_query.bindValue(QStringLiteral(":text"), conductor->properties().text);
+	if (!m_update_conductor_query.exec()) {
+		qDebug() << "projectDataBase::updateConductor update error : " << m_update_conductor_query.lastError();
+	}
+
+		//Deliberately no dataBaseUpdated() here, unlike add/remove. The only
+		//column this touches is the wire text, which no view watched by
+		//ProjectDBModel displays -- the nomenclature shows elements, and its
+		//wire_count changes when a conductor appears or disappears, not when
+		//it is renamed. Emitting would make every ProjectDBModel re-run its
+		//query, and auto-numbering renames every conductor in the project in
+		//one pass.
+}
+
+/**
+	@brief projectDataBase::watchConductor
+	Keep this conductor's row in step with its properties.
+
+	Conductor::setProperties() has a dozen call sites (auto-numbering, the
+	properties dialog, element moves, deletion re-links...), so listening to
+	the signal it already emits is the only way to catch them all -- and the
+	only way to catch the ones added later. Qt::UniqueConnection makes a
+	repeated insert or a full repopulate harmless.
+	@param conductor
+*/
+void projectDataBase::watchConductor(Conductor *conductor)
+{
+	connect(conductor, &Conductor::propertiesChange,
+			this, &projectDataBase::conductorPropertiesChanged,
+			Qt::UniqueConnection);
+}
+
+/**
+	@brief projectDataBase::conductorPropertiesChanged
+*/
+void projectDataBase::conductorPropertiesChanged()
+{
+	if (auto *conductor = qobject_cast<Conductor *>(sender())) {
+		updateConductor(conductor);
+	}
+}
+
+/**
+	@brief projectDataBase::bindConductorValues
+	One binder for both insert paths, so a conductor added to a live diagram
+	and one read from a file can never drift apart -- the same reason
+	bindElementValues() exists for elements.
+	@param query
+	@param conductor
+	@param diagram : the diagram the conductor belongs to
+*/
+void projectDataBase::bindConductorValues(QSqlQuery &query, Conductor *conductor, Diagram *diagram)
+{
+	query.bindValue(QStringLiteral(":uuid"), conductor->uuid().toString());
+	query.bindValue(QStringLiteral(":diagram_uuid"), diagram->uuid().toString());
+	query.bindValue(QStringLiteral(":terminal1_uuid"), conductor->terminal1->uuid().toString());
+	query.bindValue(QStringLiteral(":terminal1_element_uuid"), conductor->terminal1->parentElement()->uuid().toString());
+	query.bindValue(QStringLiteral(":terminal2_uuid"), conductor->terminal2->uuid().toString());
+	query.bindValue(QStringLiteral(":terminal2_element_uuid"), conductor->terminal2->parentElement()->uuid().toString());
+	query.bindValue(QStringLiteral(":text"), conductor->properties().text);
 }
 
 /**
@@ -411,6 +485,21 @@ bool projectDataBase::createDataBase()
 						  ")");
 	if (!query_.exec(conductor_table)) {
 		qDebug() << "conductor_table query : "<< query_.lastError();
+	}
+
+		//The element-facing columns are looked up per element row, not per
+		//conductor row: element_nomenclature_view carries a correlated
+		//subquery counting the wires touching each element. Without these
+		//indexes each element row full-scans the conductor table, which grows
+		//as elements x conductors.
+	for (const QString &index_ : {
+			QStringLiteral("CREATE INDEX idx_conductor_terminal1_element ON conductor (terminal1_element_uuid)"),
+			QStringLiteral("CREATE INDEX idx_conductor_terminal2_element ON conductor (terminal2_element_uuid)"),
+			QStringLiteral("CREATE INDEX idx_conductor_diagram ON conductor (diagram_uuid)") })
+	{
+		if (!query_.exec(index_)) {
+			qDebug() << "conductor index query : " << query_.lastError();
+		}
 	}
 
 	createElementNomenclatureView();
@@ -650,13 +739,8 @@ void projectDataBase::populateConductorTable()
 			insertTerminal(conductor->terminal1);
 			insertTerminal(conductor->terminal2);
 
-			m_insert_conductor_query.bindValue(":uuid", conductor->uuid().toString());
-			m_insert_conductor_query.bindValue(":diagram_uuid", diagram->uuid().toString());
-			m_insert_conductor_query.bindValue(":terminal1_uuid", conductor->terminal1->uuid().toString());
-			m_insert_conductor_query.bindValue(":terminal1_element_uuid", conductor->terminal1->parentElement()->uuid().toString());
-			m_insert_conductor_query.bindValue(":terminal2_uuid", conductor->terminal2->uuid().toString());
-			m_insert_conductor_query.bindValue(":terminal2_element_uuid", conductor->terminal2->parentElement()->uuid().toString());
-			m_insert_conductor_query.bindValue(":text", conductor->properties().text);
+			watchConductor(conductor);
+			bindConductorValues(m_insert_conductor_query, conductor, diagram);
 			if (!m_insert_conductor_query.exec()) {
 				qDebug() << "projectDataBase::populateConductorTable insert error : " << m_insert_conductor_query.lastError();
 			}
@@ -761,6 +845,10 @@ void projectDataBase::prepareQuery()
 	m_insert_conductor_query = QSqlQuery(m_data_base);
 	m_insert_conductor_query.prepare("INSERT INTO conductor (uuid, diagram_uuid, terminal1_uuid, terminal1_element_uuid, terminal2_uuid, terminal2_element_uuid, text) "
 					  "VALUES (:uuid, :diagram_uuid, :terminal1_uuid, :terminal1_element_uuid, :terminal2_uuid, :terminal2_element_uuid, :text)");
+
+		//UPDATE CONDUCTOR
+	m_update_conductor_query = QSqlQuery(m_data_base);
+	m_update_conductor_query.prepare(QStringLiteral("UPDATE conductor SET text = :text WHERE uuid = :uuid"));
 
 		//REMOVE CONDUCTOR
 	m_remove_conductor_query = QSqlQuery(m_data_base);

--- a/sources/dataBase/projectdatabase.cpp
+++ b/sources/dataBase/projectdatabase.cpp
@@ -505,6 +505,7 @@ bool projectDataBase::createDataBase()
 
 	createElementNomenclatureView();
 	createSummaryView();
+	createWiringListView();
 	prepareQuery();
 	updateDB();
 	return true;
@@ -615,6 +616,56 @@ void projectDataBase::createSummaryView()
 						 "d.pos AS pos"
 						 " FROM diagram_info di, diagram d"
 						 " WHERE di.diagram_uuid = d.uuid");
+
+	QSqlQuery query(m_data_base);
+	if (!query.exec(create_view)) {
+		qDebug() << query.lastError();
+	}
+}
+
+/**
+	@brief projectDataBase::createWiringListView
+	A from-to wiring list: one row per conductor, each endpoint resolved to
+	its element label and terminal name.
+
+	Two deliberate differences from an ordinary inner-join view like
+	element_nomenclature_view:
+
+	- No join to the element table. A terminal row already carries its
+	  element_uuid, so joining element back just to read the same uuid adds
+	  nothing -- and would actively drop rows, because populateElementTable()
+	  only inserts elements matching Simple|Terminal|Master|Thumbnail. Slave
+	  elements (relay contacts and the like, extremely common at the end of a
+	  wire) and report elements are absent from that table after a project
+	  load, so an inner join through it silently loses their conductors.
+	- element_info is LEFT joined for the same reason. A wire whose endpoint
+	  element carries no info row still belongs in a wiring list; it comes
+	  back with an empty label rather than vanishing. Losing a wire from a
+	  wiring list is a worse failure than showing one with a blank end.
+
+	The result is that this view returns exactly as many rows as the
+	conductor table holds -- what is already excluded upstream (conductors
+	on legacy terminals without uuids) stays excluded, and nothing new is
+	dropped here.
+*/
+void projectDataBase::createWiringListView()
+{
+	QString create_view ("CREATE VIEW wiring_list_view AS SELECT "
+						 "c.uuid AS conductor_uuid,"
+						 "c.text AS wire_number,"
+						 "t1.element_uuid AS from_element_uuid,"
+						 "ei1.label AS from_element_label,"
+						 "t1.name AS from_terminal,"
+						 "t2.element_uuid AS to_element_uuid,"
+						 "ei2.label AS to_element_label,"
+						 "t2.name AS to_terminal,"
+						 "d.pos AS diagram_position"
+						 " FROM conductor c"
+						 " JOIN terminal t1 ON c.terminal1_uuid = t1.uuid AND c.terminal1_element_uuid = t1.element_uuid"
+						 " JOIN terminal t2 ON c.terminal2_uuid = t2.uuid AND c.terminal2_element_uuid = t2.element_uuid"
+						 " LEFT JOIN element_info ei1 ON t1.element_uuid = ei1.element_uuid"
+						 " LEFT JOIN element_info ei2 ON t2.element_uuid = ei2.element_uuid"
+						 " JOIN diagram d ON c.diagram_uuid = d.uuid");
 
 	QSqlQuery query(m_data_base);
 	if (!query.exec(create_view)) {

--- a/sources/dataBase/projectdatabase.cpp
+++ b/sources/dataBase/projectdatabase.cpp
@@ -643,10 +643,18 @@ void projectDataBase::createSummaryView()
 	  back with an empty label rather than vanishing. Losing a wire from a
 	  wiring list is a worse failure than showing one with a blank end.
 
+	- diagram is LEFT joined for the same reason. It should
+	  always match, since QETProject::diagramAdded is wired to addDiagram()
+	  and a conductor cannot exist before its folio -- but an inner join here
+	  would make that an assumption the view silently enforces, and a wire
+	  missing from a wiring list is the one failure this view must not have.
+
 	The result is that this view returns exactly as many rows as the
 	conductor table holds -- what is already excluded upstream (conductors
 	on legacy terminals without uuids) stays excluded, and nothing new is
-	dropped here.
+	dropped here. Only the terminal joins are inner, and both are guaranteed
+	by insertTerminal() running for each endpoint before the conductor row
+	is written.
 */
 void projectDataBase::createWiringListView()
 {
@@ -665,7 +673,7 @@ void projectDataBase::createWiringListView()
 						 " JOIN terminal t2 ON c.terminal2_uuid = t2.uuid AND c.terminal2_element_uuid = t2.element_uuid"
 						 " LEFT JOIN element_info ei1 ON t1.element_uuid = ei1.element_uuid"
 						 " LEFT JOIN element_info ei2 ON t2.element_uuid = ei2.element_uuid"
-						 " JOIN diagram d ON c.diagram_uuid = d.uuid");
+						 " LEFT JOIN diagram d ON c.diagram_uuid = d.uuid");
 
 	QSqlQuery query(m_data_base);
 	if (!query.exec(create_view)) {

--- a/sources/dataBase/projectdatabase.cpp
+++ b/sources/dataBase/projectdatabase.cpp
@@ -21,7 +21,9 @@
 #include "../diagramposition.h"
 #include "../elementprovider.h"
 #include "../qetapp.h"
+#include "../qetgraphicsitem/conductor.h"
 #include "../qetgraphicsitem/element.h"
+#include "../qetgraphicsitem/terminal.h"
 #include "../qetinformation.h"
 #include "../qetproject.h"
 
@@ -87,6 +89,7 @@ void projectDataBase::updateDB()
 	populateDiagramInfoTable();
 	populateElementTable();
 	populateElementInfoTable();
+	populateConductorTable();
 	emit dataBaseUpdated();
 }
 
@@ -246,6 +249,57 @@ void projectDataBase::diagramOrderChanged()
 }
 
 /**
+	@brief projectDataBase::addConductor
+	@param conductor
+*/
+void projectDataBase::addConductor(Conductor *conductor)
+{
+	if (!conductor || !conductor->diagram()) {
+		qDebug() << "projectDataBase::addConductor: null conductor or diagram";
+		return;
+	}
+
+		//A conductor whose terminal(s) predate terminal uuids (legacy
+		//elements not yet re-saved by a uuid-aware element editor) can't
+		//be given a stable identity here -- omitted the same way
+		//element_nomenclature_view already omits exclude_from_bom elements,
+		//rather than fabricating one.
+	if (conductor->terminal1->uuid().isNull() || conductor->terminal2->uuid().isNull()) {
+		return;
+	}
+
+	insertTerminal(conductor->terminal1);
+	insertTerminal(conductor->terminal2);
+
+	m_insert_conductor_query.bindValue(":uuid", conductor->uuid().toString());
+	m_insert_conductor_query.bindValue(":diagram_uuid", conductor->diagram()->uuid().toString());
+	m_insert_conductor_query.bindValue(":terminal1_uuid", conductor->terminal1->uuid().toString());
+	m_insert_conductor_query.bindValue(":terminal1_element_uuid", conductor->terminal1->parentElement()->uuid().toString());
+	m_insert_conductor_query.bindValue(":terminal2_uuid", conductor->terminal2->uuid().toString());
+	m_insert_conductor_query.bindValue(":terminal2_element_uuid", conductor->terminal2->parentElement()->uuid().toString());
+	m_insert_conductor_query.bindValue(":text", conductor->properties().text);
+	if (!m_insert_conductor_query.exec()) {
+		qDebug() << "projectDataBase::addConductor insert error : " << m_insert_conductor_query.lastError();
+	} else {
+		emit dataBaseUpdated();
+	}
+}
+
+/**
+	@brief projectDataBase::removeConductor
+	@param conductor
+*/
+void projectDataBase::removeConductor(Conductor *conductor)
+{
+	m_remove_conductor_query.bindValue(":uuid", conductor->uuid().toString());
+	if (!m_remove_conductor_query.exec()) {
+		qDebug() << "projectDataBase::removeConductor delete error : " << m_remove_conductor_query.lastError();
+	} else {
+		emit dataBaseUpdated();
+	}
+}
+
+/**
 	@brief projectDataBase::createDataBase
 	Create the data base
 	@return : true if the data base was successfully created.
@@ -321,6 +375,42 @@ bool projectDataBase::createDataBase()
 
 	if (!query_.exec(element_info_table)) {
 		qDebug() << " element_info_table query : " << query_.lastError();
+	}
+
+	//Create the terminal table.
+	//Terminal::uuid() is the terminal-position id baked into the catalog
+	//.elmt definition (e.g. "the top terminal") -- identical across every
+	//placed instance of that catalog element, not a per-instance id. A
+	//terminal instance is only uniquely identified by (uuid, element_uuid)
+	//together, so that pair is the primary key here, not uuid alone.
+	QString terminal_table("CREATE TABLE terminal"
+						  "( "
+						  "uuid VARCHAR(50) NOT NULL, "
+						  "element_uuid VARCHAR(50) NOT NULL,"
+						  "name VARCHAR(50),"
+						  "PRIMARY KEY (uuid, element_uuid),"
+						  "FOREIGN KEY (element_uuid) REFERENCES element (uuid)"
+						  ")");
+	if (!query_.exec(terminal_table)) {
+		qDebug() << "terminal_table query : "<< query_.lastError();
+	}
+
+	//Create the conductor table
+	QString conductor_table("CREATE TABLE conductor"
+						  "( "
+						  "uuid VARCHAR(50) PRIMARY KEY NOT NULL, "
+						  "diagram_uuid VARCHAR(50) NOT NULL,"
+						  "terminal1_uuid VARCHAR(50) NOT NULL,"
+						  "terminal1_element_uuid VARCHAR(50) NOT NULL,"
+						  "terminal2_uuid VARCHAR(50) NOT NULL,"
+						  "terminal2_element_uuid VARCHAR(50) NOT NULL,"
+						  "text VARCHAR(100),"
+						  "FOREIGN KEY (diagram_uuid) REFERENCES diagram (uuid),"
+						  "FOREIGN KEY (terminal1_uuid, terminal1_element_uuid) REFERENCES terminal (uuid, element_uuid),"
+						  "FOREIGN KEY (terminal2_uuid, terminal2_element_uuid) REFERENCES terminal (uuid, element_uuid)"
+						  ")");
+	if (!query_.exec(conductor_table)) {
+		qDebug() << "conductor_table query : "<< query_.lastError();
 	}
 
 	createElementNomenclatureView();
@@ -534,6 +624,62 @@ void projectDataBase::populateDiagramInfoTable()
 	}
 }
 
+/**
+	@brief projectDataBase::populateConductorTable
+	Populate the terminal and conductor tables. Terminals only matter here
+	in the context of a conductor referencing them, so their population is
+	folded into this method rather than tracked independently.
+*/
+void projectDataBase::populateConductorTable()
+{
+	QSqlQuery query(m_data_base);
+	query.exec(QStringLiteral("DELETE FROM conductor"));
+	query.exec(QStringLiteral("DELETE FROM terminal"));
+
+	for (auto *diagram : m_project->diagrams())
+	{
+		const auto conductor_list = diagram->conductors();
+		for (auto *conductor : conductor_list)
+		{
+				//See addConductor() for why terminals without a uuid
+				//(legacy elements) are omitted rather than fabricating one.
+			if (conductor->terminal1->uuid().isNull() || conductor->terminal2->uuid().isNull()) {
+				continue;
+			}
+
+			insertTerminal(conductor->terminal1);
+			insertTerminal(conductor->terminal2);
+
+			m_insert_conductor_query.bindValue(":uuid", conductor->uuid().toString());
+			m_insert_conductor_query.bindValue(":diagram_uuid", diagram->uuid().toString());
+			m_insert_conductor_query.bindValue(":terminal1_uuid", conductor->terminal1->uuid().toString());
+			m_insert_conductor_query.bindValue(":terminal1_element_uuid", conductor->terminal1->parentElement()->uuid().toString());
+			m_insert_conductor_query.bindValue(":terminal2_uuid", conductor->terminal2->uuid().toString());
+			m_insert_conductor_query.bindValue(":terminal2_element_uuid", conductor->terminal2->parentElement()->uuid().toString());
+			m_insert_conductor_query.bindValue(":text", conductor->properties().text);
+			if (!m_insert_conductor_query.exec()) {
+				qDebug() << "projectDataBase::populateConductorTable insert error : " << m_insert_conductor_query.lastError();
+			}
+		}
+	}
+}
+
+/**
+	@brief projectDataBase::insertTerminal
+	Insert (or, if already present -- e.g. a junction shared by several
+	conductors -- silently keep) @terminal in the terminal table.
+	@param terminal
+*/
+void projectDataBase::insertTerminal(Terminal *terminal)
+{
+	m_insert_terminal_query.bindValue(":uuid", terminal->uuid().toString());
+	m_insert_terminal_query.bindValue(":element_uuid", terminal->parentElement()->uuid().toString());
+	m_insert_terminal_query.bindValue(":name", terminal->name());
+	if (!m_insert_terminal_query.exec()) {
+		qDebug() << "projectDataBase::insertTerminal insert error : " << m_insert_terminal_query.lastError();
+	}
+}
+
 void projectDataBase::prepareQuery()
 {
 		//INSERT DIAGRAM
@@ -606,6 +752,19 @@ void projectDataBase::prepareQuery()
 	update_str.append(" WHERE element_uuid = :uuid");
 	m_update_element_query = QSqlQuery(m_data_base);
 	m_update_element_query.prepare(update_str);
+
+		//INSERT TERMINAL
+	m_insert_terminal_query = QSqlQuery(m_data_base);
+	m_insert_terminal_query.prepare("INSERT OR IGNORE INTO terminal (uuid, element_uuid, name) VALUES (:uuid, :element_uuid, :name)");
+
+		//INSERT CONDUCTOR
+	m_insert_conductor_query = QSqlQuery(m_data_base);
+	m_insert_conductor_query.prepare("INSERT INTO conductor (uuid, diagram_uuid, terminal1_uuid, terminal1_element_uuid, terminal2_uuid, terminal2_element_uuid, text) "
+					  "VALUES (:uuid, :diagram_uuid, :terminal1_uuid, :terminal1_element_uuid, :terminal2_uuid, :terminal2_element_uuid, :text)");
+
+		//REMOVE CONDUCTOR
+	m_remove_conductor_query = QSqlQuery(m_data_base);
+	m_remove_conductor_query.prepare("DELETE FROM conductor WHERE uuid=:uuid");
 }
 
 /**

--- a/sources/dataBase/projectdatabase.cpp
+++ b/sources/dataBase/projectdatabase.cpp
@@ -259,12 +259,13 @@ void projectDataBase::addConductor(Conductor *conductor)
 		return;
 	}
 
-		//A conductor whose terminal(s) predate terminal uuids (legacy
-		//elements not yet re-saved by a uuid-aware element editor) can't
-		//be given a stable identity here -- omitted the same way
-		//element_nomenclature_view already omits exclude_from_bom elements,
-		//rather than fabricating one.
-	if (conductor->terminal1->uuid().isNull() || conductor->terminal2->uuid().isNull()) {
+		//Both endpoints must belong to an element: the terminal table is keyed
+		//on (terminal, element) and a terminal with no parent has no identity
+		//to key on. Terminals whose *definition* predates terminal uuids are
+		//fine -- Terminal::stableUuid() derives one from the terminal's local
+		//position, which is what the project format itself matches on.
+	if (!conductor->terminal1->parentElement()
+		|| !conductor->terminal2->parentElement()) {
 		return;
 	}
 
@@ -366,9 +367,9 @@ void projectDataBase::bindConductorValues(QSqlQuery &query, Conductor *conductor
 {
 	query.bindValue(QStringLiteral(":uuid"), conductor->uuid().toString());
 	query.bindValue(QStringLiteral(":diagram_uuid"), diagram->uuid().toString());
-	query.bindValue(QStringLiteral(":terminal1_uuid"), conductor->terminal1->uuid().toString());
+	query.bindValue(QStringLiteral(":terminal1_uuid"), conductor->terminal1->stableUuid().toString());
 	query.bindValue(QStringLiteral(":terminal1_element_uuid"), conductor->terminal1->parentElement()->uuid().toString());
-	query.bindValue(QStringLiteral(":terminal2_uuid"), conductor->terminal2->uuid().toString());
+	query.bindValue(QStringLiteral(":terminal2_uuid"), conductor->terminal2->stableUuid().toString());
 	query.bindValue(QStringLiteral(":terminal2_element_uuid"), conductor->terminal2->parentElement()->uuid().toString());
 	query.bindValue(QStringLiteral(":text"), conductor->properties().text);
 }
@@ -730,9 +731,10 @@ void projectDataBase::populateConductorTable()
 		const auto conductor_list = diagram->conductors();
 		for (auto *conductor : conductor_list)
 		{
-				//See addConductor() for why terminals without a uuid
-				//(legacy elements) are omitted rather than fabricating one.
-			if (conductor->terminal1->uuid().isNull() || conductor->terminal2->uuid().isNull()) {
+				//See addConductor(): only a terminal with no parent element is
+				//skipped. A missing terminal uuid is handled by stableUuid().
+			if (!conductor->terminal1->parentElement()
+				|| !conductor->terminal2->parentElement()) {
 				continue;
 			}
 
@@ -756,7 +758,7 @@ void projectDataBase::populateConductorTable()
 */
 void projectDataBase::insertTerminal(Terminal *terminal)
 {
-	m_insert_terminal_query.bindValue(":uuid", terminal->uuid().toString());
+	m_insert_terminal_query.bindValue(":uuid", terminal->stableUuid().toString());
 	m_insert_terminal_query.bindValue(":element_uuid", terminal->parentElement()->uuid().toString());
 	m_insert_terminal_query.bindValue(":name", terminal->name());
 	if (!m_insert_terminal_query.exec()) {

--- a/sources/dataBase/projectdatabase.h
+++ b/sources/dataBase/projectdatabase.h
@@ -27,6 +27,8 @@
 class Element;
 class QETProject;
 class Diagram;
+class Conductor;
+class Terminal;
 class sqlite3;
 
 /**
@@ -58,6 +60,9 @@ class projectDataBase : public QObject
 		void diagramInfoChanged (Diagram *diagram);
 		void diagramOrderChanged();
 
+		void addConductor       (Conductor *conductor);
+		void removeConductor    (Conductor *conductor);
+
 	signals:
 		void dataBaseUpdated();
 
@@ -69,6 +74,8 @@ class projectDataBase : public QObject
 		void populateElementTable();
 		void populateElementInfoTable();
 		void populateDiagramInfoTable();
+		void populateConductorTable();
+		void insertTerminal(Terminal *terminal);
 		void prepareQuery();
 		static QHash<QString, QString> elementInfoToString(
 				Element *elmt);
@@ -86,7 +93,10 @@ class projectDataBase : public QObject
 				  m_insert_diagram_info_query,
 				  m_update_diagram_info_query,
 				  m_diagram_order_changed,
-				  m_diagram_info_order_changed;
+				  m_diagram_info_order_changed,
+				  m_insert_terminal_query,
+				  m_insert_conductor_query,
+				  m_remove_conductor_query;
 
 #ifdef QET_EXPORT_PROJECT_DB
 	public:

--- a/sources/dataBase/projectdatabase.h
+++ b/sources/dataBase/projectdatabase.h
@@ -77,6 +77,7 @@ class projectDataBase : public QObject
 		bool createDataBase();
 		void createElementNomenclatureView();
 		void createSummaryView();
+		void createWiringListView();
 		void populateDiagramTable();
 		void populateElementTable();
 		void populateElementInfoTable();

--- a/sources/dataBase/projectdatabase.h
+++ b/sources/dataBase/projectdatabase.h
@@ -62,6 +62,13 @@ class projectDataBase : public QObject
 
 		void addConductor       (Conductor *conductor);
 		void removeConductor    (Conductor *conductor);
+		void updateConductor    (Conductor *conductor);
+
+	private slots:
+			//Refresh the sender()'s row after Conductor::setProperties().
+		void conductorPropertiesChanged();
+
+	public:
 
 	signals:
 		void dataBaseUpdated();
@@ -75,6 +82,8 @@ class projectDataBase : public QObject
 		void populateElementInfoTable();
 		void populateDiagramInfoTable();
 		void populateConductorTable();
+		void bindConductorValues(QSqlQuery &query, Conductor *conductor, Diagram *diagram);
+		void watchConductor(Conductor *conductor);
 		void insertTerminal(Terminal *terminal);
 		void prepareQuery();
 		static QHash<QString, QString> elementInfoToString(
@@ -96,6 +105,7 @@ class projectDataBase : public QObject
 				  m_diagram_info_order_changed,
 				  m_insert_terminal_query,
 				  m_insert_conductor_query,
+				  m_update_conductor_query,
 				  m_remove_conductor_query;
 
 #ifdef QET_EXPORT_PROJECT_DB

--- a/sources/diagram.cpp
+++ b/sources/diagram.cpp
@@ -1674,6 +1674,7 @@ void Diagram::addItem(QGraphicsItem *item)
 			conductor->terminal1->addConductor(conductor);
 			conductor->terminal2->addConductor(conductor);
 			conductor->calculateTextItemPosition();
+			m_project->dataBase()->addConductor(conductor);
 			break;
 		}
 		default: {break;}
@@ -1704,6 +1705,7 @@ void Diagram::removeItem(QGraphicsItem *item)
 			Conductor *conductor = static_cast<Conductor *>(item);
 			conductor->terminal1->removeConductor(conductor);
 			conductor->terminal2->removeConductor(conductor);
+			m_project->dataBase()->removeConductor(conductor);
 			break;
 		}
 		default: {break;}

--- a/sources/diagramcommands.cpp
+++ b/sources/diagramcommands.cpp
@@ -75,6 +75,13 @@ void PasteDiagramCommand::redo()
 	{
 		first_redo = false;
 
+		//make new uuid for every pasted conductor, because old uuid are
+		//the uuid of the copied conductor
+		const QList <Conductor *> all_pasted_conductors = content.conductors();
+		for (Conductor *c : all_pasted_conductors) {
+			c -> newUuid();
+		}
+
 		//this is the first paste, we do some actions for the new element
 		const QList <Element *> elmts_list = content.m_elements;
 		for (Element *e : elmts_list)

--- a/sources/elementspanelwidget.cpp
+++ b/sources/elementspanelwidget.cpp
@@ -17,6 +17,7 @@
 */
 #include "elementspanelwidget.h"
 #include "diagram.h"
+#include "qetgraphicsitem/conductor.h"
 #include "editor/ui/qetelementeditor.h"
 #include "elementscategoryeditor.h"
 #include "qetapp.h"
@@ -651,6 +652,13 @@ void ElementsPanelWidget::duplicateDiagram()
 				// silently vanish from nomenclature/summary tables.
 				elmt->newUuid();
 				new_diagram->restoreText(elmt);
+			}
+			else if (Conductor *cond = dynamic_cast<Conductor *>(item)) {
+				// Same reasoning for conductors: conductor.uuid is the PRIMARY
+				// KEY of the conductor table, and its insert is a plain INSERT,
+				// so a duplicated uuid fails and the wire silently disappears
+				// from the wiring list and the per-element wire count.
+				cond->newUuid();
 			}
 		}
 	}

--- a/sources/qetgraphicsitem/conductor.cpp
+++ b/sources/qetgraphicsitem/conductor.cpp
@@ -91,6 +91,7 @@ Conductor::Conductor(Terminal *p1, Terminal* p2) :
 		//set Zvalue at 11 to be upper than the DiagramImageItem and element
 	setZValue(11);
 	m_previous_z_value = zValue();
+	m_uuid = QUuid::createUuid();
 
 		//Add this conductor to the list of conductors of each of the two terminals
 	bool ajout_p1 = terminal1 -> addConductor(this);
@@ -1005,6 +1006,12 @@ void Conductor::pointsToSegments(const QList<QPointF>& points_list) {
 */
 bool Conductor::fromXml(QDomElement &dom_element)
 {
+		//Older project files have no conductor uuid attribute at all --
+		//generate one on load, same treatment terminal uuids got when
+		//that field was introduced (see terminal1/terminal2 handling in
+		//toXml() below).
+	m_uuid = QUuid(dom_element.attribute("uuid", QUuid::createUuid().toString()));
+
 	setPos(dom_element.attribute("x", nullptr).toDouble(),
 		   dom_element.attribute("y", nullptr).toDouble());
 
@@ -1043,6 +1050,7 @@ QDomElement Conductor::toXml(QDomDocument &dom_document,
 {
 	QDomElement dom_element = dom_document.createElement("conductor");
 
+	dom_element.setAttribute("uuid", m_uuid.toString());
 	dom_element.setAttribute("x", QString::number(pos().x()));
 	dom_element.setAttribute("y", QString::number(pos().y()));
 	

--- a/sources/qetgraphicsitem/conductor.cpp
+++ b/sources/qetgraphicsitem/conductor.cpp
@@ -1010,7 +1010,13 @@ bool Conductor::fromXml(QDomElement &dom_element)
 		//generate one on load, same treatment terminal uuids got when
 		//that field was introduced (see terminal1/terminal2 handling in
 		//toXml() below).
-	m_uuid = QUuid(dom_element.attribute("uuid", QUuid::createUuid().toString()));
+	m_uuid = QUuid(dom_element.attribute(QStringLiteral("uuid")));
+	if (m_uuid.isNull()) {
+			//Absent, empty or malformed: mint one. A null uuid is not a usable
+			//identity -- every conductor carrying one would collide with every
+			//other on the conductor table's primary key.
+		m_uuid = QUuid::createUuid();
+	}
 
 	setPos(dom_element.attribute("x", nullptr).toDouble(),
 		   dom_element.attribute("y", nullptr).toDouble());

--- a/sources/qetgraphicsitem/conductor.h
+++ b/sources/qetgraphicsitem/conductor.h
@@ -21,6 +21,7 @@
 #include "../conductorproperties.h"
 
 #include <QGraphicsPathItem>
+#include <QUuid>
 
 class ConductorProfile;
 class ConductorSegmentProfile;
@@ -77,6 +78,8 @@ class Conductor : public QGraphicsObject
 		int type() const override { return Type; }
 		Diagram *diagram() const;
 		ConductorTextItem *textItem() const;
+		QUuid uuid() const {return m_uuid;}
+		void newUuid() {m_uuid = QUuid::createUuid();}	//create new uuid for this conductor
 		void updatePath(const QRectF & = QRectF());
 
 		//This method do nothing, it's only made to be used with Q_PROPERTY
@@ -205,6 +208,7 @@ class Conductor : public QGraphicsObject
 		Highlight must_highlight_;
 		bool m_valid;
 		bool m_freeze_label = false;
+		QUuid m_uuid;
 
 			/// QPen et QBrush objects used to draw conductors
 		static QPen conductor_pen;

--- a/sources/qetgraphicsitem/terminal.cpp
+++ b/sources/qetgraphicsitem/terminal.cpp
@@ -817,6 +817,60 @@ QUuid Terminal::uuid() const
 	return d->m_uuid;
 }
 
+/**
+	@brief Terminal::stableUuid
+	An identity for this terminal that exists on every element, not only on
+	those saved by a uuid-aware element editor.
+
+	uuid() comes from the catalog .elmt definition and is empty for every
+	element authored before that field existed -- which is most of the
+	installed base. Anything keyed on uuid() alone therefore cannot see those
+	elements at all.
+
+	When there is no uuid, derive one from the terminal's local position and
+	orientation inside its element. That is not an arbitrary choice: it is the
+	same thing the project format itself uses to match a conductor back to a
+	terminal ("each connection is made by using the local position of the
+	terminal and a dynamic id" -- TerminalData::m_uuid). m_pos is the position
+	read from the definition and is not touched by moving the element on the
+	folio, so the result is stable across loads, saves and folio moves, and it
+	is unique within an element except where a definition genuinely declares
+	two terminals at the same point -- three cases in the whole example corpus,
+	and harmless, because two terminals sharing a position and orientation are
+	indistinguishable in every observable respect: they merge to one terminal
+	row and every conductor on either of them still resolves to the right
+	element and name.
+
+	Derived values are UUID v5 in a fixed namespace, so they are reproducible
+	without being written to the file, and cannot collide with the v4 uuids
+	the element editor generates.
+
+	@return the terminal's own uuid when it has one, otherwise a derived one
+*/
+QUuid Terminal::stableUuid() const
+{
+	if (!d->m_uuid.isNull()) {
+		return d->m_uuid;
+	}
+
+		//Fixed namespace for terminal identities derived from geometry.
+	static const QUuid derived_ns(QStringLiteral("{6b1f6d1e-6a1a-5f7e-9a3d-9c0a5b2d7e11}"));
+
+		//Position and orientation only. The name is deliberately excluded: it
+		//is not stable across a save cycle -- QET rewrites a terminal named
+		//"_" as unnamed, which would silently change the identity of 1421 of
+		//industrial.qet's 1790 terminals on the first resave. It is also not
+		//needed: keying on geometry alone produces exactly the same number of
+		//collisions across the example corpus, and it means renaming a
+		//terminal does not change what it is.
+	const QString key = QStringLiteral("%1|%2|%3")
+			.arg(d->m_pos.x(), 0, 'f', 4)
+			.arg(d->m_pos.y(), 0, 'f', 4)
+			.arg(static_cast<int>(d->m_orientation));
+
+	return QUuid::createUuidV5(derived_ns, key);
+}
+
 QString Terminal::name() const
 {
 	if (d->m_use_master_label && parent_element_) {

--- a/sources/qetgraphicsitem/terminal.h
+++ b/sources/qetgraphicsitem/terminal.h
@@ -75,6 +75,7 @@ class Terminal : public QGraphicsObject
 		Diagram  *diagram             () const;
 		Element  *parentElement       () const;
 		QUuid     uuid                () const;
+		QUuid     stableUuid          () const;
 		QString   name                () const;
 		QString   baseName            () const;
 		TerminalData::Type terminalType() const;


### PR DESCRIPTION
> ### Updated since first posting
>
> **`--export-wiring` is added here.** The view was reachable only through the GUI, which meant the one thing worth proving about it — that it still describes the project — could not be checked without a person clicking. This is the same shape as the existing `--export-bom`, which reads `element_nomenclature_view`: it writes `wiring_list_view` as CSV. Two consequences:
>
> - the view becomes verifiable in CI, and
> - this slice is useful on its own, rather than waiting on the dialog in #630.
>
> The overlap with the existing `--export-cables` is deliberate. That one builds the same logical list from the document XML instead, so running both and diffing them is a direct check that the cache and the document still agree — nothing else in the codebase can do that. Measured on the corpus, they also differ in what they can fill in. Rows carrying any endpoint data:
>
> | project | `--export-cables` (XML) | `--export-wiring` (DB) |
> |---|---|---|
> | `industrial.qet` | 0 / 671 | **541 / 671** |
> | `m_000.qet` | 0 / 457 | **362 / 457** |
> | `affuteuse_250h.qet` | 0 / 263 | **197 / 263** |
> | `tremie_vibrante.qet` | 0 / 77 | **61 / 77** |
> | `tableau_domestique.qet` | 58 / 130 | **104 / 130** |
>
> Both return one row per conductor; the XML-derived one leaves the component and terminal columns empty on the older projects. The cause is precise and worth recording: `WiringListExport` resolves endpoints from `element1`/`element2` **attributes on the conductor XML**, and legacy files do not write them — `industrial.qet` has them on **0 of 671** conductors, which is exactly its score. The database path resolves them because at runtime the terminals are attached to real elements. That is not an argument for removing `--export-cables`: it carries columns the view does not, and being independent is what makes it a useful second opinion.
>
> **The `diagram` join is now `LEFT`.** The comment below argued carefully for the two joins that could drop rows, then ended with an inner join to `diagram` it never mentioned. Feeding the real schema a conductor whose `diagram_uuid` has no `diagram` row returned 2 view rows for 3 conductors; as a `LEFT JOIN` it returns 3, with a null folio instead of a missing wire. In practice it should never fire — `QETProject::diagramAdded` is wired to `addDiagram()` — but an inner join makes that an assumption the view enforces silently, and of everything this view can get wrong, dropping a wire from a wiring list is the one that matters most.

**Ready for review.** Merge #625 → #628 first; the commit to review here is `Add wiring_list_view: from-to wiring list over the conductor tables`. #630 follows.

Slice 3 of #503. One row per conductor, each endpoint resolved to its element label and terminal name — the `F1:4 -> M200:U1` shape from the original prototype.

> **Stacked on #628** (slice 2), which is itself stacked on #625 (slice 1). Neither is merged yet, so this branch contains all three commits. Merge order: #625 → #628 → this. The commit to review here is just `Add wiring_list_view: from-to wiring list over the conductor tables` (2 files, +52).

## The view

```sql
CREATE VIEW wiring_list_view AS SELECT
  c.uuid AS conductor_uuid,
  c.text AS wire_number,
  t1.element_uuid AS from_element_uuid, ei1.label AS from_element_label, t1.name AS from_terminal,
  t2.element_uuid AS to_element_uuid,   ei2.label AS to_element_label,   t2.name AS to_terminal,
  d.pos AS diagram_position
FROM conductor c
  JOIN terminal t1 ON c.terminal1_uuid = t1.uuid AND c.terminal1_element_uuid = t1.element_uuid
  JOIN terminal t2 ON c.terminal2_uuid = t2.uuid AND c.terminal2_element_uuid = t2.element_uuid
  LEFT JOIN element_info ei1 ON t1.element_uuid = ei1.element_uuid
  LEFT JOIN element_info ei2 ON t2.element_uuid = ei2.element_uuid
  LEFT JOIN diagram d ON c.diagram_uuid = d.uuid;
```

## Why it differs from the SQL sketched in the discussion

Both changes exist because the sketched version **silently loses wires**:

- **No join to the `element` table.** A terminal row already carries its `element_uuid`, so joining `element` back just to read the same uuid adds nothing. Worse, it *filters*: `populateElementTable()` only inserts elements matching `Simple|Terminal|Master|Thumbnail` (`ElementData::Slave` is `16`, not in that mask). So `Slave` elements — relay contacts and the like, **extremely common at the end of a wire** — and report elements are simply absent from that table after a project load, and an inner join through it drops their conductors.
- **`element_info` is LEFT joined** for the same reason. A wire whose endpoint element has no info row still belongs in a wiring list; it comes back with an empty label rather than vanishing. Losing a wire from a wiring list is a worse failure than showing one with a blank end.

**This only bites after a save/reload**, which is why it's easy to miss: the incremental `addElement()` path does *not* apply the type filter, so a slave element placed live is present in `element`/`element_info` and an inner join looks perfectly fine. It's the bulk repopulate on project load that drops it. Testing only the live-editing path would have shown nothing wrong.

> **Note added once slice 4 was finished.** The type-filter behaviour described just above is accurate *at this point in the stack*, but #630 goes on to remove it: it turned out that `element`/`element_info` had two insert paths disagreeing with each other, so `populateElementTable()` now inserts every element type and the `Simple|Terminal|Master|Thumbnail` restriction moves into `element_nomenclature_view`.
>
> The view below is deliberately **unchanged** by that. Its shape never depended on the filter, and the `LEFT JOIN element_info` is the right call either way — a wire whose endpoint carries no label still belongs in a wiring list. Flagging this so the reasoning here doesn't read as stale to whoever reviews after #630 lands.

## Measured

Both variants built from the same tables in the same session and counted side by side:

| project | conductors | `wiring_list_view` | inner-join variant |
|---|---|---|---|
| `weneedpolonez-Polonez_MR89_wiring_diagram.qet` | 280 | 280 | 280 |
| two slave contacts, **after save + reload** | 1 | **1** | **0** |

Polonez happens to have no slave elements at conductor ends, so both agree there and the problem is invisible — that project alone would have "confirmed" the sketched view. The second case is the minimal reproduction: place two `Simple contact` elements (`link_type="slave"`) so autoconnect wires them, save, reload — the sketched view returns **zero rows for a project that plainly has a wire in it**.

Acceptance criterion held throughout: **`wiring_list_view` row count == `conductor` row count**, i.e. the view itself drops nothing. Also verified the join produces real from-to rows with real element labels (e.g. `36 dipped beam relay`) and correct folio positions.

Conductors are no longer excluded for want of a terminal uuid: `Terminal::stableUuid()` in #628 derives an identity from the terminal's geometry, so `industrial.qet` now yields 671 rows rather than none. The only conductor still absent is one whose endpoint has no parent element at all, and #630 surfaces a count for that.

Built clean, no new warnings; no SQL errors on project load.

