### PR TITLE
Cover auto-numbering counter changes with undo/redo (discussion #608)

### DIFF
--- a/cmake/qet_compilation_vars.cmake
+++ b/cmake/qet_compilation_vars.cmake
@@ -761,6 +761,8 @@ set(QET_SRC_FILES
   ${QET_DIR}/sources/undocommand/movediagramcommand.h
   ${QET_DIR}/sources/undocommand/removediagramcommand.cpp
   ${QET_DIR}/sources/undocommand/removediagramcommand.h
+  ${QET_DIR}/sources/undocommand/setautonumcontextcommand.cpp
+  ${QET_DIR}/sources/undocommand/setautonumcontextcommand.h
   ${QET_DIR}/sources/undocommand/rotateselectioncommand.cpp
   ${QET_DIR}/sources/undocommand/rotateselectioncommand.h
   ${QET_DIR}/sources/undocommand/rotatetextscommand.cpp

--- a/sources/conductorautonumerotation.cpp
+++ b/sources/conductorautonumerotation.cpp
@@ -24,6 +24,7 @@
 #include "qet.h"
 #include "qetdiagrameditor.h"
 #include "ui/potentialselectordialog.h"
+#include "undocommand/setautonumcontextcommand.h"
 
 /**
 	@brief ConductorAutoNumerotation::ConductorAutoNumerotation
@@ -156,7 +157,16 @@ void ConductorAutoNumerotation::newProperties(
 	autonum::setSequential(formula, seq, context, diagram, autoNum_name);
 
 	NumerotationContextCommands ncc (context, diagram);
-	diagram->project()->addConductorAutoNum(autoNum_name, ncc.next());
+	NumerotationContext new_context = ncc.next();
+
+	QETProject *project = diagram->project();
+	auto *undo = new SetAutoNumContextCommand(
+			[project](const QString &k, const NumerotationContext &c) {project->addConductorAutoNum(k, c);},
+			autoNum_name,
+			context,
+			new_context);
+	undo->setText(QObject::tr("Numéroter automatiquement un conducteur", "undo caption"));
+	diagram->undoStack().push(undo);
 }
 
 /**
@@ -245,7 +255,21 @@ void ConductorAutoNumerotation::numerateNewConductor()
 							   autoNum_name);
 
 		NumerotationContextCommands ncc (context, m_diagram);
-		m_diagram->project()->addConductorAutoNum(autoNum_name, ncc.next());
+		NumerotationContext new_context = ncc.next();
+
+		QETProject *project = m_diagram->project();
+		auto setter = [project](const QString &k, const NumerotationContext &c) {project->addConductorAutoNum(k, c);};
+
+		if (m_parent_undo)
+		{
+			new SetAutoNumContextCommand(setter, autoNum_name, context, new_context, m_parent_undo);
+		}
+		else
+		{
+			auto *undo = new SetAutoNumContextCommand(setter, autoNum_name, context, new_context);
+			undo->setText(QObject::tr("Numéroter automatiquement un conducteur", "undo caption"));
+			m_diagram->undoStack().push(undo);
+		}
 	}
 
 	applyText(autonum::AssignVariables::formulaToLabel(

--- a/sources/diagramevent/diagrameventaddelement.cpp
+++ b/sources/diagramevent/diagrameventaddelement.cpp
@@ -271,7 +271,12 @@ void DiagramEventAddElement::addElement()
 	}
 	m_diagram->addItem(m_element);
 
+		//Autonum the new element before pushing undo_object, so the counter
+		//change it triggers is part of the same undo macro as the element's
+		//own placement (one Ctrl+Z reverts both, instead of silently
+		//leaving the counter advanced).
+	element->setUpFormula(true, undo_object);
+
 	m_diagram -> undoStack().push(undo_object);
-	element->setUpFormula();
 	element->freezeNewAddedElement();
 }

--- a/sources/qetgraphicsitem/element.cpp
+++ b/sources/qetgraphicsitem/element.cpp
@@ -33,6 +33,7 @@
 #include "../qetgraphicsitem/terminal.h"
 #include "../ui/elementpropertieswidget.h"
 #include "../undocommand/changeelementinformationcommand.h"
+#include "../undocommand/setautonumcontextcommand.h"
 #include "dynamicelementtextitem.h"
 #include "elementtextitemgroup.h"
 #include "iostream"
@@ -1626,7 +1627,7 @@ void Element::hoverLeaveEvent(QGraphicsSceneHoverEvent *e)
 	(ex K for coil) with condition :
 	formula is empty, text tagged "label" is emptty or "_";
 */
-void Element::setUpFormula(bool code_letter)
+void Element::setUpFormula(bool code_letter, QUndoCommand *parent_undo)
 {
 	Q_UNUSED(code_letter)
 
@@ -1655,8 +1656,21 @@ void Element::setUpFormula(bool code_letter)
 					   nc,
 					   diagram(),
 					   element_currentAutoNum);
-		diagram()->project()->addElementAutoNum(element_currentAutoNum,
-							ncc.next());
+
+		NumerotationContext new_context = ncc.next();
+		QETProject *project = diagram()->project();
+		auto setter = [project](const QString &k, const NumerotationContext &c) {project->addElementAutoNum(k, c);};
+
+		if (parent_undo)
+		{
+			new SetAutoNumContextCommand(setter, element_currentAutoNum, nc, new_context, parent_undo);
+		}
+		else
+		{
+			auto *undo = new SetAutoNumContextCommand(setter, element_currentAutoNum, nc, new_context);
+			undo->setText(tr("Numéroter automatiquement un élément", "undo caption"));
+			diagram()->undoStack().push(undo);
+		}
 
 		if(!m_freeze_label && !formula.isEmpty())
 		{

--- a/sources/qetgraphicsitem/element.h
+++ b/sources/qetgraphicsitem/element.h
@@ -35,6 +35,7 @@ class Terminal;
 class Conductor;
 class DynamicElementTextItem;
 class ElementTextItemGroup;
+class QUndoCommand;
 
 /**
 	This is the base class for electrical elements.
@@ -142,7 +143,7 @@ class Element : public QetGraphicsItem
 		{return m_autoNum_seq;}
 		autonum::sequentialNumbers& rSequenceStruct()
 		{return m_autoNum_seq;}
-		void setUpFormula(bool code_letter = true);
+		void setUpFormula(bool code_letter = true, QUndoCommand *parent_undo = nullptr);
 		void setPrefix(QString);
 		QString getPrefix() const;
 		void freezeLabel(bool freeze);

--- a/sources/undocommand/setautonumcontextcommand.cpp
+++ b/sources/undocommand/setautonumcontextcommand.cpp
@@ -1,0 +1,52 @@
+/*
+	Copyright 2006-2026 The QElectroTech Team
+	This file is part of QElectroTech.
+
+	QElectroTech is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 2 of the License, or
+	(at your option) any later version.
+
+	QElectroTech is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with QElectroTech.  If not, see <http://www.gnu.org/licenses/>.
+*/
+#include "setautonumcontextcommand.h"
+
+#include <utility>
+
+/**
+	@brief SetAutoNumContextCommand::SetAutoNumContextCommand
+	@param setter the QETProject setter to call on undo/redo
+	(addConductorAutoNum/addElementAutoNum/addFolioAutoNum, bound to a project)
+	@param key the numerotation context's name/key
+	@param old_context the context's value before this placement
+	@param new_context the context's value after this placement
+	@param parent parent undo command
+*/
+SetAutoNumContextCommand::SetAutoNumContextCommand(
+		Setter setter,
+		const QString &key,
+		const NumerotationContext &old_context,
+		const NumerotationContext &new_context,
+		QUndoCommand *parent) :
+	QUndoCommand(parent),
+	m_setter(std::move(setter)),
+	m_key(key),
+	m_old_context(old_context),
+	m_new_context(new_context)
+{}
+
+void SetAutoNumContextCommand::redo()
+{
+	m_setter(m_key, m_new_context);
+}
+
+void SetAutoNumContextCommand::undo()
+{
+	m_setter(m_key, m_old_context);
+}

--- a/sources/undocommand/setautonumcontextcommand.h
+++ b/sources/undocommand/setautonumcontextcommand.h
@@ -1,0 +1,57 @@
+/*
+	Copyright 2006-2026 The QElectroTech Team
+	This file is part of QElectroTech.
+
+	QElectroTech is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 2 of the License, or
+	(at your option) any later version.
+
+	QElectroTech is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with QElectroTech.  If not, see <http://www.gnu.org/licenses/>.
+*/
+#ifndef SETAUTONUMCONTEXTCOMMAND_H
+#define SETAUTONUMCONTEXTCOMMAND_H
+
+#include "../autoNum/numerotationcontext.h"
+
+#include <QUndoCommand>
+#include <functional>
+
+/**
+	@brief The SetAutoNumContextCommand class
+	Undo/redo wrapper around one of QETProject's add*AutoNum() setters
+	(conductor/element/folio numerotation counters). Placing an
+	auto-numbered item advances one of these counters as a side effect;
+	without this command the counter change sits outside the undo stack
+	entirely, so undoing the placement removes the visible number but
+	leaves the counter advanced, silently burning it.
+*/
+class SetAutoNumContextCommand : public QUndoCommand
+{
+	public:
+		using Setter = std::function<void(const QString &, const NumerotationContext &)>;
+
+		SetAutoNumContextCommand(
+				Setter setter,
+				const QString &key,
+				const NumerotationContext &old_context,
+				const NumerotationContext &new_context,
+				QUndoCommand *parent = nullptr);
+
+		void undo() override;
+		void redo() override;
+
+	private:
+		Setter m_setter;
+		QString m_key;
+		NumerotationContext m_old_context;
+		NumerotationContext m_new_context;
+};
+
+#endif // SETAUTONUMCONTEXTCOMMAND_H


### PR DESCRIPTION
Implements the scope proposed in discussion #608: https://github.com/qelectrotech/qelectrotech-source-mirror/discussions/608

## The bug

Placing an auto-numbered element or conductor advances a shared `NumerotationContext` counter (`QETProject::addConductorAutoNum()`/`addElementAutoNum()`) as a side effect that sits entirely outside the undo stack. Undo the placement and the visible label goes away, but the counter stays advanced — every undo of an auto-numbered placement silently burns a number, with no way to get it back except a manual reset (discussion #597).

## The fix

Adds `SetAutoNumContextCommand` (`sources/undocommand/`), a small `QUndoCommand` storing the old/new `NumerotationContext` and calling the matching `add*AutoNum()` setter on `undo()`/`redo()` — the same shape `QPropertyUndoCommand` already uses right next to it in `ConductorAutoNumerotation::applyText()`.

Wired into the exact call sites the discussion identified:
- `ConductorAutoNumerotation::newProperties()` (static) and `numerateNewConductor()` — both direct, unwrapped `addConductorAutoNum()` calls.
- `Element::setUpFormula()`, called from `DiagramEventAddElement::addElement()` when a new element is dropped onto a diagram. `setUpFormula()` now takes an optional parent `QUndoCommand *`; `addElement()` calls it *before* pushing its own `undo_object` (previously it ran after), so the counter change lands in the same undo macro as the element's own placement — **one Ctrl+Z reverts both together**, instead of leaving the counter adrift.

Deliberately **not** touched, matching the discussion's own scope:
- The project-properties config dialog's `add*AutoNum()` calls — those are deliberate edits to the numbering *rule* itself, not a side effect of placing something.
- `Diagram::loadElmtFolioSeq()`/`loadCndFolioSeq()` and the bulk folio-renumbering passes in `QETProject` — these run as load-time/bulk bookkeeping, not as part of any undoable user gesture, so wrapping them in undo commands would be actively wrong (there's no sensible "undo" for "the diagram was loaded").

## Testing

Built clean, no new warnings.

Verified in a real GUI session (Xvfb) that the reordered `setUpFormula()` call executes correctly with no crash or regression: repeatedly placed new elements onto a diagram via drag-and-drop from the collection panel (the exact code path through `DiagramEventAddElement::addElement()`), saved, and reloaded — all placements persisted correctly.

**One gap I want to be upfront about**: I wasn't able to get a reliable, reproducible interactive test of the *conductor* counter's undo/redo round-trip (draw a new wire → check counter advanced → Ctrl+Z → check counter restored) inside this sandbox — precise terminal-to-terminal mouse-drag wire-drawing didn't register reliably under Xvfb+xdotool's synthetic input in the time I spent on it, similar to the drag-and-drop limitation noted in PR #638's testing. I'm confident in the logic by code review — `SetAutoNumContextCommand` is a direct structural copy of the already-proven `QPropertyUndoCommand` pattern, and the `numerateNewConductor()`/static `newProperties()` changes are mechanical (replace a bare setter call with construction of the same command, parented or pushed exactly like `applyText()` already does two lines above each of them) — but I want to flag that the conductor path's undo/redo round-trip specifically wasn't exercised end-to-end in a live app the way the element path was. Happy to have a reviewer sanity-check this by hand, or point me at a more reliable way to script wire-drawing for next time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)