### PR TITLE
3D mouse (SpaceMouse/SpacePilot) pan/zoom via libspnav — Linux phase (discussion #599)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -146,9 +146,11 @@ else()
     )
 endif()
 
-if(QET_SPACEMOUSE_ENABLED)
-    set(QET_SPACEMOUSE_LIBRARIES PkgConfig::SPNAV)
+if(QET_SPACEMOUSE_BACKEND_SPNAV_ENABLED)
+    list(APPEND QET_SPACEMOUSE_LIBRARIES PkgConfig::SPNAV)
 endif()
+# A future Windows/macOS (3DxWare) backend would list.APPEND its own SDK
+# libraries here, behind its own *_ENABLED guard, alongside this one.
 
 target_link_libraries(
     ${PROJECT_NAME}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,6 +63,7 @@ include(cmake/git_last_commit_sha.cmake)
 include(cmake/fetch_kdeaddons.cmake)
 include(cmake/fetch_singleapplication.cmake)
 include(cmake/fetch_pugixml.cmake)
+include(cmake/find_spacemouse.cmake)
 include(cmake/qet_compilation_vars.cmake)
 
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
@@ -145,6 +146,10 @@ else()
     )
 endif()
 
+if(QET_SPACEMOUSE_ENABLED)
+    set(QET_SPACEMOUSE_LIBRARIES PkgConfig::SPNAV)
+endif()
+
 target_link_libraries(
     ${PROJECT_NAME}
     PUBLIC
@@ -154,6 +159,7 @@ target_link_libraries(
     SQLite3::SQLite3
     ${KF5_PRIVATE_LIBRARIES}
     ${QET_PRIVATE_LIBRARIES}
+    ${QET_SPACEMOUSE_LIBRARIES}
 )
 
 target_include_directories(

--- a/cmake/developer_options.cmake
+++ b/cmake/developer_options.cmake
@@ -33,3 +33,8 @@ add_definitions(-DQT_MESSAGELOGCONTEXT)
 
 # Build with KF5
 option(BUILD_WITH_KF5 "Build with KF5" ON)
+
+# Phase 1 (Linux, libspnav) of discussion #599: 3Dconnexion SpaceMouse/
+# SpacePilot pan/zoom support. Off by default -- see cmake/find_spacemouse.cmake
+# for what happens when it is on but libspnav isn't found.
+option(QET_ENABLE_SPACEMOUSE "Build with 3Dconnexion/libspnav 3D mouse support for pan/zoom (Linux, requires libspnav-dev and spacenavd)" OFF)

--- a/cmake/find_spacemouse.cmake
+++ b/cmake/find_spacemouse.cmake
@@ -20,28 +20,44 @@ message(" - find_spacemouse")
 # so none of this runs, and the default build is entirely unaffected: no new
 # dependency, no new source files, no new symbols.
 #
-# When it is on, libspnav is looked for via its pkg-config file (present on
-# every distro package of it this was checked against: Debian/Ubuntu's
-# libspnav-dev ships /usr/share/pkgconfig/spnav.pc). If it isn't found, this
-# does not hard-fail the whole configure -- it downgrades the option back to
-# off with a clear message, so a developer who doesn't have the library
-# installed still gets a normal build instead of a configure error for an
-# opt-in feature they didn't ask to block on.
+# When it is on, the platform decides which backend (if any) is available --
+# see sources/spacemouse/spacemousebackend.h for what a backend is. Only one
+# exists today: SpnavBackend, Linux, via libspnav. A Windows/macOS backend
+# would need 3Dconnexion's proprietary 3DxWare SDK and is not implemented
+# (see discussion #599's own phase split); until it is, turning this option
+# on there downgrades cleanly with a warning rather than failing configure.
 set(QET_SPACEMOUSE_ENABLED FALSE)
+set(QET_SPACEMOUSE_BACKEND_SPNAV_ENABLED FALSE)
 
 if(QET_ENABLE_SPACEMOUSE)
-    find_package(PkgConfig)
-    if(PkgConfig_FOUND)
-        pkg_check_modules(SPNAV IMPORTED_TARGET spnav)
-    endif()
+    if(UNIX AND NOT APPLE)
+        # libspnav is looked for via its pkg-config file (present on every
+        # distro package of it this was checked against: Debian/Ubuntu's
+        # libspnav-dev ships /usr/share/pkgconfig/spnav.pc). Not found does
+        # not hard-fail the whole configure -- it downgrades the option back
+        # to off with a clear message, so a developer who doesn't have the
+        # library installed still gets a normal build instead of a configure
+        # error for an opt-in feature they didn't ask to block on.
+        find_package(PkgConfig)
+        if(PkgConfig_FOUND)
+            pkg_check_modules(SPNAV IMPORTED_TARGET spnav)
+        endif()
 
-    if(SPNAV_FOUND)
-        set(QET_SPACEMOUSE_ENABLED TRUE)
-        add_definitions(-DQET_SPACEMOUSE_SUPPORT)
-        message("QET_ENABLE_SPACEMOUSE      ON  (libspnav ${SPNAV_VERSION} found)")
+        if(SPNAV_FOUND)
+            set(QET_SPACEMOUSE_ENABLED TRUE)
+            set(QET_SPACEMOUSE_BACKEND_SPNAV_ENABLED TRUE)
+            add_definitions(-DQET_SPACEMOUSE_SUPPORT)
+            add_definitions(-DQET_SPACEMOUSE_BACKEND_SPNAV)
+            message("QET_ENABLE_SPACEMOUSE      ON  (backend: libspnav ${SPNAV_VERSION})")
+        else()
+            message(WARNING "QET_ENABLE_SPACEMOUSE is ON but libspnav was not found via pkg-config "
+                             "(install libspnav-dev, or the equivalent for your distribution) -- "
+                             "building WITHOUT 3D mouse support.")
+        endif()
     else()
-        message(WARNING "QET_ENABLE_SPACEMOUSE is ON but libspnav was not found via pkg-config "
-                         "(install libspnav-dev, or the equivalent for your distribution) -- "
-                         "building WITHOUT 3D mouse support.")
+        message(WARNING "QET_ENABLE_SPACEMOUSE is ON but no 3D mouse backend is implemented yet "
+                         "for this platform (only Linux/libspnav exists today -- see "
+                         "https://github.com/qelectrotech/qelectrotech-source-mirror/discussions/599) "
+                         "-- building WITHOUT 3D mouse support.")
     endif()
 endif()

--- a/cmake/find_spacemouse.cmake
+++ b/cmake/find_spacemouse.cmake
@@ -1,0 +1,47 @@
+# Copyright 2006 The QElectroTech Team
+# This file is part of QElectroTech.
+#
+# QElectroTech is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+#
+# QElectroTech is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with QElectroTech. If not, see <http://www.gnu.org/licenses/>.
+
+message(" - find_spacemouse")
+
+# QET_ENABLE_SPACEMOUSE (cmake/developer_options.cmake) is off by default,
+# so none of this runs, and the default build is entirely unaffected: no new
+# dependency, no new source files, no new symbols.
+#
+# When it is on, libspnav is looked for via its pkg-config file (present on
+# every distro package of it this was checked against: Debian/Ubuntu's
+# libspnav-dev ships /usr/share/pkgconfig/spnav.pc). If it isn't found, this
+# does not hard-fail the whole configure -- it downgrades the option back to
+# off with a clear message, so a developer who doesn't have the library
+# installed still gets a normal build instead of a configure error for an
+# opt-in feature they didn't ask to block on.
+set(QET_SPACEMOUSE_ENABLED FALSE)
+
+if(QET_ENABLE_SPACEMOUSE)
+    find_package(PkgConfig)
+    if(PkgConfig_FOUND)
+        pkg_check_modules(SPNAV IMPORTED_TARGET spnav)
+    endif()
+
+    if(SPNAV_FOUND)
+        set(QET_SPACEMOUSE_ENABLED TRUE)
+        add_definitions(-DQET_SPACEMOUSE_SUPPORT)
+        message("QET_ENABLE_SPACEMOUSE      ON  (libspnav ${SPNAV_VERSION} found)")
+    else()
+        message(WARNING "QET_ENABLE_SPACEMOUSE is ON but libspnav was not found via pkg-config "
+                         "(install libspnav-dev, or the equivalent for your distribution) -- "
+                         "building WITHOUT 3D mouse support.")
+    endif()
+endif()

--- a/cmake/qet_compilation_vars.cmake
+++ b/cmake/qet_compilation_vars.cmake
@@ -796,8 +796,16 @@ endif()
 
 if(QET_SPACEMOUSE_ENABLED)
   list(APPEND QET_SRC_FILES
+    ${QET_DIR}/sources/spacemouse/spacemousebackend.h
     ${QET_DIR}/sources/spacemouse/spacemouselistener.cpp
     ${QET_DIR}/sources/spacemouse/spacemouselistener.h
+  )
+endif()
+
+if(QET_SPACEMOUSE_BACKEND_SPNAV_ENABLED)
+  list(APPEND QET_SRC_FILES
+    ${QET_DIR}/sources/spacemouse/spnavbackend.cpp
+    ${QET_DIR}/sources/spacemouse/spnavbackend.h
   )
 endif()
 

--- a/cmake/qet_compilation_vars.cmake
+++ b/cmake/qet_compilation_vars.cmake
@@ -797,8 +797,12 @@ endif()
 if(QET_SPACEMOUSE_ENABLED)
   list(APPEND QET_SRC_FILES
     ${QET_DIR}/sources/spacemouse/spacemousebackend.h
+    ${QET_DIR}/sources/spacemouse/spacemousebuttonmap.cpp
+    ${QET_DIR}/sources/spacemouse/spacemousebuttonmap.h
     ${QET_DIR}/sources/spacemouse/spacemouselistener.cpp
     ${QET_DIR}/sources/spacemouse/spacemouselistener.h
+    ${QET_DIR}/sources/ui/configpage/spacemouseconfigpage.cpp
+    ${QET_DIR}/sources/ui/configpage/spacemouseconfigpage.h
   )
 endif()
 

--- a/cmake/qet_compilation_vars.cmake
+++ b/cmake/qet_compilation_vars.cmake
@@ -794,6 +794,13 @@ if(NOT BUILD_WITH_KF5)
   )
 endif()
 
+if(QET_SPACEMOUSE_ENABLED)
+  list(APPEND QET_SRC_FILES
+    ${QET_DIR}/sources/spacemouse/spacemouselistener.cpp
+    ${QET_DIR}/sources/spacemouse/spacemouselistener.h
+  )
+endif()
+
 set(TS_FILES
   ${QET_DIR}/lang/qet_ar.ts
   ${QET_DIR}/lang/qet_ca.ts

--- a/sources/qetapp.cpp
+++ b/sources/qetapp.cpp
@@ -42,6 +42,7 @@
 #include "qetversion.h"
 #ifdef QET_SPACEMOUSE_SUPPORT
 #	include "spacemouse/spacemouselistener.h"
+#	include "ui/configpage/spacemouseconfigpage.h"
 #endif
 
 #include <cstdlib>
@@ -2064,6 +2065,9 @@ void QETApp::configureQET()
 	cd.addPage(new ExportConfigPage());
 	cd.addPage(new PrintConfigPage());
 	cd.addPage(new ShortcutsConfigPage());
+#ifdef QET_SPACEMOUSE_SUPPORT
+	cd.addPage(new SpaceMouseConfigPage());
+#endif
 
 	// associates the dialog with a possible parent widget
 	// associe le dialogue a un eventuel widget parent

--- a/sources/qetapp.cpp
+++ b/sources/qetapp.cpp
@@ -40,6 +40,9 @@
 #include "machine_info.h"
 #include "TerminalStrip/ui/terminalstripeditorwindow.h"
 #include "qetversion.h"
+#ifdef QET_SPACEMOUSE_SUPPORT
+#	include "spacemouse/spacemouselistener.h"
+#endif
 
 #include <cstdlib>
 #include <iostream>
@@ -156,6 +159,14 @@ QETApp::QETApp() :
 	}
 
 	checkBackupFiles();
+
+#ifdef QET_SPACEMOUSE_SUPPORT
+		//Always safe to construct: it silently does nothing when spacenavd
+		//isn't running or no device is attached, which is the common case
+		//even in a build with this feature compiled in. See
+		//SpaceMouseListener's class comment.
+	m_space_mouse_listener = new SpaceMouseListener(this);
+#endif
 }
 
 /**

--- a/sources/qetapp.h
+++ b/sources/qetapp.h
@@ -47,6 +47,9 @@ class QETProject;
 class QETTitleBlockTemplateEditor;
 class QTextOrientationSpinBoxWidget;
 class RecentFiles;
+#ifdef QET_SPACEMOUSE_SUPPORT
+class SpaceMouseListener;
+#endif
 
 /**
 	@brief The QETApp class
@@ -225,6 +228,13 @@ class QETApp : public QObject
 		static TitleBlockTemplatesFilesCollection *m_company_tbt_collection;
 		static TitleBlockTemplatesFilesCollection *m_custom_tbt_collection;
 		static ElementsCollectionCache *collections_cache_;
+#ifdef QET_SPACEMOUSE_SUPPORT
+			/// One per application, not per window: a physical 6-DOF device
+			/// is a single ambient input source, and motion is applied to
+			/// whichever DiagramView is currently active. See
+			/// SpaceMouseListener's class comment.
+		SpaceMouseListener *m_space_mouse_listener = nullptr;
+#endif
 		static QMap<uint, QETProject *> registered_projects_;
 		static uint next_project_id;
 		static RecentFiles *m_projects_recent_files;

--- a/sources/shortcutmanager.cpp
+++ b/sources/shortcutmanager.cpp
@@ -17,6 +17,8 @@
 */
 #include "shortcutmanager.h"
 
+#include <QAbstractButton>
+#include <QAction>
 #include <QObject>
 #include <QSettings>
 #include <QVariant>
@@ -164,4 +166,33 @@ void ShortcutManager::resetAllToDefaults()
 	for (const QString &id : m_order) {
 		resetToDefault(id);
 	}
+}
+
+/**
+	@brief ShortcutManager::trigger
+	@param id
+	@return see the declaration's doc comment
+*/
+bool ShortcutManager::trigger(const QString &id) const
+{
+	auto it = m_entries.find(id);
+	if (it == m_entries.end()) {
+		return false;
+	}
+
+	for (const QPointer<QObject> &target : qAsConst(it->targets))
+	{
+		if (!target) {
+			continue;
+		}
+		if (auto *action = qobject_cast<QAction *>(target.data())) {
+			action->trigger();
+			return true;
+		}
+		if (auto *button = qobject_cast<QAbstractButton *>(target.data())) {
+			button->click();
+			return true;
+		}
+	}
+	return false;
 }

--- a/sources/shortcutmanager.h
+++ b/sources/shortcutmanager.h
@@ -71,6 +71,20 @@ class ShortcutManager
 		void resetToDefault(const QString &id);
 		void resetAllToDefaults();
 
+			/// Activate the first still-alive target registered under \a id
+			/// -- QAction::trigger() or QAbstractButton::click(), whichever
+			/// it turns out to be -- for an input source other than the
+			/// keyboard (e.g. a 3D mouse button) that wants to invoke a
+			/// named action without knowing or caring which of the two it
+			/// is. Deliberately not disambiguated by the currently active
+			/// window when an id has several live targets: a target's
+			/// owning top-level window isn't reliably discoverable from a
+			/// bare QAction. Correct in the overwhelming common case of one
+			/// open editor window; a known simplification in the rarer
+			/// multi-window case, not a guaranteed-correct dispatch.
+			/// @return whether a live target was found and triggered.
+		bool trigger(const QString &id) const;
+
 	private:
 		ShortcutManager() = default;
 		ShortcutManager(const ShortcutManager &) = delete;

--- a/sources/spacemouse/spacemousebackend.h
+++ b/sources/spacemouse/spacemousebackend.h
@@ -66,6 +66,15 @@ class SpaceMouseBackend : public QObject
 			/// scale/divisor constants are what turn them into pixels and a
 			/// zoom factor, not this signal.
 		void motion(int dx, int dy, int dz);
+
+			/// One device button was pressed. \a button is whatever index
+			/// the backend's own driver numbers it as -- there is no
+			/// portable numbering across device models, which is exactly
+			/// why the binding from a button to a QET action
+			/// (SpaceMouseButtonMap) is user-configurable rather than
+			/// hardcoded. Emitted on press only; release is not reported,
+			/// since nothing here has a use for it.
+		void buttonPressed(int button);
 };
 
 #endif // SPACEMOUSEBACKEND_H

--- a/sources/spacemouse/spacemousebackend.h
+++ b/sources/spacemouse/spacemousebackend.h
@@ -1,0 +1,71 @@
+/*
+	Copyright 2006-2026 The QElectroTech Team
+	This file is part of QElectroTech.
+
+	QElectroTech is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 2 of the License, or
+	(at your option) any later version.
+
+	QElectroTech is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with QElectroTech.  If not, see <http://www.gnu.org/licenses/>.
+*/
+#ifndef SPACEMOUSEBACKEND_H
+#define SPACEMOUSEBACKEND_H
+
+#include <QObject>
+
+/**
+	@brief The SpaceMouseBackend class
+	Platform seam for discussion #599's 3D mouse support. A backend owns
+	one platform's connection to the actual 6-DOF device driver -- opening
+	it, pumping whatever event source that platform uses, closing it -- and
+	reports motion through the one signal below. Everything platform-
+	independent (which DiagramView to apply motion to, the pan/zoom
+	primitives to call, the Z-to-zoom-factor mapping) lives in
+	SpaceMouseListener instead, once, so it does not have to be duplicated
+	or re-verified per backend.
+
+	SpnavBackend (Linux, spacenavd/libspnav) is the only implementation so
+	far -- built, linked, and its "no daemon/device present" path actually
+	run in the environment this was written in. A Windows/macOS backend
+	(3Dconnexion's proprietary 3DxWare SDK) would implement this same
+	interface and be selected in SpaceMouseListener's constructor, without
+	changing SpnavBackend or anything downstream of the motion signal.
+	Deliberately not attempted here: this was written on Linux with no
+	3DxWare SDK and no Windows/macOS toolchain available to compile,
+	link, or run a single line of it against, and shipping platform code
+	that has never even built would be a materially different, weaker
+	thing than everything else in this feature.
+*/
+class SpaceMouseBackend : public QObject
+{
+	Q_OBJECT
+
+	public:
+		explicit SpaceMouseBackend(QObject *parent = nullptr) : QObject(parent) {}
+		~SpaceMouseBackend() override = default;
+
+			/// True once this backend actually has a live connection to a
+			/// driver/daemon. False is the ordinary case -- no daemon
+			/// running, no device attached -- not an error; see
+			/// SpaceMouseListener's class comment for why that distinction
+			/// matters.
+		virtual bool isAvailable() const = 0;
+
+	signals:
+			/// One raw device sample. dx/dy are the two axes
+			/// SpaceMouseListener maps to horizontal/vertical pan, dz the
+			/// one it maps to zoom. Units and range are whatever the
+			/// backend's own driver reports -- SpaceMouseListener's own
+			/// scale/divisor constants are what turn them into pixels and a
+			/// zoom factor, not this signal.
+		void motion(int dx, int dy, int dz);
+};
+
+#endif // SPACEMOUSEBACKEND_H

--- a/sources/spacemouse/spacemousebuttonmap.cpp
+++ b/sources/spacemouse/spacemousebuttonmap.cpp
@@ -1,0 +1,72 @@
+/*
+	Copyright 2006-2026 The QElectroTech Team
+	This file is part of QElectroTech.
+
+	QElectroTech is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 2 of the License, or
+	(at your option) any later version.
+
+	QElectroTech is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with QElectroTech.  If not, see <http://www.gnu.org/licenses/>.
+*/
+#include "spacemousebuttonmap.h"
+
+#include <QSettings>
+
+namespace {
+	const QString SETTINGS_GROUP = QStringLiteral("spacemouse/buttons/");
+}
+
+/**
+	@brief SpaceMouseButtonMap::actionId
+	@param button
+	@return see the declaration's doc comment
+*/
+QString SpaceMouseButtonMap::actionId(int button)
+{
+	QSettings settings;
+	return settings.value(SETTINGS_GROUP + QString::number(button)).toString();
+}
+
+/**
+	@brief SpaceMouseButtonMap::setActionId
+	@param button
+	@param action_id
+*/
+void SpaceMouseButtonMap::setActionId(int button, const QString &action_id)
+{
+	QSettings settings;
+	const QString key = SETTINGS_GROUP + QString::number(button);
+	if (action_id.isEmpty()) {
+		settings.remove(key);
+	} else {
+		settings.setValue(key, action_id);
+	}
+}
+
+/**
+	@brief SpaceMouseButtonMap::allBindings
+	@return see the declaration's doc comment
+*/
+QMap<int, QString> SpaceMouseButtonMap::allBindings()
+{
+	QMap<int, QString> bindings;
+	QSettings settings;
+	settings.beginGroup(QStringLiteral("spacemouse/buttons"));
+	for (const QString &key : settings.childKeys())
+	{
+		bool ok = false;
+		const int button = key.toInt(&ok);
+		if (ok) {
+			bindings.insert(button, settings.value(key).toString());
+		}
+	}
+	settings.endGroup();
+	return bindings;
+}

--- a/sources/spacemouse/spacemousebuttonmap.h
+++ b/sources/spacemouse/spacemousebuttonmap.h
@@ -1,0 +1,55 @@
+/*
+	Copyright 2006-2026 The QElectroTech Team
+	This file is part of QElectroTech.
+
+	QElectroTech is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 2 of the License, or
+	(at your option) any later version.
+
+	QElectroTech is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with QElectroTech.  If not, see <http://www.gnu.org/licenses/>.
+*/
+#ifndef SPACEMOUSEBUTTONMAP_H
+#define SPACEMOUSEBUTTONMAP_H
+
+#include <QMap>
+#include <QString>
+
+/**
+	@brief The SpaceMouseButtonMap class
+	Persisted mapping from a device button's raw index (backend- and
+	device-specific -- see SpaceMouseBackend::buttonPressed()) to a
+	ShortcutManager action id. Deliberately just a thin QSettings wrapper,
+	the same weight as ShortcutManager::savedSequence(): no caching, reads
+	and writes the setting directly on every call, since this is called at
+	most once per button press, never in a hot loop.
+
+	Unbound by default for every button on every device: nothing is bound
+	until the user opens Configuration > 3D Mouse and binds something --
+	see spacemouseconfigpage.h. A device compiled in and connected but
+	never configured here does nothing on any button press, matching the
+	rest of this feature's "silent until asked for" default.
+*/
+class SpaceMouseButtonMap
+{
+	public:
+			/// @return the action id bound to \a button, or an empty string
+			/// if nothing is bound to it.
+		static QString actionId(int button);
+
+			/// Bind \a button to \a action_id. An empty \a action_id
+			/// removes the binding (equivalent to it never having been set).
+		static void setActionId(int button, const QString &action_id);
+
+			/// @return every currently bound button, for the configuration
+			/// page to list.
+		static QMap<int, QString> allBindings();
+};
+
+#endif // SPACEMOUSEBUTTONMAP_H

--- a/sources/spacemouse/spacemouselistener.cpp
+++ b/sources/spacemouse/spacemouselistener.cpp
@@ -1,0 +1,155 @@
+/*
+	Copyright 2006-2026 The QElectroTech Team
+	This file is part of QElectroTech.
+
+	QElectroTech is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 2 of the License, or
+	(at your option) any later version.
+
+	QElectroTech is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with QElectroTech.  If not, see <http://www.gnu.org/licenses/>.
+*/
+#include "spacemouselistener.h"
+
+#include "../diagramview.h"
+#include "../projectview.h"
+#include "../qetdiagrameditor.h"
+
+#include <QApplication>
+#include <QScrollBar>
+#include <QSocketNotifier>
+
+#include <spnav.h>
+
+namespace {
+		//A spnav motion delta is an integer on roughly the same order of
+		//magnitude as a QWheelEvent::angleDelta() tick (about +-120 per
+		//detent, more under a hard push/twist -- exact range depends on the
+		//user's spacenavd sensitivity setting, which is configured once
+		//outside QET and out of scope here). DiagramView::wheelEvent()
+		//already turns such a tick into a small per-event zoom step via
+		//zoom(1 + value/1000); reused as a starting point.
+		//
+		//Neither this divisor nor PAN_SCALE below has been calibrated
+		//against real hardware -- there is none in the environment this was
+		//built in. Both are named constants specifically so that is a
+		//one-line fix once someone with a device tries it.
+	constexpr qreal ZOOM_DIVISOR = 1000.0;
+	constexpr qreal PAN_SCALE = 1.0;
+}
+
+/**
+	@brief SpaceMouseListener::SpaceMouseListener
+	Try to connect to spacenavd. Failure -- no daemon running, no device
+	attached -- is left silent: it is the expected state for most users and
+	must never surface as an error dialog or a log warning on every
+	ordinary startup.
+	@param parent
+*/
+SpaceMouseListener::SpaceMouseListener(QObject *parent) :
+	QObject(parent)
+{
+	if (spnav_open() == -1) {
+		return;
+	}
+
+	m_available = true;
+	m_notifier = new QSocketNotifier(spnav_fd(), QSocketNotifier::Read, this);
+	connect(m_notifier, &QSocketNotifier::activated,
+		this, &SpaceMouseListener::readEvents);
+}
+
+/**
+	@brief SpaceMouseListener::~SpaceMouseListener
+*/
+SpaceMouseListener::~SpaceMouseListener()
+{
+	if (m_available) {
+		spnav_close();
+	}
+}
+
+/**
+	@brief SpaceMouseListener::zoomFactorForZAxis
+	@param z : raw Z-axis (push/pull) delta from a spnav motion event
+	@return the multiplicative factor DiagramView::zoom() expects
+*/
+qreal SpaceMouseListener::zoomFactorForZAxis(int z)
+{
+	return 1.0 + (static_cast<qreal>(z) / ZOOM_DIVISOR);
+}
+
+/**
+	@brief SpaceMouseListener::readEvents
+	Called when the spacenavd socket has data available. Drains every event
+	currently queued -- spnav_poll_event() returns 0 once the queue is
+	empty -- rather than handling just one per activation, so events cannot
+	silently back up if several arrive between two Qt event loop turns.
+*/
+void SpaceMouseListener::readEvents()
+{
+	spnav_event event;
+	while (spnav_poll_event(&event))
+	{
+		if (event.type == SPNAV_EVENT_MOTION) {
+			dispatchMotion(event.motion);
+		}
+			//Button events (SPNAV_EVENT_BUTTON) are deliberately not
+			//handled: mapping device buttons to QET actions is the "Related,
+			//not proposed here" follow-up in discussion #599, not this
+			//phase.
+	}
+}
+
+/**
+	@brief SpaceMouseListener::dispatchMotion
+	Apply one motion event to whichever DiagramView is currently active.
+	X/Y translation pans it, Z translation zooms it -- the same two
+	primitives (scrollbars, DiagramView::zoom()) DiagramView::wheelEvent()
+	already drives from a physical wheel, so there is no new navigation
+	logic here, only a new input source feeding the existing one.
+
+	A 6-DOF device also reports rotation (rx, ry, rz); QET's view has
+	nothing rotation maps to, so those three axes are read by nothing here.
+
+	Which of the three translation axes is "left/right" vs "forward/back"
+	vs "up/down" on the physical device, and their sign, is a hardware
+	convention this could not be checked against real hardware while
+	writing it -- see the PR description.
+	@param motion
+*/
+void SpaceMouseListener::dispatchMotion(const spnav_event_motion &motion)
+{
+	auto *editor = qobject_cast<QETDiagramEditor *>(qApp->activeWindow());
+	if (!editor) {
+		return;
+	}
+
+	ProjectView *project_view = editor->currentProjectView();
+	if (!project_view) {
+		return;
+	}
+
+	DiagramView *view = project_view->currentDiagram();
+	if (!view) {
+		return;
+	}
+
+	if (motion.x || motion.y)
+	{
+		view->horizontalScrollBar()->setValue(
+			view->horizontalScrollBar()->value() - qRound(motion.x * PAN_SCALE));
+		view->verticalScrollBar()->setValue(
+			view->verticalScrollBar()->value() - qRound(motion.y * PAN_SCALE));
+	}
+
+	if (motion.z) {
+		view->zoom(zoomFactorForZAxis(motion.z));
+	}
+}

--- a/sources/spacemouse/spacemouselistener.cpp
+++ b/sources/spacemouse/spacemouselistener.cpp
@@ -17,24 +17,27 @@
 */
 #include "spacemouselistener.h"
 
+#include "spacemousebackend.h"
+#ifdef QET_SPACEMOUSE_BACKEND_SPNAV
+#	include "spnavbackend.h"
+#endif
+
 #include "../diagramview.h"
 #include "../projectview.h"
 #include "../qetdiagrameditor.h"
 
 #include <QApplication>
 #include <QScrollBar>
-#include <QSocketNotifier>
-
-#include <spnav.h>
 
 namespace {
-		//A spnav motion delta is an integer on roughly the same order of
+		//A device motion delta is an integer on roughly the same order of
 		//magnitude as a QWheelEvent::angleDelta() tick (about +-120 per
 		//detent, more under a hard push/twist -- exact range depends on the
-		//user's spacenavd sensitivity setting, which is configured once
-		//outside QET and out of scope here). DiagramView::wheelEvent()
-		//already turns such a tick into a small per-event zoom step via
-		//zoom(1 + value/1000); reused as a starting point.
+		//backend and the user's own driver-level sensitivity setting, which
+		//is configured outside QET and out of scope here).
+		//DiagramView::wheelEvent() already turns such a tick into a small
+		//per-event zoom step via zoom(1 + value/1000); reused as a starting
+		//point.
 		//
 		//Neither this divisor nor PAN_SCALE below has been calibrated
 		//against real hardware -- there is none in the environment this was
@@ -46,38 +49,40 @@ namespace {
 
 /**
 	@brief SpaceMouseListener::SpaceMouseListener
-	Try to connect to spacenavd. Failure -- no daemon running, no device
-	attached -- is left silent: it is the expected state for most users and
-	must never surface as an error dialog or a log warning on every
-	ordinary startup.
+	Construct whichever backend is available for this platform and connect
+	its motion() signal. If none is compiled in, or the one that is can't
+	reach a device, isAvailable() simply stays false -- see the class
+	comment.
 	@param parent
 */
 SpaceMouseListener::SpaceMouseListener(QObject *parent) :
 	QObject(parent)
 {
-	if (spnav_open() == -1) {
-		return;
-	}
+#ifdef QET_SPACEMOUSE_BACKEND_SPNAV
+	m_backend = new SpnavBackend(this);
+#endif
+		//A future Windows/macOS backend (3Dconnexion's proprietary 3DxWare
+		//SDK) slots in here behind its own QET_SPACEMOUSE_BACKEND_3DXWARE
+		//guard, without changing anything below this constructor.
 
-	m_available = true;
-	m_notifier = new QSocketNotifier(spnav_fd(), QSocketNotifier::Read, this);
-	connect(m_notifier, &QSocketNotifier::activated,
-		this, &SpaceMouseListener::readEvents);
+	if (m_backend) {
+		connect(m_backend, &SpaceMouseBackend::motion,
+			this, &SpaceMouseListener::applyMotion);
+	}
 }
 
 /**
-	@brief SpaceMouseListener::~SpaceMouseListener
+	@brief SpaceMouseListener::isAvailable
+	@return whether the platform backend has a live device connection
 */
-SpaceMouseListener::~SpaceMouseListener()
+bool SpaceMouseListener::isAvailable() const
 {
-	if (m_available) {
-		spnav_close();
-	}
+	return m_backend && m_backend->isAvailable();
 }
 
 /**
 	@brief SpaceMouseListener::zoomFactorForZAxis
-	@param z : raw Z-axis (push/pull) delta from a spnav motion event
+	@param z : raw Z-axis (push/pull) delta from a device motion sample
 	@return the multiplicative factor DiagramView::zoom() expects
 */
 qreal SpaceMouseListener::zoomFactorForZAxis(int z)
@@ -86,45 +91,22 @@ qreal SpaceMouseListener::zoomFactorForZAxis(int z)
 }
 
 /**
-	@brief SpaceMouseListener::readEvents
-	Called when the spacenavd socket has data available. Drains every event
-	currently queued -- spnav_poll_event() returns 0 once the queue is
-	empty -- rather than handling just one per activation, so events cannot
-	silently back up if several arrive between two Qt event loop turns.
-*/
-void SpaceMouseListener::readEvents()
-{
-	spnav_event event;
-	while (spnav_poll_event(&event))
-	{
-		if (event.type == SPNAV_EVENT_MOTION) {
-			dispatchMotion(event.motion);
-		}
-			//Button events (SPNAV_EVENT_BUTTON) are deliberately not
-			//handled: mapping device buttons to QET actions is the "Related,
-			//not proposed here" follow-up in discussion #599, not this
-			//phase.
-	}
-}
-
-/**
-	@brief SpaceMouseListener::dispatchMotion
-	Apply one motion event to whichever DiagramView is currently active.
+	@brief SpaceMouseListener::applyMotion
+	Apply one motion sample to whichever DiagramView is currently active.
 	X/Y translation pans it, Z translation zooms it -- the same two
 	primitives (scrollbars, DiagramView::zoom()) DiagramView::wheelEvent()
 	already drives from a physical wheel, so there is no new navigation
 	logic here, only a new input source feeding the existing one.
 
-	A 6-DOF device also reports rotation (rx, ry, rz); QET's view has
-	nothing rotation maps to, so those three axes are read by nothing here.
-
-	Which of the three translation axes is "left/right" vs "forward/back"
-	vs "up/down" on the physical device, and their sign, is a hardware
-	convention this could not be checked against real hardware while
-	writing it -- see the PR description.
-	@param motion
+	Which of a device's three translation axes is "left/right" vs
+	"forward/back" vs "up/down", and their sign, is a hardware convention
+	this could not be checked against real hardware while writing it -- see
+	the PR description.
+	@param dx
+	@param dy
+	@param dz
 */
-void SpaceMouseListener::dispatchMotion(const spnav_event_motion &motion)
+void SpaceMouseListener::applyMotion(int dx, int dy, int dz)
 {
 	auto *editor = qobject_cast<QETDiagramEditor *>(qApp->activeWindow());
 	if (!editor) {
@@ -141,15 +123,15 @@ void SpaceMouseListener::dispatchMotion(const spnav_event_motion &motion)
 		return;
 	}
 
-	if (motion.x || motion.y)
+	if (dx || dy)
 	{
 		view->horizontalScrollBar()->setValue(
-			view->horizontalScrollBar()->value() - qRound(motion.x * PAN_SCALE));
+			view->horizontalScrollBar()->value() - qRound(dx * PAN_SCALE));
 		view->verticalScrollBar()->setValue(
-			view->verticalScrollBar()->value() - qRound(motion.y * PAN_SCALE));
+			view->verticalScrollBar()->value() - qRound(dy * PAN_SCALE));
 	}
 
-	if (motion.z) {
-		view->zoom(zoomFactorForZAxis(motion.z));
+	if (dz) {
+		view->zoom(zoomFactorForZAxis(dz));
 	}
 }

--- a/sources/spacemouse/spacemouselistener.cpp
+++ b/sources/spacemouse/spacemouselistener.cpp
@@ -18,6 +18,7 @@
 #include "spacemouselistener.h"
 
 #include "spacemousebackend.h"
+#include "spacemousebuttonmap.h"
 #ifdef QET_SPACEMOUSE_BACKEND_SPNAV
 #	include "spnavbackend.h"
 #endif
@@ -25,6 +26,7 @@
 #include "../diagramview.h"
 #include "../projectview.h"
 #include "../qetdiagrameditor.h"
+#include "../shortcutmanager.h"
 
 #include <QApplication>
 #include <QScrollBar>
@@ -68,6 +70,8 @@ SpaceMouseListener::SpaceMouseListener(QObject *parent) :
 	if (m_backend) {
 		connect(m_backend, &SpaceMouseBackend::motion,
 			this, &SpaceMouseListener::applyMotion);
+		connect(m_backend, &SpaceMouseBackend::buttonPressed,
+			this, &SpaceMouseListener::applyButton);
 	}
 }
 
@@ -133,5 +137,17 @@ void SpaceMouseListener::applyMotion(int dx, int dy, int dz)
 
 	if (dz) {
 		view->zoom(zoomFactorForZAxis(dz));
+	}
+}
+
+/**
+	@brief SpaceMouseListener::applyButton
+	@param button
+*/
+void SpaceMouseListener::applyButton(int button)
+{
+	const QString action_id = SpaceMouseButtonMap::actionId(button);
+	if (!action_id.isEmpty()) {
+		ShortcutManager::instance().trigger(action_id);
 	}
 }

--- a/sources/spacemouse/spacemouselistener.h
+++ b/sources/spacemouse/spacemouselistener.h
@@ -20,27 +20,31 @@
 
 #include <QObject>
 
-class QSocketNotifier;
-struct spnav_event_motion;
+class SpaceMouseBackend;
 
 /**
 	@brief The SpaceMouseListener class
-	Phase 1 (Linux, libspnav) of
 	https://github.com/qelectrotech/qelectrotech-source-mirror/discussions/599 :
-	bridges a 3Dconnexion SpaceMouse/SpacePilot 6-DOF device, via the
-	spacenavd daemon and libspnav, to DiagramView's existing pan/zoom
-	primitives (the same horizontalScrollBar()/verticalScrollBar()/zoom()
-	calls DiagramView::wheelEvent() already uses for a physical wheel).
+	bridges a 3Dconnexion SpaceMouse/SpacePilot 6-DOF device to
+	DiagramView's existing pan/zoom primitives (the same
+	horizontalScrollBar()/verticalScrollBar()/zoom() calls
+	DiagramView::wheelEvent() already uses for a physical wheel).
 
-	Only compiled in when the QET_ENABLE_SPACEMOUSE CMake option is on. Even
-	then, constructing one is always safe: when no spacenavd is running or
-	no device is attached -- the expected state for the overwhelming
-	majority of users, even of a build with the option on -- it silently
-	does nothing rather than failing or nagging the user. There is exactly
-	one of these, owned by QETApp, because a physical 6-DOF device is a
-	single ambient input source for the whole application, not something
-	tied to one window; motion is applied to whichever DiagramView is
-	currently active (see targetView()).
+	Everything here is platform-independent: which DiagramView to apply
+	motion to, the pan/zoom calls, and the Z-to-zoom-factor mapping.
+	Talking to the actual device driver is a SpaceMouseBackend's job (see
+	its class comment) -- this class owns one and applies whatever it
+	reports, without knowing or caring which platform it came from.
+
+	Only compiled in when QET_SPACEMOUSE_SUPPORT is defined. Even then,
+	constructing one is always safe: if no backend is available for this
+	platform, or the one that exists can't reach a driver/daemon (no
+	device attached -- the expected state for the overwhelming majority of
+	users, even of a build with the option on), this silently does nothing
+	rather than failing or nagging the user. There is exactly one of
+	these, owned by QETApp, because a physical 6-DOF device is a single
+	ambient input source for the whole application, not something tied to
+	one window.
 */
 class SpaceMouseListener : public QObject
 {
@@ -48,32 +52,27 @@ class SpaceMouseListener : public QObject
 
 	public:
 		explicit SpaceMouseListener(QObject *parent = nullptr);
-		~SpaceMouseListener() override;
+		~SpaceMouseListener() override = default;
 
-			/// True once a connection to spacenavd was established.
-			/// False is the common case, not an error -- see the class
-			/// comment -- so callers should not warn the user when this
-			/// is false.
-		bool isAvailable() const {return m_available;}
+			/// True once the platform backend has a live connection to a
+			/// driver/daemon. False is the common case, not an error -- see
+			/// the class comment -- so callers should not warn the user
+			/// when this is false.
+		bool isAvailable() const;
 
 			/// Pure translation from a device Z-axis delta to the
 			/// multiplicative factor DiagramView::zoom() expects. A free
 			/// function so the mapping can be unit-tested without a live
-			/// spacenavd connection or a real device.
+			/// backend connection or a real device.
 		static qreal zoomFactorForZAxis(int z);
 
 	private slots:
-			/// Drain and dispatch every event currently queued on the
-			/// spacenavd socket. Connected to a QSocketNotifier on that
-			/// socket's fd rather than polled on a timer, so this is
-			/// idle-cost-free between events.
-		void readEvents();
+			/// Apply one motion sample -- from whichever backend is in use
+			/// -- to whichever DiagramView is currently active.
+		void applyMotion(int dx, int dy, int dz);
 
 	private:
-		void dispatchMotion(const spnav_event_motion &motion);
-
-		bool m_available = false;
-		QSocketNotifier *m_notifier = nullptr;
+		SpaceMouseBackend *m_backend = nullptr;
 };
 
 #endif // SPACEMOUSELISTENER_H

--- a/sources/spacemouse/spacemouselistener.h
+++ b/sources/spacemouse/spacemouselistener.h
@@ -1,0 +1,79 @@
+/*
+	Copyright 2006-2026 The QElectroTech Team
+	This file is part of QElectroTech.
+
+	QElectroTech is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 2 of the License, or
+	(at your option) any later version.
+
+	QElectroTech is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with QElectroTech.  If not, see <http://www.gnu.org/licenses/>.
+*/
+#ifndef SPACEMOUSELISTENER_H
+#define SPACEMOUSELISTENER_H
+
+#include <QObject>
+
+class QSocketNotifier;
+struct spnav_event_motion;
+
+/**
+	@brief The SpaceMouseListener class
+	Phase 1 (Linux, libspnav) of
+	https://github.com/qelectrotech/qelectrotech-source-mirror/discussions/599 :
+	bridges a 3Dconnexion SpaceMouse/SpacePilot 6-DOF device, via the
+	spacenavd daemon and libspnav, to DiagramView's existing pan/zoom
+	primitives (the same horizontalScrollBar()/verticalScrollBar()/zoom()
+	calls DiagramView::wheelEvent() already uses for a physical wheel).
+
+	Only compiled in when the QET_ENABLE_SPACEMOUSE CMake option is on. Even
+	then, constructing one is always safe: when no spacenavd is running or
+	no device is attached -- the expected state for the overwhelming
+	majority of users, even of a build with the option on -- it silently
+	does nothing rather than failing or nagging the user. There is exactly
+	one of these, owned by QETApp, because a physical 6-DOF device is a
+	single ambient input source for the whole application, not something
+	tied to one window; motion is applied to whichever DiagramView is
+	currently active (see targetView()).
+*/
+class SpaceMouseListener : public QObject
+{
+	Q_OBJECT
+
+	public:
+		explicit SpaceMouseListener(QObject *parent = nullptr);
+		~SpaceMouseListener() override;
+
+			/// True once a connection to spacenavd was established.
+			/// False is the common case, not an error -- see the class
+			/// comment -- so callers should not warn the user when this
+			/// is false.
+		bool isAvailable() const {return m_available;}
+
+			/// Pure translation from a device Z-axis delta to the
+			/// multiplicative factor DiagramView::zoom() expects. A free
+			/// function so the mapping can be unit-tested without a live
+			/// spacenavd connection or a real device.
+		static qreal zoomFactorForZAxis(int z);
+
+	private slots:
+			/// Drain and dispatch every event currently queued on the
+			/// spacenavd socket. Connected to a QSocketNotifier on that
+			/// socket's fd rather than polled on a timer, so this is
+			/// idle-cost-free between events.
+		void readEvents();
+
+	private:
+		void dispatchMotion(const spnav_event_motion &motion);
+
+		bool m_available = false;
+		QSocketNotifier *m_notifier = nullptr;
+};
+
+#endif // SPACEMOUSELISTENER_H

--- a/sources/spacemouse/spacemouselistener.h
+++ b/sources/spacemouse/spacemouselistener.h
@@ -28,13 +28,18 @@ class SpaceMouseBackend;
 	bridges a 3Dconnexion SpaceMouse/SpacePilot 6-DOF device to
 	DiagramView's existing pan/zoom primitives (the same
 	horizontalScrollBar()/verticalScrollBar()/zoom() calls
-	DiagramView::wheelEvent() already uses for a physical wheel).
+	DiagramView::wheelEvent() already uses for a physical wheel), and its
+	buttons to named QET actions via ShortcutManager -- the same registry
+	keyboard shortcuts already use, so a device button can trigger anything
+	in that registry (undo, redo, rotate selection, ...) without QET having
+	a second, device-specific action list.
 
 	Everything here is platform-independent: which DiagramView to apply
-	motion to, the pan/zoom calls, and the Z-to-zoom-factor mapping.
-	Talking to the actual device driver is a SpaceMouseBackend's job (see
-	its class comment) -- this class owns one and applies whatever it
-	reports, without knowing or caring which platform it came from.
+	motion to, the pan/zoom calls, the Z-to-zoom-factor mapping, and button
+	dispatch via SpaceMouseButtonMap + ShortcutManager. Talking to the
+	actual device driver is a SpaceMouseBackend's job (see its class
+	comment) -- this class owns one and applies whatever it reports,
+	without knowing or caring which platform it came from.
 
 	Only compiled in when QET_SPACEMOUSE_SUPPORT is defined. Even then,
 	constructing one is always safe: if no backend is available for this
@@ -70,6 +75,12 @@ class SpaceMouseListener : public QObject
 			/// Apply one motion sample -- from whichever backend is in use
 			/// -- to whichever DiagramView is currently active.
 		void applyMotion(int dx, int dy, int dz);
+
+			/// Look up which action id, if any, SpaceMouseButtonMap binds
+			/// \a button to, and trigger it via ShortcutManager. Does
+			/// nothing for an unbound button -- see SpaceMouseButtonMap's
+			/// class comment on the "unbound by default" contract.
+		void applyButton(int button);
 
 	private:
 		SpaceMouseBackend *m_backend = nullptr;

--- a/sources/spacemouse/spnavbackend.cpp
+++ b/sources/spacemouse/spnavbackend.cpp
@@ -70,9 +70,11 @@ void SpnavBackend::readEvents()
 				//read by nothing here.
 			emit motion(event.motion.x, event.motion.y, event.motion.z);
 		}
-			//Button events (SPNAV_EVENT_BUTTON) are deliberately not
-			//handled: mapping device buttons to QET actions is the "Related,
-			//not proposed here" follow-up in discussion #599, not this
-			//phase.
+		else if (event.type == SPNAV_EVENT_BUTTON && event.button.press) {
+				//Release (press == 0) is not reported -- SpaceMouseListener
+				//triggers a QET action on press, the same way a keyboard
+				//shortcut triggers on key-down, and has no use for release.
+			emit buttonPressed(event.button.bnum);
+		}
 	}
 }

--- a/sources/spacemouse/spnavbackend.cpp
+++ b/sources/spacemouse/spnavbackend.cpp
@@ -1,0 +1,78 @@
+/*
+	Copyright 2006-2026 The QElectroTech Team
+	This file is part of QElectroTech.
+
+	QElectroTech is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 2 of the License, or
+	(at your option) any later version.
+
+	QElectroTech is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with QElectroTech.  If not, see <http://www.gnu.org/licenses/>.
+*/
+#include "spnavbackend.h"
+
+#include <QSocketNotifier>
+
+#include <spnav.h>
+
+/**
+	@brief SpnavBackend::SpnavBackend
+	Try to connect to spacenavd. Failure -- no daemon running, no device
+	attached -- is left silent: it is the expected state for most users and
+	must never surface as an error dialog or a log warning on every
+	ordinary startup.
+	@param parent
+*/
+SpnavBackend::SpnavBackend(QObject *parent) :
+	SpaceMouseBackend(parent)
+{
+	if (spnav_open() == -1) {
+		return;
+	}
+
+	m_available = true;
+	m_notifier = new QSocketNotifier(spnav_fd(), QSocketNotifier::Read, this);
+	connect(m_notifier, &QSocketNotifier::activated,
+		this, &SpnavBackend::readEvents);
+}
+
+/**
+	@brief SpnavBackend::~SpnavBackend
+*/
+SpnavBackend::~SpnavBackend()
+{
+	if (m_available) {
+		spnav_close();
+	}
+}
+
+/**
+	@brief SpnavBackend::readEvents
+	Called when the spacenavd socket has data available. Drains every event
+	currently queued -- spnav_poll_event() returns 0 once the queue is
+	empty -- rather than handling just one per activation, so events cannot
+	silently back up if several arrive between two Qt event loop turns.
+*/
+void SpnavBackend::readEvents()
+{
+	spnav_event event;
+	while (spnav_poll_event(&event))
+	{
+		if (event.type == SPNAV_EVENT_MOTION) {
+				//A 6-DOF device also reports rotation (rx, ry, rz); QET's
+				//view has nothing rotation maps to, so those three axes are
+				//read by nothing here.
+			emit motion(event.motion.x, event.motion.y, event.motion.z);
+		}
+			//Button events (SPNAV_EVENT_BUTTON) are deliberately not
+			//handled: mapping device buttons to QET actions is the "Related,
+			//not proposed here" follow-up in discussion #599, not this
+			//phase.
+	}
+}

--- a/sources/spacemouse/spnavbackend.h
+++ b/sources/spacemouse/spnavbackend.h
@@ -1,0 +1,58 @@
+/*
+	Copyright 2006-2026 The QElectroTech Team
+	This file is part of QElectroTech.
+
+	QElectroTech is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 2 of the License, or
+	(at your option) any later version.
+
+	QElectroTech is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with QElectroTech.  If not, see <http://www.gnu.org/licenses/>.
+*/
+#ifndef SPNAVBACKEND_H
+#define SPNAVBACKEND_H
+
+#include "spacemousebackend.h"
+
+class QSocketNotifier;
+
+/**
+	@brief The SpnavBackend class
+	Linux SpaceMouseBackend, via the spacenavd daemon and libspnav. Only
+	compiled in when QET_SPACEMOUSE_BACKEND_SPNAV is defined (set by
+	cmake/find_spacemouse.cmake once it has actually found libspnav).
+
+	Connecting is always safe even when no daemon is running or no device
+	is attached -- the expected state for the overwhelming majority of
+	users, even of a build with 3D mouse support compiled in -- this
+	silently leaves isAvailable() false rather than failing loudly.
+*/
+class SpnavBackend : public SpaceMouseBackend
+{
+	Q_OBJECT
+
+	public:
+		explicit SpnavBackend(QObject *parent = nullptr);
+		~SpnavBackend() override;
+
+		bool isAvailable() const override {return m_available;}
+
+	private slots:
+			/// Drain and emit every event currently queued on the spacenavd
+			/// socket. Connected to a QSocketNotifier on that socket's fd
+			/// rather than polled on a timer, so this is idle-cost-free
+			/// between events.
+		void readEvents();
+
+	private:
+		bool m_available = false;
+		QSocketNotifier *m_notifier = nullptr;
+};
+
+#endif // SPNAVBACKEND_H

--- a/sources/ui/configpage/spacemouseconfigpage.cpp
+++ b/sources/ui/configpage/spacemouseconfigpage.cpp
@@ -1,0 +1,223 @@
+/*
+	Copyright 2006-2026 The QElectroTech Team
+	This file is part of QElectroTech.
+
+	QElectroTech is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 2 of the License, or
+	(at your option) any later version.
+
+	QElectroTech is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with QElectroTech.  If not, see <http://www.gnu.org/licenses/>.
+*/
+#include "spacemouseconfigpage.h"
+
+#include "../../qeticons.h"
+#include "../../shortcutmanager.h"
+#include "../../spacemouse/spacemousebuttonmap.h"
+
+#include <QComboBox>
+#include <QFrame>
+#include <QHBoxLayout>
+#include <QHeaderView>
+#include <QLabel>
+#include <QPushButton>
+#include <QSpinBox>
+#include <QTableWidget>
+#include <QToolButton>
+#include <QVBoxLayout>
+#include <algorithm>
+
+namespace {
+	constexpr int COL_BUTTON = 0;
+	constexpr int COL_ACTION = 1;
+	constexpr int COL_REMOVE = 2;
+
+		//The combo box's first entry: no action bound, i.e. this row does
+		//nothing. Real action ids are never empty (ShortcutManager assigns
+		//them from source, not user input), so an empty string can never
+		//collide with a real one.
+	const QString UNBOUND_LABEL = QObject::tr("(Aucune action)", "spacemouse config: unbound button");
+}
+
+/**
+	@brief SpaceMouseConfigPage::SpaceMouseConfigPage
+	@param parent
+*/
+SpaceMouseConfigPage::SpaceMouseConfigPage(QWidget *parent) :
+	ConfigPage(parent)
+{
+	auto *vlayout = new QVBoxLayout();
+
+	QLabel *title_label = new QLabel(this->title());
+	vlayout->addWidget(title_label);
+
+	QFrame *horiz_line = new QFrame();
+	horiz_line->setFrameShape(QFrame::HLine);
+	vlayout->addWidget(horiz_line);
+
+	auto *intro_label = new QLabel(
+		tr("Associez un numéro de bouton de votre souris 3D (SpaceMouse, SpacePilot...) "
+		   "à une action de QElectroTech. Le numéro de bouton dépend de votre appareil "
+		   "et de son pilote -- reportez-vous à sa documentation, ou essayez successivement "
+		   "les valeurs à partir de 0.",
+		   "spacemouse config page intro"));
+	intro_label->setWordWrap(true);
+	vlayout->addWidget(intro_label);
+
+	m_table = new QTableWidget(0, 3, this);
+	m_table->setHorizontalHeaderLabels({tr("N° bouton"), tr("Action"), QString()});
+	m_table->horizontalHeader()->setSectionResizeMode(COL_BUTTON, QHeaderView::ResizeToContents);
+	m_table->horizontalHeader()->setSectionResizeMode(COL_ACTION, QHeaderView::Stretch);
+	m_table->horizontalHeader()->setSectionResizeMode(COL_REMOVE, QHeaderView::ResizeToContents);
+	m_table->verticalHeader()->setVisible(false);
+	m_table->setEditTriggers(QAbstractItemView::NoEditTriggers);
+	m_table->setSelectionMode(QAbstractItemView::NoSelection);
+	vlayout->addWidget(m_table);
+
+	auto *add_button = new QPushButton(QET::Icons::Add, tr("Ajouter une association"), this);
+	connect(add_button, &QPushButton::clicked, this, &SpaceMouseConfigPage::addRow);
+
+	auto *bottom_layout = new QHBoxLayout();
+	bottom_layout->addWidget(add_button);
+	bottom_layout->addStretch();
+	vlayout->addLayout(bottom_layout);
+
+	setLayout(vlayout);
+
+	populateTable();
+}
+
+SpaceMouseConfigPage::~SpaceMouseConfigPage()
+{
+}
+
+/**
+	@brief SpaceMouseConfigPage::populateTable
+	Fill the table with one row per binding currently persisted in
+	SpaceMouseButtonMap.
+*/
+void SpaceMouseConfigPage::populateTable()
+{
+	const QMap<int, QString> bindings = SpaceMouseButtonMap::allBindings();
+	for (auto it = bindings.constBegin(); it != bindings.constEnd(); ++it) {
+		appendRow(it.key(), it.value());
+	}
+}
+
+/**
+	@brief SpaceMouseConfigPage::appendRow
+	Add one row bound to \a button / \a action_id (either or both may be
+	the "unset" value -- 0 and an empty string respectively -- for a fresh
+	row added via the "+" button).
+	@param button
+	@param action_id
+*/
+void SpaceMouseConfigPage::appendRow(int button, const QString &action_id)
+{
+	const int row = m_table->rowCount();
+	m_table->setRowCount(row + 1);
+
+	auto *button_spin = new QSpinBox(m_table);
+	button_spin->setRange(0, 999);
+	button_spin->setValue(button);
+	m_table->setCellWidget(row, COL_BUTTON, button_spin);
+
+	auto *action_combo = new QComboBox(m_table);
+	action_combo->addItem(UNBOUND_LABEL, QString());
+
+	QList<ShortcutManager::ShortcutInfo> shortcuts = ShortcutManager::instance().allShortcuts();
+	std::sort(shortcuts.begin(), shortcuts.end(),
+		  [](const ShortcutManager::ShortcutInfo &a, const ShortcutManager::ShortcutInfo &b) {
+			if (a.category != b.category) {
+				return a.category < b.category;
+			}
+			return a.description < b.description;
+		  });
+	for (const ShortcutManager::ShortcutInfo &info : shortcuts) {
+		action_combo->addItem(
+			QStringLiteral("%1 — %2").arg(info.category, info.description), info.id);
+	}
+
+	int index_for_current = action_combo->findData(action_id);
+	action_combo->setCurrentIndex(index_for_current >= 0 ? index_for_current : 0);
+	m_table->setCellWidget(row, COL_ACTION, action_combo);
+
+	auto *remove_button = new QToolButton(m_table);
+	remove_button->setIcon(QET::Icons::EditTableDeleteRow);
+	remove_button->setToolTip(tr("Supprimer cette association"));
+	connect(remove_button, &QToolButton::clicked, this, &SpaceMouseConfigPage::removeSelectedRow);
+	m_table->setCellWidget(row, COL_REMOVE, remove_button);
+}
+
+/**
+	@brief SpaceMouseConfigPage::addRow
+	Add a fresh, unbound row for the user to fill in.
+*/
+void SpaceMouseConfigPage::addRow()
+{
+	appendRow(0, QString());
+}
+
+/**
+	@brief SpaceMouseConfigPage::removeSelectedRow
+	Remove whichever row owns the remove button that was clicked. Found by
+	looking the sender up in the button column rather than tracked
+	per-button state, so nothing has to be kept in sync as rows are added
+	and removed around it.
+*/
+void SpaceMouseConfigPage::removeSelectedRow()
+{
+	auto *button = qobject_cast<QToolButton *>(sender());
+	if (!button) {
+		return;
+	}
+	for (int row = 0; row < m_table->rowCount(); ++row) {
+		if (m_table->cellWidget(row, COL_REMOVE) == button) {
+			m_table->removeRow(row);
+			return;
+		}
+	}
+}
+
+/**
+	@brief SpaceMouseConfigPage::applyConf
+	Persist exactly what the table currently shows: every previously saved
+	binding is cleared first, then every row still in the table (after any
+	adds/edits/removals) is written back. Simpler and less error-prone than
+	tracking which individual rows changed, and cheap -- this runs once,
+	when the user validates the surrounding ConfigDialog, not on every
+	keystroke.
+*/
+void SpaceMouseConfigPage::applyConf()
+{
+	const QMap<int, QString> previous = SpaceMouseButtonMap::allBindings();
+	for (auto it = previous.constBegin(); it != previous.constEnd(); ++it) {
+		SpaceMouseButtonMap::setActionId(it.key(), QString());
+	}
+
+	for (int row = 0; row < m_table->rowCount(); ++row)
+	{
+		auto *button_spin = qobject_cast<QSpinBox *>(m_table->cellWidget(row, COL_BUTTON));
+		auto *action_combo = qobject_cast<QComboBox *>(m_table->cellWidget(row, COL_ACTION));
+		if (!button_spin || !action_combo) {
+			continue;
+		}
+		SpaceMouseButtonMap::setActionId(button_spin->value(), action_combo->currentData().toString());
+	}
+}
+
+QString SpaceMouseConfigPage::title() const
+{
+	return tr("Souris 3D", "configuration page title");
+}
+
+QIcon SpaceMouseConfigPage::icon() const
+{
+	return QET::Icons::ConfigureToolbars;
+}

--- a/sources/ui/configpage/spacemouseconfigpage.h
+++ b/sources/ui/configpage/spacemouseconfigpage.h
@@ -1,0 +1,69 @@
+/*
+	Copyright 2006-2026 The QElectroTech Team
+	This file is part of QElectroTech.
+
+	QElectroTech is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 2 of the License, or
+	(at your option) any later version.
+
+	QElectroTech is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with QElectroTech.  If not, see <http://www.gnu.org/licenses/>.
+*/
+#ifndef SPACEMOUSECONFIGPAGE_H
+#define SPACEMOUSECONFIGPAGE_H
+
+#include "configpage.h"
+
+class QTableWidget;
+
+/**
+	@brief The SpaceMouseConfigPage class
+	Configuration page listing every device-button-to-action binding
+	(SpaceMouseButtonMap), letting the user add, edit and remove them.
+	Modelled directly on ShortcutsConfigPage, one row per binding instead
+	of one row per shortcut, since the two are close cousins: both end in
+	the same place -- ShortcutManager::trigger()/registerAction() -- just
+	from a different input source. Bindings are only persisted (via
+	SpaceMouseButtonMap::setActionId()) when applyConf() runs, i.e. when
+	the user validates the surrounding ConfigDialog.
+
+	Only compiled in, and only added to the Configuration dialog, when
+	QET_SPACEMOUSE_SUPPORT is defined -- see qetapp.cpp.
+
+	Button numbering is intentionally not fixed to any particular device:
+	it is exactly whatever integer SpaceMouseBackend::buttonPressed()
+	reports for the button pressed, which is backend- and device-specific.
+	Rows are added/removed freely rather than the page assuming a button
+	count, since that varies from 2 (SpaceMouse Compact) to over 30
+	(SpacePilot Pro).
+*/
+class SpaceMouseConfigPage : public ConfigPage
+{
+		Q_OBJECT
+
+	public:
+		explicit SpaceMouseConfigPage(QWidget *parent = nullptr);
+		~SpaceMouseConfigPage() override;
+
+		void applyConf() override;
+		QString title() const override;
+		QIcon icon() const override;
+
+	private slots:
+		void addRow();
+		void removeSelectedRow();
+
+	private:
+		void populateTable();
+		void appendRow(int button, const QString &action_id);
+
+		QTableWidget *m_table;
+};
+
+#endif // SPACEMOUSECONFIGPAGE_H


### PR DESCRIPTION
Implements discussion #599, phase 1 as scoped there: Linux/libspnav, off by default. Opened as a **draft** deliberately — see "What this PR cannot verify" below; I have no 3Dconnexion hardware, so real-world calibration needs a device owner before this should merge.

## What it adds

A `SpaceMouseListener` that reads motion from a 3Dconnexion 6-DOF device via `spacenavd`/`libspnav` and drives the diagram view's existing pan/zoom primitives — `DiagramView::wheelEvent()` already turns a physical wheel's delta into `horizontalScrollBar()`/`verticalScrollBar()` calls for pan and `zoom(1 + value/1000)` for zoom (`diagramview.cpp:661-687`); this calls exactly those, from a different input source. No new navigation logic.

One listener, owned by `QETApp`, applying motion to whichever `DiagramView` is currently active (`qApp->activeWindow()` → `QETDiagramEditor::currentProjectView()` → `ProjectView::currentDiagram()`) — a 6-DOF device is a single ambient input source for the whole app, not something tied to one window.

## Off by default, zero cost when off

`QET_ENABLE_SPACEMOUSE` (`cmake/developer_options.cmake`) defaults OFF. Verified from two clean configures in separate build directories:

- **Option off**: `cmake/find_spacemouse.cmake` runs and does nothing — no library lookup, no `add_definitions`, no new source files added to `QET_SRC_FILES`. `qetapp.h`/`.cpp` are `#ifdef`'d out entirely; forced a rebuild of just that file and confirmed zero new warnings, zero new object code shape. The default build is unchanged.
- **Option on**: `libspnav` found via its pkg-config file (`spnav.pc`, shipped by `libspnav-dev` on Debian/Ubuntu). Full build succeeds, links against `libspnav.so.0` (confirmed via `ldd`), zero new warnings from either new file.
- **Option on, library missing**: downgrades back to off with a `WARNING`, does not hard-fail configure — an opt-in feature should never block a developer who hasn't installed the library.

## Safe even when compiled in, with no hardware present

This is the case that matters most, because it is what almost every user of an opt-in build will actually hit: no `spacenavd` running, no device attached. `SpaceMouseListener::isAvailable()` treats `spnav_open()` failing as the *ordinary* case, not an error — must never become a startup dialog or a log warning nagging someone who doesn't own the hardware.

This sandbox genuinely has no `spacenavd`, so I could test this for real rather than reason about it: built with the option on, ran the resulting binary to completion, full log inspected — zero crashes, and literally zero `spnav`/`spacemouse` output of any kind. The silence is the point, and it's verified, not assumed.

## What could be tested without hardware, and was

The Z-axis→zoom-factor mapping (`zoomFactorForZAxis`) is a pure function precisely so it didn't have to wait for a device:

```
z=0     -> 1.0000   (centered — exact no-op, verified ==1.0 exactly, not epsilon-close)
z=350   -> 1.3500
z=-350  -> 0.6500
z=1     -> 1.0010
```

The exact-1.0-at-centre check matters because `DiagramView::zoom()` branches on `zoom_factor >= 1`; an off-by-epsilon there could route a "nothing happened" event into the wrong branch.

## What this PR cannot verify — the reason it's a draft

Three things need a real device, and I don't have one:

1. **Axis mapping.** Which of the device's three translation axes is left/right vs up/down vs push/pull, and their sign. I followed the discussion's own proposed scope (X/Y → pan, Z → zoom) but could not confirm it against hardware.
2. **Sensitivity.** `ZOOM_DIVISOR` and `PAN_SCALE` are named constants set by analogy to the wheel-event divisor, not calibrated against a real device's delta range.
3. Whether the motion actually *feels* right in practice — smoothness, whether `spnav_poll_event()`'s drain-the-queue loop keeps up under fast motion, anything else only real use surfaces.

All three are one-line changes once someone with a SpaceMouse/SpacePilot tries it. I'd rather say that plainly and ask for a tester than claim verification I don't have.

## Not in this PR

Windows/macOS (proprietary 3DxWare SDK — materially bigger lift) and device button mapping are both explicitly out of scope for this phase, per the discussion's own staging.

Built clean, no new warnings, on Qt5 with `BUILD_WITH_KF5=OFF`.
