### PR TITLE
Page-match abbreviation for %{structure_id} + %{structure_id_full} token (discussion #649)

### DIFF
--- a/sources/autoNum/assignvariables.cpp
+++ b/sources/autoNum/assignvariables.cpp
@@ -210,11 +210,15 @@ namespace autonum
 		title block installation (=) / location (+) fields (IEC 81346)
 		when the element's own value is empty, so a project can set
 		these once at the folio level instead of on every element.
+		%{structure_id} is the resulting =plant+location-label designation,
+		reduced by dropping any =/+ segment that matches the diagram's own
+		title block (IEC 81346's allowance for a designation implied by
+		context); %{structure_id_full} is the same but never reduced.
 		@param formula
 		@param dc
 		@param elmt the element the formula belongs to, if any;
 		used to resolve the diagram fallback above and the
-		%{prefix}/%{structure_id} tokens. May be null.
+		%{prefix}/%{structure_id}/%{structure_id_full} tokens. May be null.
 		@return
 	*/
 	QString AssignVariables::replaceVariable(const QString &formula,
@@ -236,12 +240,29 @@ namespace autonum
 		QString prefix_value = elmt ? elmt->getPrefix() : QString();
 		QString label_value = dc.value("label").toString();
 
-			//Composite IEC 81346 reference designation (=plant+location-label),
+		QString diagram_plant = diagram ? diagram->border_and_titleblock.plant() : QString();
+		QString diagram_location = diagram ? diagram->border_and_titleblock.locmach() : QString();
+
+			//Full IEC 81346 reference designation (=plant+location-label),
 			//each segment omitted when its underlying value is empty.
-		QString structure_id;
+		QString structure_id_full;
 		if (!plant_value.isEmpty())
-			structure_id += "=" + plant_value;
+			structure_id_full += "=" + plant_value;
 		if (!location_value.isEmpty())
+			structure_id_full += "+" + location_value;
+		if (!label_value.isEmpty())
+			structure_id_full += "-" + label_value;
+
+			//Reduced form relative to the page (IEC 81346's own allowance for
+			//dropping higher-level parts already implied by context): the =/+
+			//segments are also omitted when they match the diagram's own title
+			//block, since #648's fallback already makes "no override" resolve
+			//to that value -- so this is the default for any device that
+			//doesn't explicitly belong to a different plant/location.
+		QString structure_id;
+		if (!plant_value.isEmpty() && plant_value != diagram_plant)
+			structure_id += "=" + plant_value;
+		if (!location_value.isEmpty() && location_value != diagram_location)
 			structure_id += "+" + location_value;
 		if (!label_value.isEmpty())
 			structure_id += "-" + label_value;
@@ -251,6 +272,7 @@ namespace autonum
 		str.replace("%{location}", location_value);
 		str.replace("%{prefix}", prefix_value);
 		str.replace("%{structure_id}", structure_id);
+		str.replace("%{structure_id_full}", structure_id_full);
 		str.replace("%{comment}", dc.value("comment").toString());
 		str.replace("%{description}", dc.value("description").toString());
 		str.replace("%{designation}", dc.value("designation").toString());

--- a/sources/autoNum/assignvariables.cpp
+++ b/sources/autoNum/assignvariables.cpp
@@ -205,17 +205,52 @@ namespace autonum
 	/**
 		@brief AssignVariables::replaceVariable
 		Replace the variables in formula in form %{my-var}
-		to the corresponding value stored in dc
+		to the corresponding value stored in dc.
+		%{plant} and %{location} fall back to the containing diagram's
+		title block installation (=) / location (+) fields (IEC 81346)
+		when the element's own value is empty, so a project can set
+		these once at the folio level instead of on every element.
 		@param formula
 		@param dc
+		@param elmt the element the formula belongs to, if any;
+		used to resolve the diagram fallback above and the
+		%{prefix}/%{structure_id} tokens. May be null.
 		@return
 	*/
 	QString AssignVariables::replaceVariable(const QString &formula,
-						 const DiagramContext &dc)
+						 const DiagramContext &dc,
+						 const Element *elmt)
 	{
 		QString str = formula;
-		str.replace("%{label}", dc.value("label").toString());
-		str.replace("%{plant}", dc.value("plant").toString());
+
+		Diagram *diagram = elmt ? elmt->diagram() : nullptr;
+
+		QString plant_value = dc.value("plant").toString();
+		if (plant_value.isEmpty() && diagram)
+			plant_value = diagram->border_and_titleblock.plant();
+
+		QString location_value = dc.value("location").toString();
+		if (location_value.isEmpty() && diagram)
+			location_value = diagram->border_and_titleblock.locmach();
+
+		QString prefix_value = elmt ? elmt->getPrefix() : QString();
+		QString label_value = dc.value("label").toString();
+
+			//Composite IEC 81346 reference designation (=plant+location-label),
+			//each segment omitted when its underlying value is empty.
+		QString structure_id;
+		if (!plant_value.isEmpty())
+			structure_id += "=" + plant_value;
+		if (!location_value.isEmpty())
+			structure_id += "+" + location_value;
+		if (!label_value.isEmpty())
+			structure_id += "-" + label_value;
+
+		str.replace("%{label}", label_value);
+		str.replace("%{plant}", plant_value);
+		str.replace("%{location}", location_value);
+		str.replace("%{prefix}", prefix_value);
+		str.replace("%{structure_id}", structure_id);
 		str.replace("%{comment}", dc.value("comment").toString());
 		str.replace("%{description}", dc.value("description").toString());
 		str.replace("%{designation}", dc.value("designation").toString());
@@ -267,7 +302,6 @@ namespace autonum
 		
 		str.replace("%{machine_manufacturer_reference}", dc.value("machine_manufacturer_reference").toString());
 
-		str.replace("%{location}", dc.value("location").toString());
 		str.replace("%{function}", dc.value("function").toString());
 		str.replace("%{tension_protocol}", dc.value("tension_protocol").toString());
 		str.replace("%{conductor_section}", dc.value("conductor_section").toString());

--- a/sources/autoNum/assignvariables.h
+++ b/sources/autoNum/assignvariables.h
@@ -63,7 +63,7 @@ namespace autonum
 	{
 		public:
 			static QString formulaToLabel (QString formula, sequentialNumbers &seqStruct, Diagram *diagram, const Element *elmt = nullptr, const Conductor *cndr = nullptr);
-			static QString replaceVariable (const QString &formula, const DiagramContext &dc);
+			static QString replaceVariable (const QString &formula, const DiagramContext &dc, const Element *elmt = nullptr);
 			static QString genericXref (const Element *element);
 
 		private:

--- a/sources/qetgraphicsitem/dynamicelementtextitem.cpp
+++ b/sources/qetgraphicsitem/dynamicelementtextitem.cpp
@@ -367,8 +367,8 @@ void DynamicElementTextItem::setTextFrom(DynamicElementTextItem::TextFrom text_f
 			updateLabel();
 		}
 		else
-			setPlainText(autonum::AssignVariables::replaceVariable(m_composite_text, elementUseForInfo()->elementInformations()));
-		
+			setPlainText(autonum::AssignVariables::replaceVariable(m_composite_text, elementUseForInfo()->elementInformations(), elementUseForInfo()));
+
 		if(old_text_from == UserText)
 			connect(elementUseForInfo(), &Element::elementInfoChange, this, &DynamicElementTextItem::elementInfoChanged);
 	}
@@ -501,9 +501,9 @@ void DynamicElementTextItem::setCompositeText(const QString &text)
 		DiagramContext dc;
 		if(elementUseForInfo())
 			dc = elementUseForInfo()->elementInformations();
-		setPlainText(autonum::AssignVariables::replaceVariable(m_composite_text, dc));
+		setPlainText(autonum::AssignVariables::replaceVariable(m_composite_text, dc, elementUseForInfo()));
 	}
-	
+
 	emit compositeTextChanged(m_composite_text);
 }
 
@@ -830,7 +830,7 @@ void DynamicElementTextItem::elementInfoChanged()
 		if (m_composite_text.contains("%{label}"))
 			setupFormulaConnection();
 		
-		final_text = autonum::AssignVariables::replaceVariable(m_composite_text, dc);
+		final_text = autonum::AssignVariables::replaceVariable(m_composite_text, dc, element);
 	}
 	else if (m_text_from  == UserText)
 		final_text = m_text;
@@ -1091,7 +1091,7 @@ void DynamicElementTextItem::updateLabel()
 			setPlainText(element->actualLabel());
 		}
 		else if (m_text_from == CompositeText) {
-			setPlainText(autonum::AssignVariables::replaceVariable(m_composite_text, dc));
+			setPlainText(autonum::AssignVariables::replaceVariable(m_composite_text, dc, element));
 		}
 	}
 }

--- a/sources/ui/compositetexteditdialog.cpp
+++ b/sources/ui/compositetexteditdialog.cpp
@@ -73,6 +73,14 @@ void CompositeTextEditDialog::setUpComboBox(bool is_report)
 		ui -> m_info_cb -> addItem(QETInformation::translatedInfoKey(qstrl[i]),
 								   is_report ? QETInformation::folioReportInfoToVar(qstrl[i]) : QETInformation::elementInfoToVar(qstrl[i]));
 	}
+
+		//Synthetic tokens computed by AssignVariables::replaceVariable() rather
+		//than stored directly in the element's info; not part of elementInfoKeys().
+	if (!is_report)
+	{
+		ui -> m_info_cb -> addItem(tr("Préfixe (-)"), QStringLiteral("%{prefix}"));
+		ui -> m_info_cb -> addItem(tr("Désignation IEC 81346 (=+-)"), QStringLiteral("%{structure_id}"));
+	}
 }
 
 void CompositeTextEditDialog::on_m_info_cb_activated(const QString &arg1)

--- a/sources/ui/compositetexteditdialog.cpp
+++ b/sources/ui/compositetexteditdialog.cpp
@@ -80,6 +80,7 @@ void CompositeTextEditDialog::setUpComboBox(bool is_report)
 	{
 		ui -> m_info_cb -> addItem(tr("Préfixe (-)"), QStringLiteral("%{prefix}"));
 		ui -> m_info_cb -> addItem(tr("Désignation IEC 81346 (=+-)"), QStringLiteral("%{structure_id}"));
+		ui -> m_info_cb -> addItem(tr("Désignation IEC 81346 complète (=+-)"), QStringLiteral("%{structure_id_full}"));
 	}
 }
 

--- a/sources/ui/dynamicelementtextmodel.cpp
+++ b/sources/ui/dynamicelementtextmodel.cpp
@@ -203,7 +203,7 @@ QList<QStandardItem *> DynamicElementTextModel::itemsForText(
 	QStandardItem *compositea = new QStandardItem(deti->compositeText().isEmpty()
 						      ? tr("Mon texte composé")
 						      : autonum::AssignVariables::replaceVariable(
-								deti->compositeText(), dc));
+								deti->compositeText(), dc, deti->elementUseForInfo()));
 	compositea->setFlags(Qt::ItemIsSelectable
 			     | Qt::ItemIsEnabled
 			     | Qt::ItemIsEditable);
@@ -1327,7 +1327,7 @@ void DynamicElementTextModel::itemDataChanged(QStandardItem *qsi)
 			{
 				enableSourceText(deti, DynamicElementTextItem::CompositeText);
 				QString compo = text_qsi->child(compo_txt_row,1)->data(Qt::UserRole+2).toString();
-				text_qsi->setData(autonum::AssignVariables::replaceVariable(compo, dc), Qt::DisplayRole);
+				text_qsi->setData(autonum::AssignVariables::replaceVariable(compo, dc, deti->elementUseForInfo()), Qt::DisplayRole);
 			}
 			
 			
@@ -1832,7 +1832,7 @@ void DynamicTextItemDelegate::setModelData(
 						DiagramContext dc;
 						if(deti->elementUseForInfo())
 							dc = deti->elementUseForInfo()->elementInformations();
-						assigned_text = autonum::AssignVariables::replaceVariable(edited_text, dc);
+						assigned_text = autonum::AssignVariables::replaceVariable(edited_text, dc, deti->elementUseForInfo());
 					}
 					
 					qsi->setData(assigned_text, Qt::DisplayRole);


### PR DESCRIPTION
Implements the page-match abbreviation half of discussion #649: https://github.com/qelectrotech/qelectrotech-source-mirror/discussions/649

**Stacked on #648** (this branch is built on top of that one, so the diff below includes its commit too — merge #648 first, this PR's diff then reduces to a single commit). The labeling-box exception from #649 is deliberately **not** part of this PR — that's a separate stacked follow-up on top of this one, kept independent so this smaller, self-contained piece can be reviewed and merged on its own.

## What this does

`%{structure_id}` (added in #648) now drops the `=`/`+` segments when they match the diagram's own title block plant/location — this is IEC 81346's own allowance for a reduced designation relative to a reference point, here the page. Because #648's fallback already makes "no override" resolve to the diagram's value, abbreviation becomes the automatic default for the common case (a device with no explicit plant/location of its own) with zero extra data entry. A device with an explicit, *different* plant/location still prints in full, so it's never mistaken for a local device.

`%{structure_id_full}` is a new token that always renders the complete, unabbreviated designation regardless of page context — for exports/BOM/nomenclature use where the canonical full designation is what's needed, independent of which page a device happens to be drawn on.

`CompositeTextEditDialog`'s variable picker gets the new token added alongside the existing one.

## Testing

Built clean (0 errors/warnings in the 2 changed files). Same pre-existing Qt5/Qt6 build-environment note as #648 applies here (this sandbox now has `qt6-base-dev` installed, which a *fresh* cmake configure mis-detects via the FetchContent-built KF5 addons) — worked around the same way, by reusing an already-Qt5-configured build tree.

Verified live via Xvfb against `examples/grafcet.qet`, folio Installation/Localisation set to `E1`/`A2`:
- Element with no plant/location of its own: `%{structure_id}` rendered **empty** (fully abbreviated — this grafcet element also has no label), `%{structure_id_full}` rendered `=E1+A2`.
- Element's own Installation set to `X9` (Localisation left empty): `%{structure_id}` rendered `=X9` (plant segment kept since it differs from the page; location segment still dropped since `A2` still matches the page), `%{structure_id_full}` rendered `=X9+A2`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)