### PR TITLE
Never leave a collection folder without a name (replaces #622)

### DIFF
--- a/sources/ElementsCollection/fileelementcollectionitem.cpp
+++ b/sources/ElementsCollection/fileelementcollectionitem.cpp
@@ -430,13 +430,20 @@ void FileElementCollectionItem::setUpData()
  */
 void FileElementCollectionItem::setUpIcon()
 {
-		// Directories are cheap to (re-)decide: no early return for them.
-		// setUpData() -- which resolves m_qet_directory_unreadable via
-		// localName() -- runs asynchronously (QtConcurrent::map), so this can
-		// be called for a directory before that result is known; without
-		// this, the plain folder icon would get cached by the guard below
-		// and the warning badge would never appear for that item.
-	if (!isDir() && !icon().isNull())
+		// Must return unconditionally once an icon is set: setIcon() calls
+		// setData(), which emits dataChanged() regardless of whether the new
+		// icon differs from the old one (QIcon has no meaningful equality).
+		// QTreeView responds to dataChanged() by recomputing the row's size
+		// hint, which re-enters data() for this same index -- so without this
+		// guard, any repeated setIcon() here recurses until the stack
+		// overflows. Confirmed by crash report on PR #633.
+		//
+		// This item's m_qet_directory_unreadable is already final by the time
+		// this can run at all: ElementsCollectionModel only attaches itself
+		// to the tree view (making data() reachable) from loadingFinished(),
+		// which fires after the QtConcurrent::map over every item -- this one
+		// included -- has completed. So there is no race to work around here.
+	if (!icon().isNull())
 		return;
 
 	if (isCollectionRoot()) {

--- a/sources/ElementsCollection/fileelementcollectionitem.cpp
+++ b/sources/ElementsCollection/fileelementcollectionitem.cpp
@@ -22,7 +22,39 @@
 #include "../qeticons.h"
 #include "elementslocation.h"
 
+#include <QApplication>
 #include <QDir>
+#include <QPainter>
+#include <QPixmap>
+#include <QStyle>
+
+namespace {
+	/**
+		@return the folder icon overlaid with a small warning badge in the
+		bottom-right corner. Used for a directory whose qet_directory could
+		not be read (@see FileElementCollectionItem::m_qet_directory_unreadable),
+		so the problem is visible in the tree itself and not only on hover
+		via the tooltip. Built once: same folder icon, same badge, every time.
+	*/
+	const QIcon &unreadableFolderIcon()
+	{
+		static const QIcon icon = []() {
+			QPixmap pixmap = QET::Icons::Folder.pixmap(16, 16);
+			const QPixmap badge = QApplication::style()
+				->standardIcon(QStyle::SP_MessageBoxWarning)
+				.pixmap(9, 9);
+
+			QPainter painter(&pixmap);
+			painter.drawPixmap(pixmap.width() - badge.width(),
+					    pixmap.height() - badge.height(),
+					    badge);
+			painter.end();
+
+			return QIcon(pixmap);
+		}();
+		return icon;
+	}
+}
 
 /**
 	@brief FileElementCollectionItem::FileElementCollectionItem
@@ -398,7 +430,13 @@ void FileElementCollectionItem::setUpData()
  */
 void FileElementCollectionItem::setUpIcon()
 {
-	if (!icon().isNull())
+		// Directories are cheap to (re-)decide: no early return for them.
+		// setUpData() -- which resolves m_qet_directory_unreadable via
+		// localName() -- runs asynchronously (QtConcurrent::map), so this can
+		// be called for a directory before that result is known; without
+		// this, the plain folder icon would get cached by the guard below
+		// and the warning badge would never appear for that item.
+	if (!isDir() && !icon().isNull())
 		return;
 
 	if (isCollectionRoot()) {
@@ -417,7 +455,8 @@ void FileElementCollectionItem::setUpIcon()
 	else
 	{
 		if (isDir()) {
-			setIcon(QET::Icons::Folder);
+			setIcon(m_qet_directory_unreadable ? unreadableFolderIcon()
+							    : QET::Icons::Folder);
 		} else {
 			if (m_path.endsWith(".qetmak")) {
 				setIcon(QIcon());

--- a/sources/ElementsCollection/fileelementcollectionitem.cpp
+++ b/sources/ElementsCollection/fileelementcollectionitem.cpp
@@ -136,18 +136,41 @@ QString FileElementCollectionItem::localName()
 		}
 		else
 		{
+			// Fall back to the raw directory name (m_path) whenever the
+			// translated name can't be obtained -- qet_directory missing,
+			// unreadable (e.g. a Windows path-encoding issue with special
+			// characters, see bugtracker #332), malformed, or present but
+			// without a usable name entry -- rather than leaving the item
+			// blank.
+			QString display_name;
+			bool readable = false;
 			QString str(fileSystemPath() % "/qet_directory");
 			pugi::xml_document docu;
-			if(docu.load_file(str.toStdWString().c_str()))
+			if (docu.load_file(str.toStdWString().c_str()))
 			{
 				if (QString(docu.document_element().name())
 					== "qet-directory")
 				{
+					readable = true;
 					NamesList nl;
 					nl.fromXml(docu.document_element());
-					setText(nl.name());
+						// Deliberately no fallback argument: a non-empty one
+						// is returned *before* NamesList::name() reaches its
+						// "first available translation" step, so passing
+						// m_path here would replace a perfectly good name in
+						// some other language with the raw directory name.
+						// The fallback belongs after the chain, not inside it.
+					display_name = nl.name();
 				}
 			}
+			setText(display_name.isEmpty() ? m_path : display_name);
+
+				// Only a file-level failure counts: a readable qet-directory
+				// with no entry for the current language is not an error,
+				// NamesList::name() resolves that on its own. Recorded here
+				// and reported by setUpData(), which sets the tooltip after
+				// this runs.
+			m_qet_directory_unreadable = !readable;
 		}
 	}
 	else if (isElement()) {
@@ -350,7 +373,21 @@ void FileElementCollectionItem::setUpData()
 		}
 	}
 
-	setToolTip(collectionPath());
+		// Falling back to the raw directory name keeps the folder usable, but
+		// on its own it hides the fact that a file is broken: the user sees a
+		// plausible name and never learns there is anything to repair. Say so
+		// above the collection path, which stays as the last line the way the
+		// element tooltip above builds it.
+	QStringList tip;
+	if (isDir() && m_qet_directory_unreadable)
+	{
+		tip << QObject::tr("Le fichier « %1 » est absent ou illisible : "
+				   "le nom traduit de ce dossier n'a pas pu être lu, "
+				   "son nom de dossier est affiché à la place.")
+		       .arg(fileSystemPath() % "/qet_directory");
+	}
+	tip << collectionPath();
+	setToolTip(tip.join(QLatin1Char('\n')));
 }
 
 /**

--- a/sources/ElementsCollection/fileelementcollectionitem.h
+++ b/sources/ElementsCollection/fileelementcollectionitem.h
@@ -64,6 +64,11 @@ class FileElementCollectionItem : public ElementCollectionItem
 
 	private:
 		QString m_path;
+			/// True when this directory's qet_directory file is missing or
+			/// unreadable, so setUpData() can say so in the tooltip. Recorded
+			/// rather than acted on in localName(), because setUpData() resets
+			/// the tooltip afterwards and would otherwise discard it.
+		bool m_qet_directory_unreadable = false;
 };
 
 #endif // FILEELEMENTCOLLECTIONITEM2_H


### PR DESCRIPTION
**Correction (2026-08-02):** the "Windows path-encoding problem with accented characters" cited below as a live cause was already fixed, in #524 (merged 2026-06-29, before this branch existed) — @plc-user caught this on the PR thread. That PR switched `load_file()` to the wide-char pugixml overload, which is why the snippet below already shows `toStdWString()`. What follows is corrected to reflect that: this PR is about the remaining structural gap (any *other* reason `load_file()` can fail — genuinely missing or malformed files), not that specific trigger, which is no longer live. See the discussion on the PR for the full correction.

---

Replaces #622, which GitHub will not let me reopen — I force-pushed the rebase while it was closed, and that permanently blocks reopening. Same branch, same purpose, with the corrections described below. Discussion in #622 is worth reading; @plc-user's suggestion there is implemented here.

Fixes https://qelectrotech.org/bugtracker/view.php?id=332 — which is **still open** (`Status: new`, `Resolution: open`); #622 was closed on the understanding it had been resolved.

## The bug

`FileElementCollectionItem::localName()` sets a non-root folder's label only inside the success path of loading its `qet_directory`:

```cpp
if (docu.load_file(str.toStdWString().c_str()))
    if (QString(docu.document_element().name()) == "qet-directory")
        { … setText(nl.name()); }
// nothing set at all if either test fails
```

A fresh item's `text()` is null, so any failure — file missing or malformed — leaves the folder with a completely blank label. That is the reported symptom. (The third cause originally listed here, a Windows path-encoding problem with accented characters that @plc-user diagnosed on the tracker, was already fixed in #524 before this branch existed — see the correction above.)

## The fix

Resolve the name into a local and always fall back to the folder's own directory name, so the label is never empty whatever went wrong.

**The fallback is applied after `NamesList::name()`, not passed into it.** This matters and is the part I got wrong in #622. `name()` returns a caller-supplied fallback at `nameslist.cpp:274`, *before* it reaches its "first available translation" step at line 275:

```cpp
if (!map_names["en"].isEmpty()) return (map_names["en"]);
if (!fallback_name.isEmpty())   return (fallback_name);   // <- short-circuits
if (map_names.count())          return (map_names.begin().value());
```

So passing `m_path` in would replace a perfectly good name in another language with the raw directory name. A folder named only in French, viewed under an English locale, must keep showing `Accentué` — and with my original patch it stopped doing so.

## Telling the user the file is broken (@plc-user's suggestion)

Falling back silently cures the symptom but hides the cause: the user sees a plausible name and never learns there is a file to repair. A folder whose `qet_directory` could not be read now says so in its tooltip, naming the file, above the collection path that tooltip already carried.

Only a **file-level** failure is flagged. A readable `qet-directory` with no entry for the current language is not an error — `NamesList::name()` resolves that itself — so a folder named only in French gets its name and no warning. That distinction is what keeps the indicator meaningful rather than noise.

The flag is recorded in `localName()` and consumed in `setUpData()`, because `setUpData()` ends with an unconditional `setToolTip(collectionPath())` that runs *after* `localName()`. Setting the tooltip in `localName()` — which is what I tried first — is silently overwritten and does nothing at all.

## Measured

A fixture collection of four folders, driven through the real `FileElementCollectionItem`:

| folder | master today | this PR |
|---|---|---|
| named only in French | `Accentué` | `Accentué` — no warning |
| malformed `qet_directory` | **blank** | `malformed` + warning |
| no `qet_directory` at all | **blank** | `no_file` + warning |
| valid `qet_directory` | `Valid Folder` | `Valid Folder` — no warning |

Rebased onto current master: #622's branch predated #620 and its diff would have reverted the elements-panel dark-theme fix. Two files, +45/-3, builds clean.

## What this does not do

This does not fix the Windows accented-path trigger from bugtracker #332 — that was already fixed in #524, independently of this PR (see the correction at the top). What this does is close the remaining structural gap: any other reason `load_file()` can fail — a genuinely missing or malformed `qet_directory` — still leaves a folder blank on current master, and after this PR it doesn't. If the original #332 reporter can confirm their folders now show names, that closes the loop on #524, not on this PR specifically.

