### PR TITLE
Fix Cyclique (modulo) parts defaulting to modulus 0 (follow-up to #593)

### DIFF
--- a/sources/autoNum/assignvariables.cpp
+++ b/sources/autoNum/assignvariables.cpp
@@ -39,6 +39,7 @@ namespace autonum
 	sequentialNumbers::sequentialNumbers(const sequentialNumbers &other)
 	{
 		unit          = other.unit;
+		wrap          = other.wrap;
 		unit_folio    = other.unit_folio;
 		ten           = other.ten;
 		ten_folio     = other.ten_folio;
@@ -57,6 +58,7 @@ namespace autonum
 			return (*this);
 
 		unit          = other.unit;
+		wrap          = other.wrap;
 		unit_folio    = other.unit_folio;
 		ten           = other.ten;
 		ten_folio     = other.ten_folio;
@@ -70,6 +72,7 @@ namespace autonum
 	bool sequentialNumbers::operator==(const sequentialNumbers &other) const
 	{
 		if (unit          == other.unit && \
+			wrap          == other.wrap && \
 			unit_folio    == other.unit_folio && \
 			ten           == other.ten && \
 			ten_folio     == other.ten_folio && \
@@ -107,6 +110,11 @@ namespace autonum
 						    document,
 						    "unit",
 						    unit.join(";")));
+		if (!wrap.isEmpty())
+			element.appendChild(QETXML::textToDomElement(
+						    document,
+						    "wrap",
+						    wrap.join(";")));
 		if (!unit_folio.isEmpty())
 			element.appendChild(QETXML::textToDomElement(
 						    document,
@@ -156,6 +164,11 @@ namespace autonum
 		from = element.firstChildElement("unit");
 		unit = from.text().split(";");
 
+			//Absent from files written before cyclic parts could be
+			//rendered; an empty list is the correct reading of that.
+		from = element.firstChildElement("wrap");
+		wrap = from.text().split(";");
+
 		from = element.firstChildElement("unitFolio");
 		unit_folio = from.text().split(";");
 
@@ -179,6 +192,7 @@ namespace autonum
 	void sequentialNumbers::clear()
 	{
 		unit.clear();
+		wrap.clear();
 		unit_folio.clear();
 		ten.clear();
 		ten_folio.clear();
@@ -434,13 +448,17 @@ namespace autonum
 						qMax(
 							qMax(m_seq_struct.hundred.size(),
 								 m_seq_struct.ten.size()),
-							m_seq_struct.alpha.size())
+							qMax(m_seq_struct.alpha.size(),
+								 m_seq_struct.wrap.size()))
 					);
 
 		for (int i=1; i<=max ; i++)
 		{
 			if (m_assigned_label.contains("%sequ_" + QString::number(i)) && m_seq_struct.unit.size() >= i) {
 				m_assigned_label.replace("%sequ_" + QString::number(i),m_seq_struct.unit.at(i-1));
+			}
+			if (m_assigned_label.contains("%seqw_" + QString::number(i)) && m_seq_struct.wrap.size() >= i) {
+				m_assigned_label.replace("%seqw_" + QString::number(i),m_seq_struct.wrap.at(i-1));
 			}
 			if (m_assigned_label.contains("%seqt_" + QString::number(i)) && m_seq_struct.ten.size() >= i) {
 				m_assigned_label.replace("%seqt_" + QString::number(i),m_seq_struct.ten.at(i-1));
@@ -553,6 +571,10 @@ namespace autonum
 			{
 				autonum::setSequentialToList(seqStruct.unit, context,"unit");
 			}
+			if (label.contains("%seqw_"))
+			{
+				autonum::setSequentialToList(seqStruct.wrap, context,"wrap");
+			}
 			if (label.contains("%sequf_"))
 			{
 				autonum::setSequentialToList(seqStruct.unit_folio, context,"unitfolio");
@@ -594,6 +616,7 @@ namespace autonum
 		QString value;
 		QString formula;
 		int count_unit = 0;
+		int count_wrap = 0;
 		int count_unitf = 0;
 		int count_ten = 0;
 		int count_tenf = 0;
@@ -635,6 +658,10 @@ namespace autonum
 			else if (type == "unit") {
 				count_unit++;
 				formula.append("%sequ_" + QString::number(count_unit));
+			}
+			else if (type == "wrap") {
+				count_wrap++;
+				formula.append("%seqw_" + QString::number(count_wrap));
 			}
 			else if (type == "unitfolio") {
 				count_unitf++;

--- a/sources/autoNum/assignvariables.h
+++ b/sources/autoNum/assignvariables.h
@@ -47,6 +47,8 @@ namespace autonum
 			void clear();
 
 			QStringList unit;
+				/// Values of the cyclic (modulo) parts, referenced by %seqw_N.
+			QStringList wrap;
 			QStringList unit_folio;
 			QStringList ten;
 			QStringList ten_folio;

--- a/sources/autoNum/ui/numparteditorw.cpp
+++ b/sources/autoNum/ui/numparteditorw.cpp
@@ -359,8 +359,6 @@ void NumPartEditorW::setType(NumPartEditorW::type t, bool fnum) {
 		ui -> value_field -> setValidator(intValidator);
 		ui -> increase_spinBox -> setEnabled(true);
 		ui -> increase_spinBox -> setValue(1);
-		if (t == wrap)
-			ui -> modulus_spinBox -> setValue(8);
 	}
 	//@t isn't a numeric type
 	else if (t == string
@@ -414,6 +412,16 @@ void NumPartEditorW::setType(NumPartEditorW::type t, bool fnum) {
 			ui -> increase_spinBox -> setDisabled(true);
 		}
 	}
+		//A modulus of 0 means "no cycle", which makes a Cyclique part behave
+		//exactly like a plain digit. Defaulting it used to live in the numeric
+		//behavior block above, which is skipped when the previous type was
+		//itself numeric -- so the ordinary path of turning the default
+		//"Chiffre 1" into a "Cyclique (modulo)" left the modulus at 0 and
+		//produced a wrap part that never wrapped. Kept out of that block so it
+		//applies whatever the part was before, and only when the current value
+		//is unusable, so a modulus the user chose on purpose is not clobbered.
+	if (t == wrap && ui -> modulus_spinBox -> value() <= 0)
+		ui -> modulus_spinBox -> setValue(8);
 	ui -> modulus_spinBox -> setEnabled(t == wrap);
 	type_= t;
 }


### PR DESCRIPTION
Follow-up to #593, reported by @scorpio810 [here](https://github.com/qelectrotech/qelectrotech-source-mirror/pull/593#issuecomment-5152319870): a "Cyclique (modulo)" part counts upward forever instead of wrapping.

## What was wrong

Not the wrap/carry arithmetic — that part was fine. **The modulus was silently left at 0**, and 0 means "no cycle", so the part behaved exactly like a plain digit.

`setType()` defaulted the modulus to 8 inside the block that installs numeric behaviour. That block only runs when the *previous* type was non-numeric:

```cpp
if ( ((t==unit || … || t==wrap) && (type_==string || type_==folio || …)) || fnum )
{
    …
    if (t == wrap) ui->modulus_spinBox->setValue(8);   // ← skipped when type_ was numeric
}
```

A fresh part starts as `unit` ("Chiffre 1"). So the ordinary way to reach this feature — change the type of the part sitting in front of you — is exactly the path that skips the default. Going the long way round, via "Texte", sets it to 8 and works.

Driving the real widget through the same slot the combo box fires:

| path | modulus | result |
|---|---|---|
| `Chiffre 1` → `Cyclique (modulo)` | **0** | never wraps |
| `Chiffre 1` → `Texte` → `Cyclique (modulo)` | 8 | works |

That difference is the whole bug, and it explains why the feature tests fine whenever the context is built some other way.

## The fix

Move the default out of the numeric-behaviour block so it applies whatever the part was before, and fire it only when the current modulus is unusable so a deliberate value survives switching type away and back.

After, both paths give `modulus=8`.

## The arithmetic was already correct

Worth showing, since the report understandably read as "the carry logic is broken". Stepping the real `NumerotationContextCommands` with a carry target in front of the wrap part:

```
e. + unit(inc 0) + wrap(mod 7)
  e.00 e.01 e.02 e.03 e.04 e.05 e.06 e.10 e.11 … e.16 e.20 e.21 …

%IX + unit + . + wrap(mod 32)          ← the April 5000 case
  %IX0.0 %IX0.1 … %IX0.31 %IX1.0 %IX1.1 …
```

That is the requested pattern exactly: the wrap segment cycles and resets, the card digit ticks up.

One thing this makes explicit — **the wrap part needs a numeric part in front of it to carry into.** A wrap part on its own resets correctly but has nowhere to put the carry, so it just repeats `0…6, 0…6`. That is by design (`carry()` drops a carry with no target), but it is not discoverable from the UI, and it is a plausible second way to be disappointed by this feature. Happy to look at surfacing it if you think it is worth it.

## Compatibility

Saved configurations are untouched: a stored modulus loads and round-trips exactly as saved.

```
saved modulus 32 (PLC case)     -> spinbox 32, round-trips as 32   PRESERVED
saved modulus 7                 -> spinbox 7,  round-trips as 7    PRESERVED
saved modulus 0 (left by bug)   -> spinbox 0,  round-trips as 0    PRESERVED
```

**@scorpio810 — this is the part that affects you directly.** The last row is deliberate: I did not auto-rewrite stored 0s, because silently changing a saved numbering configuration seemed worse than leaving it alone. But it means **if you already saved a numbering config while this bug was present, that config still has modulus 0 and will still count upward after this fix.** Set the modulus once on that part and it will behave. Only new/edited parts get the default. Say the word if you would rather it repaired stored 0s on load and I will change it.

Built clean, no new warnings.
