### PR TITLE
Add "Insert folio above/below" to the elements panel's folio menu

### DIFF
--- a/sources/elementspanelwidget.cpp
+++ b/sources/elementspanelwidget.cpp
@@ -61,6 +61,8 @@ ElementsPanelWidget::ElementsPanelWidget(QWidget *parent) : QWidget(parent) {
 	prj_edit_prop            = new QAction(QET::Icons::DialogInformation,      tr("Propriétés du projet"),          this);
 	prj_prop_diagram         = new QAction(QET::Icons::DialogInformation,      tr("Propriétés du folio"),       this);
 	prj_add_diagram          = new QAction(QET::Icons::DiagramAdd,              tr("Ajouter un folio"),                this);
+	prj_insert_diagram_above = new QAction(QET::Icons::DiagramAdd,              tr("Insérer un folio au-dessus"),      this);
+	prj_insert_diagram_below = new QAction(QET::Icons::DiagramAdd,              tr("Insérer un folio en dessous"),     this);
 	prj_duplicate_diagram   = new QAction(QET::Icons::IC_CopyFile,              tr("Copier et coller"),               this);
 	prj_del_diagram          = new QAction(QET::Icons::DiagramDelete,          tr("Supprimer ce folio"),              this);
 	prj_move_diagram_up      = new QAction(QET::Icons::GoUp,                   tr("Remonter ce folio"),               this);
@@ -101,6 +103,8 @@ ElementsPanelWidget::ElementsPanelWidget(QWidget *parent) : QWidget(parent) {
 	connect(prj_edit_prop,         SIGNAL(triggered()), this,           SLOT(editProjectProperties()));
 	connect(prj_prop_diagram,      SIGNAL(triggered()), this,           SLOT(editDiagramProperties()));
 	connect(prj_add_diagram,       SIGNAL(triggered()), this,           SLOT(newDiagram()));
+	connect(prj_insert_diagram_above, SIGNAL(triggered()), this,        SLOT(insertDiagramAbove()));
+	connect(prj_insert_diagram_below, SIGNAL(triggered()), this,        SLOT(insertDiagramBelow()));
 	connect(prj_del_diagram,       SIGNAL(triggered()), this,           SLOT(deleteDiagram()));
 	connect(prj_duplicate_diagram, SIGNAL(triggered()), this,           SLOT(duplicateDiagram()));
 	connect(prj_move_diagram_up,   SIGNAL(triggered()), this,           SLOT(moveDiagramUp()));
@@ -242,6 +246,32 @@ void ElementsPanelWidget::newDiagram()
 {
 	if (QETProject *selected_project = elements_panel -> selectedProject()) {
 		emit(requestForNewDiagram(selected_project));
+	}
+}
+
+/**
+	@brief ElementsPanelWidget::insertDiagramAbove
+	Emit requestForNewDiagramAt with the position of the currently
+	selected diagram, inserting the new folio right before it.
+*/
+void ElementsPanelWidget::insertDiagramAbove()
+{
+	if (Diagram *selected_diagram = elements_panel -> selectedDiagram()) {
+		QETProject *project = selected_diagram->project();
+		emit(requestForNewDiagramAt(project, project->folioIndex(selected_diagram)));
+	}
+}
+
+/**
+	@brief ElementsPanelWidget::insertDiagramBelow
+	Emit requestForNewDiagramAt with the position right after the
+	currently selected diagram, inserting the new folio right after it.
+*/
+void ElementsPanelWidget::insertDiagramBelow()
+{
+	if (Diagram *selected_diagram = elements_panel -> selectedDiagram()) {
+		QETProject *project = selected_diagram->project();
+		emit(requestForNewDiagramAt(project, project->folioIndex(selected_diagram) + 1));
 	}
 }
 
@@ -451,6 +481,8 @@ void ElementsPanelWidget::updateButtons()
 
 			prj_del_diagram           -> setEnabled(is_writable);
 			prj_duplicate_diagram     -> setEnabled(is_writable);
+			prj_insert_diagram_above -> setEnabled(is_writable);
+			prj_insert_diagram_below -> setEnabled(is_writable);
 			prj_move_diagram_up        -> setEnabled(is_writable && min_position > 0);
 			prj_move_diagram_down     -> setEnabled(is_writable && max_position < project_diagrams_count - 1);
 			prj_move_diagram_top      -> setEnabled(is_writable && min_position > 0);
@@ -504,6 +536,8 @@ void ElementsPanelWidget::handleContextMenu(const QPoint &pos) {
 			break;
 		case QET::Diagram:
 			context_menu -> addAction(prj_prop_diagram);
+			context_menu -> addAction(prj_insert_diagram_above);
+			context_menu -> addAction(prj_insert_diagram_below);
 			context_menu -> addAction(prj_del_diagram);
 			context_menu -> addAction(prj_duplicate_diagram);
 			context_menu -> addAction(prj_move_diagram_top);

--- a/sources/elementspanelwidget.h
+++ b/sources/elementspanelwidget.h
@@ -46,6 +46,8 @@ class ElementsPanelWidget : public QWidget {
 		*prj_edit_prop,
 		*prj_prop_diagram,
 		*prj_add_diagram,
+		*prj_insert_diagram_above,
+		*prj_insert_diagram_below,
 		*prj_del_diagram,
 		*prj_duplicate_diagram,
 		*prj_move_diagram_up,
@@ -66,6 +68,7 @@ class ElementsPanelWidget : public QWidget {
 	signals:
 	void requestForProject(QETProject *);
 	void requestForNewDiagram(QETProject *);
+	void requestForNewDiagramAt(QETProject *, int);
 	void requestForProjectClosing(QETProject *);
 	void requestForProjectPropertiesEdition(QETProject *);
 	void requestForDiagramPropertiesEdition(Diagram *);
@@ -88,6 +91,8 @@ class ElementsPanelWidget : public QWidget {
 	void editProjectProperties();
 	void editDiagramProperties();
 	void newDiagram();
+	void insertDiagramAbove();
+	void insertDiagramBelow();
 	void deleteDiagram();
 	void duplicateDiagram();
 	void moveDiagramUp();

--- a/sources/qetdiagrameditor.cpp
+++ b/sources/qetdiagrameditor.cpp
@@ -185,6 +185,7 @@ void QETDiagramEditor::setUpElementsPanel()
 	connect(pa, SIGNAL(requestForProjectClosing           (QETProject *)), this, SLOT(closeProject(QETProject *)));
 	connect(pa, SIGNAL(requestForProjectPropertiesEdition (QETProject *)), this, SLOT(editProjectProperties(QETProject *)));
 	connect(pa, SIGNAL(requestForNewDiagram               (QETProject *)), this, SLOT(addDiagramToProject(QETProject *)));
+	connect(pa, SIGNAL(requestForNewDiagramAt             (QETProject *, int)), this, SLOT(addDiagramToProjectAt(QETProject *, int)));
 	connect(pa, SIGNAL(requestForDiagramPropertiesEdition (Diagram *)), this, SLOT(editDiagramProperties(Diagram *)));
 	connect(pa, SIGNAL(requestForDiagramsDeletion         (const QList<Diagram *> &)), this, SLOT(removeDiagrams(const QList<Diagram *> &)));
 	connect(pa, SIGNAL(requestForDiagramMoveUp			  (const QList<Diagram *> &)), this, SLOT(moveDiagramUp(const QList<Diagram *>&)));
@@ -2272,6 +2273,25 @@ void QETDiagramEditor::addDiagramToProject(QETProject *project)
 	{
 		activateProject(project);
 		project_view->project()->addNewDiagram();
+	}
+}
+
+/**
+	@brief QETDiagramEditor::addDiagramToProjectAt
+	Add a diagram to project, inserted at a specific position.
+	@param project
+	@param pos
+*/
+void QETDiagramEditor::addDiagramToProjectAt(QETProject *project, int pos)
+{
+	if (!project) {
+		return;
+	}
+
+	if (ProjectView *project_view = findProject(project))
+	{
+		activateProject(project);
+		project_view->project()->addNewDiagram(pos);
 	}
 }
 /**

--- a/sources/qetdiagrameditor.h
+++ b/sources/qetdiagrameditor.h
@@ -137,6 +137,7 @@ class QETDiagramEditor : public QETMainWindow
 		void editDiagramProperties(DiagramView *);
 		void editDiagramProperties(Diagram *);
 		void addDiagramToProject(QETProject *);
+		void addDiagramToProjectAt(QETProject *, int);
 		void removeDiagram(Diagram *);
 		void removeDiagrams(const QList<Diagram *> &diagrams);
 		void removeDiagramFromProject();


### PR DESCRIPTION
Builds discussion #614.

## Problem

The backend already fully supports inserting a folio at an arbitrary position — only the left-panel UI action was missing. "Add folio" always appends to the end of the project, completely ignoring whatever folio is currently selected in the left panel.

## What exists today

- `QETProject::addNewDiagram(int pos = -1)` already accepts an explicit insertion index — pushed as an undoable `AddDiagramCommand`. This isn't unused capability: `QetGraphicsTableFactory::create()` already calls `project_->addNewDiagram(project_->folioIndex(actual_diagram)+1)` to insert a folio right after a specific one when a nomenclature table needs its own page.
- The left panel (`ElementsPanelWidget`) already has a rich, selection-aware context menu for the currently selected folio (add, duplicate, delete, move up/down/top/×10/×100), driven by exactly this kind of position lookup.
- But "Add folio" itself never uses any of that: `ElementsPanelWidget::newDiagram()` only looks up the selected *project*, not the selected *diagram*, and emits a signal that ultimately calls `addNewDiagram()` with no position argument at all.

## Change

- Two new context-menu actions: "Insérer un folio au-dessus" / "Insérer un folio en dessous", next to the existing add/duplicate/move set.
- Position is computed from the currently selected diagram's `folioIndex()` — the exact same lookup `qetgraphicstablefactory.cpp` already uses — and passed straight through to the existing `addNewDiagram(pos)`.
- New `requestForNewDiagramAt`/`addDiagramToProjectAt` signal/slot pair added *alongside* the existing `requestForNewDiagram`/`addDiagramToProject`, rather than changing it — the plain "Add folio" action keeps its current append-at-end behavior untouched. These are additive, not a replacement.

## Why this shape

No changes needed to `QETProject` or `AddDiagramCommand` — both already handle arbitrary-position insertion correctly and undoably. This is purely wiring the panel's already-tracked selection position through to machinery that already exists and is already proven correct elsewhere in the codebase.

## Test plan

- [x] Full project builds and links clean (`cmake --build`, default `BUILD_WITH_KF5=ON` config), zero new warnings
- [x] Existing Catch2 test suite passes (general regression check; no existing coverage of `ElementsPanelWidget` specifically)
- [ ] Manual: select a folio in the left panel, use "Insert folio above"/"below" from the context menu, confirm the new folio lands in the right position and Ctrl+Z undoes the insertion cleanly