### PR TITLE
Fix broken signal/slot relations

### DIFF
--- a/sources/autoNum/ui/autonumberingdockwidget.cpp
+++ b/sources/autoNum/ui/autonumberingdockwidget.cpp
@@ -26,6 +26,7 @@
 #include "../numerotationcontext.h"
 #include "../numerotationcontextcommands.h"
 #include "ui_autonumberingdockwidget.h"
+#include "../../undocommand/changetitleblockcommand.h"
 
 #include <QComboBox>
 #include <QLineEdit>
@@ -371,7 +372,17 @@ void AutoNumberingDockWidget::on_m_folio_cb_activated(int) {
 		ip.folio = "%id/%total";
 		m_project->setDefaultTitleBlockProperties(ip);
 	}
-		emit(folioAutoNumChanged(current_autonum));
+
+	if (m_project_view && m_project_view->currentDiagram()) {
+		Diagram *diagram = m_project_view->currentDiagram()->diagram();
+		TitleBlockProperties old_properties = diagram->border_and_titleblock.exportTitleBlock();
+		TitleBlockProperties new_properties = old_properties;
+		new_properties.auto_page_num = ip.auto_page_num;
+		new_properties.folio = ip.folio;
+		if (new_properties != old_properties)
+			diagram->undoStack().push(new ChangeTitleBlockCommand(diagram, old_properties, new_properties));
+	}
+	emit(folioAutoNumChanged(current_autonum));
 	refreshRow(AutoNumCategory::Folio);
 }
 

--- a/sources/diagramview.cpp
+++ b/sources/diagramview.cpp
@@ -100,7 +100,7 @@ DiagramView::DiagramView(Diagram *diagram, QWidget *parent) :
 
 	connect(m_diagram, SIGNAL(showDiagram(Diagram*)), this, SIGNAL(showDiagram(Diagram*)));
 	connect(m_diagram, SIGNAL(sceneRectChanged(QRectF)), this, SLOT(adjustSceneRect()));
-	connect(&(m_diagram -> border_and_titleblock), SIGNAL(diagramTitleChanged(const QString &)), this, SLOT(updateWindowTitle()));
+	connect(&(m_diagram -> border_and_titleblock), &BorderTitleBlock::informationChanged, this, &DiagramView::updateWindowTitle);
 	connect(diagram, SIGNAL(findElementRequired(ElementsLocation)), this, SIGNAL(findElementRequired(ElementsLocation)));
 
 	QShortcut *edit_conductor_color_shortcut = new QShortcut(QKeySequence(Qt::Key_F2), this);

--- a/sources/exportdialog.cpp
+++ b/sources/exportdialog.cpp
@@ -140,12 +140,21 @@ QWidget *ExportDialog::initDiagramsListPart()
 	reset_mapper_     = new QSignalMapper(this);
 	clipboard_mapper_ = new QSignalMapper(this);
 	
-	connect(preview_mapper_,   SIGNAL(mapped(int)), this, SLOT(slot_previewDiagram(int)));
-	connect(width_mapper_,     SIGNAL(mapped(int)), this, SLOT(slot_correctHeight(int)));
-	connect(height_mapper_,    SIGNAL(mapped(int)), this, SLOT(slot_correctWidth(int)));
-	connect(ratio_mapper_,     SIGNAL(mapped(int)), this, SLOT(slot_keepRatioChanged(int)));
-	connect(reset_mapper_,     SIGNAL(mapped(int)), this, SLOT(slot_resetSize(int)));
+#if QT_VERSION < QT_VERSION_CHECK(5, 15, 0) // TODO Qt6 only: remove, mappedInt() always available
+	connect(preview_mapper_, SIGNAL(mapped(int)), this, SLOT(slot_previewDiagram(int)));
+	connect(width_mapper_, SIGNAL(mapped(int)), this, SLOT(slot_correctHeight(int)));
+	connect(height_mapper_, SIGNAL(mapped(int)), this, SLOT(slot_correctWidth(int)));
+	connect(ratio_mapper_, SIGNAL(mapped(int)), this, SLOT(slot_keepRatioChanged(int)));
+	connect(reset_mapper_, SIGNAL(mapped(int)), this, SLOT(slot_resetSize(int)));
 	connect(clipboard_mapper_, SIGNAL(mapped(int)), this, SLOT(slot_exportToClipBoard(int)));
+#else
+	connect(preview_mapper_, &QSignalMapper::mappedInt, this, &ExportDialog::slot_previewDiagram);
+	connect(width_mapper_, &QSignalMapper::mappedInt, this, &ExportDialog::slot_correctHeight);
+	connect(height_mapper_, &QSignalMapper::mappedInt, this, &ExportDialog::slot_correctWidth);
+	connect(ratio_mapper_, &QSignalMapper::mappedInt, this, &ExportDialog::slot_keepRatioChanged);
+	connect(reset_mapper_, &QSignalMapper::mappedInt, this, &ExportDialog::slot_resetSize);
+	connect(clipboard_mapper_, &QSignalMapper::mappedInt, this, &ExportDialog::slot_exportToClipBoard);
+#endif
 	
 	diagrams_list_layout_ = new QGridLayout();
 	

--- a/sources/qetapp.cpp
+++ b/sources/qetapp.cpp
@@ -124,8 +124,11 @@ QETApp::QETApp() :
 	initSplashScreen();
 	initSystemTray();
 
-	connect(&signal_map, SIGNAL(mapped(QWidget *)),
-		this, SLOT(invertMainWindowVisibility(QWidget *)));
+#if QT_VERSION < QT_VERSION_CHECK(5, 15, 0) // TODO Qt6 only: remove, mappedObject() always available
+	connect(&signal_map, SIGNAL(mapped(QWidget *)), this, SLOT(invertMainWindowVisibility(QWidget *)));
+#else
+	connect(&signal_map, &QSignalMapper::mappedObject, this, [this](QObject *object) { invertMainWindowVisibility(qobject_cast<QWidget *>(object)); });
+#endif
 	qApp->setQuitOnLastWindowClosed(false);
 	connect(qApp, &QApplication::lastWindowClosed,
 		this, &QETApp::checkRemainingWindows);

--- a/sources/qetdiagrameditor.cpp
+++ b/sources/qetdiagrameditor.cpp
@@ -107,7 +107,11 @@ QETDiagramEditor::QETDiagramEditor(const QStringList &files, QWidget *parent) :
 	m_workspace.setTabsClosable(true);
 
 		//Set the signal mapper
+#if QT_VERSION < QT_VERSION_CHECK(5, 15, 0) // TODO Qt6 only: remove, mappedObject() always available
 	connect(&windowMapper, SIGNAL(mapped(QWidget *)), this, SLOT(activateWidget(QWidget *)));
+#else
+	connect(&windowMapper, &QSignalMapper::mappedObject, this, [this](QObject *object) { activateWidget(qobject_cast<QWidget *>(object)); });
+#endif
 
 	setWindowTitle(tr("QElectroTech", "window title"));
 	setWindowIcon(QET::Icons::QETLogo);

--- a/sources/qetproject.h
+++ b/sources/qetproject.h
@@ -244,7 +244,6 @@ class QETProject : public QObject
 			/// rebuild their rule lists; this one just says "re-read me".
 		void autoNumContextUpdated();
 		void folioAutoNumRemoved();
-		void folioAutoNumChanged(QString);
 		void defaultTitleBlockPropertiesChanged();
 		void conductorAutoNumChanged();
 

--- a/sources/titleblock/templatelogomanager.cpp
+++ b/sources/titleblock/templatelogomanager.cpp
@@ -217,7 +217,11 @@ QString TitleBlockTemplateLogoManager::confirmLogoName(const QString &initial_na
 			connect(replace_button, SIGNAL(clicked()), signal_mapper, SLOT(map()));
 			connect(rename_button,  SIGNAL(clicked()), signal_mapper, SLOT(map()));
 			connect(cancel_button,  SIGNAL(clicked()), signal_mapper, SLOT(map()));
+#if QT_VERSION < QT_VERSION_CHECK(5, 15, 0) // TODO Qt6 only: remove, mappedInt() always available
 			connect(signal_mapper, SIGNAL(mapped(int)), rename_dialog, SLOT(done(int)));
+#else
+			connect(signal_mapper, &QSignalMapper::mappedInt, rename_dialog, &QDialog::done);
+#endif
 		}
 		rd_label -> setText(
 			QString(tr(

--- a/sources/ui/configpage/projectconfigpages.cpp
+++ b/sources/ui/configpage/projectconfigpages.cpp
@@ -396,17 +396,29 @@ void ProjectAutoNumConfigPage::buildConnections()
 		//Conductor Tab
 	connect(m_saw_conductor, &SelectAutonumW::applyPressed,  this, &ProjectAutoNumConfigPage::saveContextConductor);
 	connect(m_saw_conductor, &SelectAutonumW::removeClicked, this, &ProjectAutoNumConfigPage::removeContextConductor);
-	connect(m_saw_conductor->contextComboBox(), SIGNAL(currentIndexChanged(QString)), this, SLOT(updateContextConductor(QString)));
+#if QT_VERSION < QT_VERSION_CHECK(5, 14, 0) // TODO Qt6 only: remove, textActivated() always available
+	connect(m_saw_conductor->contextComboBox(), SIGNAL(activated(QString)), this, SLOT(updateContextConductor(QString)));
+#else
+	connect(m_saw_conductor->contextComboBox(), &QComboBox::textActivated, this, &ProjectAutoNumConfigPage::updateContextConductor);
+#endif
 
 		//Element Tab
 	connect(m_saw_element, &SelectAutonumW::applyPressed,  this, &ProjectAutoNumConfigPage::saveContextElement);
 	connect(m_saw_element, &SelectAutonumW::removeClicked, this, &ProjectAutoNumConfigPage::removeContextElement);
-	connect(m_saw_element->contextComboBox(), SIGNAL(currentIndexChanged(QString)), this, SLOT(updateContextElement(QString)));
+#if QT_VERSION < QT_VERSION_CHECK(5, 14, 0) // TODO Qt6 only: remove, textActivated() always available
+	connect(m_saw_element->contextComboBox(), SIGNAL(activated(QString)), this, SLOT(updateContextElement(QString)));
+#else
+	connect(m_saw_element->contextComboBox(), &QComboBox::textActivated, this, &ProjectAutoNumConfigPage::updateContextElement);
+#endif
 
 		//Folio Tab
 	connect(m_saw_folio, &SelectAutonumW::applyPressed,  this, &ProjectAutoNumConfigPage::saveContextFolio);
 	connect(m_saw_folio, &SelectAutonumW::removeClicked, this, &ProjectAutoNumConfigPage::removeContextFolio);
-	connect(m_saw_folio->contextComboBox(), SIGNAL(currentIndexChanged(QString)), this, SLOT(updateContextFolio(QString)));
+#if QT_VERSION < QT_VERSION_CHECK(5, 14, 0) // TODO Qt6 only: remove, textActivated() always available
+	connect(m_saw_folio->contextComboBox(), SIGNAL(activated(QString)), this, SLOT(updateContextFolio(QString)));
+#else
+	connect(m_saw_folio->contextComboBox(), &QComboBox::textActivated, this, &ProjectAutoNumConfigPage::updateContextFolio);
+#endif
 
 		//	Auto Folio Numbering
 	connect (m_faw, SIGNAL (applyPressed()),				 this, SLOT (applyAutoNum()));
@@ -491,6 +503,10 @@ void ProjectAutoNumConfigPage::removeContextElement()
 		return;
 	m_project->removeElementAutoNum (m_saw_element->contextComboBox()->currentText());
 	m_saw_element->contextComboBox()->removeItem (m_saw_element->contextComboBox()->currentIndex());
+	// removeItem() removes the current selection programmatically but
+	// textActivated() does not react to (by design, see buildConnections()).
+	// Refresh the displayed pattern explicitly so it matches the new selection.
+	updateContextElement(m_saw_element->contextComboBox()->currentText());
 }
 
 /**
@@ -678,6 +694,10 @@ void ProjectAutoNumConfigPage::removeContextConductor()
 	if ( m_saw_conductor->contextComboBox()-> currentText() == tr("Nom de la nouvelle numérotation") ) return;
 	m_project -> removeConductorAutoNum (m_saw_conductor->contextComboBox()-> currentText() );
 	m_saw_conductor->contextComboBox()-> removeItem (m_saw_conductor->contextComboBox()-> currentIndex() );
+	// removeItem() removes the current selection programmatically but
+	// textActivated() does not react to (by design, see buildConnections()).
+	// Refresh the displayed pattern explicitly so it matches the new selection.
+	updateContextConductor(m_saw_conductor->contextComboBox()->currentText());
 	project()->conductorAutoNumRemoved();
 }
 
@@ -691,6 +711,10 @@ void ProjectAutoNumConfigPage::removeContextFolio()
 	if ( m_saw_folio->contextComboBox() -> currentText() == tr("Nom de la nouvelle numérotation") ) return;
 	m_project -> removeFolioAutoNum (m_saw_folio->contextComboBox() -> currentText() );
 	m_saw_folio->contextComboBox() -> removeItem (m_saw_folio->contextComboBox() -> currentIndex() );
+	// removeItem() removes the current selection programmatically but
+	// textActivated() does not react to (by design, see buildConnections()).
+	// Refresh the displayed pattern explicitly so it matches the new selection.
+	updateContextFolio(m_saw_folio->contextComboBox()->currentText());
 	project()->folioAutoNumRemoved();
 }
 


### PR DESCRIPTION
Selecting an entry in the conductor/element/folio drop down boxes on the project auto-numbering properties page had no effect (when compiled with QT6): the related fields never updated. Root cause: currentIndexChanged has been removed in QT6. 