### PR TITLE
IEC 81346 plant/location fallback and composite structure-id token (discussion #613)

### DIFF
--- a/sources/autoNum/assignvariables.cpp
+++ b/sources/autoNum/assignvariables.cpp
@@ -205,17 +205,52 @@ namespace autonum
 	/**
 		@brief AssignVariables::replaceVariable
 		Replace the variables in formula in form %{my-var}
-		to the corresponding value stored in dc
+		to the corresponding value stored in dc.
+		%{plant} and %{location} fall back to the containing diagram's
+		title block installation (=) / location (+) fields (IEC 81346)
+		when the element's own value is empty, so a project can set
+		these once at the folio level instead of on every element.
 		@param formula
 		@param dc
+		@param elmt the element the formula belongs to, if any;
+		used to resolve the diagram fallback above and the
+		%{prefix}/%{structure_id} tokens. May be null.
 		@return
 	*/
 	QString AssignVariables::replaceVariable(const QString &formula,
-						 const DiagramContext &dc)
+						 const DiagramContext &dc,
+						 const Element *elmt)
 	{
 		QString str = formula;
-		str.replace("%{label}", dc.value("label").toString());
-		str.replace("%{plant}", dc.value("plant").toString());
+
+		Diagram *diagram = elmt ? elmt->diagram() : nullptr;
+
+		QString plant_value = dc.value("plant").toString();
+		if (plant_value.isEmpty() && diagram)
+			plant_value = diagram->border_and_titleblock.plant();
+
+		QString location_value = dc.value("location").toString();
+		if (location_value.isEmpty() && diagram)
+			location_value = diagram->border_and_titleblock.locmach();
+
+		QString prefix_value = elmt ? elmt->getPrefix() : QString();
+		QString label_value = dc.value("label").toString();
+
+			//Composite IEC 81346 reference designation (=plant+location-label),
+			//each segment omitted when its underlying value is empty.
+		QString structure_id;
+		if (!plant_value.isEmpty())
+			structure_id += "=" + plant_value;
+		if (!location_value.isEmpty())
+			structure_id += "+" + location_value;
+		if (!label_value.isEmpty())
+			structure_id += "-" + label_value;
+
+		str.replace("%{label}", label_value);
+		str.replace("%{plant}", plant_value);
+		str.replace("%{location}", location_value);
+		str.replace("%{prefix}", prefix_value);
+		str.replace("%{structure_id}", structure_id);
 		str.replace("%{comment}", dc.value("comment").toString());
 		str.replace("%{description}", dc.value("description").toString());
 		str.replace("%{designation}", dc.value("designation").toString());
@@ -267,7 +302,6 @@ namespace autonum
 		
 		str.replace("%{machine_manufacturer_reference}", dc.value("machine_manufacturer_reference").toString());
 
-		str.replace("%{location}", dc.value("location").toString());
 		str.replace("%{function}", dc.value("function").toString());
 		str.replace("%{tension_protocol}", dc.value("tension_protocol").toString());
 		str.replace("%{conductor_section}", dc.value("conductor_section").toString());

--- a/sources/autoNum/assignvariables.h
+++ b/sources/autoNum/assignvariables.h
@@ -63,7 +63,7 @@ namespace autonum
 	{
 		public:
 			static QString formulaToLabel (QString formula, sequentialNumbers &seqStruct, Diagram *diagram, const Element *elmt = nullptr, const Conductor *cndr = nullptr);
-			static QString replaceVariable (const QString &formula, const DiagramContext &dc);
+			static QString replaceVariable (const QString &formula, const DiagramContext &dc, const Element *elmt = nullptr);
 			static QString genericXref (const Element *element);
 
 		private:

--- a/sources/qetgraphicsitem/dynamicelementtextitem.cpp
+++ b/sources/qetgraphicsitem/dynamicelementtextitem.cpp
@@ -367,8 +367,8 @@ void DynamicElementTextItem::setTextFrom(DynamicElementTextItem::TextFrom text_f
 			updateLabel();
 		}
 		else
-			setPlainText(autonum::AssignVariables::replaceVariable(m_composite_text, elementUseForInfo()->elementInformations()));
-		
+			setPlainText(autonum::AssignVariables::replaceVariable(m_composite_text, elementUseForInfo()->elementInformations(), elementUseForInfo()));
+
 		if(old_text_from == UserText)
 			connect(elementUseForInfo(), &Element::elementInfoChange, this, &DynamicElementTextItem::elementInfoChanged);
 	}
@@ -501,9 +501,9 @@ void DynamicElementTextItem::setCompositeText(const QString &text)
 		DiagramContext dc;
 		if(elementUseForInfo())
 			dc = elementUseForInfo()->elementInformations();
-		setPlainText(autonum::AssignVariables::replaceVariable(m_composite_text, dc));
+		setPlainText(autonum::AssignVariables::replaceVariable(m_composite_text, dc, elementUseForInfo()));
 	}
-	
+
 	emit compositeTextChanged(m_composite_text);
 }
 
@@ -830,7 +830,7 @@ void DynamicElementTextItem::elementInfoChanged()
 		if (m_composite_text.contains("%{label}"))
 			setupFormulaConnection();
 		
-		final_text = autonum::AssignVariables::replaceVariable(m_composite_text, dc);
+		final_text = autonum::AssignVariables::replaceVariable(m_composite_text, dc, element);
 	}
 	else if (m_text_from  == UserText)
 		final_text = m_text;
@@ -1091,7 +1091,7 @@ void DynamicElementTextItem::updateLabel()
 			setPlainText(element->actualLabel());
 		}
 		else if (m_text_from == CompositeText) {
-			setPlainText(autonum::AssignVariables::replaceVariable(m_composite_text, dc));
+			setPlainText(autonum::AssignVariables::replaceVariable(m_composite_text, dc, element));
 		}
 	}
 }

--- a/sources/ui/compositetexteditdialog.cpp
+++ b/sources/ui/compositetexteditdialog.cpp
@@ -73,6 +73,14 @@ void CompositeTextEditDialog::setUpComboBox(bool is_report)
 		ui -> m_info_cb -> addItem(QETInformation::translatedInfoKey(qstrl[i]),
 								   is_report ? QETInformation::folioReportInfoToVar(qstrl[i]) : QETInformation::elementInfoToVar(qstrl[i]));
 	}
+
+		//Synthetic tokens computed by AssignVariables::replaceVariable() rather
+		//than stored directly in the element's info; not part of elementInfoKeys().
+	if (!is_report)
+	{
+		ui -> m_info_cb -> addItem(tr("Préfixe (-)"), QStringLiteral("%{prefix}"));
+		ui -> m_info_cb -> addItem(tr("Désignation IEC 81346 (=+-)"), QStringLiteral("%{structure_id}"));
+	}
 }
 
 void CompositeTextEditDialog::on_m_info_cb_activated(const QString &arg1)

--- a/sources/ui/dynamicelementtextmodel.cpp
+++ b/sources/ui/dynamicelementtextmodel.cpp
@@ -203,7 +203,7 @@ QList<QStandardItem *> DynamicElementTextModel::itemsForText(
 	QStandardItem *compositea = new QStandardItem(deti->compositeText().isEmpty()
 						      ? tr("Mon texte composé")
 						      : autonum::AssignVariables::replaceVariable(
-								deti->compositeText(), dc));
+								deti->compositeText(), dc, deti->elementUseForInfo()));
 	compositea->setFlags(Qt::ItemIsSelectable
 			     | Qt::ItemIsEnabled
 			     | Qt::ItemIsEditable);
@@ -1327,7 +1327,7 @@ void DynamicElementTextModel::itemDataChanged(QStandardItem *qsi)
 			{
 				enableSourceText(deti, DynamicElementTextItem::CompositeText);
 				QString compo = text_qsi->child(compo_txt_row,1)->data(Qt::UserRole+2).toString();
-				text_qsi->setData(autonum::AssignVariables::replaceVariable(compo, dc), Qt::DisplayRole);
+				text_qsi->setData(autonum::AssignVariables::replaceVariable(compo, dc, deti->elementUseForInfo()), Qt::DisplayRole);
 			}
 			
 			
@@ -1832,7 +1832,7 @@ void DynamicTextItemDelegate::setModelData(
 						DiagramContext dc;
 						if(deti->elementUseForInfo())
 							dc = deti->elementUseForInfo()->elementInformations();
-						assigned_text = autonum::AssignVariables::replaceVariable(edited_text, dc);
+						assigned_text = autonum::AssignVariables::replaceVariable(edited_text, dc, deti->elementUseForInfo());
 					}
 					
 					qsi->setData(assigned_text, Qt::DisplayRole);


### PR DESCRIPTION
Implements discussion #613: https://github.com/qelectrotech/qelectrotech-source-mirror/discussions/613

## What I found before implementing

I checked the discussion's claims against the current codebase, since it makes specific claims about what's wired up. One claim doesn't hold: the diagram's Installation (=) / Localisation (+) (`DIA_PLANT`/`DIA_LOCMACH`, `BorderTitleBlock::plant()`/`locmach()`) are **not** "never read anywhere else besides a tooltip" — they're already substituted via `%M`/`%LM` in element auto-numbering formulas (`assignvariables.cpp`), so a label formula like `=%M+%LM-%prefix%id` already works today.

The real, narrower gap: nothing connects the diagram's plant/location to an element's **own** `%{plant}`/`%{location}` composite-text tokens (a separate, independent field per element), and no composite-text token could reference the diagram's values or the element's prefix at all.

## What this PR does

`AssignVariables::replaceVariable()` (`sources/autoNum/assignvariables.cpp/.h`) gains an optional `const Element *elmt = nullptr` parameter:

- **Fallback**: `%{plant}` / `%{location}` resolve to the diagram's title block values when the element's own field is empty. Three-tier priority: manual element value → diagram value → empty.
- **`%{prefix}`**: exposes `Element::getPrefix()` to the composite-text system (previously only available as `%prefix` in the separate auto-numbering label-formula system, not in `%{...}` composite text).
- **`%{structure_id}`**: assembles `=plant+location-label`, omitting any segment whose value is empty. Deliberately uses the element's resolved *label* rather than `prefix+label` — in normal QET usage the auto-num formula already bakes the prefix into the label (e.g. "Q3"), so appending the prefix again would double it for the common case. Left the deeper multi-level/hierarchical case (`=E1.1+A2.3`) out of scope, matching the discussion's own stated scope.

All 9 call sites of `replaceVariable()` were checked individually. The 7 that place text on a diagram (`dynamicelementtextitem.cpp` x3, `dynamicelementtextmodel.cpp` x4) already had the `Element*` in scope and now pass it through. The 2 in `partdynamictextfield.cpp` run inside the *element editor* (composing a symbol, no diagram exists yet) and are intentionally left on the `nullptr` default.

`CompositeTextEditDialog`'s variable picker gets two new entries ("Préfixe (-)", "Désignation IEC 81346 (=+-)") so the tokens are discoverable, appended after the existing `elementInfoKeys()`-driven list since they're synthetic tokens computed by `replaceVariable()`, not real stored element info.

## Testing

Built clean (0 errors/warnings in the 5 changed files). Note: a *fresh* cmake configure in my sandbox mixes Qt5/Qt6 headers via the FetchContent-built KF5 addons (Qt6 dev packages are now also present in that environment) and fails to build the main target — confirmed this reproduces against unmodified `master` too, so it's a pre-existing environment issue, not something introduced here or that this PR needs to fix. Built against an already-Qt5-configured tree instead.

Verified live via Xvfb:
- Opened `examples/grafcet.qet`, set the folio's Installation/Localisation to `E1`/`A2`.
- Added a `%{structure_id}` composite text to an element with no plant/location of its own → rendered `=E1+A2` (label segment correctly omitted since empty for this element).
- Set the element's own Installation to `X9`, left Localisation empty → text updated live to `=X9+A2`: the element's override wins for Installation, the diagram fallback still applies to the untouched Localisation field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)