### PR TITLE
Fix element_info orphan row causing UNIQUE constraint errors on undo

### DIFF
--- a/sources/dataBase/projectdatabase.cpp
+++ b/sources/dataBase/projectdatabase.cpp
@@ -150,10 +150,30 @@ void projectDataBase::addElement(Element *element)
 */
 void projectDataBase::removeElement(Element *element)
 {
+	bool changed = false;
+
 	m_remove_element_query.bindValue(":uuid", element->uuid().toString());
-	if(!m_remove_element_query.exec()) {
-		qDebug() << "projectDataBase::removeElement remove error : " << m_remove_element_query.lastError();
+	if (m_remove_element_query.exec()) {
+		changed = true;
 	} else {
+		qDebug() << "projectDataBase::removeElement remove error : " << m_remove_element_query.lastError();
+	}
+
+		// element_info has no ON DELETE CASCADE (foreign keys aren't enforced
+		// by this connection), so it must be cleared explicitly here. Without
+		// this, the row is orphaned under the removed element's uuid, and
+		// re-adding an element with that same uuid later (undo of this same
+		// removal, or a redo replaying it) hits element_info's PRIMARY KEY
+		// constraint on element_uuid: the element re-add itself succeeds, but
+		// its element_info insert silently fails and is lost.
+	m_remove_element_info_query.bindValue(":uuid", element->uuid().toString());
+	if (m_remove_element_info_query.exec()) {
+		changed = true;
+	} else {
+		qDebug() << "projectDataBase::removeElement remove element_info error : " << m_remove_element_info_query.lastError();
+	}
+
+	if (changed) {
 		emit dataBaseUpdated();
 	}
 }
@@ -596,6 +616,11 @@ void projectDataBase::prepareQuery()
 	QString remove_element("DELETE FROM element WHERE uuid=:uuid");
 	m_remove_element_query = QSqlQuery(m_data_base);
 	m_remove_element_query.prepare(remove_element);
+
+		//REMOVE ELEMENT INFO
+	QString remove_element_info("DELETE FROM element_info WHERE element_uuid=:uuid");
+	m_remove_element_info_query = QSqlQuery(m_data_base);
+	m_remove_element_info_query.prepare(remove_element_info);
 
 		//UPDATE ELEMENT INFO
 	QString update_str("UPDATE element_info SET ");

--- a/sources/dataBase/projectdatabase.h
+++ b/sources/dataBase/projectdatabase.h
@@ -80,6 +80,7 @@ class projectDataBase : public QObject
 		QSqlQuery m_insert_elements_query,
 				  m_insert_element_info_query,
 				  m_remove_element_query,
+				  m_remove_element_info_query,
 				  m_update_element_query,
 				  m_insert_diagram_query,
 				  m_remove_diagram_query,


### PR DESCRIPTION
## What this fixes

`projectDataBase::removeElement()` only ran `DELETE FROM element WHERE uuid=:uuid`. It never touched `element_info`, even though every element also has a row there (`element_uuid` is its `PRIMARY KEY`, with a `FOREIGN KEY` back to `element.uuid` that isn't enforced by this connection — no `ON DELETE CASCADE` in effect). So deleting an element left its `element_info` row orphaned.

Re-adding an element with that same uuid later — undo of that same deletion, or a redo replaying it — goes through `Diagram::addItem()` → `projectDataBase::addElement()`, which `INSERT`s into both tables. The `element` insert succeeds (that row really was removed). The `element_info` insert hits the orphaned row's primary key and fails, silently: the error is logged and swallowed, so the element re-enters the scene with **no `element_info` row at all**, and nothing later re-syncs it. The element then stays silently absent from the database — and from anything that reads it, e.g. nomenclature/BOM views — until something else happens to touch it again.

## How I found it

Testing the combined build in [qelectrotech-docker](https://github.com/ispyisail/qelectrotech-docker), the app lagged during a normal session. Its log showed this repeating:

```
projectDataBase::addElement insert element info error :
QSqlError("19", "Unable to fetch row",
"UNIQUE constraint failed: element_info.element_uuid")
```

six times over a ~17-minute session — not a one-off. Notably it was *always* the `element_info` insert that failed and *never* the `element` insert (0 occurrences of "insert element error" in the same log), which is what pointed at asymmetric cleanup between the two tables rather than a general uuid-collision problem.

This is pre-existing on `master` — it predates and is independent of the wiring-database PR stack (#625/#628/#629/#630); those just also use this same table.

## The fix

`removeElement()` now also runs `DELETE FROM element_info WHERE element_uuid=:uuid`, so a removed element leaves no orphaned row behind for a later re-add to collide with.

## Verification

Built and ran the fix live: placed an element already present in a project, deleted it, undid the deletion. Before the fix, that sequence reliably reproduced the exact error above. After the fix, the same sequence produces nothing — the element reappears with no database error. Confirmed with screenshots at each step (selected → deleted → undone) against the actual compiled binary, not just from reading the code.

General regression check (`tests/catch`) still passes; it doesn't cover this file specifically, so the live reproduction above is the meaningful verification here.
