### PR TITLE
Preserve master/slave links when pasting or duplicating a folio

### DIFF
--- a/sources/diagramcommands.cpp
+++ b/sources/diagramcommands.cpp
@@ -77,6 +77,20 @@ void PasteDiagramCommand::redo()
 
 		//this is the first paste, we do some actions for the new element
 		const QList <Element *> elmts_list = content.m_elements;
+
+			//Resolve master/slave links within the pasted batch before any
+			//uuid gets renewed below: each element's tmp_uuids_link still
+			//holds its source's original partner uuid at this point, which
+			//still equals the not-yet-renewed uuid of that partner's own
+			//pasted copy, if it was pasted too. Scoping the search to
+			//elmts_list (rather than the whole project) is what keeps this
+			//from matching an original element left elsewhere in the
+			//project that happens to share that same soon-to-be-replaced
+			//uuid. See Element::initLink(const QList<Element *> &).
+		for (Element *e : elmts_list) {
+			e->initLink(elmts_list);
+		}
+
 		for (Element *e : elmts_list)
 		{
 			//make new uuid, because old uuid are the uuid of the copied element

--- a/sources/elementspanelwidget.cpp
+++ b/sources/elementspanelwidget.cpp
@@ -642,16 +642,32 @@ void ElementsPanelWidget::duplicateDiagram()
 
 		new_diagram->fromXml(diagram_elmt, QPointF(0, 0), false, nullptr);
 
+		QList<Element *> new_elements;
 		for (QGraphicsItem *item : new_diagram->items()) {
 			if (Element *elmt = dynamic_cast<Element *>(item)) {
-				// The XML round-trip kept the source elements' uuids. Give the
-				// copies their own identity (as PasteDiagramCommand::redo()
-				// does for on-diagram paste): element.uuid is the PRIMARY KEY
-				// of the project database, so duplicates fail to insert and
-				// silently vanish from nomenclature/summary tables.
-				elmt->newUuid();
-				new_diagram->restoreText(elmt);
+				new_elements << elmt;
 			}
+		}
+
+			// Resolve master/slave links within the duplicated batch before
+			// any uuid gets renewed below, for the same reason
+			// PasteDiagramCommand::redo() does: each element's
+			// tmp_uuids_link still holds its source's original partner
+			// uuid at this point, matching the not-yet-renewed uuid of
+			// that partner's own copy in new_elements. See
+			// Element::initLink(const QList<Element *> &).
+		for (Element *elmt : new_elements) {
+			elmt->initLink(new_elements);
+		}
+
+		for (Element *elmt : new_elements) {
+			// The XML round-trip kept the source elements' uuids. Give the
+			// copies their own identity (as PasteDiagramCommand::redo()
+			// does for on-diagram paste): element.uuid is the PRIMARY KEY
+			// of the project database, so duplicates fail to insert and
+			// silently vanish from nomenclature/summary tables.
+			elmt->newUuid();
+			new_diagram->restoreText(elmt);
 		}
 	}
 

--- a/sources/elementspanelwidget.cpp
+++ b/sources/elementspanelwidget.cpp
@@ -26,7 +26,9 @@
 #include "titleblock/templatedeleter.h"
 #include <QFileInfo>
 #include <QMessageBox>
+#include <QSettings>
 #include "qetgraphicsitem/element.h"
+#include "qetgraphicsitem/conductor.h"
 
 /*
 	When the ENABLE_PANEL_WIDGET_DND_CHECKS flag is set, the panel
@@ -660,6 +662,19 @@ void ElementsPanelWidget::duplicateDiagram()
 			elmt->initLink(new_elements);
 		}
 
+			// Honour the same preference on-diagram paste honours
+			// (Configuration -> "Ne pas conserver les labels des éléments
+			// lors des copier coller"). Duplication ignored it, so a
+			// duplicated folio always kept the source designations -- and
+			// with links now preserved that produced two identically
+			// designated linked groups, which is a genuinely ambiguous
+			// drawing. Paste never had that problem because it clears the
+			// labels by default; duplication simply never asked.
+		QSettings settings;
+		const bool erase_label = settings.value(
+			QStringLiteral("diagramcommands/erase-label-on-copy"),
+			true).toBool();
+
 		for (Element *elmt : new_elements) {
 			// The XML round-trip kept the source elements' uuids. Give the
 			// copies their own identity (as PasteDiagramCommand::redo()
@@ -667,7 +682,31 @@ void ElementsPanelWidget::duplicateDiagram()
 			// of the project database, so duplicates fail to insert and
 			// silently vanish from nomenclature/summary tables.
 			elmt->newUuid();
+
+			if (erase_label) {
+					// Same four fields PasteDiagramCommand::redo() clears.
+				DiagramContext dc = elmt->elementInformations();
+				dc.addValue("formula", "");
+				dc.addValue("label", "");
+				dc.addValue("comment", "");
+				dc.addValue("location", "");
+				elmt->setElementInformations(dc);
+			}
+
 			new_diagram->restoreText(elmt);
+		}
+
+		if (erase_label) {
+				// Conductor texts too, as paste does -- a duplicated folio
+				// keeping conductor numbers has the same duplicate-
+				// designation problem the element labels had.
+			for (QGraphicsItem *item : new_diagram->items()) {
+				if (Conductor *c = dynamic_cast<Conductor *>(item)) {
+					ConductorProperties cp = c->properties();
+					cp.text = new_diagram->defaultConductorProperties.text;
+					c->setProperties(cp);
+				}
+			}
 		}
 	}
 

--- a/sources/qetgraphicsitem/element.cpp
+++ b/sources/qetgraphicsitem/element.cpp
@@ -1318,6 +1318,49 @@ void Element::initLink(QETProject *prj)
 }
 
 /**
+	@brief Element::initLink
+	Resolve pending links against a specific, caller-supplied list of
+	elements instead of a project-wide ElementProvider search.
+
+	This overload exists for the case where several elements are being
+	introduced together (e.g. paste, or whole-diagram duplication) via
+	an XML round-trip: right after the round-trip and before any of the
+	batch's uuids have been renewed, each element's tmp_uuids_link still
+	holds its *source*'s original partner uuid, which at that exact
+	moment still equals the not-yet-renewed uuid of the corresponding
+	element within this same batch. Searching only within @a candidates
+	-- rather than the whole project via initLink(QETProject *) -- is
+	what keeps a linked pair being pasted/duplicated together from
+	matching against an original element left elsewhere in the project
+	that happens to share that same (soon-to-be-replaced) uuid.
+
+	As with the QETProject overload, this can only usefully run once:
+	tmp_uuids_link is cleared unconditionally at the end, whether or not
+	each pending entry found a match in @a candidates. If only one half
+	of a linked group is present in @a candidates, its unmatched entry
+	is simply dropped -- the same "leave it unlinked" outcome as today.
+	@param candidates
+*/
+void Element::initLink(const QList<Element *> &candidates)
+{
+	if (tmp_uuids_link.isEmpty()) return;
+
+	for (int i = 0; i < tmp_uuids_link.size(); ++i) {
+		for (Element *elmt : candidates) {
+			if (elmt == this) continue;
+			if (elmt->uuid() == tmp_uuids_link[i].uuid) {
+				elmt->linkToElement(this);
+				if (tmp_uuids_link[i].group_index >= 0) {
+					m_group_index_map[elmt] = tmp_uuids_link[i].group_index;
+				}
+				break;
+			}
+		}
+	}
+	tmp_uuids_link.clear();
+}
+
+/**
  * @brief Element::linkTypeToString
  * \deprecated use instead ElementData::typeToString
  * \todo remove this function

--- a/sources/qetgraphicsitem/element.h
+++ b/sources/qetgraphicsitem/element.h
@@ -193,6 +193,7 @@ class Element : public QetGraphicsItem
 		virtual void unlinkAllElements() {}
 		virtual void unlinkElement(Element *) {}
 		virtual void initLink(QETProject *);
+		void initLink(const QList<Element *> &candidates);
 		QList<Element *> linkedElements ();
 
 		int groupIndexForElement(Element *elmt) const;


### PR DESCRIPTION
Builds discussion #607.

## Problem

Cutting/copying a linked group of elements (a relay coil with its contacts, a PLC master with its slave I/O elements, etc.) — even the whole group together in one paste — currently drops the master/slave link entirely. The pasted copies come in as ordinary, independent elements with no link and no warning; the user has to notice and manually re-link them afterward.

## Traced end to end

- `Element::toXml()` writes each linked partner's uuid into a `<link_uuid>` entry — the clipboard XML genuinely contains the link information.
- `Element::fromXml()` reads that back — but only into a **deferred, unresolved** buffer, `tmp_uuids_link`. No linking happens at this point.
- The only code that ever resolves `tmp_uuids_link` into a real link is `Element::initLink(QETProject *prj)`, which builds an `ElementProvider` and resolves the pending uuids project-wide.
- `initLink()` is only ever called from `Diagram::refreshContents()`, which in turn is only called from two places: full project load, and macro-block insertion.
- `DiagramView::paste()` calls `Diagram::fromXml()` directly and never calls `refreshContents()` or `initLink()` anywhere in that path. Pasted elements' `tmp_uuids_link` gets populated correctly, but nothing ever resolves it — the link is silently dropped.

This is a different, narrower problem from the uuid-*collision* issue already fixed for whole-folio duplication (an element keeping its source uuid as the project database's primary key) — that's a separate bug on a separate code path.

## Fix

Added `Element::initLink(const QList<Element *> &candidates)` — resolves pending links against a caller-supplied candidate list instead of a project-wide `ElementProvider` search.

The scoping matters and is the subtle part: right after an XML round-trip and *before* `PasteDiagramCommand::redo()`'s existing `newUuid()` loop renews each pasted element's identity, a pasted element's `tmp_uuids_link` still holds its source's original partner uuid — which at that exact moment still equals the not-yet-renewed uuid of that partner's own pasted copy, if it was pasted too. Resolving only within the pasted batch (not the whole project) is what stops a linked pair being pasted together from matching against an original element left elsewhere in the project that happens to still carry that same soon-to-be-replaced uuid. If only one half of a linked group is pasted, its entry simply finds no match in the batch and is dropped — the same "leave it unlinked" outcome as today.

Wired into `PasteDiagramCommand::redo()`, right before the existing `newUuid()` loop, gated by the same `first_redo` flag so undo/redo cycles don't re-trigger either.

## Also fixed: the same bug on the folio-duplication path

Tracing this turned up the identical gap in `ElementsPanelWidget::duplicateDiagram()`: same XML round-trip, same per-element `newUuid()` renewal loop (added by an earlier commit to fix the separate uuid-collision issue), but nothing ever resolving `tmp_uuids_link` there either. Same root cause, same fix, reusing the new overload — flagging this clearly since it's beyond discussion #607's literal scope (cut/copy/paste), not silently bundled in.

## Test plan

- [x] Full project builds and links clean (`cmake --build`, default `BUILD_WITH_KF5=ON` config), zero new warnings
- [x] Existing Catch2 test suite passes (general regression check; no existing coverage of linked-element paste specifically)
- [ ] Manual: link a master element to a slave, select both, copy, paste — confirm the pasted copies are linked to each other (not to the originals, and not silently dropped); paste only the master (partner not copied) — confirm it comes in unlinked, same as today
- [ ] Manual: duplicate a folio containing a linked master/slave pair — confirm the duplicated copies are linked to each other