### PR TITLE
Structure box: a labeling frame carrying its own IEC 81346 identity (discussion #649)

### DIFF
--- a/cmake/qet_compilation_vars.cmake
+++ b/cmake/qet_compilation_vars.cmake
@@ -292,6 +292,8 @@ set(QET_SRC_FILES
   ${QET_DIR}/sources/diagramevent/diagrameventaddimage.h
   ${QET_DIR}/sources/diagramevent/diagrameventaddshape.cpp
   ${QET_DIR}/sources/diagramevent/diagrameventaddshape.h
+  ${QET_DIR}/sources/diagramevent/diagrameventaddstructurebox.cpp
+  ${QET_DIR}/sources/diagramevent/diagrameventaddstructurebox.h
   ${QET_DIR}/sources/diagramevent/diagrameventaddtext.cpp
   ${QET_DIR}/sources/diagramevent/diagrameventaddtext.h
   ${QET_DIR}/sources/diagramevent/diagrameventinterface.cpp
@@ -492,6 +494,8 @@ set(QET_SRC_FILES
   ${QET_DIR}/sources/qetgraphicsitem/qetgraphicsitem.h
   ${QET_DIR}/sources/qetgraphicsitem/qetshapeitem.cpp
   ${QET_DIR}/sources/qetgraphicsitem/qetshapeitem.h
+  ${QET_DIR}/sources/qetgraphicsitem/structureboxitem.cpp
+  ${QET_DIR}/sources/qetgraphicsitem/structureboxitem.h
   ${QET_DIR}/sources/qetgraphicsitem/qgraphicsitemutility.cpp
   ${QET_DIR}/sources/qetgraphicsitem/qgraphicsitemutility.h
   ${QET_DIR}/sources/qetgraphicsitem/reportelement.cpp
@@ -721,6 +725,8 @@ set(QET_SRC_FILES
   ${QET_DIR}/sources/ui/reportpropertiewidget.h
   ${QET_DIR}/sources/ui/shapegraphicsitempropertieswidget.cpp
   ${QET_DIR}/sources/ui/shapegraphicsitempropertieswidget.h
+  ${QET_DIR}/sources/ui/structureboxpropertieswidget.cpp
+  ${QET_DIR}/sources/ui/structureboxpropertieswidget.h
   ${QET_DIR}/sources/ui/thirdpartybinaryinstalldialog.cpp
   ${QET_DIR}/sources/ui/thirdpartybinaryinstalldialog.h
   ${QET_DIR}/sources/ui/titleblockpropertieswidget.cpp

--- a/sources/autoNum/assignvariables.cpp
+++ b/sources/autoNum/assignvariables.cpp
@@ -231,17 +231,52 @@ namespace autonum
 	/**
 		@brief AssignVariables::replaceVariable
 		Replace the variables in formula in form %{my-var}
-		to the corresponding value stored in dc
+		to the corresponding value stored in dc.
+		%{plant} and %{location} fall back to the containing diagram's
+		title block installation (=) / location (+) fields (IEC 81346)
+		when the element's own value is empty, so a project can set
+		these once at the folio level instead of on every element.
 		@param formula
 		@param dc
+		@param elmt the element the formula belongs to, if any;
+		used to resolve the diagram fallback above and the
+		%{prefix}/%{structure_id} tokens. May be null.
 		@return
 	*/
 	QString AssignVariables::replaceVariable(const QString &formula,
-						 const DiagramContext &dc)
+						 const DiagramContext &dc,
+						 const Element *elmt)
 	{
 		QString str = formula;
-		str.replace("%{label}", dc.value("label").toString());
-		str.replace("%{plant}", dc.value("plant").toString());
+
+		Diagram *diagram = elmt ? elmt->diagram() : nullptr;
+
+		QString plant_value = dc.value("plant").toString();
+		if (plant_value.isEmpty() && diagram)
+			plant_value = diagram->border_and_titleblock.plant();
+
+		QString location_value = dc.value("location").toString();
+		if (location_value.isEmpty() && diagram)
+			location_value = diagram->border_and_titleblock.locmach();
+
+		QString prefix_value = elmt ? elmt->getPrefix() : QString();
+		QString label_value = dc.value("label").toString();
+
+			//Composite IEC 81346 reference designation (=plant+location-label),
+			//each segment omitted when its underlying value is empty.
+		QString structure_id;
+		if (!plant_value.isEmpty())
+			structure_id += "=" + plant_value;
+		if (!location_value.isEmpty())
+			structure_id += "+" + location_value;
+		if (!label_value.isEmpty())
+			structure_id += "-" + label_value;
+
+		str.replace("%{label}", label_value);
+		str.replace("%{plant}", plant_value);
+		str.replace("%{location}", location_value);
+		str.replace("%{prefix}", prefix_value);
+		str.replace("%{structure_id}", structure_id);
 		str.replace("%{comment}", dc.value("comment").toString());
 		str.replace("%{description}", dc.value("description").toString());
 		str.replace("%{designation}", dc.value("designation").toString());
@@ -293,7 +328,6 @@ namespace autonum
 		
 		str.replace("%{machine_manufacturer_reference}", dc.value("machine_manufacturer_reference").toString());
 
-		str.replace("%{location}", dc.value("location").toString());
 		str.replace("%{function}", dc.value("function").toString());
 		str.replace("%{tension_protocol}", dc.value("tension_protocol").toString());
 		str.replace("%{conductor_section}", dc.value("conductor_section").toString());

--- a/sources/autoNum/assignvariables.cpp
+++ b/sources/autoNum/assignvariables.cpp
@@ -22,11 +22,49 @@
 #include "../qetapp.h"
 #include "../qetgraphicsitem/conductor.h"
 #include "../qetgraphicsitem/element.h"
+#include "../qetgraphicsitem/structureboxitem.h"
 #include "../qetxml.h"
 #include "../qetproject.h"
 #include <QStringList>
 #include <QVariant>
 #include <utility>
+
+namespace {
+	/**
+		@brief enclosingStructureBox
+		@param elmt an element, possibly null
+		@return the smallest StructureBoxItem on elmt's diagram whose
+		geometry visually contains it, or nullptr if elmt is null, has no
+		diagram, or isn't inside any such box. When boxes are nested, the
+		smallest (most specific) one wins.
+	*/
+	const StructureBoxItem *enclosingStructureBox(const Element *elmt)
+	{
+		if (!elmt)
+			return nullptr;
+		Diagram *diagram = elmt->diagram();
+		if (!diagram)
+			return nullptr;
+
+		const StructureBoxItem *best = nullptr;
+		qreal best_area = -1;
+		const QPointF pos = elmt->sceneBoundingRect().center();
+		const auto items = diagram->items(pos);
+		for (QGraphicsItem *item : items)
+		{
+			if (item->type() != StructureBoxItem::Type)
+				continue;
+			auto box = static_cast<const StructureBoxItem *>(item);
+			const QRectF r = box->mapRectToScene(box->rect().normalized());
+			const qreal area = r.width() * r.height();
+			if (!best || area < best_area) {
+				best = box;
+				best_area = area;
+			}
+		}
+		return best;
+	}
+}
 
 namespace autonum
 {
@@ -232,18 +270,21 @@ namespace autonum
 		@brief AssignVariables::replaceVariable
 		Replace the variables in formula in form %{my-var}
 		to the corresponding value stored in dc.
-		%{plant} and %{location} fall back to the containing diagram's
-		title block installation (=) / location (+) fields (IEC 81346)
-		when the element's own value is empty, so a project can set
-		these once at the folio level instead of on every element.
+		%{plant} and %{location} fall back to a reference point's
+		installation (=) / location (+) fields (IEC 81346) when the
+		element's own value is empty, so a project can set these once
+		instead of on every element. The reference point is the nearest
+		enclosing StructureBoxItem the element is visually inside, or
+		the containing diagram's own title block if it's inside none
+		(discussion #649).
 		%{structure_id} is the resulting =plant+location-label designation,
-		reduced by dropping any =/+ segment that matches the diagram's own
-		title block (IEC 81346's allowance for a designation implied by
+		reduced by dropping any =/+ segment that matches the reference
+		point (IEC 81346's allowance for a designation implied by
 		context); %{structure_id_full} is the same but never reduced.
 		@param formula
 		@param dc
 		@param elmt the element the formula belongs to, if any;
-		used to resolve the diagram fallback above and the
+		used to resolve the reference-point fallback above and the
 		%{prefix}/%{structure_id}/%{structure_id_full} tokens. May be null.
 		@return
 	*/
@@ -255,43 +296,40 @@ namespace autonum
 
 		Diagram *diagram = elmt ? elmt->diagram() : nullptr;
 
+		QString reference_plant, reference_location;
+		if (diagram) {
+			reference_plant = diagram->border_and_titleblock.plant();
+			reference_location = diagram->border_and_titleblock.locmach();
+		}
+		if (const StructureBoxItem *box = enclosingStructureBox(elmt)) {
+			reference_plant = box->plant();
+			reference_location = box->location();
+		}
+
 		QString plant_value = dc.value("plant").toString();
-		if (plant_value.isEmpty() && diagram)
-			plant_value = diagram->border_and_titleblock.plant();
+		if (plant_value.isEmpty())
+			plant_value = reference_plant;
 
 		QString location_value = dc.value("location").toString();
-		if (location_value.isEmpty() && diagram)
-			location_value = diagram->border_and_titleblock.locmach();
+		if (location_value.isEmpty())
+			location_value = reference_location;
 
 		QString prefix_value = elmt ? elmt->getPrefix() : QString();
 		QString label_value = dc.value("label").toString();
 
-		QString diagram_plant = diagram ? diagram->border_and_titleblock.plant() : QString();
-		QString diagram_location = diagram ? diagram->border_and_titleblock.locmach() : QString();
+			//Full IEC 81346 reference designation (=plant+location-label).
+		QString structure_id_full = buildStructureId(plant_value, location_value, label_value);
 
-			//Full IEC 81346 reference designation (=plant+location-label),
-			//each segment omitted when its underlying value is empty.
-		QString structure_id_full;
-		if (!plant_value.isEmpty())
-			structure_id_full += "=" + plant_value;
-		if (!location_value.isEmpty())
-			structure_id_full += "+" + location_value;
-		if (!label_value.isEmpty())
-			structure_id_full += "-" + label_value;
-
-			//Reduced form relative to the page (IEC 81346's own allowance for
-			//dropping higher-level parts already implied by context): the =/+
-			//segments are also omitted when they match the diagram's own title
-			//block, since #648's fallback already makes "no override" resolve
-			//to that value -- so this is the default for any device that
-			//doesn't explicitly belong to a different plant/location.
-		QString structure_id;
-		if (!plant_value.isEmpty() && plant_value != diagram_plant)
-			structure_id += "=" + plant_value;
-		if (!location_value.isEmpty() && location_value != diagram_location)
-			structure_id += "+" + location_value;
-		if (!label_value.isEmpty())
-			structure_id += "-" + label_value;
+			//Reduced form relative to the reference point (IEC 81346's own
+			//allowance for dropping higher-level parts already implied by
+			//context): the =/+ segments are also omitted when they match it,
+			//since the fallback above already makes "no override" resolve to
+			//that value -- so this is the default for any device that doesn't
+			//explicitly belong to a different plant/location.
+		QString structure_id = buildStructureId(
+			plant_value != reference_plant ? plant_value : QString(),
+			location_value != reference_location ? location_value : QString(),
+			label_value);
 
 		str.replace("%{label}", label_value);
 		str.replace("%{plant}", plant_value);
@@ -463,6 +501,27 @@ namespace autonum
 			assignProjectVar();
 			assignSequence();
 		}
+	}
+
+	/**
+		@brief AssignVariables::buildStructureId
+		Assemble an IEC 81346 reference designation from its three aspects,
+		omitting any segment whose value is empty.
+		@param plant the "=" installation aspect
+		@param location the "+" location aspect
+		@param suffix the "-" product/component aspect
+		@return the assembled designation, e.g. "=E1+A2-K3"
+	*/
+	QString AssignVariables::buildStructureId(const QString &plant, const QString &location, const QString &suffix)
+	{
+		QString id;
+		if (!plant.isEmpty())
+			id += "=" + plant;
+		if (!location.isEmpty())
+			id += "+" + location;
+		if (!suffix.isEmpty())
+			id += "-" + suffix;
+		return id;
 	}
 
 	void AssignVariables::assignTitleBlockVar()

--- a/sources/autoNum/assignvariables.cpp
+++ b/sources/autoNum/assignvariables.cpp
@@ -236,11 +236,15 @@ namespace autonum
 		title block installation (=) / location (+) fields (IEC 81346)
 		when the element's own value is empty, so a project can set
 		these once at the folio level instead of on every element.
+		%{structure_id} is the resulting =plant+location-label designation,
+		reduced by dropping any =/+ segment that matches the diagram's own
+		title block (IEC 81346's allowance for a designation implied by
+		context); %{structure_id_full} is the same but never reduced.
 		@param formula
 		@param dc
 		@param elmt the element the formula belongs to, if any;
 		used to resolve the diagram fallback above and the
-		%{prefix}/%{structure_id} tokens. May be null.
+		%{prefix}/%{structure_id}/%{structure_id_full} tokens. May be null.
 		@return
 	*/
 	QString AssignVariables::replaceVariable(const QString &formula,
@@ -262,12 +266,29 @@ namespace autonum
 		QString prefix_value = elmt ? elmt->getPrefix() : QString();
 		QString label_value = dc.value("label").toString();
 
-			//Composite IEC 81346 reference designation (=plant+location-label),
+		QString diagram_plant = diagram ? diagram->border_and_titleblock.plant() : QString();
+		QString diagram_location = diagram ? diagram->border_and_titleblock.locmach() : QString();
+
+			//Full IEC 81346 reference designation (=plant+location-label),
 			//each segment omitted when its underlying value is empty.
-		QString structure_id;
+		QString structure_id_full;
 		if (!plant_value.isEmpty())
-			structure_id += "=" + plant_value;
+			structure_id_full += "=" + plant_value;
 		if (!location_value.isEmpty())
+			structure_id_full += "+" + location_value;
+		if (!label_value.isEmpty())
+			structure_id_full += "-" + label_value;
+
+			//Reduced form relative to the page (IEC 81346's own allowance for
+			//dropping higher-level parts already implied by context): the =/+
+			//segments are also omitted when they match the diagram's own title
+			//block, since #648's fallback already makes "no override" resolve
+			//to that value -- so this is the default for any device that
+			//doesn't explicitly belong to a different plant/location.
+		QString structure_id;
+		if (!plant_value.isEmpty() && plant_value != diagram_plant)
+			structure_id += "=" + plant_value;
+		if (!location_value.isEmpty() && location_value != diagram_location)
 			structure_id += "+" + location_value;
 		if (!label_value.isEmpty())
 			structure_id += "-" + label_value;
@@ -277,6 +298,7 @@ namespace autonum
 		str.replace("%{location}", location_value);
 		str.replace("%{prefix}", prefix_value);
 		str.replace("%{structure_id}", structure_id);
+		str.replace("%{structure_id_full}", structure_id_full);
 		str.replace("%{comment}", dc.value("comment").toString());
 		str.replace("%{description}", dc.value("description").toString());
 		str.replace("%{designation}", dc.value("designation").toString());

--- a/sources/autoNum/assignvariables.h
+++ b/sources/autoNum/assignvariables.h
@@ -69,6 +69,20 @@ namespace autonum
 			static QString replaceVariable (const QString &formula, const DiagramContext &dc, const Element *elmt = nullptr);
 			static QString genericXref (const Element *element);
 
+			/**
+				@brief buildStructureId
+				Assemble an IEC 81346 reference designation from its three
+				aspects, omitting any segment whose value is empty. Shared by
+				replaceVariable() (for %{structure_id}/%{structure_id_full})
+				and StructureBoxItem (for its own displayed identity).
+				@param plant the "=" installation aspect
+				@param location the "+" location aspect
+				@param suffix the "-" product/component aspect (an element's
+				label, or a structure box's own prefix)
+				@return the assembled designation, e.g. "=E1+A2-K3"
+			*/
+			static QString buildStructureId(const QString &plant, const QString &location, const QString &suffix);
+
 		private:
 			AssignVariables(const QString& formula, const sequentialNumbers& seqStruct , Diagram *diagram, const Element *elmt = nullptr, const Conductor *cndr = nullptr);
 			void assignTitleBlockVar();

--- a/sources/autoNum/assignvariables.h
+++ b/sources/autoNum/assignvariables.h
@@ -66,7 +66,7 @@ namespace autonum
 	{
 		public:
 			static QString formulaToLabel (QString formula, sequentialNumbers &seqStruct, Diagram *diagram, const Element *elmt = nullptr, const Conductor *cndr = nullptr);
-			static QString replaceVariable (const QString &formula, const DiagramContext &dc);
+			static QString replaceVariable (const QString &formula, const DiagramContext &dc, const Element *elmt = nullptr);
 			static QString genericXref (const Element *element);
 
 		private:

--- a/sources/diagram.cpp
+++ b/sources/diagram.cpp
@@ -35,6 +35,7 @@
 #include "qetgraphicsitem/elementtextitemgroup.h"
 #include "qetgraphicsitem/independenttextitem.h"
 #include "qetgraphicsitem/qetshapeitem.h"
+#include "qetgraphicsitem/structureboxitem.h"
 #include "qetgraphicsitem/terminal.h"
 #include "qetxml.h"
 #include "undocommand/addelementtextcommand.h"
@@ -946,6 +947,7 @@ QDomDocument Diagram::toXml(bool whole_content, bool is_copy_command) {
 	QVector<DiagramTextItem *> list_texts;
 	QVector<DiagramImageItem *> list_images;
 	QVector<QetShapeItem *> list_shapes;
+	QVector<StructureBoxItem *> list_structure_boxes;
 	QVector<QetGraphicsTableItem *> table_vector;
 	QVector<TerminalStripItem *> strip_vector;
 
@@ -995,6 +997,12 @@ QDomDocument Diagram::toXml(bool whole_content, bool is_copy_command) {
 				auto shape = static_cast<QetShapeItem *>(qgi);
 				if (whole_content || shape->isSelected())
 					list_shapes << shape;
+				break;
+			}
+			case StructureBoxItem::Type: {
+				auto box = static_cast<StructureBoxItem *>(qgi);
+				if (whole_content || box->isSelected())
+					list_structure_boxes << box;
 				break;
 			}
 			case QetGraphicsTableItem::Type: {
@@ -1060,6 +1068,14 @@ QDomDocument Diagram::toXml(bool whole_content, bool is_copy_command) {
 			dom_shapes.appendChild(dii -> toXml(document));
 		}
 		dom_root.appendChild(dom_shapes);
+	}
+
+	if (!list_structure_boxes.isEmpty()) {
+		auto dom_structure_boxes = document.createElement(QStringLiteral("structureBoxes"));
+		for (auto box : list_structure_boxes) {
+			dom_structure_boxes.appendChild(box -> toXml(document));
+		}
+		dom_root.appendChild(dom_structure_boxes);
 	}
 
 	if (table_vector.size()) {
@@ -1480,6 +1496,17 @@ bool Diagram::fromXml(QDomElement &document,
 		added_shapes << dii;
 	}
 
+		// Load structure box
+	QList<StructureBoxItem *> added_structure_boxes;
+	for (auto box_xml : QET::findInDomElement(root,
+												QStringLiteral("structureBoxes"),
+												StructureBoxItem::xmlTagName())) {
+		StructureBoxItem *box = new StructureBoxItem (QPointF(0,0));
+		box -> fromXml(box_xml);
+		addItem(box);
+		added_structure_boxes << box;
+	}
+
 		//Load tables
 	QVector<QetGraphicsTableItem *> added_tables;
 	for (const auto &dom_table : QETXML::subChild(root,
@@ -1501,6 +1528,7 @@ bool Diagram::fromXml(QDomElement &document,
 		QVector <QGraphicsItem *> added_items;
 		for (auto element : std::as_const(added_elements   )) added_items << element;
 		for (auto shape   : std::as_const(added_shapes     )) added_items << shape;
+		for (auto box     : std::as_const(added_structure_boxes)) added_items << box;
 		for (auto text    : std::as_const(added_texts      )) added_items << text;
 		for (auto image   : std::as_const(added_images     )) added_items << image;
 		for (auto table   : std::as_const(added_tables     )) added_items << table;

--- a/sources/diagramcontent.cpp
+++ b/sources/diagramcontent.cpp
@@ -27,6 +27,7 @@
 #include "qetgraphicsitem/elementtextitemgroup.h"
 #include "qetgraphicsitem/independenttextitem.h"
 #include "qetgraphicsitem/qetshapeitem.h"
+#include "qetgraphicsitem/structureboxitem.h"
 #include "qetgraphicsitem/terminal.h"
 #include "TerminalStrip/GraphicsItem/terminalstripitem.h"
 
@@ -89,6 +90,11 @@ DiagramContent::DiagramContent(Diagram *diagram, bool selected) :
 			}
 			case DiagramImageItem::Type:       { m_images        << qgraphicsitem_cast<DiagramImageItem *>(item);       break;}
 			case QetShapeItem::Type:           { m_shapes        << qgraphicsitem_cast<QetShapeItem *>(item);           break;}
+				//StructureBoxItem is a QetShapeItem subclass but reports its own
+				//type(), so it needs its own case here -- otherwise it falls
+				//through into no bucket and becomes impossible to cut, copy,
+				//paste or delete.
+			case StructureBoxItem::Type:       { m_shapes        << static_cast<QetShapeItem *>(item);                break;}
 			case DynamicElementTextItem::Type: { m_element_texts << qgraphicsitem_cast<DynamicElementTextItem *>(item); break;}
 			case QGraphicsItemGroup::Type: {
 				if (auto *group = dynamic_cast<ElementTextItemGroup *>(item)) {
@@ -208,6 +214,7 @@ bool DiagramContent::hasDeletableItems() const
 			|| qgi->type() == Conductor::Type
 			|| qgi->type() == IndependentTextItem::Type
 			|| qgi->type() == QetShapeItem::Type
+			|| qgi->type() == StructureBoxItem::Type
 			|| qgi->type() == DiagramImageItem::Type
 			|| qgi->type() == DynamicElementTextItem::Type
 			|| qgi->type() == QetGraphicsTableItem::Type

--- a/sources/diagramevent/diagrameventaddshape.cpp
+++ b/sources/diagramevent/diagrameventaddshape.cpp
@@ -76,7 +76,7 @@ void DiagramEventAddShape::mousePressEvent(QGraphicsSceneMouseEvent *event)
 			//Create shape item
 		if (!m_shape_item)
 		{
-			m_shape_item = new QetShapeItem(pos, pos, m_shape_type);
+			m_shape_item = createShapeItem(pos, pos, m_shape_type);
 			m_diagram->addItem (m_shape_item);
 			event->setAccepted(true);
 			return;
@@ -202,6 +202,19 @@ void DiagramEventAddShape::init()
 {
 	foreach (QGraphicsView *v, m_diagram->views())
 		v->setContextMenuPolicy(Qt::NoContextMenu);
+}
+
+/**
+	@brief DiagramEventAddShape::createShapeItem
+	@param p1
+	@param p2
+	@param shape_type
+	@return a new QetShapeItem to add to the diagram. Overridden by
+	subclasses that need a different QetShapeItem subclass instead.
+*/
+QetShapeItem *DiagramEventAddShape::createShapeItem(QPointF p1, QPointF p2, QetShapeItem::ShapeType shape_type)
+{
+	return new QetShapeItem(p1, p2, shape_type);
 }
 
 /**

--- a/sources/diagramevent/diagrameventaddshape.h
+++ b/sources/diagramevent/diagrameventaddshape.h
@@ -43,6 +43,11 @@ class DiagramEventAddShape : public DiagramEventInterface
 		void updateHelpCross (const QPointF &p);
 
 	protected:
+		//Factory hook so a subclass can create a different QetShapeItem
+		//subclass (e.g. StructureBoxItem) while reusing all the mouse
+		//handling below unchanged.
+		virtual QetShapeItem *createShapeItem(QPointF p1, QPointF p2, QetShapeItem::ShapeType shape_type);
+
 		QetShapeItem::ShapeType  m_shape_type;
 		QetShapeItem            *m_shape_item;
 		QGraphicsLineItem       *m_help_horiz, *m_help_verti;

--- a/sources/diagramevent/diagrameventaddstructurebox.cpp
+++ b/sources/diagramevent/diagrameventaddstructurebox.cpp
@@ -1,0 +1,31 @@
+/*
+	Copyright 2006-2026 The QElectroTech Team
+	This file is part of QElectroTech.
+
+	QElectroTech is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 2 of the License, or
+	(at your option) any later version.
+
+	QElectroTech is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with QElectroTech.  If not, see <http://www.gnu.org/licenses/>.
+*/
+#include "diagrameventaddstructurebox.h"
+
+#include "../qetgraphicsitem/structureboxitem.h"
+
+DiagramEventAddStructureBox::DiagramEventAddStructureBox(Diagram *diagram) :
+	DiagramEventAddShape(diagram, QetShapeItem::Rectangle)
+{
+}
+
+QetShapeItem *DiagramEventAddStructureBox::createShapeItem(QPointF p1, QPointF p2, QetShapeItem::ShapeType shape_type)
+{
+	Q_UNUSED(shape_type)
+	return new StructureBoxItem(p1, p2);
+}

--- a/sources/diagramevent/diagrameventaddstructurebox.h
+++ b/sources/diagramevent/diagrameventaddstructurebox.h
@@ -1,0 +1,40 @@
+/*
+	Copyright 2006-2026 The QElectroTech Team
+	This file is part of QElectroTech.
+
+	QElectroTech is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 2 of the License, or
+	(at your option) any later version.
+
+	QElectroTech is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with QElectroTech.  If not, see <http://www.gnu.org/licenses/>.
+*/
+#ifndef DIAGRAMEVENTADDSTRUCTUREBOX_H
+#define DIAGRAMEVENTADDSTRUCTUREBOX_H
+
+#include "diagrameventaddshape.h"
+
+/**
+	@brief The DiagramEventAddStructureBox class
+	Manages the creation of a StructureBoxItem: reuses DiagramEventAddShape's
+	drag-a-rectangle mouse handling unchanged, only overriding which item
+	class gets instantiated.
+*/
+class DiagramEventAddStructureBox : public DiagramEventAddShape
+{
+		Q_OBJECT
+
+	public:
+		explicit DiagramEventAddStructureBox(Diagram *diagram);
+
+	protected:
+		QetShapeItem *createShapeItem(QPointF p1, QPointF p2, QetShapeItem::ShapeType shape_type) override;
+};
+
+#endif // DIAGRAMEVENTADDSTRUCTUREBOX_H

--- a/sources/factory/propertieseditorfactory.cpp
+++ b/sources/factory/propertieseditorfactory.cpp
@@ -28,11 +28,13 @@
 #include "../qetgraphicsitem/elementtextitemgroup.h"
 #include "../qetgraphicsitem/independenttextitem.h"
 #include "../qetgraphicsitem/qetshapeitem.h"
+#include "../qetgraphicsitem/structureboxitem.h"
 #include "../ui/dynamicelementtextitemeditor.h"
 #include "../ui/elementpropertieswidget.h"
 #include "../ui/imagepropertieswidget.h"
 #include "../ui/inditextpropertieswidget.h"
 #include "../ui/shapegraphicsitempropertieswidget.h"
+#include "../ui/structureboxpropertieswidget.h"
 
 #include <QGraphicsItem>
 
@@ -152,6 +154,17 @@ PropertiesEditorWidget *PropertiesEditorFactory::propertiesEditor(
 			}
 
 			return new ShapeGraphicsItemPropertiesWidget(shapes_list, parent);
+		}
+		case StructureBoxItem::Type: //1012
+		{
+				//A structure box is a QetShapeItem subclass, but the useful
+				//thing to edit is its plant/location/prefix identity rather
+				//than its pen and brush -- so it gets its own editor instead
+				//of falling into the shape case above.
+			if (count_ > 1) {
+				return nullptr;
+			}
+			return new StructureBoxPropertiesWidget(static_cast<StructureBoxItem *>(item), parent);
 		}
 		case DynamicElementTextItem::Type: //1010
 		{

--- a/sources/qetdiagrameditor.cpp
+++ b/sources/qetdiagrameditor.cpp
@@ -24,6 +24,7 @@
 #include "diagramcommands.h"
 #include "diagramevent/diagrameventaddimage.h"
 #include "diagramevent/diagrameventaddshape.h"
+#include "diagramevent/diagrameventaddstructurebox.h"
 #include "diagramevent/diagrameventaddtext.h"
 #include "diagramview.h"
 #include "elementspanelwidget.h"
@@ -707,6 +708,7 @@ void QETDiagramEditor::setUpActions()
 	QAction *add_ellipse   = m_add_item_actions_group.addAction(QET::Icons::PartEllipse,   tr("Ajouter une ellipse"));
 	QAction *add_polyline  = m_add_item_actions_group.addAction(QET::Icons::PartPolygon,   tr("Ajouter une polyligne"));
 	QAction *add_terminal_strip = m_add_item_actions_group.addAction(QET::Icons::TerminalStrip, tr("Ajouter un plan de bornes"));
+	QAction *add_structure_box = m_add_item_actions_group.addAction(QET::Icons::PartRectangle, tr("Ajouter un cadre de repérage"));
 
 	add_text     ->setStatusTip(tr("Ajoute un champ de texte sur le folio actuel"));
 	add_image    ->setStatusTip(tr("Ajoute une image sur le folio actuel"));
@@ -715,6 +717,7 @@ void QETDiagramEditor::setUpActions()
 	add_ellipse  ->setStatusTip(tr("Ajoute une ellipse sur le folio actuel"));
 	add_polyline ->setStatusTip(tr("Ajoute une polyligne sur le folio actuel"));
 	add_terminal_strip->setStatusTip(tr("Ajoute un plan de bornier sur le folio actuel"));
+	add_structure_box->setStatusTip(tr("Ajoute un cadre de repérage (installation/localisation/préfixe) sur le folio actuel"));
 
 	add_text     ->setData(QStringLiteral("text"));
 	add_image    ->setData(QStringLiteral("image"));
@@ -723,12 +726,14 @@ void QETDiagramEditor::setUpActions()
 	add_ellipse  ->setData(QStringLiteral("ellipse"));
 	add_polyline ->setData(QStringLiteral("polyline"));
 	add_terminal_strip->setData(QStringLiteral("terminal_strip"));
+	add_structure_box->setData(QStringLiteral("structure_box"));
 
 	add_text->setCheckable(true);
 	add_line->setCheckable(true);
 	add_rectangle->setCheckable(true);
 	add_ellipse->setCheckable(true);
 	add_polyline->setCheckable(true);
+	add_structure_box->setCheckable(true);
 
 	connect(&m_add_item_actions_group, &QActionGroup::triggered, this, &QETDiagramEditor::addItemGroupTriggered);
 
@@ -1527,6 +1532,8 @@ void QETDiagramEditor::addItemGroupTriggered(QAction *action)
 		diagram_event = new DiagramEventAddShape (d, QetShapeItem::Rectangle);
 	else if (value == "ellipse")
 		diagram_event = new DiagramEventAddShape (d, QetShapeItem::Ellipse);
+	else if (value == "structure_box")
+		diagram_event = new DiagramEventAddStructureBox (d);
 	else if (value == "polyline")
 	{
 		diagram_event = new DiagramEventAddShape (d, QetShapeItem::Polygon);

--- a/sources/qetgraphicsitem/dynamicelementtextitem.cpp
+++ b/sources/qetgraphicsitem/dynamicelementtextitem.cpp
@@ -372,8 +372,8 @@ void DynamicElementTextItem::setTextFrom(DynamicElementTextItem::TextFrom text_f
 			updateLabel();
 		}
 		else
-			setPlainText(autonum::AssignVariables::replaceVariable(m_composite_text, elementUseForInfo()->elementInformations()));
-		
+			setPlainText(autonum::AssignVariables::replaceVariable(m_composite_text, elementUseForInfo()->elementInformations(), elementUseForInfo()));
+
 		if(old_text_from == UserText)
 			connect(elementUseForInfo(), &Element::elementInfoChange, this, &DynamicElementTextItem::elementInfoChanged);
 	}
@@ -506,9 +506,9 @@ void DynamicElementTextItem::setCompositeText(const QString &text)
 		DiagramContext dc;
 		if(elementUseForInfo())
 			dc = elementUseForInfo()->elementInformations();
-		setPlainText(autonum::AssignVariables::replaceVariable(m_composite_text, dc));
+		setPlainText(autonum::AssignVariables::replaceVariable(m_composite_text, dc, elementUseForInfo()));
 	}
-	
+
 	emit compositeTextChanged(m_composite_text);
 }
 
@@ -835,7 +835,7 @@ void DynamicElementTextItem::elementInfoChanged()
 		if (m_composite_text.contains("%{label}"))
 			setupFormulaConnection();
 		
-		final_text = autonum::AssignVariables::replaceVariable(m_composite_text, dc);
+		final_text = autonum::AssignVariables::replaceVariable(m_composite_text, dc, element);
 	}
 	else if (m_text_from  == UserText)
 		final_text = m_text;
@@ -1096,7 +1096,7 @@ void DynamicElementTextItem::updateLabel()
 			setPlainText(element->actualLabel());
 		}
 		else if (m_text_from == CompositeText) {
-			setPlainText(autonum::AssignVariables::replaceVariable(m_composite_text, dc));
+			setPlainText(autonum::AssignVariables::replaceVariable(m_composite_text, dc, element));
 		}
 	}
 }

--- a/sources/qetgraphicsitem/structureboxitem.cpp
+++ b/sources/qetgraphicsitem/structureboxitem.cpp
@@ -1,0 +1,139 @@
+/*
+	Copyright 2006-2026 The QElectroTech Team
+	This file is part of QElectroTech.
+
+	QElectroTech is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 2 of the License, or
+	(at your option) any later version.
+
+	QElectroTech is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with QElectroTech.  If not, see <http://www.gnu.org/licenses/>.
+*/
+#include "structureboxitem.h"
+
+#include "../PropertiesEditor/propertieseditordialog.h"
+#include "../autoNum/assignvariables.h"
+#include "../diagram.h"
+#include "../qetxml.h"
+#include "../ui/structureboxpropertieswidget.h"
+
+#include <QDomDocument>
+#include <QPainter>
+
+StructureBoxItem::StructureBoxItem(QPointF p1, QPointF p2, QGraphicsItem *parent) :
+	QetShapeItem(p1, p2, QetShapeItem::Rectangle, parent)
+{
+}
+
+void StructureBoxItem::setPlant(const QString &plant)
+{
+	if (m_plant == plant) return;
+	m_plant = plant;
+	update();
+}
+
+void StructureBoxItem::setLocation(const QString &location)
+{
+	if (m_location == location) return;
+	m_location = location;
+	update();
+}
+
+void StructureBoxItem::setPrefix(const QString &prefix)
+{
+	if (m_prefix == prefix) return;
+	m_prefix = prefix;
+	update();
+}
+
+/**
+	@brief StructureBoxItem::structureId
+	@return this box's own full IEC 81346 designation ("=plant+location-prefix"),
+	always unabbreviated since the box itself is a reference point, not
+	something abbreviated relative to one.
+*/
+QString StructureBoxItem::structureId() const
+{
+	return autonum::AssignVariables::buildStructureId(m_plant, m_location, m_prefix);
+}
+
+bool StructureBoxItem::fromXml(const QDomElement &e)
+{
+	if (e.tagName() != xmlTagName())
+		return false;
+
+	setPen(QETXML::penFromXml(e.firstChildElement("pen")));
+	setBrush(QETXML::brushFromXml(e.firstChildElement("brush")));
+
+	setRect(QRectF(
+		QPointF(e.attribute("x1").toDouble(), e.attribute("y1").toDouble()),
+		QPointF(e.attribute("x2").toDouble(), e.attribute("y2").toDouble())));
+
+	m_plant = e.attribute("plant");
+	m_location = e.attribute("location");
+	m_prefix = e.attribute("prefix");
+
+	setZValue(e.attribute("z", QString::number(this->zValue())).toDouble());
+
+	return true;
+}
+
+QDomElement StructureBoxItem::toXml(QDomDocument &document) const
+{
+	QDomElement result = document.createElement(xmlTagName());
+
+	result.appendChild(QETXML::penToXml(document, pen()));
+	result.appendChild(QETXML::brushToXml(document, brush()));
+
+	const QPointF p1 = mapToScene(line().p1());
+	const QPointF p2 = mapToScene(line().p2());
+	result.setAttribute("x1", QString::number(p1.x()));
+	result.setAttribute("y1", QString::number(p1.y()));
+	result.setAttribute("x2", QString::number(p2.x()));
+	result.setAttribute("y2", QString::number(p2.y()));
+
+	result.setAttribute("plant", m_plant);
+	result.setAttribute("location", m_location);
+	result.setAttribute("prefix", m_prefix);
+	result.setAttribute("z", QString::number(this->zValue()));
+
+	return result;
+}
+
+void StructureBoxItem::editProperty()
+{
+	if (diagram() && diagram()->isReadOnly())
+		return;
+
+	PropertiesEditorDialog ped(new StructureBoxPropertiesWidget(this), diagram() ? diagram()->views().value(0) : nullptr);
+	ped.exec();
+}
+
+QString StructureBoxItem::name() const
+{
+	return tr("un cadre de repérage");
+}
+
+void StructureBoxItem::paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget)
+{
+	QetShapeItem::paint(painter, option, widget);
+
+	const QString id = structureId();
+	if (id.isEmpty())
+		return;
+
+	painter->save();
+	QFont font = painter->font();
+	font.setPointSizeF(8);
+	painter->setFont(font);
+	painter->setPen(pen().color());
+	const QRectF text_rect = rect().normalized().adjusted(2, 2, -2, -2);
+	painter->drawText(text_rect, Qt::AlignLeft | Qt::AlignTop, id);
+	painter->restore();
+}

--- a/sources/qetgraphicsitem/structureboxitem.h
+++ b/sources/qetgraphicsitem/structureboxitem.h
@@ -1,0 +1,72 @@
+/*
+	Copyright 2006-2026 The QElectroTech Team
+	This file is part of QElectroTech.
+
+	QElectroTech is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 2 of the License, or
+	(at your option) any later version.
+
+	QElectroTech is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with QElectroTech.  If not, see <http://www.gnu.org/licenses/>.
+*/
+#ifndef STRUCTUREBOXITEM_H
+#define STRUCTUREBOXITEM_H
+
+#include "qetshapeitem.h"
+
+/**
+	@brief The StructureBoxItem class
+	A rectangle drawn on a diagram purely for documentation: it carries its
+	own IEC 81346 plant (=) / location (+) / prefix (-) identity and no
+	electrical meaning (no terminals). Elements visually contained within it
+	use its identity as their reference point for %{plant}/%{location}/
+	%{structure_id} instead of the diagram's own title block -- see
+	discussion #649. Implemented as a QetShapeItem subclass, always using
+	ShapeType::Rectangle, to reuse its resize-handle/move/selection behavior.
+*/
+class StructureBoxItem : public QetShapeItem
+{
+	Q_OBJECT
+
+	public:
+		enum { Type = UserType + 1012 };
+
+		explicit StructureBoxItem(QPointF p1, QPointF p2 = QPointF(0, 0), QGraphicsItem *parent = nullptr);
+		~StructureBoxItem() override = default;
+
+		int type() const override { return Type; }
+
+		QString plant() const { return m_plant; }
+		void setPlant(const QString &plant);
+		QString location() const { return m_location; }
+		void setLocation(const QString &location);
+		QString prefix() const { return m_prefix; }
+		void setPrefix(const QString &prefix);
+
+		QString structureId() const;
+
+		bool fromXml(const QDomElement &e) override;
+		QDomElement toXml(QDomDocument &document) const override;
+
+		void editProperty() override;
+		QString name() const override;
+
+		static QString xmlTagName() { return QStringLiteral("structureBox"); }
+
+	protected:
+		void paint(
+				QPainter *painter,
+				const QStyleOptionGraphicsItem *option,
+				QWidget *widget) override;
+
+	private:
+		QString m_plant, m_location, m_prefix;
+};
+
+#endif // STRUCTUREBOXITEM_H

--- a/sources/ui/compositetexteditdialog.cpp
+++ b/sources/ui/compositetexteditdialog.cpp
@@ -73,6 +73,14 @@ void CompositeTextEditDialog::setUpComboBox(bool is_report)
 		ui -> m_info_cb -> addItem(QETInformation::translatedInfoKey(qstrl[i]),
 								   is_report ? QETInformation::folioReportInfoToVar(qstrl[i]) : QETInformation::elementInfoToVar(qstrl[i]));
 	}
+
+		//Synthetic tokens computed by AssignVariables::replaceVariable() rather
+		//than stored directly in the element's info; not part of elementInfoKeys().
+	if (!is_report)
+	{
+		ui -> m_info_cb -> addItem(tr("Préfixe (-)"), QStringLiteral("%{prefix}"));
+		ui -> m_info_cb -> addItem(tr("Désignation IEC 81346 (=+-)"), QStringLiteral("%{structure_id}"));
+	}
 }
 
 void CompositeTextEditDialog::on_m_info_cb_activated(const QString &arg1)

--- a/sources/ui/compositetexteditdialog.cpp
+++ b/sources/ui/compositetexteditdialog.cpp
@@ -80,6 +80,7 @@ void CompositeTextEditDialog::setUpComboBox(bool is_report)
 	{
 		ui -> m_info_cb -> addItem(tr("Préfixe (-)"), QStringLiteral("%{prefix}"));
 		ui -> m_info_cb -> addItem(tr("Désignation IEC 81346 (=+-)"), QStringLiteral("%{structure_id}"));
+		ui -> m_info_cb -> addItem(tr("Désignation IEC 81346 complète (=+-)"), QStringLiteral("%{structure_id_full}"));
 	}
 }
 

--- a/sources/ui/dynamicelementtextmodel.cpp
+++ b/sources/ui/dynamicelementtextmodel.cpp
@@ -203,7 +203,7 @@ QList<QStandardItem *> DynamicElementTextModel::itemsForText(
 	QStandardItem *compositea = new QStandardItem(deti->compositeText().isEmpty()
 						      ? tr("Mon texte composé")
 						      : autonum::AssignVariables::replaceVariable(
-								deti->compositeText(), dc));
+								deti->compositeText(), dc, deti->elementUseForInfo()));
 	compositea->setFlags(Qt::ItemIsSelectable
 			     | Qt::ItemIsEnabled
 			     | Qt::ItemIsEditable);
@@ -1327,7 +1327,7 @@ void DynamicElementTextModel::itemDataChanged(QStandardItem *qsi)
 			{
 				enableSourceText(deti, DynamicElementTextItem::CompositeText);
 				QString compo = text_qsi->child(compo_txt_row,1)->data(Qt::UserRole+2).toString();
-				text_qsi->setData(autonum::AssignVariables::replaceVariable(compo, dc), Qt::DisplayRole);
+				text_qsi->setData(autonum::AssignVariables::replaceVariable(compo, dc, deti->elementUseForInfo()), Qt::DisplayRole);
 			}
 			
 			
@@ -1832,7 +1832,7 @@ void DynamicTextItemDelegate::setModelData(
 						DiagramContext dc;
 						if(deti->elementUseForInfo())
 							dc = deti->elementUseForInfo()->elementInformations();
-						assigned_text = autonum::AssignVariables::replaceVariable(edited_text, dc);
+						assigned_text = autonum::AssignVariables::replaceVariable(edited_text, dc, deti->elementUseForInfo());
 					}
 					
 					qsi->setData(assigned_text, Qt::DisplayRole);

--- a/sources/ui/structureboxpropertieswidget.cpp
+++ b/sources/ui/structureboxpropertieswidget.cpp
@@ -1,0 +1,63 @@
+/*
+	Copyright 2006-2026 The QElectroTech Team
+	This file is part of QElectroTech.
+
+	QElectroTech is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 2 of the License, or
+	(at your option) any later version.
+
+	QElectroTech is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with QElectroTech.  If not, see <http://www.gnu.org/licenses/>.
+*/
+#include "structureboxpropertieswidget.h"
+
+#include "../qetgraphicsitem/structureboxitem.h"
+
+#include <QFormLayout>
+#include <QLineEdit>
+
+StructureBoxPropertiesWidget::StructureBoxPropertiesWidget(StructureBoxItem *item, QWidget *parent) :
+	PropertiesEditorWidget(parent),
+	m_item(item),
+	m_plant_edit(new QLineEdit(this)),
+	m_location_edit(new QLineEdit(this)),
+	m_prefix_edit(new QLineEdit(this))
+{
+	auto layout = new QFormLayout(this);
+	layout->addRow(tr("Installation (=)"), m_plant_edit);
+	layout->addRow(tr("Localisation (+)"), m_location_edit);
+	layout->addRow(tr("Préfixe (-)"), m_prefix_edit);
+
+	updateUi();
+}
+
+void StructureBoxPropertiesWidget::apply()
+{
+	if (!m_item)
+		return;
+
+	m_item->setPlant(m_plant_edit->text());
+	m_item->setLocation(m_location_edit->text());
+	m_item->setPrefix(m_prefix_edit->text());
+}
+
+void StructureBoxPropertiesWidget::reset()
+{
+	updateUi();
+}
+
+void StructureBoxPropertiesWidget::updateUi()
+{
+	if (!m_item)
+		return;
+
+	m_plant_edit->setText(m_item->plant());
+	m_location_edit->setText(m_item->location());
+	m_prefix_edit->setText(m_item->prefix());
+}

--- a/sources/ui/structureboxpropertieswidget.h
+++ b/sources/ui/structureboxpropertieswidget.h
@@ -1,0 +1,50 @@
+/*
+	Copyright 2006-2026 The QElectroTech Team
+	This file is part of QElectroTech.
+
+	QElectroTech is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 2 of the License, or
+	(at your option) any later version.
+
+	QElectroTech is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with QElectroTech.  If not, see <http://www.gnu.org/licenses/>.
+*/
+#ifndef STRUCTUREBOXPROPERTIESWIDGET_H
+#define STRUCTUREBOXPROPERTIESWIDGET_H
+
+#include "../PropertiesEditor/propertieseditorwidget.h"
+
+class QLineEdit;
+class StructureBoxItem;
+
+/**
+	@brief The StructureBoxPropertiesWidget class
+	Provide a widget to edit the plant/location/prefix identity
+	of a StructureBoxItem.
+*/
+class StructureBoxPropertiesWidget : public PropertiesEditorWidget
+{
+		Q_OBJECT
+
+	public:
+		explicit StructureBoxPropertiesWidget(StructureBoxItem *item, QWidget *parent = nullptr);
+
+		void apply() override;
+		void reset() override;
+		void updateUi() override;
+		QString title() const override { return tr("Éditer les propriétés d'un cadre de repérage"); }
+
+	private:
+		StructureBoxItem *m_item;
+		QLineEdit *m_plant_edit;
+		QLineEdit *m_location_edit;
+		QLineEdit *m_prefix_edit;
+};
+
+#endif // STRUCTUREBOXPROPERTIESWIDGET_H


### PR DESCRIPTION
Second half of discussion #649. **Stacked on #650** (page-match abbreviation), which is itself stacked on #648 — the diff shown here includes both until they merge.

## What it is

A **structure box** is a rectangle drawn on a folio purely for documentation. It carries its own plant (`=`) / location (`+`) / prefix (`-`) identity and has **no electrical meaning** — no terminals, no connectivity.

Elements visually inside it resolve `%{plant}` / `%{location}` / `%{structure_id}` against **the box** rather than the folio's title block. So a sub-assembly drawn on a shared page can carry its own designation without setting it on every device individually.

Resolution order is now: the element's own value → nearest enclosing box → the diagram's title block. Where boxes are nested, the **smallest (most specific)** one wins.

## Implementation notes

- Implemented as a `QetShapeItem` subclass fixed to `Rectangle`, so it reuses the existing resize-handle, move and selection behaviour unchanged.
- `DiagramEventAddShape` gained a `createShapeItem()` factory hook, so the new tool reuses all of its mouse handling instead of duplicating it.
- `buildStructureId()` was extracted from `replaceVariable()` so the box and the formula tokens assemble designations identically rather than by two parallel implementations.

## Three integration points a compile cannot catch

Worth calling out, because they're the ones a new `QGraphicsItem` type is easy to miss — all three were found by auditing dispatch sites rather than by the build:

1. **`DiagramContent`** switches on `item->type()`, and `StructureBoxItem` reports its own type rather than `QetShapeItem`'s — so boxes fell through into no bucket, leaving them **impossible to cut, copy, paste or delete**. Added to both the type switch and `hasDeletableItems()`.
2. **`PropertiesEditorFactory`** likewise had no case, so selecting a box left the selection-properties dock empty. It now returns the box's own editor — the useful thing to edit is its identity, not its pen and brush.
3. **`Diagram::toXml()`/`fromXml()`** persist boxes under a `structureBoxes` element, and they join `added_items` so paste positioning applies to them.

## Scope

Deliberately **excludes** discussion #617 (composite device grouping with real terminals and auto-wiring). That solves connectivity; this solves labeling. If #617 is ever built, its boundary could adopt the same reference-point mechanism — but they shouldn't block each other.

## Testing

Full Qt6 build, clean. **Also verified at runtime** on an isolated Xvfb display, driving the real GUI:

| # | Check | Result |
|---|---|---|
| 1 | Toolbar tool present, tooltip "Ajouter un cadre de repérage" | pass |
| 2 | Box draws at the intended size (click–move–click, like the other shape tools) | pass |
| 3 | Undo stack entry reads "Annuler Ajouter un cadre de repérage" | pass |
| 4 | Selection-properties dock shows Installation (=) / Localisation (+) / Préfixe (-) | pass — exercises the `PropertiesEditorFactory` case |
| 5 | Double-click opens the properties dialog | pass |
| 6 | Setting `E1` / `A2` / `K9` renders `=E1+A2-K9` on the box | pass — exercises `buildStructureId()` |
| 7 | Couper / Copier / Supprimer are enabled with a box selected | pass — exercises the `DiagramContent` fix |
| 8 | Supprimer actually removes the box | pass |
| 9 | Save writes `<structureBox location="A2" plant="E1" prefix="K9" …>` with pen, brush, geometry and z | pass |
| 10 | Reopening the saved file restores the box and its rendered identity | pass — full `toXml`/`fromXml` round-trip |

Checks 4, 7 and 8 are the ones that matter most, because they cover the three integration points above — those were written from reading dispatch sites, so they needed exercising rather than reasoning about.

### Still not covered

Being explicit about the gap rather than implying full coverage:

- **The core resolution path** — placing an element *inside* a box and confirming `%{structure_id}` resolves against the box rather than the title block. The plumbing either side of it is verified, but not that end-to-end behaviour.
- **Nested boxes** — that the smallest enclosing box wins.
- **Copy/paste round-trip** — the menu entries are enabled and delete works, but I didn't paste a box back.

Worth a reviewer's eye on those three, and on whether the draw-tool feel matches the other shape tools.