### PR TITLE
Add adjustable background frame in the element editor (discussion #604)

### DIFF
--- a/sources/editor/elementscene.cpp
+++ b/sources/editor/elementscene.cpp
@@ -17,6 +17,7 @@
 */
 #include "elementscene.h"
 
+#include "../borderproperties.h"
 #include "../NameList/ui/namelistdialog.h"
 #include "../NameList/ui/namelistwidget.h"
 #include "../QPropertyUndoCommand/qpropertyundocommand.h"
@@ -73,6 +74,49 @@ ElementScene::ElementScene(QETElementEditor *editor, QObject *parent) :
 		this, SLOT(managePrimitivesGroups()));
 	connect(this, SIGNAL(selectionChanged()),
 			this, SLOT(managePrimitivesGroups()));
+
+	QSettings settings;
+	m_background_frame_visible = settings.value(
+			QStringLiteral("elementeditor/background_frame_visible"), false).toBool();
+	BorderProperties bp = BorderProperties::defaultProperties();
+	m_background_frame_size = QSizeF(
+			settings.value(QStringLiteral("elementeditor/background_frame_width"),
+						   bp.columns_count * bp.columns_width).toReal(),
+			settings.value(QStringLiteral("elementeditor/background_frame_height"),
+						   bp.rows_count * bp.rows_height).toReal());
+}
+
+/**
+	@brief ElementScene::setBackgroundFrameVisible
+	Toggle the visual-only background frame used to proportion this
+	element's drawing against a representative folio surface. Like the
+	hotspot indicator, this frame is never written to the saved .elmt file.
+	@param visible
+*/
+void ElementScene::setBackgroundFrameVisible(bool visible)
+{
+	if (m_background_frame_visible == visible) {
+		return;
+	}
+	m_background_frame_visible = visible;
+	QSettings().setValue(QStringLiteral("elementeditor/background_frame_visible"), visible);
+	update();
+}
+
+/**
+	@brief ElementScene::setBackgroundFrameSize
+	@param size the new size (in scene/grid units) of the background frame
+*/
+void ElementScene::setBackgroundFrameSize(const QSizeF &size)
+{
+	if (m_background_frame_size == size) {
+		return;
+	}
+	m_background_frame_size = size;
+	QSettings settings;
+	settings.setValue(QStringLiteral("elementeditor/background_frame_width"), size.width());
+	settings.setValue(QStringLiteral("elementeditor/background_frame_height"), size.height());
+	update();
 }
 
 /**

--- a/sources/editor/elementscene.h
+++ b/sources/editor/elementscene.h
@@ -90,6 +90,9 @@ class ElementScene : public QGraphicsScene
 		    m_y_grid;
 
 		QPointer<CustomElementGraphicPart> m_single_selected_item;
+
+		bool m_background_frame_visible = false;
+		QSizeF m_background_frame_size;
 	
 		// methods
 	public:
@@ -132,6 +135,11 @@ class ElementScene : public QGraphicsScene
 		QETElementEditor* editor() const;
 		void addItems(QVector<QGraphicsItem *> items);
 		void removeItems(QVector<QGraphicsItem *> items);
+
+		bool backgroundFrameVisible() const {return m_background_frame_visible;}
+		void setBackgroundFrameVisible(bool visible);
+		QSizeF backgroundFrameSize() const {return m_background_frame_size;}
+		void setBackgroundFrameSize(const QSizeF &size);
 	
 	protected:
 		void mouseMoveEvent         (QGraphicsSceneMouseEvent *) override;

--- a/sources/editor/elementview.cpp
+++ b/sources/editor/elementview.cpp
@@ -598,6 +598,19 @@ void ElementView::drawBackground(QPainter *p, const QRectF &r) {
 			}
 		}
 	}
+
+	if (m_scene->backgroundFrameVisible()) {
+		const QSizeF frame_size = m_scene->backgroundFrameSize();
+		const QRectF frame_rect(-frame_size.width() / 2.0, -frame_size.height() / 2.0,
+					 frame_size.width(), frame_size.height());
+		QPen frame_pen(Qt::blue);
+		frame_pen.setCosmetic(true);
+		frame_pen.setStyle(Qt::DashLine);
+		p -> setPen(frame_pen);
+		p -> setBrush(Qt::NoBrush);
+		p -> drawRect(frame_rect);
+	}
+
 	p -> restore();
 }
 

--- a/sources/editor/ui/qetelementeditor.cpp
+++ b/sources/editor/ui/qetelementeditor.cpp
@@ -53,6 +53,10 @@
 
 #include <QSettings>
 #include <QActionGroup>
+#include <QDialog>
+#include <QDialogButtonBox>
+#include <QDoubleSpinBox>
+#include <QFormLayout>
 
 /**
  * @brief QETElementEditor::QETElementEditor
@@ -1076,6 +1080,46 @@ void QETElementEditor::setupActions()
 	parts_toolbar -> setObjectName("parts");
 	parts_toolbar -> addActions(m_add_part_action_grp -> actions());
 	addToolBar(Qt::LeftToolBarArea, parts_toolbar);
+
+		//Background frame action: a visual-only reference rectangle, never
+		//written to the saved .elmt file, to help proportion the drawing
+		//against a representative folio surface.
+	auto *toggle_background_frame_action = new QAction(tr("Afficher le cadre de fond"), this);
+	toggle_background_frame_action -> setCheckable(true);
+	toggle_background_frame_action -> setChecked(m_elmt_scene -> backgroundFrameVisible());
+	connect(toggle_background_frame_action, &QAction::toggled, m_elmt_scene, &ElementScene::setBackgroundFrameVisible);
+	ShortcutManager::instance().registerAction(toggle_background_frame_action, "elementeditor.toggle_background_frame", tr("Éditeur d'élément"), QKeySequence());
+	ui->m_display_menu->addAction(toggle_background_frame_action);
+	ui->m_view_toolbar->addAction(toggle_background_frame_action);
+
+	auto *configure_background_frame_action = new QAction(tr("Taille du cadre de fond..."), this);
+	connect(configure_background_frame_action, &QAction::triggered, this, [this]() {
+		QDialog dialog(this);
+		dialog.setWindowTitle(tr("Taille du cadre de fond"));
+		auto *layout = new QFormLayout(&dialog);
+
+		auto *width_spin = new QDoubleSpinBox(&dialog);
+		width_spin -> setRange(1.0, 100000.0);
+		width_spin -> setSuffix(tr(" px"));
+		width_spin -> setValue(m_elmt_scene -> backgroundFrameSize().width());
+		layout -> addRow(tr("Largeur"), width_spin);
+
+		auto *height_spin = new QDoubleSpinBox(&dialog);
+		height_spin -> setRange(1.0, 100000.0);
+		height_spin -> setSuffix(tr(" px"));
+		height_spin -> setValue(m_elmt_scene -> backgroundFrameSize().height());
+		layout -> addRow(tr("Hauteur"), height_spin);
+
+		auto *buttons = new QDialogButtonBox(QDialogButtonBox::Ok | QDialogButtonBox::Cancel, &dialog);
+		connect(buttons, &QDialogButtonBox::accepted, &dialog, &QDialog::accept);
+		connect(buttons, &QDialogButtonBox::rejected, &dialog, &QDialog::reject);
+		layout -> addRow(buttons);
+
+		if (dialog.exec() == QDialog::Accepted) {
+			m_elmt_scene -> setBackgroundFrameSize(QSizeF(width_spin -> value(), height_spin -> value()));
+		}
+	});
+	ui->m_display_menu->addAction(configure_background_frame_action);
 }
 
 /**


### PR DESCRIPTION
Implements the scope proposed in discussion #604: https://github.com/qelectrotech/qelectrotech-source-mirror/discussions/604

## What this adds

A toggleable, visual-only background frame in the element editor, letting an element's drawing be proportioned directly against a realistic folio reference instead of a bare grid.

- Follows the exact precedent of the existing hotspot indicator (`ElementScene::drawForeground()`, `elementscene.cpp:318-333`): drawn in `ElementView::drawBackground()`, centered on the same origin, and never written to the saved `.elmt` XML.
- **"Afficher le cadre de fond"** toggles the frame on/off (menu + toolbar).
- **"Taille du cadre de fond..."** opens a small width/height dialog to resize it.
- Defaults to a representative folio's drawable area, derived from `BorderProperties::defaultProperties()` (`columns_count * columns_width` by `rows_count * rows_height` — 1020×640 out of the box), since element coordinates and diagram scene coordinates already share the same grid-unit space.
- Both the visibility and the last-used size persist via `QSettings`, the same way the existing grid-dot rendering prefs (`elementeditor/grid_pointsize_min`/`max`) already do — no reset between sessions.

## Testing

Built clean, no new warnings. Verified end-to-end in a real GUI session (Xvfb):
- Opened the element editor on an existing element, toggled the frame on, confirmed a dashed rectangle appears centered on the same origin as the hotspot crosshair, sized to the default 1020×640.
- Opened "Taille du cadre de fond...", changed it to 500×500, confirmed the drawn frame updates and stays centered on the origin.
- Fully quit and relaunched the element editor: confirmed the toggle was still on and the frame was still 500×500, restored from `QSettings` with no reconfiguration needed.
- Confirmed the element's `.elmt` file has zero diff and contains no trace of the frame — it's genuinely visual-only, like the hotspot marker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)