### PR TITLE
Fix crash when opening a project: invalid index in corner layout

### DIFF
--- a/sources/projectview.cpp
+++ b/sources/projectview.cpp
@@ -842,7 +842,7 @@ void ProjectView::initWidgets()
 	QHBoxLayout *TopRightCorner_Layout = new QHBoxLayout();
 	TopRightCorner_Layout->setContentsMargins(0,0,0,0);
 	// some place left to the 'next_right_view_button' button
-	TopRightCorner_Layout->insertSpacing(1,10);
+	TopRightCorner_Layout->addSpacing(10);
 
 	QHBoxLayout *TopLeftCorner_Layout = new QHBoxLayout();
 	TopLeftCorner_Layout->setContentsMargins(0,0,0,0);


### PR DESCRIPTION
ProjectView::initWidgets() called insertSpacing(1, 10) on a QHBoxLayout that was still empty, inserting past the end of the item list. The corrupted layout crashed later in QWidget::setLayout() via QLayoutPrivate::reparentChildWidgets() and QBoxLayout::itemAt().

Use addSpacing(10) instead, which is equivalent for an empty layout.

## How it was found

Ubuntu 24.04, Qt 6.4, master r9164, built with `-fsanitize=address`.
The crash happens for every project on open.

```
==23414==ERROR: AddressSanitizer: SEGV on unknown address
    #0 QBoxLayout::itemAt(int) const
    #1 QLayoutPrivate::reparentChildWidgets(QWidget*)
    #2 QWidget::setLayout(QLayout*)
    #3 ProjectView::initWidgets() sources/projectview.cpp:883
    #4 ProjectView::ProjectView(QETProject*, QWidget*) sources/projectview.cpp:49
    #5 QETDiagramEditor::addProject(QETProject*, bool) sources/qetdiagrameditor.cpp:1282
```

The empty-layout `insertSpacing(1, 10)` was introduced together with the
corner layouts in 2ed8d76e ("add buttons 'one page left/right' to
projectView tab bar").