### PR TITLE
Fix combo box slots silently disconnected under Qt 6

### DIFF
--- a/sources/editor/ui/dynamictextfieldeditor.cpp
+++ b/sources/editor/ui/dynamictextfieldeditor.cpp
@@ -219,6 +219,11 @@ void DynamicTextFieldEditor::disconnectConnections()
 */
 void DynamicTextFieldEditor::fillInfoComboBox()
 {
+	if (ui->m_elmt_info_cb->view() && ui->m_elmt_info_cb->view()->isVisible()) {
+		return;
+	}
+
+	const QString current = ui->m_elmt_info_cb->currentData().toString();
 	ui -> m_elmt_info_cb -> clear();
 
 	QStringList strl;
@@ -264,6 +269,11 @@ void DynamicTextFieldEditor::fillInfoComboBox()
 
 	for (int i=0; i<strl.size();++i) {
 		ui -> m_elmt_info_cb -> addItem(QETInformation::translatedInfoKey(strl[i]), strl[i]);
+	}
+
+	int index = ui->m_elmt_info_cb->findData(current);
+	if (index >= 0) {
+		ui->m_elmt_info_cb->setCurrentIndex(index);
 	}
 }
 
@@ -347,8 +357,8 @@ void DynamicTextFieldEditor::on_m_width_sb_editingFinished()
 	}
 }
 
-void DynamicTextFieldEditor::on_m_elmt_info_cb_activated(const QString &arg1) {
-	Q_UNUSED(arg1)
+void DynamicTextFieldEditor::on_m_elmt_info_cb_activated(int index) {
+	Q_UNUSED(index)
 
 	QString info = ui -> m_elmt_info_cb -> currentData().toString();
 	for (int i = 0; i < m_parts.length(); i++) {
@@ -372,19 +382,9 @@ void DynamicTextFieldEditor::on_m_elmt_info_cb_activated(const QString &arg1) {
 */
 void DynamicTextFieldEditor::updateTextFromWidgetsEnabled(int index)
 {
-	ui -> m_user_text_le -> setDisabled(true);
-	ui -> m_elmt_info_cb -> setDisabled(true);
-	ui -> m_composite_text_pb -> setDisabled(true);
-
-	if(index == 0) {
-		ui->m_user_text_le->setEnabled(true);
-	}
-	else if (index == 1) {
-		ui->m_elmt_info_cb->setEnabled(true);
-	}
-	else {
-		ui->m_composite_text_pb->setEnabled(true);
-	}
+	ui->m_user_text_le->setEnabled(index == 0);
+	ui->m_elmt_info_cb->setEnabled(index == 1);
+	ui->m_composite_text_pb->setEnabled(index == 2);
 }
 
 void DynamicTextFieldEditor::on_m_text_from_cb_activated(int index) {

--- a/sources/editor/ui/dynamictextfieldeditor.h
+++ b/sources/editor/ui/dynamictextfieldeditor.h
@@ -62,7 +62,7 @@ class DynamicTextFieldEditor : public ElementItemEditor {
 		void on_m_size_sb_editingFinished();	
 		void on_m_frame_cb_clicked();
 		void on_m_width_sb_editingFinished();
-		void on_m_elmt_info_cb_activated(const QString &arg1);
+		void on_m_elmt_info_cb_activated(int index);
 		void on_m_text_from_cb_activated(int index);
 		void on_m_composite_text_pb_clicked();
 		void on_m_alignment_pb_clicked();

--- a/sources/ui/compositetexteditdialog.cpp
+++ b/sources/ui/compositetexteditdialog.cpp
@@ -75,9 +75,9 @@ void CompositeTextEditDialog::setUpComboBox(bool is_report)
 	}
 }
 
-void CompositeTextEditDialog::on_m_info_cb_activated(const QString &arg1)
+void CompositeTextEditDialog::on_m_info_cb_activated(int index)
 {
-	Q_UNUSED(arg1)
+	Q_UNUSED(index)
 	ui->m_plain_text_edit->insertPlainText(ui->m_info_cb->currentData().toString());
 }
 

--- a/sources/ui/compositetexteditdialog.h
+++ b/sources/ui/compositetexteditdialog.h
@@ -28,7 +28,7 @@ class CompositeTextEditDialog : public QDialog
 		QString plainText() const;
 	
 	private slots:
-		void on_m_info_cb_activated(const QString &arg1);
+		void on_m_info_cb_activated(int index);
 		
 	protected:
 		void focusInEvent(QFocusEvent *event) override;


### PR DESCRIPTION
`QComboBox::activated(const QString&)` was deprecated in Qt 5.15 and removed
in Qt 6. Auto-connected slots using that signature are never invoked,
`connectSlotsByName()` finds no matching signal and fails silently.

Two dialogs are affected:

**`DynamicTextFieldEditor`**: in the element editor, adding a dynamic text
field with text source *element information* and picking an entry from the
lower combo box did nothing at all: no undo command, nothing saved, and the
next `updateForm()` restored the previous value.

**`CompositeTextEditDialog`**: picking an information inserted nothing into
the composite text.

## Fix

Both slots now take `int`. `activated(int)` exists in Qt 5 and Qt 6 alike,
so Qt 5 builds are unaffected. Neither slot body used the signal argument,
both read the value through `currentData()`, so nothing else changed.

Additionally, `fillInfoComboBox()` now preserves the current selection
across its `clear()`/`addItem()` cycle and skips the rebuild while the popup
is open. Rebuilding the list previously reset the choice to the first entry.

## Tested on

Ubuntu 24.04, Qt 6.4, master r9164.

## Related

Any other `SIGNAL()`-based connection using a removed Qt 5 signature is dead
the same way. I found `QSignalMapper::mapped()` still in use in
`qetapp.cpp:125`, `qetdiagrameditor.cpp:110` and
`templatelogomanager.cpp:220`, each logging a connect warning on every start
(`RecentFiles` was already migrated). Happy to send that as a separate PR if
you want it.