### PR TITLE
Add optional precompiled headers behind QET_ENABLE_PCH (default OFF)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -145,6 +145,34 @@ else()
     )
 endif()
 
+# Optional precompiled headers -- see QET_ENABLE_PCH in
+# cmake/developer_options.cmake for what this trades away.
+#
+# target_precompile_headers() needs CMake 3.16; the project still declares a
+# 3.5 minimum, so guard rather than raise it for an opt-in developer feature.
+#
+# The generator expressions are load-bearing, not decoration: this target also
+# compiles the 18 C files of the bundled LZMA decoder
+# (sources/import/edz/lzma/*.c), and an unguarded list applies to every
+# language in the target, so the Qt headers would reach the C compiler and fail
+# with "unknown type name 'namespace'". $<ANGLE-R> is required because a
+# literal '>' would terminate the generator expression.
+if(QET_ENABLE_PCH)
+    if(CMAKE_VERSION VERSION_LESS 3.16)
+        message(WARNING
+            "QET_ENABLE_PCH needs CMake 3.16 or newer (found ${CMAKE_VERSION}); "
+            "building without precompiled headers.")
+    else()
+        target_precompile_headers(${PROJECT_NAME} PRIVATE
+            "$<$<COMPILE_LANGUAGE:CXX>:<QtCore/QtCore$<ANGLE-R>>"
+            "$<$<COMPILE_LANGUAGE:CXX>:<QtGui/QtGui$<ANGLE-R>>"
+            "$<$<COMPILE_LANGUAGE:CXX>:<QtWidgets/QtWidgets$<ANGLE-R>>"
+            "$<$<COMPILE_LANGUAGE:CXX>:<QtXml/QtXml$<ANGLE-R>>"
+        )
+        message(STATUS "QET_ENABLE_PCH: precompiled headers enabled")
+    endif()
+endif()
+
 target_link_libraries(
     ${PROJECT_NAME}
     PUBLIC

--- a/cmake/developer_options.cmake
+++ b/cmake/developer_options.cmake
@@ -33,3 +33,17 @@ add_definitions(-DQT_MESSAGELOGCONTEXT)
 
 # Build with KF5
 option(BUILD_WITH_KF5 "Build with KF5" ON)
+
+# Precompiled headers for the Qt umbrella headers.
+#
+# Off by default and intended for local development only. Building QET is
+# dominated by re-parsing Qt's headers: a 214-line .cpp expands to ~198,000
+# preprocessed lines, and compiling one translation unit costs ~4.1 s of which
+# only ~0.35 s is optimisation (-O0 instead of -O3 saves 8%). A PCH caches the
+# parsed header state and takes that ~4.1 s down to ~1.2 s.
+#
+# It is deliberately NOT on by default: a PCH satisfies includes that a source
+# file forgot to make itself, so code written with it enabled can fail to
+# compile for everyone else. Leaving it off keeps CI and contributors on the
+# strict behaviour, and only developers who opt in trade that for the speed.
+option(QET_ENABLE_PCH "Use precompiled headers (developer build speed; may mask missing #includes)" OFF)


### PR DESCRIPTION
Opt-in developer build-speed option. **Off by default — nothing changes unless you ask for it.**

## Why

Building QET is dominated by re-parsing Qt's headers. Measuring one ordinary source file:

```
sources/undocommand/rotateselectioncommand.cpp        214 lines
  after preprocessing                             197,796 lines   (6.5 MB)
```

A 924× amplification, paid for every one of ~420 translation units.

The part I found surprising, and the reason I went with a PCH rather than the usual advice:

| | compile 1 TU |
|---|---:|
| `-O3` (as configured) | 4.12 s |
| `-O2` | 4.14 s |
| `-O1` | 3.90 s |
| `-O0` | 3.77 s |
| `-E` (preprocess only) | 0.59 s |

**Dropping `-O3` to `-O0` saves 0.35 s — 8%.** "Build Debug, it compiles faster" barely helps, because the cost is the front-end doing semantic analysis on the preprocessed Qt headers, not the optimiser. A PCH is the one thing that caches exactly that.

## Measured

24-thread Xeon E5-2650 v4, Qt 5.15.18, GCC 15.2, same build tree, only the option differing:

| | OFF | ON |
|---|---:|---:|
| Compile one translation unit | 4.12 s | **1.21 s** |
| Edit one `.cpp` → linked binary | 5.22 s | **1.65 s** |

(Timed with real semantic edits. A comment-only change is invisible after preprocessing and produces a misleading result if ccache is in the picture.)

One-off cost: the PCH itself takes 7.5 s to build and occupies 218 MB.

## Why it defaults to OFF

A PCH satisfies includes that a source file neglected to make for itself. Code written with it enabled can compile locally and fail for everyone else. Keeping the default off means CI and contributors get the strict behaviour, and only developers who opt in take that trade.

I'd rather it stay off by default permanently for that reason, not just initially.

## Two implementation details that are load-bearing

**The generator expressions aren't decoration.** This target also compiles the 18 C files of the bundled LZMA decoder (`sources/import/edz/lzma/*.c`). `target_precompile_headers()` with a plain list applies to *every* language in the target, so the Qt headers get handed to the C compiler:

```
qnamespace.h:64:1: error: unknown type name 'namespace'
```

Hence `$<$<COMPILE_LANGUAGE:CXX>:...>` — and `$<ANGLE-R>`, because a literal `>` would terminate the generator expression. I've noted this in a comment so it doesn't get "simplified" later and break the C build.

**CMake version.** `target_precompile_headers()` needs 3.16, but the project still declares `cmake_minimum_required(VERSION 3.5...4.2)`. Rather than raise the project-wide minimum for an opt-in developer feature, the block warns and skips on older CMake.

## Verified both ways

With the option **off**:
- no `cmake_pch*` artefacts generated at all
- no `QET_ENABLE_PCH` status message
- builds and runs

With the option **on**:
- all 18 C files still compile
- the generated PCH is C++-only — `cmake_pch.hxx` exists, `cmake_pch.h` does not
- the C compile commands carry no PCH include
- builds and runs

Both configurations built clean (CMake/Ninja Release, Qt 5.15.18) and the resulting binaries report `0.100.1-dev`.

## Not included

Two other changes gave large wins but need no patch, so they're just notes for anyone interested rather than part of this PR: `-fuse-ld=mold` takes the link from 0.95 s to 0.10 s, and `ccache` takes a full rebuild from 236 s to 4.4 s. Also worth recording a negative result — clang is *slower* than GCC on this codebase (5.29 s vs 4.03 s per TU), so switching compilers is not the answer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)