### PR TITLE
Fix command-line tools hanging forever on a modal message box

### DIFF
--- a/sources/main.cpp
+++ b/sources/main.cpp
@@ -19,6 +19,7 @@
 #include "machine_info.h"
 #include "qet.h"
 #include "qetapp.h"
+#include "qetmessagebox.h"
 #include "qetproject.h"
 #include "singleapplication.h"
 #include "utils/qetsettings.h"
@@ -249,6 +250,11 @@ QGuiApplication::setHighDpiScaleFactorRoundingPolicy(QetSettings::hdpiScaleFacto
 			// runs on a background thread referencing the project and races the
 			// process exit (intermittent segfault in QET::writeToFile).
 			QETProject::setBackupEnabled(false);
+			// Answer message boxes instead of showing them: opening a project
+			// saved by an older QElectroTech raises a warning from
+			// QETProject::readProjectXml(), and with nobody able to dismiss it
+			// QDialog::exec() would spin its event loop forever.
+			QET::QetMessageBox::setNonInteractive(true);
 			return CLIExport::run(export_app.arguments());
 		}
 	}

--- a/sources/qetmessagebox.cpp
+++ b/sources/qetmessagebox.cpp
@@ -17,6 +17,84 @@
 */
 #include "qetmessagebox.h"
 
+#include <QTextStream>
+
+namespace {
+	bool g_non_interactive = false;
+
+	/**
+		@brief autoAnswer
+		Report a message box on stderr and pick an answer, for use when there
+		is no user to click anything. @see QET::QetMessageBox::setNonInteractive
+		@param severity : short word naming the kind of box, for the log line
+		@param title
+		@param text
+		@param buttons : the buttons the caller offered
+		@param defaultButton : the caller's preferred answer, may be NoButton
+		@return the button to report as pressed
+	*/
+	QMessageBox::StandardButton autoAnswer(
+			const char *severity,
+			const QString &title,
+			const QString &text,
+			QMessageBox::StandardButtons buttons,
+			QMessageBox::StandardButton defaultButton)
+	{
+			//Honour the caller's own default when it named one.
+		if (defaultButton != QMessageBox::NoButton
+			&& (buttons & defaultButton)) {
+			QTextStream(stderr) << severity << ": " << title << " -- " << text
+								<< "\n(no display: answered with the caller's default button)\n";
+			return defaultButton;
+		}
+
+			//Otherwise prefer a "carry on" answer over one that cancels, so a
+			//batch run completes rather than silently doing nothing.
+		static const QMessageBox::StandardButton preference[] = {
+			QMessageBox::Ok,     QMessageBox::Open,   QMessageBox::Yes,
+			QMessageBox::Save,   QMessageBox::Apply,  QMessageBox::YesToAll,
+			QMessageBox::Retry,  QMessageBox::Ignore, QMessageBox::Close
+		};
+		for (auto candidate : preference) {
+			if (buttons & candidate) {
+				QTextStream(stderr) << severity << ": " << title << " -- " << text
+									<< "\n(no display: continuing)\n";
+				return candidate;
+			}
+		}
+
+			//Nothing affirmative on offer -- fall back to whatever is set.
+		for (int bit = QMessageBox::Ok; bit <= QMessageBox::RestoreDefaults; bit <<= 1) {
+			auto candidate = static_cast<QMessageBox::StandardButton>(bit);
+			if (buttons & candidate) {
+				QTextStream(stderr) << severity << ": " << title << " -- " << text
+									<< "\n(no display: answered automatically)\n";
+				return candidate;
+			}
+		}
+
+		QTextStream(stderr) << severity << ": " << title << " -- " << text
+							<< "\n(no display: no button offered)\n";
+		return QMessageBox::NoButton;
+	}
+}
+
+/**
+	@brief QET::QetMessageBox::setNonInteractive
+	@param non_interactive
+*/
+void QET::QetMessageBox::setNonInteractive(bool non_interactive) {
+	g_non_interactive = non_interactive;
+}
+
+/**
+	@brief QET::QetMessageBox::isNonInteractive
+	@return true when message boxes are answered without a user
+*/
+bool QET::QetMessageBox::isNonInteractive() {
+	return g_non_interactive;
+}
+
 /**
 	@see Documentation Qt pour QMessageBox::critical
 */
@@ -27,6 +105,9 @@ QMessageBox::StandardButton QET::QetMessageBox::critical (
 		QMessageBox::StandardButtons buttons,
 		QMessageBox::StandardButton defaultButton)
 {
+	if (g_non_interactive) {
+		return autoAnswer("Critical", title, text, buttons, defaultButton);
+	}
 #ifdef Q_OS_MACOS
 	QMessageBox message_box(
 				QMessageBox::Critical,
@@ -59,6 +140,9 @@ QMessageBox::StandardButton QET::QetMessageBox::information(
 		QMessageBox::StandardButtons buttons,
 		QMessageBox::StandardButton defaultButton)
 {
+	if (g_non_interactive) {
+		return autoAnswer("Information", title, text, buttons, defaultButton);
+	}
 #ifdef Q_OS_MACOS
 	QMessageBox message_box(
 				QMessageBox::Information,
@@ -91,6 +175,9 @@ QMessageBox::StandardButton QET::QetMessageBox::question (
 		QMessageBox::StandardButtons buttons,
 		QMessageBox::StandardButton defaultButton)
 {
+	if (g_non_interactive) {
+		return autoAnswer("Question", title, text, buttons, defaultButton);
+	}
 #ifdef Q_OS_MACOS
 	QMessageBox message_box(
 				QMessageBox::Question,
@@ -123,6 +210,9 @@ QMessageBox::StandardButton QET::QetMessageBox::warning (
 		QMessageBox::StandardButtons buttons,
 		QMessageBox::StandardButton defaultButton)
 {
+	if (g_non_interactive) {
+		return autoAnswer("Warning", title, text, buttons, defaultButton);
+	}
 #ifdef Q_OS_MACOS
 	QMessageBox message_box(
 				QMessageBox::Warning,

--- a/sources/qetmessagebox.h
+++ b/sources/qetmessagebox.h
@@ -27,6 +27,28 @@ namespace QET {
 		Qt:Sheet flag, thus enabling a better MacOS integration.
 	*/
 	namespace QetMessageBox {
+		/**
+			Enable non-interactive mode.
+
+			In non-interactive mode the functions below never construct a
+			dialog. They write the message to stderr and return an answer
+			immediately, so a headless run cannot block on a modal box that
+			nobody is there to dismiss.
+
+			This is needed because these are reachable from the command-line
+			tools: opening a project written by an older QElectroTech raises
+			a warning from QETProject::readProjectXml(), and with no display
+			to click it, QDialog::exec() spins its event loop forever.
+
+			The answer is chosen as: the caller's defaultButton when it gave
+			one, otherwise the first "carry on" button among those offered
+			(Ok, Open, Yes, Save, Apply...), otherwise the first button set.
+			So the two warnings above resolve to Open and the project loads,
+			which is what a batch invocation wants.
+		*/
+		void setNonInteractive(bool non_interactive);
+		bool isNonInteractive();
+
 		QMessageBox::StandardButton critical (
 				QWidget *,
 				const QString &,

--- a/sources/qetproject.cpp
+++ b/sources/qetproject.cpp
@@ -1202,7 +1202,7 @@ ElementsLocation QETProject::importElement(ElementsLocation &location)
 				// Warn if the new element introduces slave contact groups
 				QDomElement new_kind = location.xml().firstChildElement("kindInformations");
 				if (!new_kind.firstChildElement("slaveContactGroups").isNull()) {
-					QMessageBox::StandardButton answer = QMessageBox::warning(nullptr,
+					QMessageBox::StandardButton answer = QET::QetMessageBox::warning(nullptr,
 						tr("Système de contacts modifié"),
 						tr("Le nouvel élément définit des groupes de contacts esclaves.\n"
 						   "Les éléments esclaves existants ne seront pas automatiquement "


### PR DESCRIPTION
## The bug

`qelectrotech --resave examples/schema_indus.qet out.qet` never returns.

It isn't slow. Ten minutes of wall clock consumed **0.16 seconds of CPU** — it's blocked, not working. The GUI opens the very same project without complaint, so the file is fine and the fault is in the headless path.

A backtrace of the stuck process says exactly what's wrong:

```
main
  CLIExport::run
    QETProject::QETProject(QString const&, QObject*)
      QETProject::openFile(QFile*)
        QETProject::readProjectXml(QDomDocument&)
          QET::QetMessageBox::warning(...)
            QDialog::exec()          <- waits forever
```

`examples/schema_indus.qet` records `version="0.3"`, so loading it raises the *"partially compatible with your version"* warning in `readProjectXml()`. Interactively somebody presses **Open**; with no display nobody can, and `exec()` spins its event loop indefinitely.

The version warning is just the box an example file happens to trigger — **any** modal reachable during a load does this, so anyone scripting the CLI over a directory of older projects hangs on the first one.

## The fix

Fixed at the wrapper that all 52 call sites already funnel through, rather than at the one warning, so the whole class is closed rather than one symptom.

`QET::QetMessageBox` gains a non-interactive mode. When on, the four functions write the message to stderr and return an answer instead of constructing a dialog. `main.cpp` turns it on in the CLI branch, right beside the existing `QETProject::setBackupEnabled(false)` — which is there for the same underlying reason, that this path has no user and no event loop of its own.

The answer is chosen as:

1. the caller's `defaultButton`, when it named one and it's on offer;
2. otherwise the first "carry on" button offered — `Ok`, `Open`, `Yes`, `Save`, `Apply`…;
3. otherwise the first button set at all.

Both warnings in `readProjectXml()` offer `Open | Cancel` and abort the load on `Cancel`, so they resolve to `Open` and the project loads — which is what a batch invocation wants. The message text still reaches the user on stderr, where previously it was lost inside a dialog nobody could see.

**GUI behaviour is unchanged.** The flag defaults to `false` and is set in exactly one place — the command-line branch of `main()` — so no interactive path can reach it.

## Verification

- `schema_indus.qet`: **hangs indefinitely → resaves in 0.3s**, exit 0, valid output
- All **23** shipped example projects now complete a double `--resave`, with element / conductor / terminal counts and the full uuid set intact
- Builds clean, no new warnings; Catch2 suite passes

Found while building a save-determinism corpus over `examples/`, which is also how I know the 23-project sweep is clean — before this, one project could not be checked at all because the tooling hung on it.

## Test plan

- [x] The previously-hanging project resaves
- [x] All 23 examples double-resave with contents preserved
- [x] Builds clean, unit tests pass
- [ ] Manual: confirm message boxes still appear normally in the GUI (unchanged by construction — flag is CLI-only)