### PR TITLE
Remember last-used shape/text style for new items this session

### DIFF
--- a/cmake/qet_compilation_vars.cmake
+++ b/cmake/qet_compilation_vars.cmake
@@ -205,6 +205,8 @@ set(QET_SRC_FILES
   ${QET_DIR}/sources/exportpropertieswidget.h
   ${QET_DIR}/sources/genericpanel.cpp
   ${QET_DIR}/sources/genericpanel.h
+  ${QET_DIR}/sources/lastusedstyle.cpp
+  ${QET_DIR}/sources/lastusedstyle.h
   ${QET_DIR}/sources/machine_info.cpp
   ${QET_DIR}/sources/machine_info.h
   ${QET_DIR}/sources/main.cpp

--- a/sources/diagramevent/diagrameventaddshape.cpp
+++ b/sources/diagramevent/diagrameventaddshape.cpp
@@ -18,6 +18,7 @@
 #include "diagrameventaddshape.h"
 
 #include "../diagram.h"
+#include "../lastusedstyle.h"
 #include "../undocommand/addgraphicsobjectcommand.h"
 
 /**
@@ -77,6 +78,14 @@ void DiagramEventAddShape::mousePressEvent(QGraphicsSceneMouseEvent *event)
 		if (!m_shape_item)
 		{
 			m_shape_item = new QetShapeItem(pos, pos, m_shape_type);
+				//Start from whatever pen/brush was last applied this
+				//session, rather than always the hardcoded default.
+			if (LastUsedStyle::hasShapePen()) {
+				m_shape_item->setPen(LastUsedStyle::shapePen());
+			}
+			if (LastUsedStyle::hasShapeBrush()) {
+				m_shape_item->setBrush(LastUsedStyle::shapeBrush());
+			}
 			m_diagram->addItem (m_shape_item);
 			event->setAccepted(true);
 			return;

--- a/sources/lastusedstyle.cpp
+++ b/sources/lastusedstyle.cpp
@@ -1,0 +1,106 @@
+/*
+	Copyright 2006-2026 The QElectroTech Team
+	This file is part of QElectroTech.
+
+	QElectroTech is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 2 of the License, or
+	(at your option) any later version.
+
+	QElectroTech is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with QElectroTech.  If not, see <http://www.gnu.org/licenses/>.
+*/
+#include "lastusedstyle.h"
+
+QPen  LastUsedStyle::m_shape_pen;
+bool  LastUsedStyle::m_has_shape_pen = false;
+QBrush LastUsedStyle::m_shape_brush;
+bool  LastUsedStyle::m_has_shape_brush = false;
+QFont LastUsedStyle::m_text_font;
+bool  LastUsedStyle::m_has_text_font = false;
+
+/**
+	@return true if a shape pen was set this session
+*/
+bool LastUsedStyle::hasShapePen()
+{
+	return m_has_shape_pen;
+}
+
+/**
+	@return the last pen applied to a shape this session
+*/
+QPen LastUsedStyle::shapePen()
+{
+	return m_shape_pen;
+}
+
+/**
+	@brief LastUsedStyle::setShapePen
+	Record @a pen as the last-used shape pen for this session
+	@param pen
+*/
+void LastUsedStyle::setShapePen(const QPen &pen)
+{
+	m_shape_pen = pen;
+	m_has_shape_pen = true;
+}
+
+/**
+	@return true if a shape brush was set this session
+*/
+bool LastUsedStyle::hasShapeBrush()
+{
+	return m_has_shape_brush;
+}
+
+/**
+	@return the last brush applied to a shape this session
+*/
+QBrush LastUsedStyle::shapeBrush()
+{
+	return m_shape_brush;
+}
+
+/**
+	@brief LastUsedStyle::setShapeBrush
+	Record @a brush as the last-used shape brush for this session
+	@param brush
+*/
+void LastUsedStyle::setShapeBrush(const QBrush &brush)
+{
+	m_shape_brush = brush;
+	m_has_shape_brush = true;
+}
+
+/**
+	@return true if a text font was set this session
+*/
+bool LastUsedStyle::hasTextFont()
+{
+	return m_has_text_font;
+}
+
+/**
+	@return the last font applied to a free text item this session
+*/
+QFont LastUsedStyle::textFont()
+{
+	return m_text_font;
+}
+
+/**
+	@brief LastUsedStyle::setTextFont
+	Record @a font as the last-used free text font for this session
+	@param font
+*/
+void LastUsedStyle::setTextFont(const QFont &font)
+{
+	m_text_font = font;
+	m_has_text_font = true;
+}

--- a/sources/lastusedstyle.h
+++ b/sources/lastusedstyle.h
@@ -1,0 +1,63 @@
+/*
+	Copyright 2006-2026 The QElectroTech Team
+	This file is part of QElectroTech.
+
+	QElectroTech is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 2 of the License, or
+	(at your option) any later version.
+
+	QElectroTech is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with QElectroTech.  If not, see <http://www.gnu.org/licenses/>.
+*/
+#ifndef LAST_USED_STYLE_H
+#define LAST_USED_STYLE_H
+
+#include <QBrush>
+#include <QFont>
+#include <QPen>
+
+/**
+	@brief The LastUsedStyle class
+	Session-scoped "last used" style for new shapes and free text created
+	on the diagram canvas: whatever pen/brush/font was last applied through
+	the properties editors becomes the starting point for the next new
+	item of that type, the way most drawing tools behave.
+
+	Deliberately in-memory only, not QSettings-backed: this is a live
+	"what did I just use" value for the current editing session, not an
+	app-wide default (that's already covered by the Preferences dialog's
+	font setting, read as the fallback when nothing has been set yet).
+*/
+class LastUsedStyle
+{
+	public:
+		static bool hasShapePen();
+		static QPen shapePen();
+		static void setShapePen(const QPen &pen);
+
+		static bool hasShapeBrush();
+		static QBrush shapeBrush();
+		static void setShapeBrush(const QBrush &brush);
+
+		static bool hasTextFont();
+		static QFont textFont();
+		static void setTextFont(const QFont &font);
+
+	private:
+		LastUsedStyle() = delete;
+
+		static QPen m_shape_pen;
+		static bool m_has_shape_pen;
+		static QBrush m_shape_brush;
+		static bool m_has_shape_brush;
+		static QFont m_text_font;
+		static bool m_has_text_font;
+};
+
+#endif // LAST_USED_STYLE_H

--- a/sources/qetgraphicsitem/independenttextitem.cpp
+++ b/sources/qetgraphicsitem/independenttextitem.cpp
@@ -19,6 +19,7 @@
 
 #include "../diagram.h"
 #include "../diagramcommands.h"
+#include "../lastusedstyle.h"
 #include "../qet.h"
 #include "../qetapp.h"
 #include "../utils/qetutils.h"
@@ -33,7 +34,10 @@
 IndependentTextItem::IndependentTextItem() :
 	DiagramTextItem(nullptr)
 {
-	setFont(QETApp::indiTextsItemFont());
+		//Start from the font last applied to a text item this session,
+		//falling back to the app-wide Preferences default otherwise.
+	setFont(LastUsedStyle::hasTextFont() ? LastUsedStyle::textFont()
+					      : QETApp::indiTextsItemFont());
 	QSettings settings;
 	setRotation(settings.value("diagrameditor/independent_text_rotation", 0).toInt());
 }

--- a/sources/ui/inditextpropertieswidget.cpp
+++ b/sources/ui/inditextpropertieswidget.cpp
@@ -20,6 +20,7 @@
 #include "../QPropertyUndoCommand/qpropertyundocommand.h"
 #include "../diagram.h"
 #include "../diagramcommands.h"
+#include "../lastusedstyle.h"
 #include "../qetgraphicsitem/independenttextitem.h"
 #include "../ui_inditextpropertieswidget.h"
 
@@ -455,6 +456,7 @@ void IndiTextPropertiesWidget::on_m_font_pb_clicked()
 		m_font_is_selected = true;
 		ui->m_font_pb->setText(font.family());
 		ui->m_size_sb->setValue(font.pointSize());
+		LastUsedStyle::setTextFont(m_selected_font);
 		apply();
 	} else {
 		ui->m_font_pb->setText(tr("Police"));

--- a/sources/ui/shapegraphicsitempropertieswidget.cpp
+++ b/sources/ui/shapegraphicsitempropertieswidget.cpp
@@ -20,6 +20,7 @@
 
 #include "../QPropertyUndoCommand/qpropertyundocommand.h"
 #include "../diagram.h"
+#include "../lastusedstyle.h"
 #include "../qetgraphicsitem/qetshapeitem.h"
 #include "../ui_shapegraphicsitempropertieswidget.h"
 
@@ -180,6 +181,7 @@ QUndoCommand* ShapeGraphicsItemPropertiesWidget::associatedUndo() const
 			{
 				undo = new QPropertyUndoCommand(m_shape, "pen", old_pen, new_pen);
 				undo->setText(tr("Modifier le trait d'une forme"));
+				LastUsedStyle::setShapePen(new_pen);
 			}
 
 			QBrush old_brush = m_shape->brush();
@@ -196,6 +198,7 @@ QUndoCommand* ShapeGraphicsItemPropertiesWidget::associatedUndo() const
 					undo = new QPropertyUndoCommand(m_shape, "brush", old_brush, new_brush);
 					undo->setText(tr("Modifier le remplissage d'une forme"));
 				}
+				LastUsedStyle::setShapeBrush(new_brush);
 			}
 
 			if (ui->m_close_polygon->isChecked() != m_shape->isClosed())
@@ -321,6 +324,7 @@ QUndoCommand* ShapeGraphicsItemPropertiesWidget::associatedUndo() const
 
 		if (new_pen != old_pen) {
 			new QPropertyUndoCommand(m_shape, "pen", old_pen, new_pen, undo);
+			LastUsedStyle::setShapePen(new_pen);
 		}
 
 		QBrush old_brush = m_shape->brush();
@@ -330,6 +334,7 @@ QUndoCommand* ShapeGraphicsItemPropertiesWidget::associatedUndo() const
 
 		if (new_brush != old_brush) {
 			new QPropertyUndoCommand(m_shape, "brush", old_brush, new_brush, undo);
+			LastUsedStyle::setShapeBrush(new_brush);
 		}
 
 		if (ui->m_close_polygon->isChecked() != m_shape->isClosed()) {


### PR DESCRIPTION
Builds discussion #600.

## Problem

Drawing tools on the diagram canvas (line/rectangle/ellipse/polygon shapes, free text) always start from the same fixed default style. If you draw a line and change it to blue, the next line you draw is still black — you have to reapply the same color/width/font change to every new item, even within the same editing session.

## What exists today

- **Shapes** (`QetShapeItem`): created in `DiagramEventAddShape::mousePressEvent` with a plain default-constructed `QPen()`/`QBrush()` (black, width 1, `Qt::NoBrush`) — nothing read from anywhere.
- **Free text** (`IndependentTextItem`): font comes from `QETApp::indiTextsItemFont()`, a static app-wide Preferences setting, not a live "last used" value. Text color is hardcoded and has no UI control at all.
- No existing "remember last used" mechanism anywhere in the codebase (grepped for `lastUsed`, `defaultColor`, `defaultPen`, etc.) — editing an item's style through the property editors only pushes an undo command onto that item's own undo stack; it never affects what the next new item gets.

## Change

Added `LastUsedStyle` (`sources/lastusedstyle.{h,cpp}`): a small, in-memory, session-scoped static helper — deliberately **not** `QSettings`-backed, since this is a live "what did I just use" value for the current session, not a new persisted app-wide default (that's already the existing Preferences font setting, kept as the fallback).

Two hook points per item type:
- **Write side**: `ShapeGraphicsItemPropertiesWidget::associatedUndo()` — captures the new pen/brush right where an undo command is actually pushed. Covers both code paths that can edit a single shape: the live-edit properties dock, and the modal dialog opened by `QetShapeItem::editProperty()` (right-click → edit). `IndiTextPropertiesWidget::on_m_font_pb_clicked()` — captures the font right after `QFontDialog::getFont()` returns.
- **Read side**: `DiagramEventAddShape::mousePressEvent`, right after constructing a new shape — applies the stored pen/brush if one exists this session. `IndependentTextItem`'s constructor — uses the stored font if set, else falls back to `QETApp::indiTextsItemFont()` exactly as before.

## Why this shape

Keeping it in-memory rather than `QSettings`-backed matches the reported behavior exactly ("subsequent lines drawn will also be blue," within the session) without opening the separate question of what a persisted-across-restarts default should look like relative to the existing Preferences font default. Doesn't touch the undo/redo system at all — the property editors keep working exactly as they do now, this just adds a side-effect write next to the existing `apply()` call.

## Not in scope (per discussion)

- Last-used text color — no color control exists in the text properties UI to originate the value from yet; worth a follow-up if that control is added.
- Persisting last-used style across app restarts.
- The element/symbol editor's own drawing tools (`sources/editor/`) — a separate subsystem from diagram-canvas annotations.

## Test plan

- [x] Full project builds and links clean (`cmake --build`, default `BUILD_WITH_KF5=ON` config), zero new warnings in any touched/new file
- [ ] Manual: draw a shape, change its color/width in the properties dock, draw a new shape of the same type, confirm it starts with the just-used style; same for free text and font
- [ ] Manual: same check via the modal shape-properties dialog (right-click → edit) instead of the dock