### PR TITLE
Fix: Save the default cross-reference properties to QSettings

### DIFF
--- a/sources/ui/configpage/configpages.cpp
+++ b/sources/ui/configpage/configpages.cpp
@@ -214,7 +214,11 @@ void NewDiagramPage::applyConf()
 		rpw->toSettings(settings, "diagrameditor/defaultreport");
 
 		// default xref properties
-		QHash <QString, XRefProperties> hash_xrp = xrefpw -> properties();
+		const QHash<QString, XRefProperties> hash_xrp = xrefpw->properties();
+		for (auto it = hash_xrp.constBegin() ; it != hash_xrp.constEnd() ; ++it) {
+			it.value().toSettings(settings,
+						  QStringLiteral("diagrameditor/defaultxref") % it.key());
+		}
 
 		// Global in QSettings speichern
 		QList<Diagram::Guide> current_guides = m_gpw->guides();


### PR DESCRIPTION
Changing the cross-reference defaults under *Settings → New project* has
no effect: the values are not stored, and every new project falls back to
the hardcoded defaults.

## Cause

`NewDiagramPage::applyConf()` (`sources/ui/configpage/configpages.cpp:217`)
reads the properties into a local hash and never writes them:

```cpp
// default xref properties
QHash <QString, XRefProperties> hash_xrp = xrefpw -> properties();

// Global in QSettings speichern
QList<Diagram::Guide> current_guides = m_gpw->guides();
```

`hash_xrp` is used nowhere else in the file. Every neighbouring default —
border, title block, conductors, folio reports — calls `toSettings()`
right there; only this one is missing. The read side has always been
complete: `XRefProperties::defaultProperties()` looks for
`diagrameditor/defaultxref` + type for `coil`, `protection`, `commutator`
and `plc`.

## Fix

Iterate the hash and write each type with the prefix
`defaultProperties()` already expects.

## Testing

Before: no `defaultxref*` key exists in `QElectroTech.conf`, whatever you
set in the dialog.

After: changing the settings, closing QET and running
`grep defaultxref ~/.config/QElectroTech/QElectroTech.conf` shows the
keys for all four types, and new projects pick them up.

Tested on Ubuntu 26, Qt 5.15.18 and Qt6.10.2