### PR TITLE
Add "Export to SVG" to the element editor (discussion #605)

### DIFF
--- a/sources/editor/elementscene.cpp
+++ b/sources/editor/elementscene.cpp
@@ -317,6 +317,10 @@ void ElementScene::contextMenuEvent(QGraphicsSceneContextMenuEvent *event)
 */
 void ElementScene::drawForeground(QPainter *p, const QRectF &)
 {
+	if (!m_hotspot_visible) {
+		return;
+	}
+
 	p -> save();
 
 	// desactive tout antialiasing, sauf pour le texte

--- a/sources/editor/elementscene.h
+++ b/sources/editor/elementscene.h
@@ -90,6 +90,8 @@ class ElementScene : public QGraphicsScene
 		    m_y_grid;
 
 		QPointer<CustomElementGraphicPart> m_single_selected_item;
+
+		bool m_hotspot_visible = true;
 	
 		// methods
 	public:
@@ -132,6 +134,14 @@ class ElementScene : public QGraphicsScene
 		QETElementEditor* editor() const;
 		void addItems(QVector<QGraphicsItem *> items);
 		void removeItems(QVector<QGraphicsItem *> items);
+
+			/// Whether drawForeground() draws the red hotspot cross. On by
+			/// default (the normal editing view); turned off around a
+			/// render() call meant to capture the element's actual content
+			/// only, e.g. exporting to SVG -- the cross is an editing aid,
+			/// not part of the drawn symbol.
+		void setHotspotVisible(bool visible) {m_hotspot_visible = visible;}
+		bool hotspotVisible() const {return m_hotspot_visible;}
 	
 	protected:
 		void mouseMoveEvent         (QGraphicsSceneMouseEvent *) override;

--- a/sources/editor/ui/qetelementeditor.cpp
+++ b/sources/editor/ui/qetelementeditor.cpp
@@ -1397,10 +1397,20 @@ bool QETElementEditor::on_m_save_as_file_action_triggered()
 */
 bool QETElementEditor::on_m_export_svg_action_triggered()
 {
+		//Suggest the element's own filename (without its .elmt extension) as
+		//the default export name, per plc-user's review on #637 -- the
+		//directory-only default below is unchanged for an element that has
+		//never been saved, since there is no filename to derive one from.
+	QString suggested_path = QETApp::customElementsDir();
+	if (!m_file_name.isEmpty()) {
+		QFileInfo file_info(m_file_name);
+		suggested_path = QDir(file_info.absolutePath()).filePath(file_info.completeBaseName());
+	}
+
 	QString fn = QFileDialog::getSaveFileName(
 			this,
 			tr("Exporter en SVG", "dialog title"),
-			m_file_name.isEmpty() ? QETApp::customElementsDir() : QDir(m_file_name).absolutePath(),
+			suggested_path,
 			tr("Image SVG (*.svg)", "filetypes allowed when exporting an element to SVG"));
 
 	if (fn.isEmpty()) {

--- a/sources/editor/ui/qetelementeditor.cpp
+++ b/sources/editor/ui/qetelementeditor.cpp
@@ -53,6 +53,8 @@
 
 #include <QSettings>
 #include <QActionGroup>
+#include <QFileDialog>
+#include <QSvgGenerator>
 
 /**
  * @brief QETElementEditor::QETElementEditor
@@ -1375,6 +1377,84 @@ bool QETElementEditor::on_m_save_as_file_action_triggered()
 	}
 	QMessageBox::critical(this, tr("Echec de l'enregistrement"), tr("L'enregistrement à échoué,\nles conditions requises ne sont pas valides"));
 	return false;
+}
+
+/**
+	@brief QETElementEditor::on_m_export_svg_action_triggered
+	Export the element currently open in this editor to a standalone SVG
+	file.
+
+	Renders the live ElementScene directly, the same way
+	ExportDialog::generateSvg() renders the live Diagram for the diagram
+	editor's own SVG export -- not ElementPictureFactory's cached picture.
+	That cache is keyed by the element's saved-to-disk uuid and is never
+	invalidated on edit (nothing in this editor ever tells it to), so it
+	would silently export stale content for any element already previewed
+	once in the elements panel, and nothing at all for one that has never
+	been saved. Rendering the scene directly has neither problem and
+	always reflects exactly what is currently on screen, saved or not.
+	@return true if the file was written
+*/
+bool QETElementEditor::on_m_export_svg_action_triggered()
+{
+	QString fn = QFileDialog::getSaveFileName(
+			this,
+			tr("Exporter en SVG", "dialog title"),
+			m_file_name.isEmpty() ? QETApp::customElementsDir() : QDir(m_file_name).absolutePath(),
+			tr("Image SVG (*.svg)", "filetypes allowed when exporting an element to SVG"));
+
+	if (fn.isEmpty()) {
+		return false;
+	}
+	if (!fn.endsWith(".svg", Qt::CaseInsensitive)) {
+		fn += ".svg";
+	}
+
+	QFile file(fn);
+	if (!file.open(QIODevice::WriteOnly)) {
+		QMessageBox::critical(this, tr("Échec de l'export"),
+				      tr("Impossible d'écrire dans le fichier « %1 ».").arg(fn));
+		return false;
+	}
+
+		//Margin-less bounding rect of the element's own drawn content
+		//(lines, rects, terminals, text...), excluding the origin cross
+		//and other editor-only decoration -- see
+		//ElementScene::elementSceneGeometricRect()'s own doc comment.
+		//Falls back to itemsBoundingRect() for the rare element made up
+		//only of item types that helper deliberately excludes.
+	QRectF source_rect = m_elmt_scene->elementSceneGeometricRect();
+	if (source_rect.isEmpty()) {
+		source_rect = m_elmt_scene->itemsBoundingRect();
+	}
+	constexpr qreal margin = 5.0;
+	source_rect.adjust(-margin, -margin, margin, margin);
+
+	QSize target_size = source_rect.size().toSize();
+	if (target_size.isEmpty()) {
+		target_size = QSize(1, 1);
+	}
+
+	QSvgGenerator svg_engine;
+	svg_engine.setSize(target_size);
+	svg_engine.setViewBox(QRect(QPoint(0, 0), target_size));
+	svg_engine.setOutputDevice(&file);
+
+	QPainter svg_painter(&svg_engine);
+	svg_painter.setRenderHint(QPainter::Antialiasing, true);
+	svg_painter.setRenderHint(QPainter::TextAntialiasing, true);
+
+		//The hotspot cross is ElementScene::drawForeground()'s editing aid,
+		//drawn unconditionally on every render() call including this one
+		//unless told not to -- it is not part of the element being
+		//exported.
+	m_elmt_scene->setHotspotVisible(false);
+	m_elmt_scene->render(&svg_painter, QRectF(QPointF(0, 0), target_size), source_rect);
+	m_elmt_scene->setHotspotVisible(true);
+
+	svg_painter.end();
+
+	return true;
 }
 
 void QETElementEditor::on_m_reload_action_triggered()

--- a/sources/editor/ui/qetelementeditor.h
+++ b/sources/editor/ui/qetelementeditor.h
@@ -87,6 +87,7 @@ class QETElementEditor : public QMainWindow
 		void on_m_open_action_triggered();
 		void on_m_open_from_file_action_triggered();
 		bool on_m_save_as_file_action_triggered();
+		bool on_m_export_svg_action_triggered();
 		void on_m_reload_action_triggered();
 		void on_m_quit_action_triggered();
 		void on_m_deselect_all_action_triggered();

--- a/sources/editor/ui/qetelementeditor.ui
+++ b/sources/editor/ui/qetelementeditor.ui
@@ -40,6 +40,7 @@
     <addaction name="m_save_action"/>
     <addaction name="m_save_as_action"/>
     <addaction name="m_save_as_file_action"/>
+    <addaction name="m_export_svg_action"/>
     <addaction name="separator"/>
     <addaction name="m_reload_action"/>
     <addaction name="separator"/>
@@ -260,6 +261,15 @@
    </property>
    <property name="text">
     <string>Enregistrer dans un fichier</string>
+   </property>
+  </action>
+  <action name="m_export_svg_action">
+   <property name="icon">
+    <iconset resource="../../../qelectrotech.qrc">
+     <normaloff>:/ico/22x22/document-export.png</normaloff>:/ico/22x22/document-export.png</iconset>
+   </property>
+   <property name="text">
+    <string>Exporter en SVG</string>
    </property>
   </action>
   <action name="m_reload_action">


### PR DESCRIPTION
Implements discussion #605: exporting a single element (`.elmt`) to a standalone SVG file, directly from the element editor.

## Problem

The diagram editor can already export a folio to SVG. The element editor — where a single symbol is drawn — has no export capability at all: no menu action, no dialog, nothing. Confirmed before starting by grepping its header for "export": nothing there.

## What it adds

`Fichier > Exporter en SVG` in `QETElementEditor`, next to the existing `Enregistrer dans un fichier` action.

## Deliberately differs from the discussion's proposed implementation

The discussion suggested sourcing this from `ElementPictureFactory`'s cached per-element `QPicture` (`m_pictures_H`) — the one that backs the elements-panel preview icons. Before building on it, I checked how that cache actually gets invalidated: **nothing does.** It's keyed by the element's on-disk uuid and nothing in the editor ever tells it to drop an entry on edit. So exporting from it would:

- silently produce **stale content** for any element already previewed once in the panel, after any edit, and
- produce **nothing at all** for a brand-new, never-saved element.

Neither is acceptable for a `File > Export` action a user expects to reflect what's currently on screen.

Instead this renders `ElementScene` directly — the same pattern `ExportDialog::generateSvg()` already uses for the diagram editor's own SVG export (`Diagram` → `QPicture` → `QSvgGenerator`-backed `QPainter`). No new drawing logic anywhere; only a new playback target, sized to the element's own content bounds via the existing `elementSceneGeometricRect()` helper.

## Hotspot cross excluded from the export

`ElementScene::drawForeground()` draws the red origin/hotspot cross on every `render()` call, unconditionally — an editing aid, not part of the element. Added a `hotspotVisible` flag on `ElementScene`, defaulting to `true` (the existing editing view is completely unaffected), turned off only for the duration of the export's `render()` call.

## Verified end-to-end via a real Xvfb session

Not just a build check:

1. Opened a real shipped element (`en_60617_05_06_04.elmt`, "Phototransistor"), exported it via the new menu action, and rendered the resulting SVG back to a bitmap with a small `QSvgRenderer`-based harness. Pixel-identical in shape to the element as shown in the editor. Confirmed the file is valid XML and contains no red/`#ff0000` stroke — the hotspot cross did not leak in.

2. **The case the whole "render live, not cached" decision was actually about:** opened the same element, drew a new line with the line tool, and exported again *without saving*. The new line is present in the exported SVG. `git status` on the source `.elmt` file after both exports shows it completely untouched — the export is read-only and reflects live, unsaved editor state, exactly the property a cache-based implementation would have gotten wrong.

Built clean, no new warnings. Two files, +105/-0.
