### PR TITLE
Wiring list dialog + excluded-conductor count (discussion #503, slice 4)

### DIFF
--- a/cmake/qet_compilation_vars.cmake
+++ b/cmake/qet_compilation_vars.cmake
@@ -155,6 +155,8 @@ set(QET_SRC_FILES
   ${QET_DIR}/sources/conductornumexport.cpp
   ${QET_DIR}/sources/wiringlistexport.h
   ${QET_DIR}/sources/wiringlistexport.cpp
+  ${QET_DIR}/sources/ui/wiringlistdialog.h
+  ${QET_DIR}/sources/ui/wiringlistdialog.cpp
   ${QET_DIR}/sources/conductornumexport.h
   ${QET_DIR}/sources/conductorprofile.cpp
   ${QET_DIR}/sources/conductorprofile.h

--- a/sources/cli_export.cpp
+++ b/sources/cli_export.cpp
@@ -70,6 +70,7 @@ const QHash<QString, QString> &exportFlags()
 		{"--export-cables", "cables"},
 		{"--export-wires", "wires"},
 		{"--export-bom", "bom"},
+		{"--export-wiring", "wiring"},
 		{"--export-nets", "nets"},
 		{"--export-links", "links"},
 		{"--info", "info"},
@@ -525,6 +526,54 @@ QHash<Element *, int> folioIndex(QETProject &project)
 	return folio;
 }
 
+/// From-to wiring list: one row per conductor, each endpoint resolved to its
+/// element label and terminal name.
+///
+/// Reads wiring_list_view out of the project database. --export-cables produces
+/// the same logical list from the document XML instead, and the two are meant
+/// to agree: running both and diffing them is a direct check that the database
+/// still describes the project, which is otherwise only observable through the
+/// GUI.
+int exportWiring(QETProject &project, const QString &output)
+{
+	// The project database is built lazily; force a (re)build before querying.
+	project.dataBase()->updateDB();
+
+	static const QStringList columns {
+		"wire_number", "from_element_label", "from_terminal",
+		"to_element_label", "to_terminal", "diagram_position", "conductor_uuid"
+	};
+
+	QSqlQuery query = project.dataBase()->newQuery(
+		"SELECT " % columns.join(", ") %
+		" FROM wiring_list_view ORDER BY diagram_position, wire_number");
+	if (!query.exec()) {
+		err << "Wiring list query failed: " << query.lastError().text() << "\n";
+		return 1;
+	}
+
+	QString csv = columns.join(";") % "\n";
+	int rows = 0;
+	while (query.next()) {
+		QStringList values;
+		for (int i = 0; i < columns.size(); ++i)
+			values << csvField(query.value(i).toString());
+		csv += values.join(";") % "\n";
+		++rows;
+	}
+
+	QFile file(output);
+	if (!file.open(QIODevice::WriteOnly | QIODevice::Text)) {
+		err << "Cannot open '" << output << "' for writing.\n";
+		return 1;
+	}
+	QTextStream fout(&file);
+	fout << csv;
+	file.close();
+	out << "Exported " << rows << " conductor(s) -> " << output << "\n";
+	return 0;
+}
+
 /// Electrical nets: groups of terminals joined into one potential.
 /// Walks QET's own potential graph, so each net is a connected component
 /// of terminals across all folios. The ground truth for connectivity.
@@ -823,6 +872,8 @@ int run(const QStringList &args)
 		return exportCsv(project, format, output);
 	if (format == "bom")
 		return exportBom(project, output);
+	if (format == "wiring")
+		return exportWiring(project, output);
 	if (format == "nets")
 		return exportNets(project, output);
 	if (format == "links")

--- a/sources/cli_export.h
+++ b/sources/cli_export.h
@@ -48,6 +48,7 @@ namespace CLIExport {
 		  qelectrotech --export-cables  <project.qet> <output.csv>
 		  qelectrotech --export-wires   <project.qet> <output.csv>
 		  qelectrotech --export-bom     <project.qet> <output.csv>
+		  qelectrotech --export-wiring  <project.qet> <output.csv>
 		  qelectrotech --export-nets    <project.qet> <output.json>
 		  qelectrotech --export-links   <project.qet> <output.csv>
 		  qelectrotech --info           <project.qet> [output.json]
@@ -60,6 +61,11 @@ namespace CLIExport {
 		cables: wiring list (one row per conductor) as CSV.
 		wires: list of distinct wire numbers as CSV.
 		bom: bill of materials (one row per element) as CSV.
+		wiring: from-to wiring list (one row per conductor) as CSV, read from
+		        the project database. Same logical list as `cables`, which
+		        reads the document XML instead; the two are meant to agree,
+		        so diffing them checks that the database still describes the
+		        project.
 		nets: electrical nets (connected-terminal groups) as JSON.
 		links: element cross-references (coil/contact) as CSV, with
 		       unresolved links flagged.

--- a/sources/dataBase/projectdatabase.cpp
+++ b/sources/dataBase/projectdatabase.cpp
@@ -113,14 +113,17 @@ QSqlQuery projectDataBase::newQuery(const QString &query) {
 
 /**
 	@brief projectDataBase::excludedConductorCount
-	@return how many conductors of the project are deliberately absent from
-	the conductor table because at least one of their terminals has no uuid.
+	@return how many conductors of the project are absent from the conductor
+	table because an endpoint has no parent element to key on.
 
 	Counted from the live scene rather than from the database, precisely
-	because the database is where these conductors are *not*. See
-	addConductor() for why they are omitted: a terminal uuid comes from the
-	catalog .elmt definition, so an element whose definition predates that
-	field yields terminals with no stable identity to key on.
+	because the database is where these conductors are *not*.
+
+	This used to count conductors whose terminals had no uuid, which was most
+	of them on most projects. Terminal::stableUuid() now derives an identity
+	from the terminal's geometry when the definition provides no uuid, so that
+	is no longer a reason to exclude anything, and this counts only the case
+	that remains genuinely unkeyable.
 
 	This is what lets a caller tell the user "N wires are missing and here
 	is why", instead of silently presenting a short list as if it were
@@ -138,8 +141,10 @@ int projectDataBase::excludedConductorCount() const
 		const auto conductor_list = diagram->conductors();
 		for (auto *conductor : conductor_list)
 		{
-			if (conductor->terminal1->uuid().isNull()
-				|| conductor->terminal2->uuid().isNull()) {
+				//Must match addConductor()'s guard exactly, or this reports
+				//wires as missing that the list is in fact showing.
+			if (!conductor->terminal1->parentElement()
+				|| !conductor->terminal2->parentElement()) {
 				++count;
 			}
 		}

--- a/sources/dataBase/projectdatabase.cpp
+++ b/sources/dataBase/projectdatabase.cpp
@@ -620,7 +620,13 @@ void projectDataBase::createElementNomenclatureView()
 						 "di.folio AS folio,"
 						 "e.pos AS position "
 						 " FROM element_info ei, diagram_info di, element e, diagram d"
-						 " WHERE ei.element_uuid = e.uuid AND e.diagram_uuid = d.uuid AND di.diagram_uuid = d.uuid AND (ei.exclude_from_bom IS NOT 'true')");
+						 " WHERE ei.element_uuid = e.uuid AND e.diagram_uuid = d.uuid AND di.diagram_uuid = d.uuid AND (ei.exclude_from_bom IS NOT 'true')"
+							//The element table holds every element of the project; which
+							//kinds belong in a nomenclature is this view's business, not
+							//the table's. Kept identical to the mask populateElementTable()
+							//used to apply, so what this view returns does not change --
+							//a slave element (a relay contact) is still not a line item.
+						 " AND e.type IN ('simple', 'terminal', 'master', 'thumbnail')");
 
 	QSqlQuery query(m_data_base);
 	if (!query.exec(create_view)) {
@@ -733,6 +739,30 @@ void projectDataBase::populateDiagramTable()
 }
 
 /**
+	@brief allElementTypes
+	Every ElementData::Type, i.e. no filtering at all.
+
+	The element table used to be populated with only
+	Simple|Terminal|Master|Thumbnail, which quietly made it "the elements a
+	nomenclature cares about" rather than "the elements of the project".
+	Anything else reading the table -- the wiring list, and terminal plans
+	later -- then could not see slave elements (relay contacts) or report
+	elements, which are ordinary conductor endpoints. The filter now lives in
+	element_nomenclature_view, where it belongs; see createElementNomenclatureView().
+*/
+static ElementData::Types allElementTypes()
+{
+	return ElementData::Simple
+		   | ElementData::NextReport
+		   | ElementData::PreviousReport
+		   | ElementData::Master
+		   | ElementData::Slave
+		   | ElementData::Terminal
+		   | ElementData::Thumbnail
+		   | ElementData::ConductorDefinition;
+}
+
+/**
 	@brief projectDataBase::populateElementTable
 	Populate the element table
 */
@@ -744,7 +774,7 @@ void projectDataBase::populateElementTable()
 	for (auto diagram : m_project->diagrams())
 	{
 		const ElementProvider ep(diagram);
-		const auto elmt_vector = ep.find(ElementData::Simple | ElementData::Terminal | ElementData::Master | ElementData::Thumbnail);
+		const auto elmt_vector = ep.find(allElementTypes());
 			//Insert all values into the database
 		for (const auto &elmt : elmt_vector)
 		{
@@ -773,7 +803,7 @@ void projectDataBase::populateElementInfoTable()
 	for (const auto &diagram : m_project->diagrams())
 	{
 		const ElementProvider ep(diagram);
-		const auto elmt_vector = ep.find(ElementData::Simple | ElementData::Terminal | ElementData::Master | ElementData::Thumbnail);
+		const auto elmt_vector = ep.find(allElementTypes());
 
 			//Insert all values into the database
 		for (const auto &elmt : elmt_vector)

--- a/sources/dataBase/projectdatabase.cpp
+++ b/sources/dataBase/projectdatabase.cpp
@@ -271,13 +271,8 @@ void projectDataBase::addConductor(Conductor *conductor)
 	insertTerminal(conductor->terminal1);
 	insertTerminal(conductor->terminal2);
 
-	m_insert_conductor_query.bindValue(":uuid", conductor->uuid().toString());
-	m_insert_conductor_query.bindValue(":diagram_uuid", conductor->diagram()->uuid().toString());
-	m_insert_conductor_query.bindValue(":terminal1_uuid", conductor->terminal1->uuid().toString());
-	m_insert_conductor_query.bindValue(":terminal1_element_uuid", conductor->terminal1->parentElement()->uuid().toString());
-	m_insert_conductor_query.bindValue(":terminal2_uuid", conductor->terminal2->uuid().toString());
-	m_insert_conductor_query.bindValue(":terminal2_element_uuid", conductor->terminal2->parentElement()->uuid().toString());
-	m_insert_conductor_query.bindValue(":text", conductor->properties().text);
+	watchConductor(conductor);
+	bindConductorValues(m_insert_conductor_query, conductor, conductor->diagram());
 	if (!m_insert_conductor_query.exec()) {
 		qDebug() << "projectDataBase::addConductor insert error : " << m_insert_conductor_query.lastError();
 	} else {
@@ -297,6 +292,85 @@ void projectDataBase::removeConductor(Conductor *conductor)
 	} else {
 		emit dataBaseUpdated();
 	}
+}
+
+/**
+	@brief projectDataBase::updateConductor
+	Refresh the mutable columns of an already-inserted conductor.
+
+	Only the text (the wire number) can change without the conductor being
+	removed and re-added: its endpoints are fixed for its lifetime. Without
+	this, renaming a wire left the database holding the old number and the
+	wiring list showed a stale value until the next full repopulate.
+	@param conductor
+*/
+void projectDataBase::updateConductor(Conductor *conductor)
+{
+	if (!conductor) {
+		return;
+	}
+
+	m_update_conductor_query.bindValue(QStringLiteral(":uuid"), conductor->uuid().toString());
+	m_update_conductor_query.bindValue(QStringLiteral(":text"), conductor->properties().text);
+	if (!m_update_conductor_query.exec()) {
+		qDebug() << "projectDataBase::updateConductor update error : " << m_update_conductor_query.lastError();
+	}
+
+		//Deliberately no dataBaseUpdated() here, unlike add/remove. The only
+		//column this touches is the wire text, which no view watched by
+		//ProjectDBModel displays -- the nomenclature shows elements, and its
+		//wire_count changes when a conductor appears or disappears, not when
+		//it is renamed. Emitting would make every ProjectDBModel re-run its
+		//query, and auto-numbering renames every conductor in the project in
+		//one pass.
+}
+
+/**
+	@brief projectDataBase::watchConductor
+	Keep this conductor's row in step with its properties.
+
+	Conductor::setProperties() has a dozen call sites (auto-numbering, the
+	properties dialog, element moves, deletion re-links...), so listening to
+	the signal it already emits is the only way to catch them all -- and the
+	only way to catch the ones added later. Qt::UniqueConnection makes a
+	repeated insert or a full repopulate harmless.
+	@param conductor
+*/
+void projectDataBase::watchConductor(Conductor *conductor)
+{
+	connect(conductor, &Conductor::propertiesChange,
+			this, &projectDataBase::conductorPropertiesChanged,
+			Qt::UniqueConnection);
+}
+
+/**
+	@brief projectDataBase::conductorPropertiesChanged
+*/
+void projectDataBase::conductorPropertiesChanged()
+{
+	if (auto *conductor = qobject_cast<Conductor *>(sender())) {
+		updateConductor(conductor);
+	}
+}
+
+/**
+	@brief projectDataBase::bindConductorValues
+	One binder for both insert paths, so a conductor added to a live diagram
+	and one read from a file can never drift apart -- the same reason
+	bindElementValues() exists for elements.
+	@param query
+	@param conductor
+	@param diagram : the diagram the conductor belongs to
+*/
+void projectDataBase::bindConductorValues(QSqlQuery &query, Conductor *conductor, Diagram *diagram)
+{
+	query.bindValue(QStringLiteral(":uuid"), conductor->uuid().toString());
+	query.bindValue(QStringLiteral(":diagram_uuid"), diagram->uuid().toString());
+	query.bindValue(QStringLiteral(":terminal1_uuid"), conductor->terminal1->uuid().toString());
+	query.bindValue(QStringLiteral(":terminal1_element_uuid"), conductor->terminal1->parentElement()->uuid().toString());
+	query.bindValue(QStringLiteral(":terminal2_uuid"), conductor->terminal2->uuid().toString());
+	query.bindValue(QStringLiteral(":terminal2_element_uuid"), conductor->terminal2->parentElement()->uuid().toString());
+	query.bindValue(QStringLiteral(":text"), conductor->properties().text);
 }
 
 /**
@@ -411,6 +485,21 @@ bool projectDataBase::createDataBase()
 						  ")");
 	if (!query_.exec(conductor_table)) {
 		qDebug() << "conductor_table query : "<< query_.lastError();
+	}
+
+		//The element-facing columns are looked up per element row, not per
+		//conductor row: element_nomenclature_view carries a correlated
+		//subquery counting the wires touching each element. Without these
+		//indexes each element row full-scans the conductor table, which grows
+		//as elements x conductors.
+	for (const QString &index_ : {
+			QStringLiteral("CREATE INDEX idx_conductor_terminal1_element ON conductor (terminal1_element_uuid)"),
+			QStringLiteral("CREATE INDEX idx_conductor_terminal2_element ON conductor (terminal2_element_uuid)"),
+			QStringLiteral("CREATE INDEX idx_conductor_diagram ON conductor (diagram_uuid)") })
+	{
+		if (!query_.exec(index_)) {
+			qDebug() << "conductor index query : " << query_.lastError();
+		}
 	}
 
 	createElementNomenclatureView();
@@ -650,13 +739,8 @@ void projectDataBase::populateConductorTable()
 			insertTerminal(conductor->terminal1);
 			insertTerminal(conductor->terminal2);
 
-			m_insert_conductor_query.bindValue(":uuid", conductor->uuid().toString());
-			m_insert_conductor_query.bindValue(":diagram_uuid", diagram->uuid().toString());
-			m_insert_conductor_query.bindValue(":terminal1_uuid", conductor->terminal1->uuid().toString());
-			m_insert_conductor_query.bindValue(":terminal1_element_uuid", conductor->terminal1->parentElement()->uuid().toString());
-			m_insert_conductor_query.bindValue(":terminal2_uuid", conductor->terminal2->uuid().toString());
-			m_insert_conductor_query.bindValue(":terminal2_element_uuid", conductor->terminal2->parentElement()->uuid().toString());
-			m_insert_conductor_query.bindValue(":text", conductor->properties().text);
+			watchConductor(conductor);
+			bindConductorValues(m_insert_conductor_query, conductor, diagram);
 			if (!m_insert_conductor_query.exec()) {
 				qDebug() << "projectDataBase::populateConductorTable insert error : " << m_insert_conductor_query.lastError();
 			}
@@ -761,6 +845,10 @@ void projectDataBase::prepareQuery()
 	m_insert_conductor_query = QSqlQuery(m_data_base);
 	m_insert_conductor_query.prepare("INSERT INTO conductor (uuid, diagram_uuid, terminal1_uuid, terminal1_element_uuid, terminal2_uuid, terminal2_element_uuid, text) "
 					  "VALUES (:uuid, :diagram_uuid, :terminal1_uuid, :terminal1_element_uuid, :terminal2_uuid, :terminal2_element_uuid, :text)");
+
+		//UPDATE CONDUCTOR
+	m_update_conductor_query = QSqlQuery(m_data_base);
+	m_update_conductor_query.prepare(QStringLiteral("UPDATE conductor SET text = :text WHERE uuid = :uuid"));
 
 		//REMOVE CONDUCTOR
 	m_remove_conductor_query = QSqlQuery(m_data_base);

--- a/sources/dataBase/projectdatabase.cpp
+++ b/sources/dataBase/projectdatabase.cpp
@@ -158,24 +158,12 @@ void projectDataBase::addElement(Element *element)
 		return;
 	}
 
-	m_insert_elements_query.bindValue(":uuid", element->uuid().toString());
-	m_insert_elements_query.bindValue(":diagram_uuid", element->diagram()->uuid().toString());
-	m_insert_elements_query.bindValue(":pos", element->diagram()->convertPosition(element->scenePos()).toString());
-	m_insert_elements_query.bindValue(":type", element->elementData().typeToString());
-	m_insert_elements_query.bindValue(":sub_type", element->kindInformations()["type"].toString());
+	bindElementValues(m_insert_elements_query, element, element->diagram());
 	if (!m_insert_elements_query.exec()) {
 		qDebug() << "projectDataBase::addElement insert element error : " << m_insert_elements_query.lastError();
 	}
 
-	m_insert_element_info_query.bindValue(":uuid", element->uuid().toString());
-	auto hash = elementInfoToString(element);
-	for (auto key : hash.keys())
-	{
-		QString value = hash.value(key);
-		QString bind = key.prepend(":");
-		m_insert_element_info_query.bindValue(bind, value);
-	}
-
+	bindElementInfoValues(m_insert_element_info_query, element);
 	if (!m_insert_element_info_query.exec()) {
 		qDebug() << "projectDataBase::addElement insert element info error : " << m_insert_element_info_query.lastError();
 	} else {
@@ -778,12 +766,7 @@ void projectDataBase::populateElementTable()
 			//Insert all values into the database
 		for (const auto &elmt : elmt_vector)
 		{
-			const auto elmt_data = elmt->elementData();
-			m_insert_elements_query.bindValue(":uuid", elmt->uuid().toString());
-			m_insert_elements_query.bindValue(":diagram_uuid", diagram->uuid().toString());
-			m_insert_elements_query.bindValue(":pos", diagram->convertPosition(elmt->scenePos()).toString());
-			m_insert_elements_query.bindValue(":type", elmt_data.typeToString());
-			m_insert_elements_query.bindValue(":sub_type", elmt_data.masterTypeToString());
+			bindElementValues(m_insert_elements_query, elmt, diagram);
 			if (!m_insert_elements_query.exec()) {
 				qDebug() << "projectDataBase::populateElementTable insert error : " << m_insert_elements_query.lastError();
 			}
@@ -808,15 +791,7 @@ void projectDataBase::populateElementInfoTable()
 			//Insert all values into the database
 		for (const auto &elmt : elmt_vector)
 		{
-			m_insert_element_info_query.bindValue(QStringLiteral(":uuid"), elmt->uuid().toString());
-			const auto hash = elementInfoToString(elmt);
-			for (const auto &key : hash.keys())
-			{
-				QString value = hash.value(key);
-				QString bind = QStringLiteral(":") + key;
-				m_insert_element_info_query.bindValue(bind, value);
-			}
-
+			bindElementInfoValues(m_insert_element_info_query, elmt);
 			if (!m_insert_element_info_query.exec()) {
 				qDebug() << "projectDataBase::populateElementInfoTable insert error : " << m_insert_element_info_query.lastError();
 			}
@@ -1001,6 +976,52 @@ QHash<QString, QString> projectDataBase::elementInfoToString(Element *elmt)
 	}
 
 	return hash;
+}
+
+/**
+	@brief projectDataBase::bindElementValues
+	Bind one element's row for the element table.
+
+	Shared by addElement() (a single element added to a live diagram) and
+	populateElementTable() (a full rebuild), because those two used to bind
+	the same row differently: the incremental path wrote
+	kindInformations()["type"] into sub_type while the bulk path wrote
+	elementData().masterTypeToString(). The element table therefore held
+	different values depending on whether the project had been reloaded
+	since the element was placed. One binder means live and reloaded agree
+	by construction rather than by coincidence.
+
+	The bulk path's values are the ones kept: they are what every already
+	saved project contains, so nothing a reload produces changes.
+	@param query : prepared insert query to bind into
+	@param element : element to bind
+	@param diagram : diagram holding @element
+*/
+void projectDataBase::bindElementValues(QSqlQuery &query, Element *element, Diagram *diagram)
+{
+	const auto element_data = element->elementData();
+	query.bindValue(QStringLiteral(":uuid"), element->uuid().toString());
+	query.bindValue(QStringLiteral(":diagram_uuid"), diagram->uuid().toString());
+	query.bindValue(QStringLiteral(":pos"), diagram->convertPosition(element->scenePos()).toString());
+	query.bindValue(QStringLiteral(":type"), element_data.typeToString());
+	query.bindValue(QStringLiteral(":sub_type"), element_data.masterTypeToString());
+}
+
+/**
+	@brief projectDataBase::bindElementInfoValues
+	Bind one element's row for the element info table.
+	Shared by addElement() and populateElementInfoTable() for the same
+	reason as bindElementValues().
+	@param query : prepared insert query to bind into
+	@param element : element to bind
+*/
+void projectDataBase::bindElementInfoValues(QSqlQuery &query, Element *element)
+{
+	query.bindValue(QStringLiteral(":uuid"), element->uuid().toString());
+	const auto hash = elementInfoToString(element);
+	for (const auto &key : hash.keys()) {
+		query.bindValue(QStringLiteral(":") + key, hash.value(key));
+	}
 }
 
 void projectDataBase::bindDiagramInfoValues(QSqlQuery &query, Diagram *diagram)

--- a/sources/dataBase/projectdatabase.cpp
+++ b/sources/dataBase/projectdatabase.cpp
@@ -505,6 +505,7 @@ bool projectDataBase::createDataBase()
 
 	createElementNomenclatureView();
 	createSummaryView();
+	createWiringListView();
 	prepareQuery();
 	updateDB();
 	return true;
@@ -615,6 +616,56 @@ void projectDataBase::createSummaryView()
 						 "d.pos AS pos"
 						 " FROM diagram_info di, diagram d"
 						 " WHERE di.diagram_uuid = d.uuid");
+
+	QSqlQuery query(m_data_base);
+	if (!query.exec(create_view)) {
+		qDebug() << query.lastError();
+	}
+}
+
+/**
+	@brief projectDataBase::createWiringListView
+	A from-to wiring list: one row per conductor, each endpoint resolved to
+	its element label and terminal name.
+
+	Two deliberate differences from an ordinary inner-join view like
+	element_nomenclature_view:
+
+	- No join to the element table. A terminal row already carries its
+	  element_uuid, so joining element back just to read the same uuid adds
+	  nothing -- and would actively drop rows, because populateElementTable()
+	  only inserts elements matching Simple|Terminal|Master|Thumbnail. Slave
+	  elements (relay contacts and the like, extremely common at the end of a
+	  wire) and report elements are absent from that table after a project
+	  load, so an inner join through it silently loses their conductors.
+	- element_info is LEFT joined for the same reason. A wire whose endpoint
+	  element carries no info row still belongs in a wiring list; it comes
+	  back with an empty label rather than vanishing. Losing a wire from a
+	  wiring list is a worse failure than showing one with a blank end.
+
+	The result is that this view returns exactly as many rows as the
+	conductor table holds -- what is already excluded upstream (conductors
+	on legacy terminals without uuids) stays excluded, and nothing new is
+	dropped here.
+*/
+void projectDataBase::createWiringListView()
+{
+	QString create_view ("CREATE VIEW wiring_list_view AS SELECT "
+						 "c.uuid AS conductor_uuid,"
+						 "c.text AS wire_number,"
+						 "t1.element_uuid AS from_element_uuid,"
+						 "ei1.label AS from_element_label,"
+						 "t1.name AS from_terminal,"
+						 "t2.element_uuid AS to_element_uuid,"
+						 "ei2.label AS to_element_label,"
+						 "t2.name AS to_terminal,"
+						 "d.pos AS diagram_position"
+						 " FROM conductor c"
+						 " JOIN terminal t1 ON c.terminal1_uuid = t1.uuid AND c.terminal1_element_uuid = t1.element_uuid"
+						 " JOIN terminal t2 ON c.terminal2_uuid = t2.uuid AND c.terminal2_element_uuid = t2.element_uuid"
+						 " LEFT JOIN element_info ei1 ON t1.element_uuid = ei1.element_uuid"
+						 " LEFT JOIN element_info ei2 ON t2.element_uuid = ei2.element_uuid"
+						 " JOIN diagram d ON c.diagram_uuid = d.uuid");
 
 	QSqlQuery query(m_data_base);
 	if (!query.exec(create_view)) {

--- a/sources/dataBase/projectdatabase.cpp
+++ b/sources/dataBase/projectdatabase.cpp
@@ -643,10 +643,18 @@ void projectDataBase::createSummaryView()
 	  back with an empty label rather than vanishing. Losing a wire from a
 	  wiring list is a worse failure than showing one with a blank end.
 
+	- diagram is LEFT joined for the same reason. It should
+	  always match, since QETProject::diagramAdded is wired to addDiagram()
+	  and a conductor cannot exist before its folio -- but an inner join here
+	  would make that an assumption the view silently enforces, and a wire
+	  missing from a wiring list is the one failure this view must not have.
+
 	The result is that this view returns exactly as many rows as the
 	conductor table holds -- what is already excluded upstream (conductors
 	on legacy terminals without uuids) stays excluded, and nothing new is
-	dropped here.
+	dropped here. Only the terminal joins are inner, and both are guaranteed
+	by insertTerminal() running for each endpoint before the conductor row
+	is written.
 */
 void projectDataBase::createWiringListView()
 {
@@ -665,7 +673,7 @@ void projectDataBase::createWiringListView()
 						 " JOIN terminal t2 ON c.terminal2_uuid = t2.uuid AND c.terminal2_element_uuid = t2.element_uuid"
 						 " LEFT JOIN element_info ei1 ON t1.element_uuid = ei1.element_uuid"
 						 " LEFT JOIN element_info ei2 ON t2.element_uuid = ei2.element_uuid"
-						 " JOIN diagram d ON c.diagram_uuid = d.uuid");
+						 " LEFT JOIN diagram d ON c.diagram_uuid = d.uuid");
 
 	QSqlQuery query(m_data_base);
 	if (!query.exec(create_view)) {

--- a/sources/dataBase/projectdatabase.cpp
+++ b/sources/dataBase/projectdatabase.cpp
@@ -112,6 +112,42 @@ QSqlQuery projectDataBase::newQuery(const QString &query) {
 }
 
 /**
+	@brief projectDataBase::excludedConductorCount
+	@return how many conductors of the project are deliberately absent from
+	the conductor table because at least one of their terminals has no uuid.
+
+	Counted from the live scene rather than from the database, precisely
+	because the database is where these conductors are *not*. See
+	addConductor() for why they are omitted: a terminal uuid comes from the
+	catalog .elmt definition, so an element whose definition predates that
+	field yields terminals with no stable identity to key on.
+
+	This is what lets a caller tell the user "N wires are missing and here
+	is why", instead of silently presenting a short list as if it were
+	complete.
+*/
+int projectDataBase::excludedConductorCount() const
+{
+	if (!m_project) {
+		return 0;
+	}
+
+	int count = 0;
+	for (auto *diagram : m_project->diagrams())
+	{
+		const auto conductor_list = diagram->conductors();
+		for (auto *conductor : conductor_list)
+		{
+			if (conductor->terminal1->uuid().isNull()
+				|| conductor->terminal2->uuid().isNull()) {
+				++count;
+			}
+		}
+	}
+	return count;
+}
+
+/**
 	@brief projectDataBase::addElement
 	@param element
 */

--- a/sources/dataBase/projectdatabase.cpp
+++ b/sources/dataBase/projectdatabase.cpp
@@ -21,7 +21,9 @@
 #include "../diagramposition.h"
 #include "../elementprovider.h"
 #include "../qetapp.h"
+#include "../qetgraphicsitem/conductor.h"
 #include "../qetgraphicsitem/element.h"
+#include "../qetgraphicsitem/terminal.h"
 #include "../qetinformation.h"
 #include "../qetproject.h"
 
@@ -87,6 +89,7 @@ void projectDataBase::updateDB()
 	populateDiagramInfoTable();
 	populateElementTable();
 	populateElementInfoTable();
+	populateConductorTable();
 	emit dataBaseUpdated();
 }
 
@@ -246,6 +249,57 @@ void projectDataBase::diagramOrderChanged()
 }
 
 /**
+	@brief projectDataBase::addConductor
+	@param conductor
+*/
+void projectDataBase::addConductor(Conductor *conductor)
+{
+	if (!conductor || !conductor->diagram()) {
+		qDebug() << "projectDataBase::addConductor: null conductor or diagram";
+		return;
+	}
+
+		//A conductor whose terminal(s) predate terminal uuids (legacy
+		//elements not yet re-saved by a uuid-aware element editor) can't
+		//be given a stable identity here -- omitted the same way
+		//element_nomenclature_view already omits exclude_from_bom elements,
+		//rather than fabricating one.
+	if (conductor->terminal1->uuid().isNull() || conductor->terminal2->uuid().isNull()) {
+		return;
+	}
+
+	insertTerminal(conductor->terminal1);
+	insertTerminal(conductor->terminal2);
+
+	m_insert_conductor_query.bindValue(":uuid", conductor->uuid().toString());
+	m_insert_conductor_query.bindValue(":diagram_uuid", conductor->diagram()->uuid().toString());
+	m_insert_conductor_query.bindValue(":terminal1_uuid", conductor->terminal1->uuid().toString());
+	m_insert_conductor_query.bindValue(":terminal1_element_uuid", conductor->terminal1->parentElement()->uuid().toString());
+	m_insert_conductor_query.bindValue(":terminal2_uuid", conductor->terminal2->uuid().toString());
+	m_insert_conductor_query.bindValue(":terminal2_element_uuid", conductor->terminal2->parentElement()->uuid().toString());
+	m_insert_conductor_query.bindValue(":text", conductor->properties().text);
+	if (!m_insert_conductor_query.exec()) {
+		qDebug() << "projectDataBase::addConductor insert error : " << m_insert_conductor_query.lastError();
+	} else {
+		emit dataBaseUpdated();
+	}
+}
+
+/**
+	@brief projectDataBase::removeConductor
+	@param conductor
+*/
+void projectDataBase::removeConductor(Conductor *conductor)
+{
+	m_remove_conductor_query.bindValue(":uuid", conductor->uuid().toString());
+	if (!m_remove_conductor_query.exec()) {
+		qDebug() << "projectDataBase::removeConductor delete error : " << m_remove_conductor_query.lastError();
+	} else {
+		emit dataBaseUpdated();
+	}
+}
+
+/**
 	@brief projectDataBase::createDataBase
 	Create the data base
 	@return : true if the data base was successfully created.
@@ -321,6 +375,42 @@ bool projectDataBase::createDataBase()
 
 	if (!query_.exec(element_info_table)) {
 		qDebug() << " element_info_table query : " << query_.lastError();
+	}
+
+	//Create the terminal table.
+	//Terminal::uuid() is the terminal-position id baked into the catalog
+	//.elmt definition (e.g. "the top terminal") -- identical across every
+	//placed instance of that catalog element, not a per-instance id. A
+	//terminal instance is only uniquely identified by (uuid, element_uuid)
+	//together, so that pair is the primary key here, not uuid alone.
+	QString terminal_table("CREATE TABLE terminal"
+						  "( "
+						  "uuid VARCHAR(50) NOT NULL, "
+						  "element_uuid VARCHAR(50) NOT NULL,"
+						  "name VARCHAR(50),"
+						  "PRIMARY KEY (uuid, element_uuid),"
+						  "FOREIGN KEY (element_uuid) REFERENCES element (uuid)"
+						  ")");
+	if (!query_.exec(terminal_table)) {
+		qDebug() << "terminal_table query : "<< query_.lastError();
+	}
+
+	//Create the conductor table
+	QString conductor_table("CREATE TABLE conductor"
+						  "( "
+						  "uuid VARCHAR(50) PRIMARY KEY NOT NULL, "
+						  "diagram_uuid VARCHAR(50) NOT NULL,"
+						  "terminal1_uuid VARCHAR(50) NOT NULL,"
+						  "terminal1_element_uuid VARCHAR(50) NOT NULL,"
+						  "terminal2_uuid VARCHAR(50) NOT NULL,"
+						  "terminal2_element_uuid VARCHAR(50) NOT NULL,"
+						  "text VARCHAR(100),"
+						  "FOREIGN KEY (diagram_uuid) REFERENCES diagram (uuid),"
+						  "FOREIGN KEY (terminal1_uuid, terminal1_element_uuid) REFERENCES terminal (uuid, element_uuid),"
+						  "FOREIGN KEY (terminal2_uuid, terminal2_element_uuid) REFERENCES terminal (uuid, element_uuid)"
+						  ")");
+	if (!query_.exec(conductor_table)) {
+		qDebug() << "conductor_table query : "<< query_.lastError();
 	}
 
 	createElementNomenclatureView();
@@ -534,6 +624,62 @@ void projectDataBase::populateDiagramInfoTable()
 	}
 }
 
+/**
+	@brief projectDataBase::populateConductorTable
+	Populate the terminal and conductor tables. Terminals only matter here
+	in the context of a conductor referencing them, so their population is
+	folded into this method rather than tracked independently.
+*/
+void projectDataBase::populateConductorTable()
+{
+	QSqlQuery query(m_data_base);
+	query.exec(QStringLiteral("DELETE FROM conductor"));
+	query.exec(QStringLiteral("DELETE FROM terminal"));
+
+	for (auto *diagram : m_project->diagrams())
+	{
+		const auto conductor_list = diagram->conductors();
+		for (auto *conductor : conductor_list)
+		{
+				//See addConductor() for why terminals without a uuid
+				//(legacy elements) are omitted rather than fabricating one.
+			if (conductor->terminal1->uuid().isNull() || conductor->terminal2->uuid().isNull()) {
+				continue;
+			}
+
+			insertTerminal(conductor->terminal1);
+			insertTerminal(conductor->terminal2);
+
+			m_insert_conductor_query.bindValue(":uuid", conductor->uuid().toString());
+			m_insert_conductor_query.bindValue(":diagram_uuid", diagram->uuid().toString());
+			m_insert_conductor_query.bindValue(":terminal1_uuid", conductor->terminal1->uuid().toString());
+			m_insert_conductor_query.bindValue(":terminal1_element_uuid", conductor->terminal1->parentElement()->uuid().toString());
+			m_insert_conductor_query.bindValue(":terminal2_uuid", conductor->terminal2->uuid().toString());
+			m_insert_conductor_query.bindValue(":terminal2_element_uuid", conductor->terminal2->parentElement()->uuid().toString());
+			m_insert_conductor_query.bindValue(":text", conductor->properties().text);
+			if (!m_insert_conductor_query.exec()) {
+				qDebug() << "projectDataBase::populateConductorTable insert error : " << m_insert_conductor_query.lastError();
+			}
+		}
+	}
+}
+
+/**
+	@brief projectDataBase::insertTerminal
+	Insert (or, if already present -- e.g. a junction shared by several
+	conductors -- silently keep) @terminal in the terminal table.
+	@param terminal
+*/
+void projectDataBase::insertTerminal(Terminal *terminal)
+{
+	m_insert_terminal_query.bindValue(":uuid", terminal->uuid().toString());
+	m_insert_terminal_query.bindValue(":element_uuid", terminal->parentElement()->uuid().toString());
+	m_insert_terminal_query.bindValue(":name", terminal->name());
+	if (!m_insert_terminal_query.exec()) {
+		qDebug() << "projectDataBase::insertTerminal insert error : " << m_insert_terminal_query.lastError();
+	}
+}
+
 void projectDataBase::prepareQuery()
 {
 		//INSERT DIAGRAM
@@ -606,6 +752,19 @@ void projectDataBase::prepareQuery()
 	update_str.append(" WHERE element_uuid = :uuid");
 	m_update_element_query = QSqlQuery(m_data_base);
 	m_update_element_query.prepare(update_str);
+
+		//INSERT TERMINAL
+	m_insert_terminal_query = QSqlQuery(m_data_base);
+	m_insert_terminal_query.prepare("INSERT OR IGNORE INTO terminal (uuid, element_uuid, name) VALUES (:uuid, :element_uuid, :name)");
+
+		//INSERT CONDUCTOR
+	m_insert_conductor_query = QSqlQuery(m_data_base);
+	m_insert_conductor_query.prepare("INSERT INTO conductor (uuid, diagram_uuid, terminal1_uuid, terminal1_element_uuid, terminal2_uuid, terminal2_element_uuid, text) "
+					  "VALUES (:uuid, :diagram_uuid, :terminal1_uuid, :terminal1_element_uuid, :terminal2_uuid, :terminal2_element_uuid, :text)");
+
+		//REMOVE CONDUCTOR
+	m_remove_conductor_query = QSqlQuery(m_data_base);
+	m_remove_conductor_query.prepare("DELETE FROM conductor WHERE uuid=:uuid");
 }
 
 /**

--- a/sources/dataBase/projectdatabase.cpp
+++ b/sources/dataBase/projectdatabase.cpp
@@ -259,12 +259,13 @@ void projectDataBase::addConductor(Conductor *conductor)
 		return;
 	}
 
-		//A conductor whose terminal(s) predate terminal uuids (legacy
-		//elements not yet re-saved by a uuid-aware element editor) can't
-		//be given a stable identity here -- omitted the same way
-		//element_nomenclature_view already omits exclude_from_bom elements,
-		//rather than fabricating one.
-	if (conductor->terminal1->uuid().isNull() || conductor->terminal2->uuid().isNull()) {
+		//Both endpoints must belong to an element: the terminal table is keyed
+		//on (terminal, element) and a terminal with no parent has no identity
+		//to key on. Terminals whose *definition* predates terminal uuids are
+		//fine -- Terminal::stableUuid() derives one from the terminal's local
+		//position, which is what the project format itself matches on.
+	if (!conductor->terminal1->parentElement()
+		|| !conductor->terminal2->parentElement()) {
 		return;
 	}
 
@@ -366,9 +367,9 @@ void projectDataBase::bindConductorValues(QSqlQuery &query, Conductor *conductor
 {
 	query.bindValue(QStringLiteral(":uuid"), conductor->uuid().toString());
 	query.bindValue(QStringLiteral(":diagram_uuid"), diagram->uuid().toString());
-	query.bindValue(QStringLiteral(":terminal1_uuid"), conductor->terminal1->uuid().toString());
+	query.bindValue(QStringLiteral(":terminal1_uuid"), conductor->terminal1->stableUuid().toString());
 	query.bindValue(QStringLiteral(":terminal1_element_uuid"), conductor->terminal1->parentElement()->uuid().toString());
-	query.bindValue(QStringLiteral(":terminal2_uuid"), conductor->terminal2->uuid().toString());
+	query.bindValue(QStringLiteral(":terminal2_uuid"), conductor->terminal2->stableUuid().toString());
 	query.bindValue(QStringLiteral(":terminal2_element_uuid"), conductor->terminal2->parentElement()->uuid().toString());
 	query.bindValue(QStringLiteral(":text"), conductor->properties().text);
 }
@@ -730,9 +731,10 @@ void projectDataBase::populateConductorTable()
 		const auto conductor_list = diagram->conductors();
 		for (auto *conductor : conductor_list)
 		{
-				//See addConductor() for why terminals without a uuid
-				//(legacy elements) are omitted rather than fabricating one.
-			if (conductor->terminal1->uuid().isNull() || conductor->terminal2->uuid().isNull()) {
+				//See addConductor(): only a terminal with no parent element is
+				//skipped. A missing terminal uuid is handled by stableUuid().
+			if (!conductor->terminal1->parentElement()
+				|| !conductor->terminal2->parentElement()) {
 				continue;
 			}
 
@@ -756,7 +758,7 @@ void projectDataBase::populateConductorTable()
 */
 void projectDataBase::insertTerminal(Terminal *terminal)
 {
-	m_insert_terminal_query.bindValue(":uuid", terminal->uuid().toString());
+	m_insert_terminal_query.bindValue(":uuid", terminal->stableUuid().toString());
 	m_insert_terminal_query.bindValue(":element_uuid", terminal->parentElement()->uuid().toString());
 	m_insert_terminal_query.bindValue(":name", terminal->name());
 	if (!m_insert_terminal_query.exec()) {

--- a/sources/dataBase/projectdatabase.h
+++ b/sources/dataBase/projectdatabase.h
@@ -49,6 +49,8 @@ class projectDataBase : public QObject
 		void updateDB();
 		QETProject *project() const;
 		QSqlQuery newQuery(const QString &query = QString());
+		QSqlDatabase database() const {return m_data_base;}
+		int excludedConductorCount() const;
 
 		void addElement         (Element *element);
 		void removeElement      (Element *element);

--- a/sources/dataBase/projectdatabase.h
+++ b/sources/dataBase/projectdatabase.h
@@ -27,6 +27,8 @@
 class Element;
 class QETProject;
 class Diagram;
+class Conductor;
+class Terminal;
 class sqlite3;
 
 /**
@@ -58,6 +60,9 @@ class projectDataBase : public QObject
 		void diagramInfoChanged (Diagram *diagram);
 		void diagramOrderChanged();
 
+		void addConductor       (Conductor *conductor);
+		void removeConductor    (Conductor *conductor);
+
 	signals:
 		void dataBaseUpdated();
 
@@ -69,6 +74,8 @@ class projectDataBase : public QObject
 		void populateElementTable();
 		void populateElementInfoTable();
 		void populateDiagramInfoTable();
+		void populateConductorTable();
+		void insertTerminal(Terminal *terminal);
 		void prepareQuery();
 		static QHash<QString, QString> elementInfoToString(
 				Element *elmt);
@@ -86,7 +93,10 @@ class projectDataBase : public QObject
 				  m_insert_diagram_info_query,
 				  m_update_diagram_info_query,
 				  m_diagram_order_changed,
-				  m_diagram_info_order_changed;
+				  m_diagram_info_order_changed,
+				  m_insert_terminal_query,
+				  m_insert_conductor_query,
+				  m_remove_conductor_query;
 
 #ifdef QET_EXPORT_PROJECT_DB
 	public:

--- a/sources/dataBase/projectdatabase.h
+++ b/sources/dataBase/projectdatabase.h
@@ -77,6 +77,7 @@ class projectDataBase : public QObject
 		bool createDataBase();
 		void createElementNomenclatureView();
 		void createSummaryView();
+		void createWiringListView();
 		void populateDiagramTable();
 		void populateElementTable();
 		void populateElementInfoTable();

--- a/sources/dataBase/projectdatabase.h
+++ b/sources/dataBase/projectdatabase.h
@@ -92,6 +92,8 @@ class projectDataBase : public QObject
 		static QHash<QString, QString> elementInfoToString(
 				Element *elmt);
 		void bindDiagramInfoValues(QSqlQuery &query, Diagram *diagram);
+		static void bindElementValues(QSqlQuery &query, Element *element, Diagram *diagram);
+		static void bindElementInfoValues(QSqlQuery &query, Element *element);
 
 	private:
 		QPointer<QETProject> m_project;

--- a/sources/dataBase/projectdatabase.h
+++ b/sources/dataBase/projectdatabase.h
@@ -62,6 +62,13 @@ class projectDataBase : public QObject
 
 		void addConductor       (Conductor *conductor);
 		void removeConductor    (Conductor *conductor);
+		void updateConductor    (Conductor *conductor);
+
+	private slots:
+			//Refresh the sender()'s row after Conductor::setProperties().
+		void conductorPropertiesChanged();
+
+	public:
 
 	signals:
 		void dataBaseUpdated();
@@ -75,6 +82,8 @@ class projectDataBase : public QObject
 		void populateElementInfoTable();
 		void populateDiagramInfoTable();
 		void populateConductorTable();
+		void bindConductorValues(QSqlQuery &query, Conductor *conductor, Diagram *diagram);
+		void watchConductor(Conductor *conductor);
 		void insertTerminal(Terminal *terminal);
 		void prepareQuery();
 		static QHash<QString, QString> elementInfoToString(
@@ -96,6 +105,7 @@ class projectDataBase : public QObject
 				  m_diagram_info_order_changed,
 				  m_insert_terminal_query,
 				  m_insert_conductor_query,
+				  m_update_conductor_query,
 				  m_remove_conductor_query;
 
 #ifdef QET_EXPORT_PROJECT_DB

--- a/sources/diagram.cpp
+++ b/sources/diagram.cpp
@@ -1674,6 +1674,7 @@ void Diagram::addItem(QGraphicsItem *item)
 			conductor->terminal1->addConductor(conductor);
 			conductor->terminal2->addConductor(conductor);
 			conductor->calculateTextItemPosition();
+			m_project->dataBase()->addConductor(conductor);
 			break;
 		}
 		default: {break;}
@@ -1704,6 +1705,7 @@ void Diagram::removeItem(QGraphicsItem *item)
 			Conductor *conductor = static_cast<Conductor *>(item);
 			conductor->terminal1->removeConductor(conductor);
 			conductor->terminal2->removeConductor(conductor);
+			m_project->dataBase()->removeConductor(conductor);
 			break;
 		}
 		default: {break;}

--- a/sources/diagramcommands.cpp
+++ b/sources/diagramcommands.cpp
@@ -75,6 +75,13 @@ void PasteDiagramCommand::redo()
 	{
 		first_redo = false;
 
+		//make new uuid for every pasted conductor, because old uuid are
+		//the uuid of the copied conductor
+		const QList <Conductor *> all_pasted_conductors = content.conductors();
+		for (Conductor *c : all_pasted_conductors) {
+			c -> newUuid();
+		}
+
 		//this is the first paste, we do some actions for the new element
 		const QList <Element *> elmts_list = content.m_elements;
 		for (Element *e : elmts_list)

--- a/sources/elementspanelwidget.cpp
+++ b/sources/elementspanelwidget.cpp
@@ -17,6 +17,7 @@
 */
 #include "elementspanelwidget.h"
 #include "diagram.h"
+#include "qetgraphicsitem/conductor.h"
 #include "editor/ui/qetelementeditor.h"
 #include "elementscategoryeditor.h"
 #include "qetapp.h"
@@ -651,6 +652,13 @@ void ElementsPanelWidget::duplicateDiagram()
 				// silently vanish from nomenclature/summary tables.
 				elmt->newUuid();
 				new_diagram->restoreText(elmt);
+			}
+			else if (Conductor *cond = dynamic_cast<Conductor *>(item)) {
+				// Same reasoning for conductors: conductor.uuid is the PRIMARY
+				// KEY of the conductor table, and its insert is a plain INSERT,
+				// so a duplicated uuid fails and the wire silently disappears
+				// from the wiring list and the per-element wire count.
+				cond->newUuid();
 			}
 		}
 	}

--- a/sources/qetdiagrameditor.cpp
+++ b/sources/qetdiagrameditor.cpp
@@ -53,6 +53,7 @@
 #include "ui/diagrameditorhandlersizewidget.h"
 #include "TerminalStrip/ui/addterminalstripitemdialog.h"
 #include "wiringlistexport.h"
+#include "ui/wiringlistdialog.h"
 #include "ui/terminalnumberingdialog.h"
 #include <QDateTime>
 #include <QDebug>
@@ -503,6 +504,17 @@ void QETDiagramEditor::setUpActions()
 		}
 	});
 
+	// Show the wiring list read from the project database
+	m_project_wiring_list_view = new QAction(QET::Icons::DocumentSpreadsheet, tr("Liste de câblage (base de données)"), this);
+	connect(m_project_wiring_list_view, &QAction::triggered, [this]() {
+		QETProject *project = this->currentProject();
+		if (project)
+		{
+			WiringListDialog dialog(project, this);
+			dialog.exec();
+		}
+	});
+
 	// Terminal Numbering
 	m_terminal_numbering = new QAction(QET::Icons::TerminalStrip, tr("Numérotation automatique des bornes"), this);
 	connect(m_terminal_numbering, &QAction::triggered, this, &QETDiagramEditor::slot_terminalNumbering);
@@ -892,6 +904,7 @@ void QETDiagramEditor::setUpMenu()
 	menu_project -> addAction(m_terminal_strip_dialog);
 	menu_project -> addAction(m_project_terminalBloc);
 	menu_project -> addAction(m_project_export_wiring_list);
+	menu_project -> addAction(m_project_wiring_list_view);
 	menu_project -> addAction(m_terminal_numbering);
 #ifdef QET_EXPORT_PROJECT_DB
 	menu_project -> addSeparator();
@@ -1680,6 +1693,7 @@ void QETDiagramEditor::slot_updateActions()
 	m_project_export_conductor_num-> setEnabled(opened_project);
 	m_terminal_strip_dialog       -> setEnabled(editable_project);
 	m_project_export_wiring_list  -> setEnabled(opened_project);
+	m_project_wiring_list_view    -> setEnabled(opened_project);
 	m_terminal_numbering          -> setEnabled(editable_project);
 #ifdef QET_EXPORT_PROJECT_DB
 	m_export_project_db           -> setEnabled(editable_project);

--- a/sources/qetdiagrameditor.h
+++ b/sources/qetdiagrameditor.h
@@ -207,6 +207,7 @@ class QETDiagramEditor : public QETMainWindow
 		*m_project_terminalBloc,	///< generate terminal block
 		*m_project_export_conductor_num,///<Export the wire num to csv
 		*m_project_export_wiring_list, ///< Action to export the wiring list
+		*m_project_wiring_list_view,   ///< Action to show the wiring list read from the project database
 		*m_terminal_numbering,         ///< Action to launch terminal numbering
 		*m_export_project_db,		///Export to file the internal database of the current project
 		*m_tile_window,			///< Show MDI subwindows as tile

--- a/sources/qetgraphicsitem/conductor.cpp
+++ b/sources/qetgraphicsitem/conductor.cpp
@@ -91,6 +91,7 @@ Conductor::Conductor(Terminal *p1, Terminal* p2) :
 		//set Zvalue at 11 to be upper than the DiagramImageItem and element
 	setZValue(11);
 	m_previous_z_value = zValue();
+	m_uuid = QUuid::createUuid();
 
 		//Add this conductor to the list of conductors of each of the two terminals
 	bool ajout_p1 = terminal1 -> addConductor(this);
@@ -1005,6 +1006,12 @@ void Conductor::pointsToSegments(const QList<QPointF>& points_list) {
 */
 bool Conductor::fromXml(QDomElement &dom_element)
 {
+		//Older project files have no conductor uuid attribute at all --
+		//generate one on load, same treatment terminal uuids got when
+		//that field was introduced (see terminal1/terminal2 handling in
+		//toXml() below).
+	m_uuid = QUuid(dom_element.attribute("uuid", QUuid::createUuid().toString()));
+
 	setPos(dom_element.attribute("x", nullptr).toDouble(),
 		   dom_element.attribute("y", nullptr).toDouble());
 
@@ -1043,6 +1050,7 @@ QDomElement Conductor::toXml(QDomDocument &dom_document,
 {
 	QDomElement dom_element = dom_document.createElement("conductor");
 
+	dom_element.setAttribute("uuid", m_uuid.toString());
 	dom_element.setAttribute("x", QString::number(pos().x()));
 	dom_element.setAttribute("y", QString::number(pos().y()));
 	

--- a/sources/qetgraphicsitem/conductor.cpp
+++ b/sources/qetgraphicsitem/conductor.cpp
@@ -1010,7 +1010,13 @@ bool Conductor::fromXml(QDomElement &dom_element)
 		//generate one on load, same treatment terminal uuids got when
 		//that field was introduced (see terminal1/terminal2 handling in
 		//toXml() below).
-	m_uuid = QUuid(dom_element.attribute("uuid", QUuid::createUuid().toString()));
+	m_uuid = QUuid(dom_element.attribute(QStringLiteral("uuid")));
+	if (m_uuid.isNull()) {
+			//Absent, empty or malformed: mint one. A null uuid is not a usable
+			//identity -- every conductor carrying one would collide with every
+			//other on the conductor table's primary key.
+		m_uuid = QUuid::createUuid();
+	}
 
 	setPos(dom_element.attribute("x", nullptr).toDouble(),
 		   dom_element.attribute("y", nullptr).toDouble());

--- a/sources/qetgraphicsitem/conductor.h
+++ b/sources/qetgraphicsitem/conductor.h
@@ -21,6 +21,7 @@
 #include "../conductorproperties.h"
 
 #include <QGraphicsPathItem>
+#include <QUuid>
 
 class ConductorProfile;
 class ConductorSegmentProfile;
@@ -77,6 +78,8 @@ class Conductor : public QGraphicsObject
 		int type() const override { return Type; }
 		Diagram *diagram() const;
 		ConductorTextItem *textItem() const;
+		QUuid uuid() const {return m_uuid;}
+		void newUuid() {m_uuid = QUuid::createUuid();}	//create new uuid for this conductor
 		void updatePath(const QRectF & = QRectF());
 
 		//This method do nothing, it's only made to be used with Q_PROPERTY
@@ -205,6 +208,7 @@ class Conductor : public QGraphicsObject
 		Highlight must_highlight_;
 		bool m_valid;
 		bool m_freeze_label = false;
+		QUuid m_uuid;
 
 			/// QPen et QBrush objects used to draw conductors
 		static QPen conductor_pen;

--- a/sources/qetgraphicsitem/terminal.cpp
+++ b/sources/qetgraphicsitem/terminal.cpp
@@ -817,6 +817,60 @@ QUuid Terminal::uuid() const
 	return d->m_uuid;
 }
 
+/**
+	@brief Terminal::stableUuid
+	An identity for this terminal that exists on every element, not only on
+	those saved by a uuid-aware element editor.
+
+	uuid() comes from the catalog .elmt definition and is empty for every
+	element authored before that field existed -- which is most of the
+	installed base. Anything keyed on uuid() alone therefore cannot see those
+	elements at all.
+
+	When there is no uuid, derive one from the terminal's local position and
+	orientation inside its element. That is not an arbitrary choice: it is the
+	same thing the project format itself uses to match a conductor back to a
+	terminal ("each connection is made by using the local position of the
+	terminal and a dynamic id" -- TerminalData::m_uuid). m_pos is the position
+	read from the definition and is not touched by moving the element on the
+	folio, so the result is stable across loads, saves and folio moves, and it
+	is unique within an element except where a definition genuinely declares
+	two terminals at the same point -- three cases in the whole example corpus,
+	and harmless, because two terminals sharing a position and orientation are
+	indistinguishable in every observable respect: they merge to one terminal
+	row and every conductor on either of them still resolves to the right
+	element and name.
+
+	Derived values are UUID v5 in a fixed namespace, so they are reproducible
+	without being written to the file, and cannot collide with the v4 uuids
+	the element editor generates.
+
+	@return the terminal's own uuid when it has one, otherwise a derived one
+*/
+QUuid Terminal::stableUuid() const
+{
+	if (!d->m_uuid.isNull()) {
+		return d->m_uuid;
+	}
+
+		//Fixed namespace for terminal identities derived from geometry.
+	static const QUuid derived_ns(QStringLiteral("{6b1f6d1e-6a1a-5f7e-9a3d-9c0a5b2d7e11}"));
+
+		//Position and orientation only. The name is deliberately excluded: it
+		//is not stable across a save cycle -- QET rewrites a terminal named
+		//"_" as unnamed, which would silently change the identity of 1421 of
+		//industrial.qet's 1790 terminals on the first resave. It is also not
+		//needed: keying on geometry alone produces exactly the same number of
+		//collisions across the example corpus, and it means renaming a
+		//terminal does not change what it is.
+	const QString key = QStringLiteral("%1|%2|%3")
+			.arg(d->m_pos.x(), 0, 'f', 4)
+			.arg(d->m_pos.y(), 0, 'f', 4)
+			.arg(static_cast<int>(d->m_orientation));
+
+	return QUuid::createUuidV5(derived_ns, key);
+}
+
 QString Terminal::name() const
 {
 	if (d->m_use_master_label && parent_element_) {

--- a/sources/qetgraphicsitem/terminal.h
+++ b/sources/qetgraphicsitem/terminal.h
@@ -75,6 +75,7 @@ class Terminal : public QGraphicsObject
 		Diagram  *diagram             () const;
 		Element  *parentElement       () const;
 		QUuid     uuid                () const;
+		QUuid     stableUuid          () const;
 		QString   name                () const;
 		QString   baseName            () const;
 		TerminalData::Type terminalType() const;

--- a/sources/ui/wiringlistdialog.cpp
+++ b/sources/ui/wiringlistdialog.cpp
@@ -41,6 +41,12 @@ WiringListDialog::WiringListDialog(QETProject *project, QWidget *parent) :
 
 	auto *layout = new QVBoxLayout(this);
 
+		//The wiring list reads the database rather than the diagrams, and a
+		//conductor's row is only as fresh as the last thing that touched it.
+		//Refresh before querying so the dialog cannot show a wire number that
+		//was edited earlier in the session.
+	m_project->dataBase()->updateDB();
+
 	auto *model = new QSqlQueryModel(this);
 	model->setQuery(QStringLiteral(
 				"SELECT wire_number, from_element_label, from_terminal,"
@@ -57,6 +63,14 @@ WiringListDialog::WiringListDialog(QETProject *project, QWidget *parent) :
 	model->setHeaderData(5, Qt::Horizontal, tr("Folio", "column title"));
 
 	const int excluded = m_project->dataBase()->excludedConductorCount();
+
+		//QSqlQueryModel fetches lazily, so rowCount() straight after
+		//setQuery() reports the first batch (256) rather than the query's
+		//size. Draining it first is what makes the count below true for a
+		//project with more wires than that.
+	while (model->canFetchMore()) {
+		model->fetchMore();
+	}
 	const int listed = model->rowCount();
 
 	auto *summary = new QLabel(this);

--- a/sources/ui/wiringlistdialog.cpp
+++ b/sources/ui/wiringlistdialog.cpp
@@ -77,14 +77,14 @@ WiringListDialog::WiringListDialog(QETProject *project, QWidget *parent) :
 	summary->setWordWrap(true);
 	if (excluded > 0)
 	{
-			//The count matters more than it looks: a project whose elements
-			//all predate terminal uuids yields an entirely empty list, and
-			//without this line that is indistinguishable from a project with
-			//no wires in it.
+			//Rare now that Terminal::stableUuid() gives every terminal an
+			//identity: what is left is a conductor whose endpoint has no
+			//parent element at all. Still worth saying out loud rather than
+			//presenting a short list as if it were complete.
 		summary->setText(tr("%n conducteur(s) listé(s).", "wiring list summary", listed)
 				 % QStringLiteral(" ")
-				 % tr("%n conducteur(s) exclu(s) : leurs éléments ne définissent pas"
-				      " d'identifiant de borne (définition d'élément trop ancienne).",
+				 % tr("%n conducteur(s) exclu(s) : une extrémité n'est rattachée"
+				      " à aucun élément.",
 				      "wiring list exclusion warning", excluded));
 	}
 	else {

--- a/sources/ui/wiringlistdialog.cpp
+++ b/sources/ui/wiringlistdialog.cpp
@@ -1,0 +1,93 @@
+/*
+	Copyright 2006-2026 The QElectroTech Team
+	This file is part of QElectroTech.
+
+	QElectroTech is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 2 of the License, or
+	(at your option) any later version.
+
+	QElectroTech is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with QElectroTech.  If not, see <http://www.gnu.org/licenses/>.
+*/
+#include "wiringlistdialog.h"
+
+#include "../dataBase/projectdatabase.h"
+#include "../qetproject.h"
+
+#include <QDialogButtonBox>
+#include <QHeaderView>
+#include <QLabel>
+#include <QSqlQueryModel>
+#include <QTableView>
+#include <QVBoxLayout>
+
+/**
+	@brief WiringListDialog::WiringListDialog
+	@param project : project whose wiring list is shown
+	@param parent : parent widget
+*/
+WiringListDialog::WiringListDialog(QETProject *project, QWidget *parent) :
+	QDialog(parent),
+	m_project(project)
+{
+	setWindowTitle(tr("Liste de câblage", "window title"));
+	resize(900, 500);
+
+	auto *layout = new QVBoxLayout(this);
+
+	auto *model = new QSqlQueryModel(this);
+	model->setQuery(QStringLiteral(
+				"SELECT wire_number, from_element_label, from_terminal,"
+				" to_element_label, to_terminal, diagram_position"
+				" FROM wiring_list_view"
+				" ORDER BY diagram_position, wire_number"),
+			m_project->dataBase()->database());
+
+	model->setHeaderData(0, Qt::Horizontal, tr("Fil", "column title"));
+	model->setHeaderData(1, Qt::Horizontal, tr("Composant 1", "column title"));
+	model->setHeaderData(2, Qt::Horizontal, tr("Borne 1", "column title"));
+	model->setHeaderData(3, Qt::Horizontal, tr("Composant 2", "column title"));
+	model->setHeaderData(4, Qt::Horizontal, tr("Borne 2", "column title"));
+	model->setHeaderData(5, Qt::Horizontal, tr("Folio", "column title"));
+
+	const int excluded = m_project->dataBase()->excludedConductorCount();
+	const int listed = model->rowCount();
+
+	auto *summary = new QLabel(this);
+	summary->setWordWrap(true);
+	if (excluded > 0)
+	{
+			//The count matters more than it looks: a project whose elements
+			//all predate terminal uuids yields an entirely empty list, and
+			//without this line that is indistinguishable from a project with
+			//no wires in it.
+		summary->setText(tr("%n conducteur(s) listé(s).", "wiring list summary", listed)
+				 % QStringLiteral(" ")
+				 % tr("%n conducteur(s) exclu(s) : leurs éléments ne définissent pas"
+				      " d'identifiant de borne (définition d'élément trop ancienne).",
+				      "wiring list exclusion warning", excluded));
+	}
+	else {
+		summary->setText(tr("%n conducteur(s) listé(s).", "wiring list summary", listed));
+	}
+	layout->addWidget(summary);
+
+	auto *view = new QTableView(this);
+	view->setModel(model);
+	view->setEditTriggers(QAbstractItemView::NoEditTriggers);
+	view->setSelectionBehavior(QAbstractItemView::SelectRows);
+	view->setAlternatingRowColors(true);
+	view->verticalHeader()->setVisible(false);
+	view->horizontalHeader()->setSectionResizeMode(QHeaderView::Stretch);
+	layout->addWidget(view);
+
+	auto *buttons = new QDialogButtonBox(QDialogButtonBox::Close, this);
+	connect(buttons, &QDialogButtonBox::rejected, this, &QDialog::reject);
+	layout->addWidget(buttons);
+}

--- a/sources/ui/wiringlistdialog.h
+++ b/sources/ui/wiringlistdialog.h
@@ -1,0 +1,48 @@
+/*
+	Copyright 2006-2026 The QElectroTech Team
+	This file is part of QElectroTech.
+
+	QElectroTech is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 2 of the License, or
+	(at your option) any later version.
+
+	QElectroTech is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with QElectroTech.  If not, see <http://www.gnu.org/licenses/>.
+*/
+#ifndef WIRINGLISTDIALOG_H
+#define WIRINGLISTDIALOG_H
+
+#include <QDialog>
+
+class QETProject;
+
+/**
+	@brief The WiringListDialog class
+	Read-only view of the project's from-to wiring list, read from the
+	wiring_list_view of projectDataBase.
+
+	Deliberately not an exporter: QET already ships a wiring-list CSV export
+	(Projet > Exporter le plan de câblage, and --export-cables), which walks
+	the project XML and covers that need. This dialog exists to make the
+	database view inspectable, and above all to state how many conductors
+	are missing from it and why -- a count the CSV export cannot give,
+	because it never excludes anything in the first place.
+*/
+class WiringListDialog : public QDialog
+{
+	Q_OBJECT
+
+	public:
+		explicit WiringListDialog(QETProject *project, QWidget *parent = nullptr);
+
+	private:
+		QETProject *m_project = nullptr;
+};
+
+#endif // WIRINGLISTDIALOG_H


### PR DESCRIPTION
> ### Updated since first posting
>
> **The excluded-conductor count no longer describes reality, and has been realigned.** It counted conductors whose terminals had no uuid — the right rule when that was why they were dropped. `Terminal::stableUuid()` in #628 means those conductors are now *in* the table, so left unchanged this dialog would have announced **"671 conductors excluded" on `industrial.qet` while listing all 671 of them** — a worse failure than the one the count exists to prevent, because it undermines a list that is now correct. Both the count and its message now describe the case that actually remains: an endpoint attached to no element at all.
>
> **The "N conducteur(s) listé(s)" figure was wrong above 256.** `QSqlQueryModel` fetches lazily, so `rowCount()` straight after `setQuery()` returns the rows fetched so far, not the size of the query. Measured with Qt's own QSQLITE driver: a 1000-row view reports 256 until the model is drained, then 1000. The test project quoted in #628 has 280 conductors, so this was already displaying 256 on our own data. The irony is that this line exists to *stop* a misleading number. The model is now drained before the count is read.
>
> **The dialog refreshes the database before building its model.** It queries the database rather than the diagrams, so anything not yet written through was invisible here.

Slice 4 of #503. **Ready for review** — the gap that originally made this a draft is closed; see "The gap that made this a draft" below for what changed and what a reviewer should sign off on.

> Stacked on #629 → #628 → #625. Merge in that order. The commits to review here are the last three: `a0fcfb8`, `07377c4`, `2cc02ec`.

## What it adds

`Projet > Liste de câblage (base de données)` opens a read-only table of `wiring_list_view`, headed by a line saying how many conductors are listed and — when non-zero — how many were **excluded and why**.

`projectDataBase::excludedConductorCount()` counts, from the live scene, the conductors absent from the `conductor` table. Counted from the scene precisely because the database is where those conductors *are not*.

| project | listed | excluded |
|---|---|---|
| `examples/industrial.qet` | **671** | **0** |
| two contacts with uuid-bearing terminals | 1 | 0 |

## Deliberately *not* another exporter

While building this I checked what already ships: `Projet > Exporter le plan de câblage` and `--export-cables` (`WiringListExport`) walk the project XML and already produce a from-to CSV.

**Correction to an earlier revision of this description.** It said my impression that that exporter produced blank output was wrong, and blamed unlabelled test projects. Measuring properly says otherwise: on the *same* project, `--export-cables` fills endpoint data on **0 of 671** rows of `industrial.qet` while the database view fills **541 of 671**. The cause is specific — `WiringListExport` resolves endpoints from `element1`/`element2` attributes on the conductor XML, and legacy files never write them (0 of 671 conductors in `industrial.qet` carry one). So it is not the projects being unlabelled; it is that the XML exporter has nothing to resolve on files that use the older positional scheme, while the database path resolves them because at runtime the terminals are attached to real elements.

That still is not an argument for a competing CSV export, and `--export-cables` keeps columns the view does not have. It *is* the argument for this dialog: on the projects people actually have, the database path is the one with the data in it.

## The gap that made this a draft — now closed

The draft flagged that after a save/reload the component columns came back blank for slave elements, and offered three ways out. Two of them were workarounds. The last two commits take the third route and fix the cause, because the cause turned out to be worth fixing on its own merits.

**The actual cause was not the type filter.** It was that `element`/`element_info` had *two* insert paths that disagreed with each other:

- incremental — `addElement()`, via `Diagram::addItem()`, applied **no** type filter;
- bulk — `populateElementTable()`/`populateElementInfoTable()`, via `updateDB()`, applied `Simple|Terminal|Master|Thumbnail`.

So the same project produced a different `element` table depending on whether you had just drawn it or just opened it. That is why the symptom was invisible while editing and appeared only after reload — and it was never specific to the wiring list.

Two commits close it:

- **`07377c4` — populate every element type; move the nomenclature filter into its view.** The bulk path now inserts all eight types, and the `Simple|Terminal|Master|Thumbnail` restriction moves into `element_nomenclature_view`, where it is a property of the nomenclature rather than of the table everything else reads. BOM contents are unchanged by construction: the same filter, applied one layer later.
- **`2cc02ec` — insert an element the same way whether it is added live or on load.** Both paths now bind through shared `bindElementValues()`/`bindElementInfoValues()` helpers, modelled on the existing `bindDiagramInfoValues()` idiom, so the two paths cannot drift apart again. This is the part that makes the fix structural rather than a second filter kept in sync by hand.

## Verification

| check | result |
|---|---|
| `--export-bom` vs pre-change baseline, 19 projects | identical content on 19/19; line-for-line on 18/19 |
| wiring list end-to-end, after save + reload | `K2 → K1`, re-confirmed on the final commit |
| live vs reloaded `element` table | identical (`slave/ ×1` in both) |
| excluded-conductor count | 0 on `industrial.qet` and on a uuid-bearing project alike |
| load cost, `industrial.qet` (150 folios) | 0.210 s → 0.233 s |
| build | clean, no new warnings |

On the one project that is not line-for-line identical (`photovoltaique`), three **byte-identical** rows appear in a different order. They tie on `ORDER BY label`, and the existing query never defined an order among ties — both orderings are equally valid outputs of the unchanged query. No row was added, removed or altered.

## What a reviewer should decide consciously

**In a live session, nomenclature contents now match what a reload produces.** Before, the two could disagree; they now agree by construction. The saved-and-reloaded result was already the one users saw in a fresh session, so this aligns the live case to it rather than the other way round — but it *is* a behaviour change in the live case, and it belongs to you, not to me.

## Known limitations, deliberately not addressed here

- `removeDiagram()` does not cascade-delete that diagram's `conductor` rows. This matches its existing behaviour for `element`/`element_info`; a full `updateDB()` clears them, and the view selects `FROM conductor`, so orphans never surface in output. Worth fixing, but as its own change to the existing pattern.
- Terminal-name columns are blank for catalog elements that define no terminal names. That is source data, not a defect.

