### PR TITLE
Numbering parts: user-settable display format (zero mask)

### DIFF
--- a/sources/autoNum/assignvariables.cpp
+++ b/sources/autoNum/assignvariables.cpp
@@ -39,6 +39,7 @@ namespace autonum
 	sequentialNumbers::sequentialNumbers(const sequentialNumbers &other)
 	{
 		unit          = other.unit;
+		wrap          = other.wrap;
 		unit_folio    = other.unit_folio;
 		ten           = other.ten;
 		ten_folio     = other.ten_folio;
@@ -57,6 +58,7 @@ namespace autonum
 			return (*this);
 
 		unit          = other.unit;
+		wrap          = other.wrap;
 		unit_folio    = other.unit_folio;
 		ten           = other.ten;
 		ten_folio     = other.ten_folio;
@@ -70,6 +72,7 @@ namespace autonum
 	bool sequentialNumbers::operator==(const sequentialNumbers &other) const
 	{
 		if (unit          == other.unit && \
+			wrap          == other.wrap && \
 			unit_folio    == other.unit_folio && \
 			ten           == other.ten && \
 			ten_folio     == other.ten_folio && \
@@ -107,6 +110,11 @@ namespace autonum
 						    document,
 						    "unit",
 						    unit.join(";")));
+		if (!wrap.isEmpty())
+			element.appendChild(QETXML::textToDomElement(
+						    document,
+						    "wrap",
+						    wrap.join(";")));
 		if (!unit_folio.isEmpty())
 			element.appendChild(QETXML::textToDomElement(
 						    document,
@@ -156,6 +164,11 @@ namespace autonum
 		from = element.firstChildElement("unit");
 		unit = from.text().split(";");
 
+			//Absent from files written before cyclic parts could be
+			//rendered; an empty list is the correct reading of that.
+		from = element.firstChildElement("wrap");
+		wrap = from.text().split(";");
+
 		from = element.firstChildElement("unitFolio");
 		unit_folio = from.text().split(";");
 
@@ -179,6 +192,7 @@ namespace autonum
 	void sequentialNumbers::clear()
 	{
 		unit.clear();
+		wrap.clear();
 		unit_folio.clear();
 		ten.clear();
 		ten_folio.clear();
@@ -434,13 +448,17 @@ namespace autonum
 						qMax(
 							qMax(m_seq_struct.hundred.size(),
 								 m_seq_struct.ten.size()),
-							m_seq_struct.alpha.size())
+							qMax(m_seq_struct.alpha.size(),
+								 m_seq_struct.wrap.size()))
 					);
 
 		for (int i=1; i<=max ; i++)
 		{
 			if (m_assigned_label.contains("%sequ_" + QString::number(i)) && m_seq_struct.unit.size() >= i) {
 				m_assigned_label.replace("%sequ_" + QString::number(i),m_seq_struct.unit.at(i-1));
+			}
+			if (m_assigned_label.contains("%seqw_" + QString::number(i)) && m_seq_struct.wrap.size() >= i) {
+				m_assigned_label.replace("%seqw_" + QString::number(i),m_seq_struct.wrap.at(i-1));
 			}
 			if (m_assigned_label.contains("%seqt_" + QString::number(i)) && m_seq_struct.ten.size() >= i) {
 				m_assigned_label.replace("%seqt_" + QString::number(i),m_seq_struct.ten.at(i-1));
@@ -553,6 +571,10 @@ namespace autonum
 			{
 				autonum::setSequentialToList(seqStruct.unit, context,"unit");
 			}
+			if (label.contains("%seqw_"))
+			{
+				autonum::setSequentialToList(seqStruct.wrap, context,"wrap");
+			}
 			if (label.contains("%sequf_"))
 			{
 				autonum::setSequentialToList(seqStruct.unit_folio, context,"unitfolio");
@@ -594,6 +616,7 @@ namespace autonum
 		QString value;
 		QString formula;
 		int count_unit = 0;
+		int count_wrap = 0;
 		int count_unitf = 0;
 		int count_ten = 0;
 		int count_tenf = 0;
@@ -635,6 +658,10 @@ namespace autonum
 			else if (type == "unit") {
 				count_unit++;
 				formula.append("%sequ_" + QString::number(count_unit));
+			}
+			else if (type == "wrap") {
+				count_wrap++;
+				formula.append("%seqw_" + QString::number(count_wrap));
 			}
 			else if (type == "unitfolio") {
 				count_unitf++;

--- a/sources/autoNum/assignvariables.cpp
+++ b/sources/autoNum/assignvariables.cpp
@@ -497,15 +497,26 @@ namespace autonum
 		{
 			if (context.itemAt(i).at(0) == type)
 			{
+				const QStringList item = context.itemAt(i);
+					//A zero-padding mask, spreadsheet style: its length is the
+					//minimum number of digits. It overrides the width implied
+					//by the part type, so "Chiffre 01" with a mask of "0000"
+					//pads to four. An absent mask -- which is every context
+					//written before the field existed -- falls through to the
+					//type's own width, so nothing about existing projects
+					//changes.
+				const QString mask = NumerotationContext::formatOf(item);
 				QString number;
-				if (type == "ten" || type == "tenfolio")
-					number = QString("%1").arg(context.itemAt(i).at(1).toInt(), 2, 10, QChar('0'));
-				else if (type == "hundred" || type == "hundredfolio")
-					number = QString("%1").arg(context.itemAt(i).at(1).toInt(), 3, 10, QChar('0'));
-				else if (type == "alpha")
+				if (type == "alpha")
 						//Alphabetic value, not an integer -- used as-is.
-					number = context.itemAt(i).at(1);
-				else number = QString::number(context.itemAt(i).at(1).toInt());
+					number = item.at(1);
+				else if (!mask.isEmpty())
+					number = QString("%1").arg(item.at(1).toInt(), mask.length(), 10, QChar('0'));
+				else if (type == "ten" || type == "tenfolio")
+					number = QString("%1").arg(item.at(1).toInt(), 2, 10, QChar('0'));
+				else if (type == "hundred" || type == "hundredfolio")
+					number = QString("%1").arg(item.at(1).toInt(), 3, 10, QChar('0'));
+				else number = QString::number(item.at(1).toInt());
 					list.append(number);
 			}
 		}

--- a/sources/autoNum/assignvariables.h
+++ b/sources/autoNum/assignvariables.h
@@ -47,6 +47,8 @@ namespace autonum
 			void clear();
 
 			QStringList unit;
+				/// Values of the cyclic (modulo) parts, referenced by %seqw_N.
+			QStringList wrap;
 			QStringList unit_folio;
 			QStringList ten;
 			QStringList ten_folio;

--- a/sources/autoNum/numerotationcontext.cpp
+++ b/sources/autoNum/numerotationcontext.cpp
@@ -52,13 +52,18 @@ void NumerotationContext::clear ()
 	@param increase the increase number of value
 	@param initialvalue
 	@param modulus wrap-and-carry modulus (0 means "not a wrapping part")
+	@param format zero-padding mask, spreadsheet style: "00" pads to two
+	digits, "000" to three. Empty keeps the part type's natural width, so
+	an absent format reproduces exactly the behaviour of every context
+	written before this field existed.
 	@return true if value is append
 */
 bool NumerotationContext::addValue(const QString &type,
 				   const QVariant &value,
 				   const int increase,
 				   const int initialvalue,
-				   const int modulus) {
+				   const int modulus,
+				   const QString &format) {
 	if (!keyIsAcceptable(type) && !value.canConvert<QString>())
 		return false;
 	if (keyIsNumber(type) && !value.canConvert<int>())
@@ -74,7 +79,9 @@ bool NumerotationContext::addValue(const QString &type,
 		    + "|"
 		    + QString::number(initialvalue)
 		    + "|"
-		    + QString::number(modulus);
+		    + QString::number(modulus)
+		    + "|"
+		    + QString(format).remove("|");
 	return true;
 }
 
@@ -179,6 +186,9 @@ QDomElement NumerotationContext::toXml(QDomDocument &d, const QString& str) {
 		if (strl.at(0) == ("wrap") && strl.size() > 4) {
 			part.setAttribute("modulus", strl.at(4));
 		}
+		if (strl.size() > 5 && !strl.at(5).isEmpty()) {
+			part.setAttribute("format", strl.at(5));
+		}
 		num_auto.appendChild(part);
 	}
 	return num_auto;
@@ -190,7 +200,7 @@ QDomElement NumerotationContext::toXml(QDomDocument &d, const QString& str) {
 */
 void NumerotationContext::fromXml(QDomElement &e) {
 	clear();
-	foreach(QDomElement qde, QET::findInDomElement(e, "part")) addValue(qde.attribute("type"), qde.attribute("value"), qde.attribute("increase").toInt(), qde.attribute("initialvalue").toInt(), qde.attribute("modulus").toInt());
+	foreach(QDomElement qde, QET::findInDomElement(e, "part")) addValue(qde.attribute("type"), qde.attribute("value"), qde.attribute("increase").toInt(), qde.attribute("initialvalue").toInt(), qde.attribute("modulus").toInt(), qde.attribute("format"));
 }
 
 /**
@@ -206,5 +216,17 @@ void NumerotationContext::replaceValue(int index, QString content) {
 	QString increase = strl.at(2);
 	QString initvalue = strl.at(3);
 	QString modulus = strl.size() > 4 ? strl.at(4) : QStringLiteral("0");
-	content_[index] = type + "|" + value + "|" + increase + "|" + initvalue + "|" + modulus;
+	QString format  = strl.size() > 5 ? strl.at(5) : QString();
+	content_[index] = type + "|" + value + "|" + increase + "|" + initvalue + "|" + modulus + "|" + format;
+}
+
+/**
+	@brief NumerotationContext::formatOf
+	@param item : a context item as returned by itemAt()
+	@return the part's zero-padding mask, or an empty string when it has
+	none -- which every context written before the field existed will be.
+*/
+QString NumerotationContext::formatOf(const QStringList &item)
+{
+	return item.size() > 5 ? item.at(5) : QString();
 }

--- a/sources/autoNum/numerotationcontext.h
+++ b/sources/autoNum/numerotationcontext.h
@@ -37,7 +37,11 @@ class NumerotationContext
 		      const QVariant & = QVariant(1),
 		      const int = 1,
 		      const int = 0,
-		      const int = 0);
+		      const int = 0,
+		      const QString & = QString());
+		/// Zero-padding mask of a part, e.g. "00"; empty means the type's
+		/// own natural width. See addValue().
+	static QString formatOf(const QStringList &item);
 	QString operator[] (const int &) const;
 	void operator << (const NumerotationContext &);
 	int size() const;

--- a/sources/autoNum/numerotationcontextcommands.cpp
+++ b/sources/autoNum/numerotationcontextcommands.cpp
@@ -259,7 +259,7 @@ NumerotationContext NumStrategy::nextString (const NumerotationContext &nc,
 {
 	QStringList strl = nc.itemAt(i);
 	NumerotationContext newnc;
-	newnc.addValue(strl.at(0), strl.at(1), strl.at(2).toInt());
+	newnc.addValue(strl.at(0), strl.at(1), strl.at(2).toInt(), 0, 0, NumerotationContext::formatOf(strl));
 	return (newnc);
 }
 
@@ -273,7 +273,7 @@ NumerotationContext NumStrategy::nextNumber (const NumerotationContext &nc,
 	QStringList strl = nc.itemAt(i);
 	NumerotationContext newnc;
 	QString value = QString::number( (strl.at(1).toInt()) + (strl.at(2).toInt()) );
-	newnc.addValue(strl.at(0), value, strl.at(2).toInt(), strl.at(3).toInt());
+	newnc.addValue(strl.at(0), value, strl.at(2).toInt(), strl.at(3).toInt(), 0, NumerotationContext::formatOf(strl));
 	return (newnc);
 }
 
@@ -287,7 +287,7 @@ NumerotationContext NumStrategy::previousNumber(const NumerotationContext &nc,
 	QStringList strl = nc.itemAt(i);
 	NumerotationContext newnc;
 	QString value = QString::number( (strl.at(1).toInt()) - (strl.at(2).toInt()) );
-	newnc.addValue(strl.at(0), value, strl.at(2).toInt(), strl.at(3).toInt());
+	newnc.addValue(strl.at(0), value, strl.at(2).toInt(), strl.at(3).toInt(), 0, NumerotationContext::formatOf(strl));
 	return (newnc);
 }
 
@@ -550,7 +550,7 @@ NumerotationContext WrapNum::next (const NumerotationContext &nc, const int i) c
 	int new_value = strl.at(1).toInt() + increase;
 	if (modulus > 0)
 		new_value %= modulus;
-	newnc.addValue(strl.at(0), QString::number(new_value), increase, strl.at(3).toInt(), modulus);
+	newnc.addValue(strl.at(0), QString::number(new_value), increase, strl.at(3).toInt(), modulus, NumerotationContext::formatOf(strl));
 	return (newnc);
 }
 
@@ -570,7 +570,7 @@ NumerotationContext WrapNum::previous(const NumerotationContext &nc, const int i
 		if (new_value < 0)
 			new_value += modulus;
 	}
-	newnc.addValue(strl.at(0), QString::number(new_value), increase, strl.at(3).toInt(), modulus);
+	newnc.addValue(strl.at(0), QString::number(new_value), increase, strl.at(3).toInt(), modulus, NumerotationContext::formatOf(strl));
 	return (newnc);
 }
 
@@ -706,7 +706,7 @@ NumerotationContext AlphaNum::next (const NumerotationContext &nc, const int i) 
 {
 	QStringList strl = nc.itemAt(i);
 	NumerotationContext newnc;
-	newnc.addValue(strl.at(0), incrementAlpha(strl.at(1)), strl.at(2).toInt());
+	newnc.addValue(strl.at(0), incrementAlpha(strl.at(1)), strl.at(2).toInt(), 0, 0, NumerotationContext::formatOf(strl));
 	return (newnc);
 }
 
@@ -718,7 +718,7 @@ NumerotationContext AlphaNum::previous(const NumerotationContext &nc, const int 
 {
 	QStringList strl = nc.itemAt(i);
 	NumerotationContext newnc;
-	newnc.addValue(strl.at(0), decrementAlpha(strl.at(1)), strl.at(2).toInt());
+	newnc.addValue(strl.at(0), decrementAlpha(strl.at(1)), strl.at(2).toInt(), 0, 0, NumerotationContext::formatOf(strl));
 	return (newnc);
 }
 

--- a/sources/autoNum/ui/numparteditorw.cpp
+++ b/sources/autoNum/ui/numparteditorw.cpp
@@ -18,6 +18,8 @@
 #include "numparteditorw.h"
 #include "ui_numparteditorw.h"
 
+#include "../numerotationcontext.h"
+
 #include <QRegularExpressionValidator>
 
 /**
@@ -35,6 +37,9 @@ NumPartEditorW::NumPartEditorW(int type, QWidget *parent) :
 {
 	ui -> setupUi(this);
 	setVisibleItems();
+		//The mask is a run of zeros and nothing else, so it cannot be typed
+		//into a state the renderer would have to reject.
+	ui -> format_le -> setValidator(new QRegularExpressionValidator(QRegularExpression("0*"), this));
 	setType(NumPartEditorW::unit, true);
 }
 
@@ -99,6 +104,7 @@ NumPartEditorW::NumPartEditorW (NumerotationContext &context,
 		ui -> increase_spinBox -> setValue(strl.at(2).toInt());
 		if (strl.at(0)=="wrap" && strl.size() > 4)
 			ui -> modulus_spinBox -> setValue(strl.at(4).toInt());
+		ui -> format_le -> setText(NumerotationContext::formatOf(strl));
 	}
 }
 
@@ -219,23 +225,30 @@ NumerotationContext NumPartEditorW::toNumContext()
 			type_str = "alpha";
 			break;
 	}
+	const QString number_format = ui -> format_le -> text();
 	if (type_str == "unitfolio"
 			|| type_str == "tenfolio"
 			|| type_str == "hundredfolio")
 		nc.addValue(type_str,
 			    ui -> value_field -> displayText(),
 			    ui -> increase_spinBox -> value(),
-			    ui->value_field->displayText().toInt());
+			    ui->value_field->displayText().toInt(),
+			    0,
+			    number_format);
 	else if (type_str == "wrap")
 		nc.addValue(type_str,
 			    ui -> value_field -> displayText(),
 			    ui -> increase_spinBox -> value(),
 			    0,
-			    ui -> modulus_spinBox -> value());
+			    ui -> modulus_spinBox -> value(),
+			    number_format);
 	else
 	nc.addValue(type_str,
 		    ui -> value_field -> displayText(),
-		    ui -> increase_spinBox -> value());
+		    ui -> increase_spinBox -> value(),
+		    0,
+		    0,
+		    number_format);
 	return nc;
 }
 
@@ -317,6 +330,14 @@ void NumPartEditorW::on_increase_spinBox_valueChanged(int) {
 	@brief NumPartEditorW::on_modulus_spinBox_valueChanged
 	emit changed when modulus_spinBox value changed
 */
+/**
+	@brief NumPartEditorW::on_format_le_textEdited
+	emit changed when the display format is edited
+*/
+void NumPartEditorW::on_format_le_textEdited(const QString &) {
+	emit changed();
+}
+
 void NumPartEditorW::on_modulus_spinBox_valueChanged(int) {
 	if (!ui -> value_field -> text().isEmpty()) emit changed();
 }
@@ -423,6 +444,13 @@ void NumPartEditorW::setType(NumPartEditorW::type t, bool fnum) {
 	if (t == wrap && ui -> modulus_spinBox -> value() <= 0)
 		ui -> modulus_spinBox -> setValue(8);
 	ui -> modulus_spinBox -> setEnabled(t == wrap);
+		//A padding mask only means anything for a part rendered as a number.
+	const bool numeric = (t == unit || t == unitfolio || t == ten
+			      || t == tenfolio || t == hundred || t == hundredfolio
+			      || t == wrap);
+	ui -> format_le -> setEnabled(numeric);
+	if (!numeric)
+		ui -> format_le -> clear();
 	type_= t;
 }
 

--- a/sources/autoNum/ui/numparteditorw.cpp
+++ b/sources/autoNum/ui/numparteditorw.cpp
@@ -359,8 +359,6 @@ void NumPartEditorW::setType(NumPartEditorW::type t, bool fnum) {
 		ui -> value_field -> setValidator(intValidator);
 		ui -> increase_spinBox -> setEnabled(true);
 		ui -> increase_spinBox -> setValue(1);
-		if (t == wrap)
-			ui -> modulus_spinBox -> setValue(8);
 	}
 	//@t isn't a numeric type
 	else if (t == string
@@ -414,6 +412,16 @@ void NumPartEditorW::setType(NumPartEditorW::type t, bool fnum) {
 			ui -> increase_spinBox -> setDisabled(true);
 		}
 	}
+		//A modulus of 0 means "no cycle", which makes a Cyclique part behave
+		//exactly like a plain digit. Defaulting it used to live in the numeric
+		//behavior block above, which is skipped when the previous type was
+		//itself numeric -- so the ordinary path of turning the default
+		//"Chiffre 1" into a "Cyclique (modulo)" left the modulus at 0 and
+		//produced a wrap part that never wrapped. Kept out of that block so it
+		//applies whatever the part was before, and only when the current value
+		//is unusable, so a modulus the user chose on purpose is not clobbered.
+	if (t == wrap && ui -> modulus_spinBox -> value() <= 0)
+		ui -> modulus_spinBox -> setValue(8);
 	ui -> modulus_spinBox -> setEnabled(t == wrap);
 	type_= t;
 }

--- a/sources/autoNum/ui/numparteditorw.h
+++ b/sources/autoNum/ui/numparteditorw.h
@@ -66,6 +66,7 @@ class NumPartEditorW : public QWidget
 		void on_value_field_textEdited();
 		void on_increase_spinBox_valueChanged(int);
 		void on_modulus_spinBox_valueChanged(int);
+		void on_format_le_textEdited(const QString &);
 		void setType (NumPartEditorW::type t, bool=false);
 
 	signals:

--- a/sources/autoNum/ui/numparteditorw.ui
+++ b/sources/autoNum/ui/numparteditorw.ui
@@ -126,6 +126,28 @@
      </property>
     </widget>
    </item>
+   <item>
+    <widget class="QLineEdit" name="format_le">
+     <property name="enabled">
+      <bool>false</bool>
+     </property>
+     <property name="maximumSize">
+      <size>
+       <width>70</width>
+       <height>16777215</height>
+      </size>
+     </property>
+     <property name="toolTip">
+      <string>Format d'affichage : une suite de zéros donne le nombre minimum de chiffres (00 = 07, 000 = 007). Vide = largeur naturelle du type.</string>
+     </property>
+     <property name="placeholderText">
+      <string>0</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignCenter</set>
+     </property>
+    </widget>
+   </item>
   </layout>
  </widget>
  <resources/>


### PR DESCRIPTION
**Stacked on #632** — merge that first; the commit to review here is the last one, `Add a display format to numbering parts`.

Follows @scorpio810's two real PLC layouts described on #632. They conflict, which is the whole point:

| layout | addressing | padding |
|---|---|---|
| April 5000/2000, 32-point cards | `%IX0.0` … `%IX0.31`, then `%IX1.0` | **none** |
| Schneider M340, 64-point cards | `I1.00` … `I1.63`, then `I2.00` | **two digits** |

The same mechanism has to produce both, so the width cannot be derived from the modulus or from the part type. It has to be the user's to set.

## The format field

A run of zeros — the convention a spreadsheet uses for integer padding. Its length is the minimum number of digits.

```
Type                Valeur   Incr.   modulus   Format
Cyclique (modulo)     0        1        32     (vide)   ->  %IX0.0   %IX0.31  %IX1.0
Cyclique (modulo)     0        1        64       00     ->  I1.00    I1.63    I2.00
Chiffre 01            7        1         -      0000    ->  0007
```

It applies to **every numeric part type**, not only cyclic ones, so `Chiffre 01` can be widened past two digits without inventing another type for it.

## Why this is safe for existing projects

**An empty mask means the part type's own natural width**, so it reproduces exactly what every existing context does today. Absent is the default, and absent changes nothing:

```
no mask   Chiffre 1    7 8 9
no mask   Chiffre 01   07 08 09
no mask   Chiffre 001  007 008 009
```

Stored as a sixth field on the context part, and as an XML attribute written only when set — the same way `modulus` was added. Readers guard on `size()` and treat a short item as "no format", so an old project parses unchanged and an older QElectroTech ignores an attribute it does not know.

## The part that would have bitten silently

Seven places rebuild a part while incrementing it (`UnitNum::next`, `WrapNum::next`, `previous()`, the alpha pair, …). Each constructs a fresh part from the old one's fields. Missing any one of them would have dropped the padding on the *second* element numbered and looked fine on the first — so all seven carry the format through, and the measurements below step far enough to prove it.

## Measured

```
April, mask empty     %IX0.29 %IX0.30 %IX0.31 %IX1.0 %IX1.1 %IX1.2
M340,  mask "00"      I1.00 I1.01 I1.02 ...  I1.62 I1.63 I2.00 I2.01
ten with mask "0000"  0007 0008 0009
unit with mask "000"  007 008 009
```

Both of @scorpio810's layouts now come out of one mechanism, and the rollover carries into the card digit in each.

The editor field is restricted to zeros by a validator, so it cannot be typed into a state the renderer would have to reject, and it is enabled only for types that render as a number. Built clean, no new warnings.

## Not addressed here

This is only about how a part is *displayed*. The separate question raised on #632 — whether the digit in front of a cyclic part should default to increment 0 so it moves only on carry — is deliberately left alone, since @scorpio810 asked to wait for field feedback before choosing between leaving it to the user and defaulting it.
