### PR TITLE
Color management for conductor auto-numbering (discussion #606)

### DIFF
--- a/cmake/qet_compilation_vars.cmake
+++ b/cmake/qet_compilation_vars.cmake
@@ -155,6 +155,8 @@ set(QET_SRC_FILES
   ${QET_DIR}/sources/conductornumexport.cpp
   ${QET_DIR}/sources/wiringlistexport.h
   ${QET_DIR}/sources/wiringlistexport.cpp
+  ${QET_DIR}/sources/conductorcolorrule.cpp
+  ${QET_DIR}/sources/conductorcolorrule.h
   ${QET_DIR}/sources/conductornumexport.h
   ${QET_DIR}/sources/conductorprofile.cpp
   ${QET_DIR}/sources/conductorprofile.h
@@ -269,6 +271,8 @@ set(QET_SRC_FILES
   ${QET_DIR}/sources/autoNum/ui/autonumberingdockwidget.h
   ${QET_DIR}/sources/autoNum/ui/autonumberingmanagementw.cpp
   ${QET_DIR}/sources/autoNum/ui/autonumberingmanagementw.h
+  ${QET_DIR}/sources/autoNum/ui/conductorcolorrulesw.cpp
+  ${QET_DIR}/sources/autoNum/ui/conductorcolorrulesw.h
   ${QET_DIR}/sources/autoNum/ui/folioautonumbering.cpp
   ${QET_DIR}/sources/autoNum/ui/folioautonumbering.h
   ${QET_DIR}/sources/autoNum/ui/formulaautonumberingw.cpp

--- a/sources/autoNum/ui/conductorcolorrulesw.cpp
+++ b/sources/autoNum/ui/conductorcolorrulesw.cpp
@@ -1,0 +1,219 @@
+/*
+	Copyright 2006-2026 The QElectroTech Team
+	This file is part of QElectroTech.
+
+	QElectroTech is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 2 of the License, or
+	(at your option) any later version.
+
+	QElectroTech is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with QElectroTech.  If not, see <http://www.gnu.org/licenses/>.
+*/
+#include "conductorcolorrulesw.h"
+
+#include "../../conductorcolorrule.h"
+#include "../../qeticons.h"
+#include "../../qetproject.h"
+
+#include <kcolorbutton.h>
+
+#include <QCheckBox>
+#include <QFrame>
+#include <QHBoxLayout>
+#include <QHeaderView>
+#include <QLabel>
+#include <QLineEdit>
+#include <QPushButton>
+#include <QTableWidget>
+#include <QToolButton>
+#include <QVBoxLayout>
+
+namespace {
+	constexpr int COL_TEXT    = 0;
+	constexpr int COL_COLOR   = 1;
+	constexpr int COL_BICOLOR = 2;
+	constexpr int COL_COLOR_2 = 3;
+	constexpr int COL_REMOVE  = 4;
+}
+
+/**
+	@brief ConductorColorRulesW::ConductorColorRulesW
+	@param project
+	@param parent
+*/
+ConductorColorRulesW::ConductorColorRulesW(QETProject *project, QWidget *parent) :
+	QWidget(parent),
+	m_project(project)
+{
+	auto *vlayout = new QVBoxLayout();
+
+	auto *intro_label = new QLabel(
+		tr("Quand la numérotation automatique des conducteurs résout une étiquette identique au texte "
+		   "d'une association ci-dessous, la couleur du conducteur -- et de tous les conducteurs du "
+		   "même potentiel -- est appliquée automatiquement.",
+		   "conductor color rules page intro"));
+	intro_label->setWordWrap(true);
+	vlayout->addWidget(intro_label);
+
+	m_table = new QTableWidget(0, 5, this);
+	m_table->setHorizontalHeaderLabels({
+		tr("Texte", "column title"),
+		tr("Couleur", "column title"),
+		tr("Bicolore", "column title"),
+		tr("Couleur 2", "column title"),
+		QString()
+	});
+	m_table->horizontalHeader()->setSectionResizeMode(COL_TEXT, QHeaderView::Stretch);
+	m_table->horizontalHeader()->setSectionResizeMode(COL_COLOR, QHeaderView::ResizeToContents);
+	m_table->horizontalHeader()->setSectionResizeMode(COL_BICOLOR, QHeaderView::ResizeToContents);
+	m_table->horizontalHeader()->setSectionResizeMode(COL_COLOR_2, QHeaderView::ResizeToContents);
+	m_table->horizontalHeader()->setSectionResizeMode(COL_REMOVE, QHeaderView::ResizeToContents);
+	m_table->verticalHeader()->setVisible(false);
+	m_table->setEditTriggers(QAbstractItemView::AllEditTriggers);
+	m_table->setSelectionMode(QAbstractItemView::NoSelection);
+	vlayout->addWidget(m_table);
+
+	auto *add_button = new QPushButton(QET::Icons::Add, tr("Ajouter une association"), this);
+	connect(add_button, &QPushButton::clicked, this, &ConductorColorRulesW::addRow);
+
+	auto *save_button = new QPushButton(tr("Enregistrer"), this);
+	connect(save_button, &QPushButton::clicked, this, &ConductorColorRulesW::save);
+
+	auto *bottom_layout = new QHBoxLayout();
+	bottom_layout->addWidget(add_button);
+	bottom_layout->addStretch();
+	bottom_layout->addWidget(save_button);
+	vlayout->addLayout(bottom_layout);
+
+	setLayout(vlayout);
+
+	populateTable();
+}
+
+/**
+	@brief ConductorColorRulesW::populateTable
+	Fill the table with one row per rule currently persisted in the
+	project's conductorColorRules() map.
+*/
+void ConductorColorRulesW::populateTable()
+{
+	const QHash<QString, ConductorColorRule> rules = m_project->conductorColorRules();
+	for (auto it = rules.constBegin(); it != rules.constEnd(); ++it) {
+		appendRow(it.key(), it.value().color, it.value().m_bicolor, it.value().color_2);
+	}
+}
+
+/**
+	@brief ConductorColorRulesW::appendRow
+	@param text
+	@param color
+	@param bicolor
+	@param color_2
+*/
+void ConductorColorRulesW::appendRow(const QString &text, const QColor &color, bool bicolor, const QColor &color_2)
+{
+	const int row = m_table->rowCount();
+	m_table->setRowCount(row + 1);
+
+	auto *text_edit = new QLineEdit(text, m_table);
+	m_table->setCellWidget(row, COL_TEXT, text_edit);
+
+	auto *color_button = new KColorButton(m_table);
+	color_button->setColor(color);
+	m_table->setCellWidget(row, COL_COLOR, color_button);
+
+	auto *color_2_button = new KColorButton(m_table);
+	color_2_button->setColor(color_2);
+	color_2_button->setEnabled(bicolor);
+	m_table->setCellWidget(row, COL_COLOR_2, color_2_button);
+
+	auto *bicolor_check = new QCheckBox(m_table);
+	bicolor_check->setChecked(bicolor);
+	connect(bicolor_check, &QCheckBox::toggled, color_2_button, &QWidget::setEnabled);
+	auto *bicolor_cell = new QWidget(m_table);
+	auto *bicolor_layout = new QHBoxLayout(bicolor_cell);
+	bicolor_layout->addWidget(bicolor_check);
+	bicolor_layout->setAlignment(Qt::AlignCenter);
+	bicolor_layout->setContentsMargins(0, 0, 0, 0);
+	m_table->setCellWidget(row, COL_BICOLOR, bicolor_cell);
+
+	auto *remove_button = new QToolButton(m_table);
+	remove_button->setIcon(QET::Icons::EditTableDeleteRow);
+	remove_button->setToolTip(tr("Supprimer cette association"));
+	connect(remove_button, &QToolButton::clicked, this, &ConductorColorRulesW::removeRow);
+	m_table->setCellWidget(row, COL_REMOVE, remove_button);
+}
+
+/**
+	@brief ConductorColorRulesW::addRow
+	Add a fresh, blank row for the user to fill in.
+*/
+void ConductorColorRulesW::addRow()
+{
+	appendRow(QString(), QColor(Qt::black), false, QColor(Qt::black));
+}
+
+/**
+	@brief ConductorColorRulesW::removeRow
+	Remove whichever row owns the remove button that was clicked. Found by
+	looking the sender up in the remove-button column rather than tracked
+	per-button state, so nothing has to be kept in sync as rows are added
+	and removed around it -- same approach as SpaceMouseConfigPage's own
+	row removal.
+*/
+void ConductorColorRulesW::removeRow()
+{
+	auto *button = qobject_cast<QToolButton *>(sender());
+	if (!button) {
+		return;
+	}
+	for (int row = 0; row < m_table->rowCount(); ++row) {
+		if (m_table->cellWidget(row, COL_REMOVE) == button) {
+			m_table->removeRow(row);
+			return;
+		}
+	}
+}
+
+/**
+	@brief ConductorColorRulesW::save
+	Persist exactly what the table currently shows to the project. A row
+	with empty text is skipped -- an unnamed rule can never match a
+	resolved label, so keeping it would be silent dead weight rather than
+	a rule the user actually meant to configure.
+*/
+void ConductorColorRulesW::save()
+{
+	QHash<QString, ConductorColorRule> rules;
+
+	for (int row = 0; row < m_table->rowCount(); ++row)
+	{
+		auto *text_edit    = qobject_cast<QLineEdit *>(m_table->cellWidget(row, COL_TEXT));
+		auto *color_button = qobject_cast<KColorButton *>(m_table->cellWidget(row, COL_COLOR));
+		auto *bicolor_cell = m_table->cellWidget(row, COL_BICOLOR);
+		auto *bicolor_check = bicolor_cell ? bicolor_cell->findChild<QCheckBox *>() : nullptr;
+		auto *color_2_button = qobject_cast<KColorButton *>(m_table->cellWidget(row, COL_COLOR_2));
+		if (!text_edit || !color_button || !bicolor_check || !color_2_button) {
+			continue;
+		}
+
+		const QString text = text_edit->text().trimmed();
+		if (text.isEmpty()) {
+			continue;
+		}
+
+		rules.insert(text, ConductorColorRule(
+					color_button->color(),
+					bicolor_check->isChecked(),
+					color_2_button->color()));
+	}
+
+	m_project->setConductorColorRules(rules);
+	m_project->setModified(true);
+}

--- a/sources/autoNum/ui/conductorcolorrulesw.h
+++ b/sources/autoNum/ui/conductorcolorrulesw.h
@@ -1,0 +1,63 @@
+/*
+	Copyright 2006-2026 The QElectroTech Team
+	This file is part of QElectroTech.
+
+	QElectroTech is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 2 of the License, or
+	(at your option) any later version.
+
+	QElectroTech is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with QElectroTech.  If not, see <http://www.gnu.org/licenses/>.
+*/
+#ifndef CONDUCTORCOLORRULESW_H
+#define CONDUCTORCOLORRULESW_H
+
+#include <QWidget>
+
+class QETProject;
+class QTableWidget;
+class QToolButton;
+
+/**
+	@brief The ConductorColorRulesW class
+	Discussion #606 configuration UI: lists every entry of the project's
+	QETProject::conductorColorRules() map and lets the user add, edit and
+	remove them. One row per rule: the resolved label text it applies to,
+	its color, and an optional second stripe color for a dual-color rule
+	(e.g. "PE").
+
+	Modelled on SelectAutonumW, the sibling tab this sits next to in
+	ProjectAutoNumConfigPage: takes the QETProject in its constructor and
+	reads its own data from it, and only writes changes back to the
+	project when the user presses this widget's own save button -- exactly
+	like every other tab in that same page, none of which are gated by the
+	surrounding ConfigDialog's own OK button (see
+	ProjectAutoNumConfigPage::applyProjectConf(), deliberately empty).
+*/
+class ConductorColorRulesW : public QWidget
+{
+		Q_OBJECT
+
+	public:
+		explicit ConductorColorRulesW(QETProject *project, QWidget *parent = nullptr);
+
+	private slots:
+		void addRow();
+		void removeRow();
+		void save();
+
+	private:
+		void populateTable();
+		void appendRow(const QString &text, const QColor &color, bool bicolor, const QColor &color_2);
+
+		QETProject *m_project;
+		QTableWidget *m_table;
+};
+
+#endif // CONDUCTORCOLORRULESW_H

--- a/sources/conductorautonumerotation.cpp
+++ b/sources/conductorautonumerotation.cpp
@@ -16,6 +16,7 @@
 	along with QElectroTech.  If not, see <http://www.gnu.org/licenses/>.
 */
 #include "conductorautonumerotation.h"
+#include "conductorcolorrule.h"
 #include "qetproject.h"
 #include "QPropertyUndoCommand/qpropertyundocommand.h"
 #include "autoNum/assignvariables.h"
@@ -71,10 +72,35 @@ void ConductorAutoNumerotation::applyText(const QString& t)
 {
 	if (!m_conductor) return;
 
+		//Discussion #606: if t exactly matches a configured color rule --
+		//e.g. the numbering context resolved to the literal "L1" or "PE" --
+		//color follows text the same way text itself is set below, for
+		//m_conductor and for every conductor in conductor_list. Looked up
+		//once here rather than per-conductor since it does not depend on
+		//which conductor is being updated, only on the resolved label.
+	bool has_color_rule = false;
+	ConductorColorRule color_rule;
+	if (m_diagram && m_diagram->project())
+	{
+		const auto rules = m_diagram->project()->conductorColorRules();
+		auto it = rules.constFind(t);
+		if (it != rules.constEnd())
+		{
+			color_rule = it.value();
+			has_color_rule = true;
+		}
+	}
+
 	QVariant old_value, new_value;
 	ConductorProperties cp = m_conductor -> properties();
 	old_value.setValue(cp);
 	cp.text = t;
+	if (has_color_rule)
+	{
+		cp.color     = color_rule.color;
+		cp.m_color_2 = color_rule.color_2;
+		cp.m_bicolor = color_rule.m_bicolor;
+	}
 	new_value.setValue(cp);
 
 	QUndoCommand *undo = nullptr;
@@ -117,6 +143,12 @@ void ConductorAutoNumerotation::applyText(const QString& t)
 			ConductorProperties cp2 = cond -> properties();
 			old_value.setValue(cp2);
 			cp2.text = t;
+			if (has_color_rule)
+			{
+				cp2.color     = color_rule.color;
+				cp2.m_color_2 = color_rule.color_2;
+				cp2.m_bicolor = color_rule.m_bicolor;
+			}
 			new_value.setValue(cp2);
 			new QPropertyUndoCommand(
 						cond,

--- a/sources/conductorcolorrule.cpp
+++ b/sources/conductorcolorrule.cpp
@@ -1,0 +1,75 @@
+/*
+	Copyright 2006-2026 The QElectroTech Team
+	This file is part of QElectroTech.
+
+	QElectroTech is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 2 of the License, or
+	(at your option) any later version.
+
+	QElectroTech is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with QElectroTech.  If not, see <http://www.gnu.org/licenses/>.
+*/
+#include "conductorcolorrule.h"
+
+/**
+	@brief ConductorColorRule::toXml
+	@param xml_document : document used to create the returned element
+	@return a "color_rule" element. The caller sets the "text" attribute
+	(the key this rule is stored under) -- see QETProject::
+	writeDefaultPropertiesXml(), which mirrors how XRefProperties::toXml()
+	and its "type" attribute are handled the same way.
+*/
+QDomElement ConductorColorRule::toXml(QDomDocument &xml_document) const
+{
+	QDomElement e = xml_document.createElement(QStringLiteral("color_rule"));
+	e.setAttribute(QStringLiteral("color"),   color.name());
+	e.setAttribute(QStringLiteral("bicolor"), m_bicolor ? QStringLiteral("true") : QStringLiteral("false"));
+	e.setAttribute(QStringLiteral("color2"),  color_2.name());
+	return e;
+}
+
+/**
+	@brief ConductorColorRule::fromXml
+	@param xml_element
+*/
+void ConductorColorRule::fromXml(const QDomElement &xml_element)
+{
+	const QColor xml_color(xml_element.attribute(QStringLiteral("color")));
+	color = xml_color.isValid() ? xml_color : QColor(Qt::black);
+
+	m_bicolor = xml_element.attribute(QStringLiteral("bicolor")) == QLatin1String("true");
+
+	const QColor xml_color_2(xml_element.attribute(QStringLiteral("color2")));
+	color_2 = xml_color_2.isValid() ? xml_color_2 : QColor(Qt::black);
+}
+
+bool ConductorColorRule::operator==(const ConductorColorRule &other) const
+{
+	return color == other.color && color_2 == other.color_2 && m_bicolor == other.m_bicolor;
+}
+
+bool ConductorColorRule::operator!=(const ConductorColorRule &other) const
+{
+	return !(*this == other);
+}
+
+/**
+	@brief ConductorColorRule::defaultRules
+	@return see the declaration's doc comment
+*/
+QHash<QString, ConductorColorRule> ConductorColorRule::defaultRules()
+{
+	return {
+		{QStringLiteral("L1"), ConductorColorRule(QColor(0x8B, 0x45, 0x13), false)},
+		{QStringLiteral("L2"), ConductorColorRule(QColor(Qt::black),         false)},
+		{QStringLiteral("L3"), ConductorColorRule(QColor(Qt::gray),          false)},
+		{QStringLiteral("N"),  ConductorColorRule(QColor(Qt::blue),          false)},
+		{QStringLiteral("PE"), ConductorColorRule(QColor(0x00, 0x80, 0x00), true, QColor(0xFF, 0xD7, 0x00))},
+	};
+}

--- a/sources/conductorcolorrule.h
+++ b/sources/conductorcolorrule.h
@@ -1,0 +1,72 @@
+/*
+	Copyright 2006-2026 The QElectroTech Team
+	This file is part of QElectroTech.
+
+	QElectroTech is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 2 of the License, or
+	(at your option) any later version.
+
+	QElectroTech is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with QElectroTech.  If not, see <http://www.gnu.org/licenses/>.
+*/
+#ifndef CONDUCTORCOLORRULE_H
+#define CONDUCTORCOLORRULE_H
+
+#include <QColor>
+#include <QDomElement>
+#include <QHash>
+#include <QString>
+
+/**
+	@brief The ConductorColorRule class
+	Implements discussion #606: the color a conductor should be drawn in
+	when its auto-numbering-resolved label text exactly matches a
+	configured entry -- "L1" gets colored brown, "PE" gets colored
+	green/yellow, etc. One instance is one entry of the project-level
+	QHash<QString, ConductorColorRule> that mapping lives in (see
+	QETProject::conductorColorRules()); the QString key is the resolved
+	label text this rule applies to, not stored on the rule itself.
+
+	Deliberately just color + a second stripe color + whether the second
+	color is used at all -- the three ConductorProperties fields
+	(color/m_color_2/m_bicolor) that already exist for exactly this
+	purpose (conductor.cpp:545 draws the m_color_2 stripe only when
+	m_bicolor is set). Nothing new to teach the drawing code.
+*/
+class ConductorColorRule
+{
+	public:
+		ConductorColorRule() = default;
+		ConductorColorRule(const QColor &c, bool bicolor, const QColor &c2 = QColor(Qt::black)) :
+			color(c), color_2(c2), m_bicolor(bicolor) {}
+
+		QColor color   = QColor(Qt::black);
+		QColor color_2 = QColor(Qt::black);
+			/// Whether color_2 is drawn as a second stripe alongside color.
+			/// Mirrors ConductorProperties::m_bicolor exactly -- a
+			/// single-color rule (e.g. "L1") leaves this false and color_2
+			/// unused; a dual-color rule (e.g. "PE") sets it true.
+		bool m_bicolor = false;
+
+		QDomElement toXml(QDomDocument &xml_document) const;
+		void fromXml(const QDomElement &xml_element);
+
+		bool operator==(const ConductorColorRule &other) const;
+		bool operator!=(const ConductorColorRule &other) const;
+
+			/// One common phase/neutral/earth wiring color convention
+			/// (L1 brown, L2 black, L3 grey, N blue, PE green/yellow) as a
+			/// starting point for a new project -- not a claim of
+			/// regulatory correctness for any specific country or
+			/// standard, and every entry is user-editable and removable
+			/// once loaded into a project's rule set.
+		static QHash<QString, ConductorColorRule> defaultRules();
+};
+
+#endif // CONDUCTORCOLORRULE_H

--- a/sources/qetproject.cpp
+++ b/sources/qetproject.cpp
@@ -1687,7 +1687,7 @@ void QETProject::readDefaultPropertiesXml(QDomDocument &xml_project)
 	m_default_xref_properties	   = XRefProperties::      defaultProperties();
 
 		//Read values indicate in project
-	QDomElement border_elmt, titleblock_elmt, conductors_elmt, report_elmt, xref_elmt, conds_autonums, folio_autonums, element_autonums, guides_elmt;
+	QDomElement border_elmt, titleblock_elmt, conductors_elmt, report_elmt, xref_elmt, conds_autonums, conductor_colors_elmt, folio_autonums, element_autonums, guides_elmt;
 
 	for (QDomNode child = newdiagrams_elmt.firstChild() ; !child.isNull() ; child = child.nextSibling())
 	{
@@ -1706,6 +1706,8 @@ void QETProject::readDefaultPropertiesXml(QDomDocument &xml_project)
 			xref_elmt = child_elmt;
 		else if (child_elmt.tagName() == QLatin1String("conductors_autonums"))
 			conds_autonums = child_elmt;
+		else if (child_elmt.tagName() == QLatin1String("conductor_autonum_colors"))
+			conductor_colors_elmt = child_elmt;
 		else if (child_elmt.tagName()== QLatin1String("folio_autonums"))
 			folio_autonums = child_elmt;
 		else if (child_elmt.tagName()== QLatin1String("element_autonums"))
@@ -1737,6 +1739,23 @@ void QETProject::readDefaultPropertiesXml(QDomDocument &xml_project)
 			NumerotationContext nc;
 			nc.fromXml(elmt);
 			m_conductor_autonum.insert(elmt.attribute("title"), nc);
+		}
+	}
+		//Absent entirely in a project saved before discussion #606 --
+		//leave m_conductor_color_rules at its in-class default
+		//(ConductorColorRule::defaultRules()) rather than clearing it, so
+		//an old project still gets sensible starting colors rather than
+		//none at all. Present-but-empty (the user deleted every rule and
+		//saved) is different and is honoured: the loop below still runs
+		//and m_conductor_color_rules ends up genuinely empty.
+	if (!conductor_colors_elmt.isNull())
+	{
+		m_conductor_color_rules.clear();
+		for (auto elmt : QET::findInDomElement(conductor_colors_elmt, QStringLiteral("color_rule")))
+		{
+			ConductorColorRule rule;
+			rule.fromXml(elmt);
+			m_conductor_color_rules.insert(elmt.attribute(QStringLiteral("text")), rule);
 		}
 	}
 	if (!folio_autonums.isNull())
@@ -1867,6 +1886,16 @@ void QETProject::writeDefaultPropertiesXml(QDomElement &xml_element)
 		}
 	}
 	xml_element.appendChild(conductor_autonums);
+
+	//Export conductor auto-numbering color rules (discussion #606)
+	QDomElement conductor_colors_elmt = xml_document.createElement("conductor_autonum_colors");
+	for (auto it = m_conductor_color_rules.constBegin(); it != m_conductor_color_rules.constEnd(); ++it)
+	{
+		QDomElement rule_elmt = it.value().toXml(xml_document);
+		rule_elmt.setAttribute("text", it.key());
+		conductor_colors_elmt.appendChild(rule_elmt);
+	}
+	xml_element.appendChild(conductor_colors_elmt);
 
 	//Export Folio Autonums
 	QDomElement folio_autonums = xml_document.createElement("folio_autonums");

--- a/sources/qetproject.h
+++ b/sources/qetproject.h
@@ -22,6 +22,7 @@
 #include "NameList/nameslist.h"
 #include "project/projectpropertieshandler.h"
 #include "borderproperties.h"
+#include "conductorcolorrule.h"
 #include "conductorproperties.h"
 #include "dataBase/projectdatabase.h"
 #include "properties/reportproperties.h"
@@ -143,6 +144,18 @@ class QETProject : public QObject
 
 		XRefProperties					defaultXRefProperties (const QString &type) const {return m_default_xref_properties[type];}
 		QHash <QString, XRefProperties> defaultXRefProperties() const					  {return m_default_xref_properties;}
+
+			/// Discussion #606: value (resolved conductor auto-numbering
+			/// label text) -> color mapping. Consulted in
+			/// ConductorAutoNumerotation::applyText(), the single place an
+			/// auto-numbered conductor's resolved label is set.
+		QHash <QString, ConductorColorRule> conductorColorRules() const {return m_conductor_color_rules;}
+			/// Does not itself flag the project modified -- matches
+			/// setDefaultXRefProperties()'s own shape; the caller (the
+			/// configuration page) calls setModified(true) once after
+			/// applying the whole edited table, the same way that page
+			/// already does for its other tabs.
+		void setConductorColorRules(const QHash <QString, ConductorColorRule> &rules) {m_conductor_color_rules = rules;}
 		void setDefaultXRefProperties(const QString& type, const XRefProperties &properties);
 		void setDefaultXRefProperties(QHash <QString, XRefProperties> hash);
 
@@ -297,6 +310,9 @@ class QETProject : public QObject
 		QString m_default_report_properties = ReportProperties::defaultProperties();
 			/// Default xref properties
 		QHash <QString, XRefProperties> m_default_xref_properties = XRefProperties::defaultProperties();
+			/// Discussion #606: resolved conductor auto-numbering label
+			/// text -> color rule
+		QHash <QString, ConductorColorRule> m_conductor_color_rules = ConductorColorRule::defaultRules();
 			/// Embedded title block templates collection
 		TitleBlockTemplatesProjectCollection m_titleblocks_collection;
 			/// project-wide variables that will be made available to child diagrams

--- a/sources/ui/configpage/projectconfigpages.cpp
+++ b/sources/ui/configpage/projectconfigpages.cpp
@@ -19,6 +19,7 @@
 
 #include "../autoNum/numerotationcontext.h"
 #include "../autoNum/ui/autonumberingmanagementw.h"
+#include "../autoNum/ui/conductorcolorrulesw.h"
 #include "../autoNum/ui/folioautonumbering.h"
 #include "../autoNum/ui/formulaautonumberingw.h"
 #include "../autoNum/ui/selectautonumw.h"
@@ -336,7 +337,11 @@ void ProjectAutoNumConfigPage::initWidgets()
 		//Conductor tab
 	m_saw_conductor = new SelectAutonumW(1);
 	tab_widget->addTab(m_saw_conductor, tr("Conducteurs"));
-	
+
+		//Conductor color rules tab (discussion #606)
+	m_ccrw = new ConductorColorRulesW(project());
+	tab_widget->addTab(m_ccrw, tr("Couleurs des conducteurs"));
+
 		//Element tab
 	m_saw_element = new SelectAutonumW(0);
 	tab_widget->addTab(m_saw_element, tr("Eléments"));

--- a/sources/ui/configpage/projectconfigpages.h
+++ b/sources/ui/configpage/projectconfigpages.h
@@ -33,6 +33,7 @@ class SelectAutonumW;
 class FolioAutonumberingW;
 class FormulaAutonumberingW;
 class AutoNumberingManagementW;
+class ConductorColorRulesW;
 
 /**
 	@brief The ProjectConfigPage class
@@ -173,6 +174,7 @@ class ProjectAutoNumConfigPage : public ProjectConfigPage {
 		SelectAutonumW        *m_saw_element;
 		FolioAutonumberingW   *m_faw;
 		AutoNumberingManagementW *m_amw;
+		ConductorColorRulesW  *m_ccrw;
 
 };
 


### PR DESCRIPTION
Implements discussion #606: when conductor auto-numbering resolves a label text that matches a configured rule (e.g. "L1", "PE"), the conductor's color is set automatically — the same way its text already is — instead of every conductor needing recoloring by hand afterward.

## The single integration point

`ConductorAutoNumerotation::applyText(const QString& t)` is where every auto-numbered conductor's resolved label actually gets set. Checked before touching anything: it's called exactly once in the whole codebase, from `numerateNewConductor()`. So a lookup placed right next to the existing `cp.text = t` line reaches every auto-numbered conductor, applied identically to `m_conductor` and to every conductor in `conductor_list` — the same same-potential group whose text the existing code already keeps in sync.

`cp.color`, `cp.m_color_2` and `cp.m_bicolor` are exactly the three `ConductorProperties` fields `conductor.cpp:545` already reads to draw a conductor's line and its second stripe. Nothing new for the drawing code to learn.

## `ConductorColorRule` + `QETProject::conductorColorRules()`

A small class (`color`, `color_2`, `bicolor`) plus a project-level `QHash<QString, ConductorColorRule>`, persisted the same way `m_default_xref_properties` already is: an in-class default (`ConductorColorRule::defaultRules()` — one common phase/neutral/earth convention, not a claim of regulatory correctness for any specific country), read from a `<conductor_autonum_colors>` element alongside the existing `<conductors_autonums>`, and only replaced when that element is actually present — so a project saved before this feature keeps sensible built-in defaults rather than nothing.

## Configuration UI

A new **"Couleurs des conducteurs"** tab in `ProjectAutoNumConfigPage`, next to the existing "Conducteurs" tab. One row per rule: label text, a `KColorButton` for its color (the same picker class `conductorpropertieswidget.ui` already uses for conductor color), a bicolor checkbox, and a second `KColorButton` enabled only when bicolor is checked. Modelled on `SelectAutonumW`: applies via its own "Enregistrer" button, not gated by the surrounding dialog's OK — matching every sibling tab in that page (`applyProjectConf()` is deliberately empty; each tab applies itself).

## Verified

Built clean from a fresh configure, zero new warnings across all seven new/changed files.

Via a real Xvfb session:
- Config page renders with all five default rules in their real colors (L1 brown, L2 black, L3 grey, N blue, PE green + gold bicolor stripe).
- **Full persistence round trip through an actual project file**, not just the write path: saved a project, inspected the written XML directly (`<conductor_autonum_colors>` with five `<color_rule>` entries in the expected shape), hand-edited L1's color *in the file* to confirm the read path genuinely parses rather than reusing in-memory defaults, reopened the project, and confirmed the config page showed the hand-edited color — not the default — with everything else unchanged.
- Set up a numbering context resolving to the literal text "L1" and selected it as the diagram's active conductor auto-numbering scheme.

## What this could not verify

I could not get a live, on-canvas conductor auto-numbered end-to-end in this sandbox. Placing two connected elements requires drag-and-drop from the collection panel into the `QGraphicsView`, and this environment's synthetic X11 automation does not reliably trigger Qt's `QDrag`/XDND handshake — tried both a single-motion drag and a slow multi-step drag; no drag cursor or drop ever registered. That's a tooling limitation, not a code question: the one choke-point function this relies on was read in full and the change mirrors the existing, already-working text-assignment line for line, and every other part — the rule lookup's data source, the exact fields it writes, and their persistence — was independently verified above. Flagging the gap plainly rather than presenting a screenshot I don't have.

If anyone can try it against a real drag-and-drop session (or has a project file with two elements already wired), confirming the color actually paints on a live redraw would close that last gap.
