### PR TITLE
Add two orphaned actions to the menus, drop two dead members

### DIFF
--- a/sources/qetdiagrameditor.cpp
+++ b/sources/qetdiagrameditor.cpp
@@ -882,6 +882,8 @@ void QETDiagramEditor::setUpMenu()
 
 	// menu Projet
 	menu_project -> addAction(m_project_edit_properties);
+	menu_project -> addAction(m_auto_conductor);
+	menu_project -> addSeparator();
 	menu_project -> addAction(m_project_add_diagram);
 	menu_project -> addAction(m_remove_diagram_from_project);
 	menu_project -> addAction(m_clean_project);
@@ -917,6 +919,7 @@ void QETDiagramEditor::setUpMenu()
 	menu_affichage -> addAction(m_mode_visualise);
 	menu_affichage -> addSeparator();
 	menu_affichage -> addAction(m_draw_grid);
+	menu_affichage -> addAction(m_draw_guides);
 	menu_affichage -> addAction(m_grey_background);
 	menu_affichage -> addSeparator();
 	menu_affichage -> addActions(m_zoom_actions_group.actions());

--- a/sources/qetdiagrameditor.h
+++ b/sources/qetdiagrameditor.h
@@ -192,7 +192,6 @@ class QETDiagramEditor : public QETMainWindow
 		*redo,				///< Redo the latest cancelled operation
 		*m_paste,			///< Paste clipboard content on the current diagram
 		*m_auto_conductor,		///< Enable/Disable the use of auto conductor
-		*conductor_default,		///< Show a dialog to edit default conductor properties
 		*m_grey_background,		///< Switch the background color in white or grey
 		*m_draw_grid,			///< Switch the background grid display or not
 		*m_draw_guides = nullptr,	///< Switch the custom guides display or not
@@ -200,7 +199,6 @@ class QETDiagramEditor : public QETMainWindow
 		*m_project_add_diagram,		///< Add a diagram to the current project.
 		*m_remove_diagram_from_project,	///< Delete a diagram from the current project
 		*m_clean_project,		///< Clean the content of the current project by removing useless items
-		*m_project_folio_list,		///< Sommaire des schemas
 		*m_csv_export,			///< generate nomenclature
 		*m_add_nomenclature,		///< Add nomenclature graphics item;
 		*m_add_summary,			///<Add summary graphics item


### PR DESCRIPTION
Small, self-contained piece of the menu audit in #677. Nothing here depends on the menu-structure question raised there — these are the uncontroversial parts.

## Two actions that exist but have no menu entry

Both already work. Both were only reachable from a toolbar, and those toolbars are user-hideable via **Configuration → Afficher** — so hiding one made the feature unreachable entirely: no menu, no shortcut, no context menu.

### `m_draw_guides` → Affichage

```cpp
view_tool_bar->addAction(m_draw_grid);     // also in the Affichage menu
view_tool_bar->addAction(m_draw_guides);   // toolbar only
```

Adjacent lines in the view toolbar doing the same kind of thing, and only the grid had a menu entry. Guides now sit directly under "Afficher la grille".

### `m_auto_conductor` → Projet

This one writes a *project* setting:

```cpp
connect(m_auto_conductor, &QAction::triggered, [this](bool ac) {
    if (ProjectView *pv = currentProjectView())
        pv->project()->setAutoConductor(ac);
});
```

...but lived only on the diagram toolbar, so the Projet menu is where a user would look and not find it. Placed with the project properties, above a new separator that keeps the folio operations grouped exactly as before:

```
Propriétés du projet
Création automatique de conducteur(s)   [checkable]
──────────
Ajouter un folio
Supprimer le folio
Nettoyer le projet
──────────
(exports and tools, unchanged)
```

Both actions already have their enabled/checked state managed in `slot_updateComplexActions()` and `slot_updateModeActions()`, so no state handling was needed — they just had nowhere to be shown.

## Two dead members

`conductor_default` and `m_project_folio_list` are declared in `qetdiagrameditor.h` but have no allocation and no remaining reference anywhere in the tree:

```
$ grep -rn "conductor_default\|m_project_folio_list" sources/
sources/qetdiagrameditor.h:195:  *conductor_default,
sources/qetdiagrameditor.h:203:  *m_project_folio_list,
```

To be precise about what these are: both are leftovers from features that were deliberately removed, not members that were never wired up.

- **`conductor_default`** was orphaned by `0ae33913e` (2010-12-28), *"Integrated the 'Default conductor properties' dialog into the 'Diagram properties' one."*
- **`m_project_folio_list`** was orphaned by `132f3ad1b` (2020-07-14), *"Remove old summary feature."* Until then it was a live action — `tr("Ajouter un sommaire")`, connected, and carrying its own entry in the Projet menu.

In both cases the usage was removed and the declaration was left behind. `5d92393e` (2020-09-07, "Wrap code for better readability") later folded the orphans into the comma-separated declaration block they sit in today, which is why they have been easy to overlook since.

That the features were removed on purpose is the argument for removing the declarations too. They are declaration-only uninitialised raw pointers, and the build still links without them.

## Notes

- **No new strings.** Both actions already carry translated text; this only adds them to menus.
- Built clean: CMake/Ninja Release, Qt 5.15.18, 819/819.
- `setUpMenu()` runs after `setUpActions()` (`qetdiagrameditor.cpp:122-124`), so both pointers are valid at the point they are added.

Found while diffing every `QAction` against every menu for #677. The larger findings from that audit — the seven add-item actions and the element editor's eight drawing actions being toolbar-only — are deliberately **not** in this PR, since they involve a menu-structure decision worth agreeing on first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
