### PR TITLE
Use global font as default for terminal label font

### DIFF
--- a/sources/properties/terminaldata.cpp
+++ b/sources/properties/terminaldata.cpp
@@ -17,6 +17,7 @@
 */
 #include "terminaldata.h"
 
+#include "../qetapp.h"
 #include "../utils/qetutils.h"
 
 #include <QGraphicsObject>
@@ -38,6 +39,7 @@ TerminalData::TerminalData(QGraphicsObject *parent):
 
 void TerminalData::init()
 {
+	m_label_font = QETApp::diagramTextsFont();
 }
 
 TerminalData::~TerminalData()


### PR DESCRIPTION
Summary: Initialize m_label_font in TerminalData::init() with QETApp::diagramTextsFont() so new terminals use the globally configured element text font (default: Liberation Sans) instead of an uninitialized Qt default font. This matches the behavior of other element text parts like PartText and PartDynamicTextField.