### PR TITLE
Avoid needless dock churn in QETElementEditor::updateInformations()

### DIFF
--- a/sources/editor/ui/qetelementeditor.cpp
+++ b/sources/editor/ui/qetelementeditor.cpp
@@ -573,9 +573,11 @@ void QETElementEditor::updateInformations()
 			|| selection_xml_name == "ellipse"
 			|| selection_xml_name == "arc")
 		{
-			clearToolsDock();
 			//We add the editor widget
 			ElementItemEditor *editor = static_cast<ElementItemEditor*>(m_editors[selection_xml_name]);
+			if (m_tools_dock_stack -> widget(1) != editor) {
+				clearToolsDock();
+			}
 
 #if TODO_LIST
 #pragma message("@TODO Check if it takes longer than setting the parts again to the editor.")
@@ -608,7 +610,9 @@ void QETElementEditor::updateInformations()
 					success = editor -> setParts(cep_list);
 				}
 				if (success) {
-					m_tools_dock_stack -> insertWidget(1, editor);
+					if (m_tools_dock_stack -> widget(1) != editor) {
+						m_tools_dock_stack -> insertWidget(1, editor);
+					}
 					m_tools_dock_stack -> setCurrentIndex(1);
 				}
 				else {
@@ -626,8 +630,10 @@ void QETElementEditor::updateInformations()
 			// multi edit for polygons makes no sense
 			// TODO: maybe allowing multipart edit when number of points is the same?
 			//We add the editor widget
-			clearToolsDock();
 			ElementItemEditor *editor = static_cast<ElementItemEditor*>(m_editors[selection_xml_name]);
+			if (m_tools_dock_stack -> widget(1) != editor) {
+				clearToolsDock();
+			}
 			CustomElementPart* part = editor -> currentPart();
 			bool equal = part == cep_list.first();
 
@@ -637,7 +643,9 @@ void QETElementEditor::updateInformations()
 					success = editor -> setPart(cep_list.first());
 				}
 				if (success) {
-					m_tools_dock_stack -> insertWidget(1, editor);
+					if (m_tools_dock_stack -> widget(1) != editor) {
+						m_tools_dock_stack -> insertWidget(1, editor);
+					}
 					m_tools_dock_stack -> setCurrentIndex(1);
 				}
 				else {
@@ -655,11 +663,15 @@ void QETElementEditor::updateInformations()
 
 	//There's several parts selecteds and all can be edited by style editor.
 	if (style_editable) {
-		clearToolsDock();
 		ElementItemEditor *selection_editor = m_editors["style"];
+		if (m_tools_dock_stack -> widget(1) != selection_editor) {
+			clearToolsDock();
+		}
 		if (selection_editor) {
 			if (selection_editor -> setParts(cep_list)) {
-				m_tools_dock_stack -> insertWidget(1, selection_editor);
+				if (m_tools_dock_stack -> widget(1) != selection_editor) {
+					m_tools_dock_stack -> insertWidget(1, selection_editor);
+				}
 				m_tools_dock_stack -> setCurrentIndex(1);
 			}
 			else {


### PR DESCRIPTION
`updateInformations()` runs on every selection change and on every undo
stack index change. It unconditionally called `clearToolsDock()`, which
removes and hides the current editor widget, and then re-inserted the same
widget into the stack — so when the selection needs the editor that is
already shown, the widget gets removed, hidden, reparented and re-added only
to end up in exactly the same state.

## Change

Look up the editor first and only clear and re-insert the tools dock when a
different editor is actually needed. `setPart()`/`setParts()` still updates
the contents in every case, so the visible result is unchanged.

Applies to all three branches: the single/multi part editors, the
polygon/terminal branch, and the style editor for mixed selections.

## Scope

This is a cleanup, not a bug fix. I am not aware of a user-visible defect it
resolves. It came out of investigating unrelated widget behaviour in the
element editor and seemed worth sending on its own merits. Happy to drop it
if you would rather leave that code path alone.