### PR TITLE
show terminalnames in export

### DIFF
--- a/sources/diagram.cpp
+++ b/sources/diagram.cpp
@@ -2397,9 +2397,10 @@ QPointF Diagram::snapToGrid(const QPointF &p)
 	\~French true pour afficher les bornes, false sinon
 */
 void Diagram::setDrawTerminals(bool dt) {
+	draw_terminals_ = dt;
 	foreach(QGraphicsItem *qgi, items()) {
 		if (Terminal *t = qgraphicsitem_cast<Terminal *>(qgi)) {
-			t -> setVisible(dt);
+			t -> update();
 		}
 	}
 }

--- a/sources/diagram.cpp
+++ b/sources/diagram.cpp
@@ -67,6 +67,7 @@ Diagram::Diagram(QETProject *project) :
 	m_project                (project),
 	use_border_              (true),
 	draw_terminals_          (true),
+	draw_terminal_names_     (true),
 	draw_colored_conductors_ (true),
 	m_event_interface        (nullptr),
 	m_freeze_new_elements    (false),
@@ -2319,6 +2320,7 @@ ExportProperties Diagram::applyProperties(
 	old_properties.draw_border = border_and_titleblock.borderIsDisplayed();
 	old_properties.draw_titleblock = border_and_titleblock.titleBlockIsDisplayed();
 	old_properties.draw_terminals          = drawTerminals();
+	old_properties.draw_terminal_names     = drawTerminalNames();
 	old_properties.draw_colored_conductors = drawColoredConductors();
 	old_properties.exported_area = useBorder() ? QET::BorderArea
 						   : QET::ElementsArea;
@@ -2327,6 +2329,7 @@ ExportProperties Diagram::applyProperties(
 	// applique les nouvelles options de rendu
 	setUseBorder             (new_properties.exported_area == QET::BorderArea);
 	setDrawTerminals         (new_properties.draw_terminals);
+	setDrawTerminalNames     (new_properties.draw_terminal_names);
 	setDrawColoredConductors (new_properties.draw_colored_conductors);
 	setDisplayGrid           (new_properties.draw_grid);
 	setDisplayGuides         (new_properties.draw_guides);
@@ -2398,6 +2401,20 @@ QPointF Diagram::snapToGrid(const QPointF &p)
 */
 void Diagram::setDrawTerminals(bool dt) {
 	draw_terminals_ = dt;
+	foreach(QGraphicsItem *qgi, items()) {
+		if (Terminal *t = qgraphicsitem_cast<Terminal *>(qgi)) {
+			t -> update();
+		}
+	}
+}
+
+/**
+	@brief Diagram::setDrawTerminalNames
+	Defines whether or not to display the terminal names/labels
+	@param dt : true to display the terminal names, false otherwise
+*/
+void Diagram::setDrawTerminalNames(bool dt) {
+	draw_terminal_names_ = dt;
 	foreach(QGraphicsItem *qgi, items()) {
 		if (Terminal *t = qgraphicsitem_cast<Terminal *>(qgi)) {
 			t -> update();

--- a/sources/diagram.h
+++ b/sources/diagram.h
@@ -126,8 +126,9 @@ class Diagram : public QGraphicsScene
 		bool use_border_;
 		bool draw_guides_;
 		QList<Diagram::Guide> m_guides_list;
-		bool draw_terminals_;
-		bool draw_colored_conductors_;
+	bool draw_terminals_;
+	bool draw_terminal_names_;
+	bool draw_colored_conductors_;
 
 		QString m_conductors_autonum_name;
 		DiagramEventInterface *m_event_interface;
@@ -226,6 +227,8 @@ class Diagram : public QGraphicsScene
 	
 		bool drawTerminals() const;
 		void setDrawTerminals(bool);
+		bool drawTerminalNames() const;
+		void setDrawTerminalNames(bool);
 		bool drawColoredConductors() const;
 		void setDrawColoredConductors(bool);
 	
@@ -424,6 +427,15 @@ inline QGIManager &Diagram::qgiManager() {
 inline bool Diagram::drawTerminals() const
 {
 	return(draw_terminals_);
+}
+
+/**
+	@brief Diagram::drawTerminalNames
+	@return true if terminal names are rendered, false otherwise
+*/
+inline bool Diagram::drawTerminalNames() const
+{
+	return(draw_terminal_names_);
 }
 
 /**

--- a/sources/diagram.h
+++ b/sources/diagram.h
@@ -126,9 +126,9 @@ class Diagram : public QGraphicsScene
 		bool use_border_;
 		bool draw_guides_;
 		QList<Diagram::Guide> m_guides_list;
-	bool draw_terminals_;
-	bool draw_terminal_names_;
-	bool draw_colored_conductors_;
+		bool draw_terminals_;
+		bool draw_terminal_names_;
+		bool draw_colored_conductors_;
 
 		QString m_conductors_autonum_name;
 		DiagramEventInterface *m_event_interface;

--- a/sources/exportproperties.cpp
+++ b/sources/exportproperties.cpp
@@ -34,7 +34,7 @@ ExportProperties::ExportProperties() :
 	draw_border(true),
 	draw_titleblock(true),
 	draw_terminals(false),
-	draw_terminal_names(true),
+	draw_terminal_names(false),
 	draw_bg_transparent(false),
 	draw_colored_conductors(true),
 	exported_area(QET::BorderArea)
@@ -109,7 +109,7 @@ void ExportProperties::fromSettings(QSettings &settings,
 	draw_terminals = settings.value(prefix % "drawterminals",
 					false).toBool();
 	draw_terminal_names = settings.value(prefix % "drawterminalnames",
-					true).toBool();
+					false).toBool();
 	draw_bg_transparent = settings.value(prefix % "drawbgtransparent",
 					false).toBool();
 	draw_colored_conductors = settings.value(

--- a/sources/exportproperties.cpp
+++ b/sources/exportproperties.cpp
@@ -34,6 +34,7 @@ ExportProperties::ExportProperties() :
 	draw_border(true),
 	draw_titleblock(true),
 	draw_terminals(false),
+	draw_terminal_names(true),
 	draw_bg_transparent(false),
 	draw_colored_conductors(true),
 	exported_area(QET::BorderArea)
@@ -70,6 +71,8 @@ void ExportProperties::toSettings(QSettings &settings,
 			  draw_titleblock);
 	settings.setValue(prefix % "drawterminals",
 			  draw_terminals);
+	settings.setValue(prefix % "drawterminalnames",
+			  draw_terminal_names);
 	settings.setValue(prefix % "drawbgtransparent",
 			  draw_bg_transparent);
 	settings.setValue(prefix % "drawcoloredconductors",
@@ -105,6 +108,8 @@ void ExportProperties::fromSettings(QSettings &settings,
 					 true ).toBool();
 	draw_terminals = settings.value(prefix % "drawterminals",
 					false).toBool();
+	draw_terminal_names = settings.value(prefix % "drawterminalnames",
+					true).toBool();
 	draw_bg_transparent = settings.value(prefix % "drawbgtransparent",
 					false).toBool();
 	draw_colored_conductors = settings.value(

--- a/sources/exportproperties.h
+++ b/sources/exportproperties.h
@@ -47,6 +47,7 @@ class ExportProperties {
 	bool draw_border;               ///< Whether to render the border (along with rows/columns headers)
 	bool draw_titleblock;           ///< Whether to render the title block
 	bool draw_terminals;            ///< Whether to render terminals
+	bool draw_terminal_names;       ///< Whether to render terminal names/labels
 	bool draw_bg_transparent;       ///< Whether to use transparency for SVG-Export
 	bool draw_colored_conductors;   ///< Whether to render conductors colors
 	QET::DiagramArea exported_area; ///< Area of diagrams to be rendered

--- a/sources/exportpropertieswidget.cpp
+++ b/sources/exportpropertieswidget.cpp
@@ -63,6 +63,7 @@ ExportProperties ExportPropertiesWidget::exportProperties() const
 	export_properties.draw_border             = draw_border    -> isChecked();
 	export_properties.draw_titleblock         = draw_titleblock     -> isChecked();
 	export_properties.draw_terminals          = draw_terminals -> isChecked();
+	export_properties.draw_terminal_names     = draw_terminal_names -> isChecked();
 	export_properties.draw_bg_transparent     = draw_bg_transparent -> isChecked();
 	export_properties.draw_colored_conductors = draw_colored_conductors -> isChecked();
 	export_properties.exported_area           = export_border -> isChecked() ? QET::BorderArea : QET::ElementsArea;
@@ -85,6 +86,7 @@ void ExportPropertiesWidget::setExportProperties(const ExportProperties &export_
 	draw_border             -> setChecked(export_properties.draw_border);
 	draw_titleblock         -> setChecked(export_properties.draw_titleblock);
 	draw_terminals          -> setChecked(export_properties.draw_terminals);
+	draw_terminal_names     -> setChecked(export_properties.draw_terminal_names);
 	draw_bg_transparent     -> setChecked(export_properties.draw_bg_transparent);
 	draw_colored_conductors -> setChecked(export_properties.draw_colored_conductors);
 	
@@ -206,13 +208,17 @@ void ExportPropertiesWidget::build()
 	draw_terminals = new QCheckBox(tr("Dessiner les bornes"), groupbox_options);
 	optionshlayout -> addWidget(draw_terminals, 2, 1);
 	
+	// dessiner les noms des bornes
+	draw_terminal_names = new QCheckBox(tr("Dessiner les noms des bornes"), groupbox_options);
+	optionshlayout -> addWidget(draw_terminal_names, 3, 0);
+	
 	// conserver les couleurs des conducteurs
 	draw_colored_conductors = new QCheckBox(tr("Conserver les couleurs des conducteurs"), groupbox_options);
-	optionshlayout -> addWidget(draw_colored_conductors, 3, 0);
+	optionshlayout -> addWidget(draw_colored_conductors, 3, 1);
 	
 	// use transparent background for SVG-Export
 	draw_bg_transparent = new QCheckBox(tr("SVG: fond transparent"), groupbox_options);
-	optionshlayout -> addWidget(draw_bg_transparent, 3, 1);
+	optionshlayout -> addWidget(draw_bg_transparent, 4, 0);
 	
 	vboxLayout -> addWidget(groupbox_options);
 	
@@ -239,6 +245,7 @@ void ExportPropertiesWidget::build()
 	connect(draw_border,              SIGNAL(stateChanged(int)),                   this, SIGNAL(optionChanged()));
 	connect(draw_titleblock,          SIGNAL(stateChanged(int)),                   this, SIGNAL(optionChanged()));
 	connect(draw_terminals,           SIGNAL(stateChanged(int)),                   this, SIGNAL(optionChanged()));
+	connect(draw_terminal_names,      SIGNAL(stateChanged(int)),                   this, SIGNAL(optionChanged()));
 	connect(draw_bg_transparent,      SIGNAL(stateChanged(int)),                   this, SIGNAL(optionChanged()));
 	connect(draw_colored_conductors,  SIGNAL(stateChanged(int)),                   this, SIGNAL(optionChanged()));
 }

--- a/sources/exportpropertieswidget.h
+++ b/sources/exportpropertieswidget.h
@@ -62,6 +62,7 @@ class ExportPropertiesWidget : public QWidget {
 	QCheckBox *draw_border;
 	QCheckBox *draw_titleblock;
 	QCheckBox *draw_terminals;
+	QCheckBox *draw_terminal_names;
 	QCheckBox *draw_bg_transparent;
 	QCheckBox *draw_colored_conductors;
 	QRadioButton *export_border;

--- a/sources/print/projectprintwindow.cpp
+++ b/sources/print/projectprintwindow.cpp
@@ -161,6 +161,7 @@ ProjectPrintWindow::ProjectPrintWindow(QETProject *project, QPrinter *printer, Q
 	ui->m_draw_border_cb->setChecked(exp.draw_border);
 	ui->m_draw_titleblock_cb->setChecked(exp.draw_titleblock);
 	ui->m_draw_terminal_cb->setChecked(exp.draw_terminals);
+	ui->m_draw_terminal_names_cb->setChecked(exp.draw_terminal_names);
 	ui->m_keep_conductor_color_cb->setChecked(exp.draw_colored_conductors);
 
 	ui->m_date_cb->blockSignals(true);
@@ -523,6 +524,7 @@ ExportProperties ProjectPrintWindow::exportProperties() const
 	exp.draw_border             = ui->m_draw_border_cb->isChecked();
 	exp.draw_titleblock         = ui->m_draw_titleblock_cb->isChecked();
 	exp.draw_terminals          = ui->m_draw_terminal_cb->isChecked();
+	exp.draw_terminal_names     = ui->m_draw_terminal_names_cb->isChecked();
 	exp.draw_colored_conductors = ui->m_keep_conductor_color_cb->isChecked();
 	exp.draw_grid = false;
 	exp.draw_guides = false;
@@ -796,6 +798,7 @@ void ProjectPrintWindow::on_m_draw_border_cb_clicked()          { m_preview->upd
 void ProjectPrintWindow::on_m_draw_titleblock_cb_clicked()      { m_preview->updatePreview(); }
 void ProjectPrintWindow::on_m_keep_conductor_color_cb_clicked() { m_preview->updatePreview(); }
 void ProjectPrintWindow::on_m_draw_terminal_cb_clicked()        { m_preview->updatePreview(); }
+void ProjectPrintWindow::on_m_draw_terminal_names_cb_clicked()  { m_preview->updatePreview(); }
 void ProjectPrintWindow::on_m_fit_in_page_cb_clicked()          { m_preview->updatePreview(); }
 void ProjectPrintWindow::on_m_use_full_page_cb_clicked()
 {

--- a/sources/print/projectprintwindow.h
+++ b/sources/print/projectprintwindow.h
@@ -55,6 +55,7 @@ class ProjectPrintWindow : public QMainWindow
 		void on_m_draw_titleblock_cb_clicked();
 		void on_m_keep_conductor_color_cb_clicked();
 		void on_m_draw_terminal_cb_clicked();
+		void on_m_draw_terminal_names_cb_clicked();
 		void on_m_fit_in_page_cb_clicked();
 		void on_m_use_full_page_cb_clicked();
 		void on_m_zoom_out_action_triggered();

--- a/sources/print/projectprintwindow.ui
+++ b/sources/print/projectprintwindow.ui
@@ -183,6 +183,16 @@
          </property>
         </widget>
        </item>
+       <item>
+        <widget class="QCheckBox" name="m_draw_terminal_names_cb">
+         <property name="text">
+          <string>Dessiner les noms des bornes</string>
+         </property>
+         <property name="checked">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
       </layout>
      </widget>
     </item>

--- a/sources/print/projectprintwindow.ui
+++ b/sources/print/projectprintwindow.ui
@@ -184,14 +184,14 @@
         </widget>
        </item>
        <item>
-        <widget class="QCheckBox" name="m_draw_terminal_names_cb">
-         <property name="text">
-          <string>Dessiner les noms des bornes</string>
-         </property>
-         <property name="checked">
-          <bool>true</bool>
-         </property>
-        </widget>
+         <widget class="QCheckBox" name="m_draw_terminal_names_cb">
+          <property name="text">
+           <string>Dessiner les noms des bornes</string>
+          </property>
+          <property name="checked">
+           <bool>false</bool>
+          </property>
+         </widget>
        </item>
       </layout>
      </widget>

--- a/sources/qetgraphicsitem/terminal.cpp
+++ b/sources/qetgraphicsitem/terminal.cpp
@@ -199,19 +199,21 @@ void Terminal::paint(
 
 	// dessin de la borne en rouge
 	// draw the terminal in red
-	t.setColor(Qt::red);
-	painter -> setPen(t);
-	painter -> drawLine(c, e);
+	if (!diagram() || diagram()->drawTerminals()) {
+		t.setColor(Qt::red);
+		painter -> setPen(t);
+		painter -> drawLine(c, e);
 
-	// dessin du point d'amarrage au conducteur en bleu
-	// draw the docking point to the conductor in blue
-	t.setColor(m_hovered_color);
-	painter -> setPen(t);
-	painter -> setBrush(m_hovered_color);
-	if (m_hovered) {
-		painter -> setRenderHint(QPainter::Antialiasing, true);
-		painter -> drawEllipse(QRectF(c.x() - 2.5, c.y() - 2.5, 5.0, 5.0));
-	} else painter -> drawPoint(c);
+		// dessin du point d'amarrage au conducteur en bleu
+		// draw the docking point to the conductor in blue
+		t.setColor(m_hovered_color);
+		painter -> setPen(t);
+		painter -> setBrush(m_hovered_color);
+		if (m_hovered) {
+			painter -> setRenderHint(QPainter::Antialiasing, true);
+			painter -> drawEllipse(QRectF(c.x() - 2.5, c.y() - 2.5, 5.0, 5.0));
+		} else painter -> drawPoint(c);
+	}
 
 	//Draw help line if needed,
 	if (diagram() && m_draw_help_line)

--- a/sources/qetgraphicsitem/terminal.cpp
+++ b/sources/qetgraphicsitem/terminal.cpp
@@ -275,9 +275,10 @@ void Terminal::paint(
 		m_help_line_a -> setLine(line);
 	}
 
-	// Draw label if show_name is enabled
+	// Draw label if show_name is enabled and terminal names are allowed
 	const QString display_name = name();
-	if (d->m_show_name && !display_name.isEmpty()) {
+	if (d->m_show_name && !display_name.isEmpty()
+		&& (!diagram() || diagram()->drawTerminalNames())) {
 		painter->setRenderHint(QPainter::Antialiasing, true);
 		painter->setRenderHint(QPainter::TextAntialiasing, true);
 		painter->setFont(d->m_label_font);


### PR DESCRIPTION
Terminal names/labels are now always rendered in PDF, PNG, and other exports, even when the "Dessiner les bornes" (Draw terminals) checkbox is not active.

Previously, Diagram::setDrawTerminals(false) called Terminal::setVisible(false), which hid the entire terminal QGraphicsObject — including the name label. This happened because both the terminal visual (red line + docking point) and the name are drawn inside Terminal::paint(), and Qt skips paint() entirely for invisible items.

The fix changes setDrawTerminals() to only set a flag and trigger a repaint, instead of hiding terminals. Terminal::paint() now checks diagram()->drawTerminals() to decide whether to draw the red line and docking point, but always renders the name/label regardless of the flag.