### PR TITLE
Add configurable conductor end-cap style (square/round/flat)

### DIFF
--- a/sources/conductorproperties.cpp
+++ b/sources/conductorproperties.cpp
@@ -250,7 +250,8 @@ ConductorProperties::ConductorProperties() :
 	horiz_rotate_text(0),
 	m_show_text(true),
 	m_one_text_per_folio(false),
-	style(Qt::SolidLine)
+	style(Qt::SolidLine),
+	cap_style(Qt::SquareCap)
 {}
 
 /**
@@ -772,6 +773,7 @@ bool ConductorProperties::operator==(const ConductorProperties &other) const
 		other.m_color_2 == m_color_2 &&\
 		other.m_dash_size == m_dash_size &&\
 		other.style == style &&\
+		other.cap_style == cap_style &&\
 		other.text == text &&\
 		other.text_color == text_color &&\
 		other.m_formula == m_formula &&\
@@ -807,6 +809,7 @@ bool ConductorProperties::operator!=(const ConductorProperties &other) const{
 */
 void ConductorProperties::readStyle(const QString &style_string) {
 	style = Qt::SolidLine; // style par defaut
+	cap_style = Qt::SquareCap; // style d'extremite par defaut
 
 	if (style_string.isEmpty()) return;
 
@@ -846,6 +849,14 @@ void ConductorProperties::readStyle(const QString &style_string) {
 					qWarning()<<"style_value not known"
 						 <<style_value;
 				}
+			} else if (style_name == "cap-style") {
+				if (style_value == "round") cap_style = Qt::RoundCap;
+				else if (style_value == "flat") cap_style = Qt::FlatCap;
+				else if (style_value == "square") cap_style = Qt::SquareCap;
+				else {
+					qWarning()<<"style_value not known"
+						 <<style_value;
+				}
 			}
 		}
 	}
@@ -857,13 +868,23 @@ void ConductorProperties::readStyle(const QString &style_string) {
 */
 QString ConductorProperties::writeStyle() const
 {
+	QStringList parts;
+
 	if (style == Qt::DashLine) {
-		return("line-style: dashed;");
+		parts << "line-style: dashed";
 	} else if (style == Qt::DashDotLine) {
-		return("line-style: dashdotted");
-	} else {
-		return(QString());
+		parts << "line-style: dashdotted";
 	}
+
+	if (cap_style == Qt::RoundCap) {
+		parts << "cap-style: round";
+	} else if (cap_style == Qt::FlatCap) {
+		parts << "cap-style: flat";
+	}
+
+	if (parts.isEmpty())
+		return(QString());
+	return(parts.join("; ") + ";");
 }
 
 /**

--- a/sources/conductorproperties.h
+++ b/sources/conductorproperties.h
@@ -116,6 +116,7 @@ class ConductorProperties
 		m_vertical_alignment = Qt::AlignRight;
 
 		Qt::PenStyle style;
+		Qt::PenCapStyle cap_style;
 
 		SingleLineProperties singleLineProperties;
 

--- a/sources/qetgraphicsitem/conductor.cpp
+++ b/sources/qetgraphicsitem/conductor.cpp
@@ -529,6 +529,7 @@ void Conductor::paint(QPainter *painter, const QStyleOptionGraphicsItem *options
 		//Set the conductor style
 	final_conductor_pen.setColor(final_conductor_color);
 	final_conductor_pen.setStyle(m_properties.style);
+	final_conductor_pen.setCapStyle(m_properties.cap_style);
 	final_conductor_pen.setJoinStyle(Qt::SvgMiterJoin); // better rendering with dot
 
 		//Use a cosmetic line, below a certain zoom

--- a/sources/ui/conductorpropertieswidget.cpp
+++ b/sources/ui/conductorpropertieswidget.cpp
@@ -80,6 +80,9 @@ void ConductorPropertiesWidget::setProperties(
 	int index = ui -> m_line_style_cb -> findData(QPen(m_properties.style));
 	if (index != -1) ui -> m_line_style_cb -> setCurrentIndex(index);
 
+	int cap_index = ui -> m_cap_style_cb -> findData(QVariant::fromValue(m_properties.cap_style));
+	if (cap_index != -1) ui -> m_cap_style_cb -> setCurrentIndex(cap_index);
+
 	ui->m_color_2_gb            -> setChecked  (m_properties.m_bicolor);
 	ui->m_dash_size_sb          -> setValue    (m_properties.m_dash_size);
 	ui->m_formula_le            -> setText    (m_properties.m_formula);
@@ -127,6 +130,7 @@ ConductorProperties ConductorPropertiesWidget::properties() const
 	properties_.m_color_2               = ui->m_color_2_kpb->color();
 	properties_.m_dash_size             = ui->m_dash_size_sb->value();
 	properties_.style                   = ui -> m_line_style_cb->itemData(ui->m_line_style_cb->currentIndex()).value<QPen>().style();
+	properties_.cap_style               = ui -> m_cap_style_cb->itemData(ui->m_cap_style_cb->currentIndex()).value<Qt::PenCapStyle>();
 	properties_.m_formula               = ui->m_formula_le->text();
 	properties_.text                    = ui -> m_text_le -> text();
 	properties_.text_color              = ui -> m_text_color_kpb->color();
@@ -234,6 +238,10 @@ void ConductorPropertiesWidget::initWidget()
 	ui -> m_line_style_cb -> addItem(tr("Trait plein", "conductor style: solid line"), QPen(Qt::SolidLine));
 	ui -> m_line_style_cb -> addItem(tr("Trait en pointillés", "conductor style: dashed line"), QPen(Qt::DashLine));
 	ui -> m_line_style_cb -> addItem(tr("Traits et points", "conductor style: dashed and dotted line"), QPen(Qt::DashDotLine));
+
+	ui -> m_cap_style_cb -> addItem(tr("Carré", "conductor cap style: square"), QVariant::fromValue(Qt::SquareCap));
+	ui -> m_cap_style_cb -> addItem(tr("Rond", "conductor cap style: round"), QVariant::fromValue(Qt::RoundCap));
+	ui -> m_cap_style_cb -> addItem(tr("Plat", "conductor cap style: flat"), QVariant::fromValue(Qt::FlatCap));
 
 	ui -> m_update_preview_pb -> setHidden(true);
 

--- a/sources/ui/conductorpropertieswidget.ui
+++ b/sources/ui/conductorpropertieswidget.ui
@@ -467,7 +467,7 @@
          </property>
         </widget>
        </item>
-       <item row="4" column="1">
+       <item row="5" column="1">
         <spacer name="verticalSpacer">
          <property name="orientation">
           <enum>Qt::Vertical</enum>
@@ -479,6 +479,23 @@
           </size>
          </property>
         </spacer>
+       </item>
+       <item row="4" column="0">
+        <widget class="QLabel" name="label_14">
+         <property name="toolTip">
+          <string>Style de l'extrémité du conducteur</string>
+         </property>
+         <property name="text">
+          <string>Extrémité :</string>
+         </property>
+        </widget>
+       </item>
+       <item row="4" column="1">
+        <widget class="QComboBox" name="m_cap_style_cb">
+         <property name="toolTip">
+          <string>Style de l'extrémité du conducteur</string>
+         </property>
+        </widget>
        </item>
        <item row="1" column="0">
         <widget class="QLabel" name="label_7">
@@ -615,6 +632,7 @@
   <tabstop>m_color_2_kpb</tabstop>
   <tabstop>m_cond_size_sb</tabstop>
   <tabstop>m_line_style_cb</tabstop>
+  <tabstop>m_cap_style_cb</tabstop>
  </tabstops>
  <resources>
   <include location="../../qelectrotech.qrc"/>


### PR DESCRIPTION
Builds discussion #616.

## Problem

Conductors (wires) are always drawn with a flush/square end — there's no way to control how a wire's stroke is rendered at its endpoint (square/flush, rounded, or projecting square past the point). `Conductor::conductor_pen` hardcodes `Qt::SquareCap` (`sources/qetgraphicsitem/conductor.cpp`) and `Conductor::paint()` never overrides it, even though every other pen attribute on the same `QPen` — line style, thickness, color — is already exposed as a user-configurable `ConductorProperties` field with a dialog control.

## Change

- Added a `Qt::PenCapStyle cap_style` field to `ConductorProperties`, alongside the existing `Qt::PenStyle style` field. Default is `Qt::SquareCap`, matching current behavior.
- Persisted through the same CSS-like `"style"` XML attribute / `QSettings` key that line style already uses (`readStyle`/`writeStyle` in `conductorproperties.cpp`) — e.g. `line-style: dashed; cap-style: round;`. A conductor using only defaults still produces an empty `writeStyle()`, so existing `.qet` files get no new attribute and round-trip unchanged.
- Added a combo box (Square/Round/Flat) next to the existing line-style combo in `ConductorPropertiesWidget`'s "Apparence" tab, wired the same way.
- `Conductor::paint()` now applies `m_properties.cap_style` onto the pen instead of leaving the hardcoded static value untouched.

## Why this shape

Same class, same dialog, same XML/QSettings round-trip pattern as line style — a small, idiomatic extension rather than new architecture. Only changes how the stroke terminates at both ends of the conductor line itself; doesn't touch terminal/junction rendering (junction dots are filled ellipses, unaffected by cap style) or the connection model.

## Not in scope (per discussion)

- Any marker (dot/tick/arrowhead) at the wire-terminal connection point — a different, unimplemented rendering concept.
- Dangling/unconnected conductor ends — conductors always connect exactly two terminals today; unchanged.

## Test plan

- [x] Full project builds and links clean (`cmake --build`, default `BUILD_WITH_KF5=ON` config), zero new warnings in the touched files
- [x] Verified by construction: default properties (`Qt::SolidLine` + `Qt::SquareCap`) produce an empty `writeStyle()`, so pre-existing `.qet` files are unaffected
- [ ] Manual: open the conductor properties dialog, switch cap style, confirm the wire endpoint changes visually and survives save/reload