### PR TITLE
Configuration export/import for switching QET config profiles (discussion #610)

### DIFF
--- a/sources/qetapp.cpp
+++ b/sources/qetapp.cpp
@@ -45,9 +45,12 @@
 #include <iostream>
 #define QUOTE(x) STRINGIFY(x)
 #define STRINGIFY(x) #x
+#include <QFileDialog>
 #include <QFontDatabase>
+#include <QProcess>
 #include <QProcessEnvironment>
 #include <QRegularExpression>
+#include <QSettings>
 #ifdef BUILD_WITHOUT_KF5
 #	include "ui/nokde/kautosavefile.h"
 #else
@@ -2068,6 +2071,122 @@ void QETApp::configureQET()
 	// affiche le dialogue puis evite de le lier a un quelconque widget parent
 	cd.exec();
 	cd.setParent(nullptr, cd.windowFlags());
+}
+
+/**
+	@brief QETApp::exportConfiguration
+	Write every key of the live QSettings (organization/application
+	"QElectroTech", set in main.cpp -- the platform-native store: an ini
+	file on Linux, the registry on Windows, a plist on macOS) out to a
+	user-chosen .conf file, read back and written with
+	QSettings::IniFormat regardless of the live platform, so the exported
+	file has the same, plain key=value shape everywhere. That shared
+	format is what makes the resulting file portable between platforms,
+	and what lets exportConfiguration()/importConfiguration() share one
+	plain copy loop instead of needing per-platform code.
+*/
+void QETApp::exportConfiguration()
+{
+	QWidget *parent_widget = qApp->activeWindow();
+
+	QString path = QFileDialog::getSaveFileName(
+				parent_widget,
+				tr("Enregistrer la configuration sous...", "dialog title"),
+				QString(),
+				tr("Fichiers de configuration QElectroTech (*.conf)", "file dialog filter"));
+	if (path.isEmpty()) {
+		return;
+	}
+	if (!path.endsWith(QLatin1String(".conf"), Qt::CaseInsensitive)) {
+		path += QLatin1String(".conf");
+	}
+
+	QSettings live_settings;
+	QSettings file_settings(path, QSettings::IniFormat);
+	file_settings.clear();
+	const QStringList keys = live_settings.allKeys();
+	for (const QString &key : keys) {
+		file_settings.setValue(key, live_settings.value(key));
+	}
+	file_settings.sync();
+
+	if (file_settings.status() != QSettings::NoError) {
+		QET::QetMessageBox::critical(
+					parent_widget,
+					tr("Erreur", "message box title"),
+					tr("Impossible d'enregistrer la configuration dans « %1 ».").arg(path));
+	}
+}
+
+/**
+	@brief QETApp::importConfiguration
+	Replace every key of the live QSettings with the contents of a
+	user-chosen .conf file (see exportConfiguration()), then restart QET.
+
+	The live settings are cleared before copying the file's keys in, not
+	merged: a key present in the current configuration but absent from the
+	loaded file must not survive the switch, or loading a profile that
+	never mentions a given key would silently keep whatever the previous
+	profile set for it -- the opposite of what "switch profiles" means.
+
+	Restarting rather than reloading in place is a deliberate scope
+	decision (see discussion #610): QET has no settings-changed signal
+	reaching every consumer (shortcuts, autosave interval, docks...), so
+	faking a live reload would risk parts of the UI silently running on
+	stale settings. QET's SingleApplication is constructed with
+	allowSecondary=true (main.cpp), so a second instance can be started
+	before this one quits without racing a single-instance lock.
+*/
+void QETApp::importConfiguration()
+{
+	QWidget *parent_widget = qApp->activeWindow();
+
+	QString path = QFileDialog::getOpenFileName(
+				parent_widget,
+				tr("Charger une configuration...", "dialog title"),
+				QString(),
+				tr("Fichiers de configuration QElectroTech (*.conf)", "file dialog filter"));
+	if (path.isEmpty()) {
+		return;
+	}
+
+	QSettings file_settings(path, QSettings::IniFormat);
+	if (file_settings.status() != QSettings::NoError || file_settings.allKeys().isEmpty()) {
+		QET::QetMessageBox::critical(
+					parent_widget,
+					tr("Erreur", "message box title"),
+					tr("« %1 » n'est pas un fichier de configuration valide.").arg(path));
+		return;
+	}
+
+	QMessageBox::StandardButton answer = QET::QetMessageBox::question(
+				parent_widget,
+				tr("Charger une configuration", "message box title"),
+				tr("QElectroTech doit redémarrer pour appliquer cette configuration.\n"
+				   "Voulez-vous continuer ?"),
+				QMessageBox::Yes | QMessageBox::No,
+				QMessageBox::No);
+	if (answer != QMessageBox::Yes) {
+		return;
+	}
+
+		//closeEveryEditor() prompts to save any unsaved project, the same
+		//way quitQET() already does; a cancelled save must abort the whole
+		//operation, since the settings have not been touched yet at this point.
+	if (!QETApp::instance()->closeEveryEditor()) {
+		return;
+	}
+
+	QSettings live_settings;
+	live_settings.clear();
+	const QStringList keys = file_settings.allKeys();
+	for (const QString &key : keys) {
+		live_settings.setValue(key, file_settings.value(key));
+	}
+	live_settings.sync();
+
+	QProcess::startDetached(qApp->applicationFilePath(), QStringList());
+	qApp->quit();
 }
 
 /**

--- a/sources/qetapp.h
+++ b/sources/qetapp.h
@@ -270,6 +270,16 @@ class QETApp : public QObject
 		void openTitleBlockTemplate(const QString &);
 		void openTitleBlockTemplateFiles(const QStringList &);
 		void configureQET();
+			/// Discussion #610: write every key of the live QSettings out to a
+			/// user-chosen .conf file, so it can be handed to another machine
+			/// or kept as a named profile to reload later.
+		void exportConfiguration();
+			/// Discussion #610: replace the live QSettings with the contents
+			/// of a user-chosen .conf file, then restart QET so every
+			/// consumer of QSettings (shortcuts, docks, autosave interval...)
+			/// picks up the change -- QET has no settings-changed signal
+			/// wired through all of those, so a live reload isn't attempted.
+		void importConfiguration();
 		void aboutQET();
 		void receiveMessage(int instanceId, QByteArray message);
 	

--- a/sources/qetmainwindow.cpp
+++ b/sources/qetmainwindow.cpp
@@ -81,6 +81,18 @@ void QETMainWindow::initCommonActions()
 		}
 	});
 
+	export_config_action_ = new QAction(QET::Icons::DocumentExport, tr("Enregistrer la configuration sous..."), this);
+	export_config_action_ -> setStatusTip(tr("Enregistre la configuration actuelle de QElectroTech dans un fichier", "status bar tip"));
+	connect(export_config_action_, &QAction::triggered, [qet_app]() {
+		qet_app->exportConfiguration();
+	});
+
+	import_config_action_ = new QAction(QET::Icons::DocumentImport, tr("Charger une configuration..."), this);
+	import_config_action_ -> setStatusTip(tr("Charge une configuration depuis un fichier et redémarre QElectroTech", "status bar tip"));
+	connect(import_config_action_, &QAction::triggered, [qet_app]() {
+		qet_app->importConfiguration();
+	});
+
 	fullscreen_action_ = new QAction(this);
 	updateFullScreenAction();
 	connect(fullscreen_action_, SIGNAL(triggered()), this, SLOT(toggleFullScreen()));
@@ -146,6 +158,9 @@ void QETMainWindow::initCommonMenus()
 	settings_menu_ = new QMenu(tr("&Configuration", "window menu"), this);
 	settings_menu_ -> addAction(fullscreen_action_);
 	settings_menu_ -> addAction(configure_action_);
+	settings_menu_ -> addSeparator();
+	settings_menu_ -> addAction(export_config_action_);
+	settings_menu_ -> addAction(import_config_action_);
 	connect(settings_menu_, SIGNAL(aboutToShow()), this, SLOT(checkToolbarsmenu()));
 
 	help_menu_ = new QMenu(tr("&Aide", "window menu"), this);

--- a/sources/qetmainwindow.h
+++ b/sources/qetmainwindow.h
@@ -53,6 +53,8 @@ class QETMainWindow : public QMainWindow {
 	// attributes
 	protected:
 	QAction *configure_action_;              ///< Launch the QElectroTech configuration dialog
+	QAction *export_config_action_;          ///< Save the live configuration to a .conf file
+	QAction *import_config_action_;          ///< Load a .conf file and restart QET
 	QAction *fullscreen_action_;             ///< Toggle full screen
 	QAction *whatsthis_action_;              ///< Toggle "What's this" mode
 	QAction *about_qet_;                     ///< Launch the "About QElectroTech" dialog


### PR DESCRIPTION
Implements discussion #610: an in-app way to save and load QET configuration profiles, replacing the manual OS-settings-file-renaming workaround Nuri (a translator working with multiple clients) currently uses.

## Why `--config-dir` doesn't already solve this

Checked before writing anything: `QETApp::configDir()` (overridable via `--config-dir`) is only consulted for a handful of specific paths — element text patterns, the custom stylesheet, directory creation at startup. It never touches `QSettings`, which uses Qt's own OS-native backend (an ini file on Linux, the registry on Windows, a plist on macOS) tied to the organization/application name set in `main.cpp`. Shortcuts, autosave interval, recent files, UI layout — the bulk of actual preferences — aren't affected by `--config-dir` at all. Nuri's manual file-renaming workaround is genuinely the only option that exists today.

## What it adds

Two entries under `Configuration`: **"Enregistrer la configuration sous..."** and **"Charger une configuration..."**.

Both go through `QSettings(path, QSettings::IniFormat)` for the saved/loaded file specifically, regardless of the live backend on that platform — a plain key/value copy loop (`allKeys()` + `value()`/`setValue()`), identical code on Windows, Linux and macOS. Export writes every key from the live settings to a chosen file. Import **clears** the live settings first, then copies the file's keys in.

Clearing rather than merging is deliberate: a key present in the current configuration but absent from the loaded file must not survive the switch, or loading a profile that never mentions a given key would silently keep whatever the previous profile set for it — the opposite of what "switch profiles" means.

## Why restart, not live reload

QET has no settings-changed signal wired through every consumer (shortcuts, autosave timer, docks, etc.), so faking a live reload risks parts of the UI silently running on stale settings — worse than the restart the original forum request already said was acceptable. Import reuses the exact same `closeEveryEditor()` call `quitQET()` already uses, so an unsaved project still prompts to save, and a cancelled prompt aborts the whole import before the settings are touched.

The restart starts a detached second instance of the same executable, then quits the current one. Checked `SingleApplication`'s construction in `main.cpp` first: it's built with `allowSecondary=true`, so a second instance starting before the first fully exits doesn't race a single-instance lock.

## UI placement

Both actions live in `QETMainWindow`, the shared base every top-level QET window already builds its `&Configuration` menu from — so they appear consistently in the diagram editor and the element editor with no per-window wiring. Uses `DocumentImport` (already defined, previously unused anywhere) paired with the existing `DocumentExport`.

## Verified end-to-end via a real Xvfb session, not just a build

Built clean, zero new warnings.

Exported the live configuration and confirmed a clean round trip: 102 keys on both sides, plain ini format.

Then the actual scenario the discussion describes: closed QET cleanly, hand-edited a live setting on disk (`zoom-out-beyond-of-folio`, flipped to `true`) to simulate drift since the export, relaunched, used "Charger une configuration..." to load the earlier export (which had that key as `false`), confirmed the restart-confirmation dialog appears with the expected message, clicked Yes, and confirmed:
- the old process actually exited and a **new** one started (different PID, no `--config-dir` argument — a genuinely fresh launch, not the same process reusing its window)
- the setting on disk read back as `false` again — reverted to exactly what the loaded profile contained, not left at the drifted value.

## Not in this PR (per the discussion's own scope)

Live reload without restart, automatic per-client profile detection, and cloud sync/sharing infrastructure are all deliberately out of scope — sharing a profile with someone is already "hand them the file."
