### PR TITLE
Reject non-finite element positions and illegal XML control bytes

### DIFF
--- a/sources/qet.cpp
+++ b/sources/qet.cpp
@@ -19,6 +19,7 @@
 #include "qeticons.h"
 #include "shortcutmanager.h"
 
+#include <cmath>
 #include <limits>
 #include <QGraphicsSceneContextMenuEvent>
 #include <QAction>
@@ -248,7 +249,58 @@ bool QET::attributeIsAReal(
 	bool ok;
 	qreal tmp = e.attribute(nom_attribut).toDouble(&ok);
 	if (!ok) return(false);
+		// QString::toDouble() parses "nan"/"inf"/"-inf" successfully (ok
+		// stays true), so a non-finite value would otherwise sail through
+		// every geometry attribute this function gates -- including an
+		// element's own x/y in Element::fromXml(). A non-finite position
+		// there propagates into QPainterPathStroker via a conductor's
+		// shape() during diagram load and spins forever (confirmed with
+		// gdb: 100% CPU inside QPainterPathStroker::createStroke(), not a
+		// blocked wait). Reject it here, at the shared parsing point,
+		// rather than downstream in every geometry consumer.
+	if (!std::isfinite(tmp)) return(false);
 	if (reel != nullptr) *reel = tmp;
+	return(true);
+}
+
+/**
+	@brief QET::isWellFormedXmlByteStream
+	Check a raw byte stream for control characters the XML 1.0 spec does
+	not permit, before handing it to a QDomDocument.
+
+	Per the XML spec's Char production, the only C0 control characters
+	allowed anywhere in an XML document are tab (0x09), line feed (0x0A)
+	and carriage return (0x0D); every other byte in the 0x00-0x1F range
+	(and 0x7F) is illegal. QDomDocument::setContent() does not reject
+	these cleanly -- it crashes inside libQt5Xml's own DOM parser
+	(confirmed with gdb: identical SIGSEGV several frames deep in
+	QDomDocument::setContent(), never reaching any QET code, for a NUL
+	byte, an 0x0E, and an 0x19, each found independently by fuzzing --
+	so this is a class of input, not one specific byte value). A single
+	corrupted byte -- one bit flip -- is enough to trigger it.
+
+	Only checked here, at the one call site (QETProject::openFile())
+	this was found and reproduced against. The same setContent() pattern
+	appears at roughly twenty other call sites across the codebase
+	(element loading, title block templates, EDZ import, clipboard
+	paste, translations, ...) which likely share this same crash and are
+	not covered by this check -- deliberately left for a follow-up
+	rather than folded into this fix.
+
+	Multi-byte UTF-8 sequences are unaffected: a control-character byte
+	value (< 0x20) never appears as a lead or continuation byte of a
+	multi-byte UTF-8 encoding, so a plain byte-level scan is sufficient
+	and does not need to decode the stream first.
+	@param bytes raw file content, not yet parsed
+	@return false if a disallowed control character is present
+*/
+bool QET::isWellFormedXmlByteStream(const QByteArray &bytes)
+{
+	for (const char c : bytes) {
+		const auto uc = static_cast<unsigned char>(c);
+		if (uc < 0x20 && uc != 0x09 && uc != 0x0A && uc != 0x0D) return(false);
+		if (uc == 0x7F) return(false);
+	}
 	return(true);
 }
 

--- a/sources/qet.h
+++ b/sources/qet.h
@@ -160,6 +160,7 @@ namespace QET {
 	bool orthogonalProjection(const QPointF &, const QLineF &, QPointF * = nullptr);
 	bool attributeIsAnInteger(const QDomElement &, const QString& , int * = nullptr);
 	bool attributeIsAReal(const QDomElement &, const QString& , qreal * = nullptr);
+	bool isWellFormedXmlByteStream(const QByteArray &);
 	QString ElementsAndConductorsSentence(int elements=0,
 										  int conductors=0,
 										  int indi_texts=0,

--- a/sources/qetgraphicsitem/element.cpp
+++ b/sources/qetgraphicsitem/element.cpp
@@ -689,12 +689,14 @@ bool Element::valideXml(QDomElement &e)
 		return(false);
 	}
 
-	bool conv_ok;
-	e.attribute(QStringLiteral("x")).toDouble(&conv_ok);
-	if (!conv_ok) return(false);
-
-	e.attribute(QStringLiteral("y")).toDouble(&conv_ok);
-	if (!conv_ok) return(false);
+		// QET::attributeIsAReal() also rejects non-finite values
+		// (nan/inf), unlike a raw QString::toDouble(&ok) check -- see
+		// its definition in qet.cpp for why that distinction matters
+		// here specifically.
+	if (!QET::attributeIsAReal(e, QStringLiteral("x")) ||
+		!QET::attributeIsAReal(e, QStringLiteral("y"))) {
+		return(false);
+	}
 
 	return(true);
 }

--- a/sources/qetgraphicsitem/terminal.cpp
+++ b/sources/qetgraphicsitem/terminal.cpp
@@ -737,15 +737,16 @@ bool Terminal::valideXml(QDomElement &terminal)
 	if (!terminal.hasAttribute("y")) return(false);
 	if (!terminal.hasAttribute("orientation")) return(false);
 
+		// QET::attributeIsAReal() also rejects non-finite values
+		// (nan/inf), unlike a raw QString::toDouble(&ok) check -- see
+		// its definition in qet.cpp for why that distinction matters
+		// here specifically.
+	if (!QET::attributeIsAReal(terminal, QStringLiteral("x")) ||
+		!QET::attributeIsAReal(terminal, QStringLiteral("y"))) {
+		return(false);
+	}
+
 	bool conv_ok;
-	// parse l'abscisse
-	terminal.attribute("x").toDouble(&conv_ok);
-	if (!conv_ok) return(false);
-
-	// parse l'ordonnee
-	terminal.attribute("y").toDouble(&conv_ok);
-	if (!conv_ok) return(false);
-
 	// parse l'id
 	terminal.attribute("id").toInt(&conv_ok);
 	if (!conv_ok) return(false);

--- a/sources/qetproject.cpp
+++ b/sources/qetproject.cpp
@@ -243,7 +243,8 @@ QETProject::ProjectState QETProject::openFile(QFile *file)
 
 		//Extract the content of the xml
 	QDomDocument xml_project;
-	if (!xml_project.setContent(file))
+	const QByteArray xml_bytes = file->readAll();
+	if (!QET::isWellFormedXmlByteStream(xml_bytes) || !xml_project.setContent(xml_bytes))
 	{
 		if(opened_here) {
 			file->close();


### PR DESCRIPTION
Two independent crash/hang bugs, found by an adversarial mutation harness I built this session specifically to stress-test `--resave` against corrupted real project files and check results with gdb rather than guess.

## 1. A single NaN/Inf coordinate hangs `--resave` forever, not crashes

`x="nan"` on an `<element>` (or `<terminal>`) survives XML parsing — `QString::toDouble(&ok)` returns `ok=true` for `"nan"`/`"inf"`/`"-inf"`, which I verified directly rather than assumed:

```
nan  -> ok=true  value=nan  isfinite=false
inf  -> ok=true  value=inf  isfinite=false
```

The non-finite position then propagates into `Conductor::shape()` during diagram load. gdb on the hung process shows it stuck at 100% CPU — not a blocked wait, confirmed via `/proc/<pid>/stat`: 2.98 of 3.00 wall-clock seconds were user CPU time:

```
QPainterPathStroker::createStroke()
<- Conductor::shape()
<- QGraphicsItem::collidesWithItem()
<- Conductor::calculateTextItemPosition()
<- Diagram::addItem() <- Diagram::fromXml()
```

**Fix:** `QET::attributeIsAReal()` (`sources/qet.cpp`) — the shared "is this XML attribute a usable real number" helper already used at 26 call sites across the codebase — now also rejects non-finite values. `Element::valideXml()` and `Terminal::valideXml()` had their own duplicate, equally-buggy `toDouble(&conv_ok)` parsing (same gap: `conv_ok` is also `true` for `"nan"`), so I switched both to use the shared, now-correct helper instead of maintaining a second copy of the same check.

## 2. A single corrupted byte segfaults inside Qt's own XML parser

`QETProject::openFile()` hands the raw file straight to `QDomDocument::setContent(QIODevice*)`, which does not fail cleanly on a control character XML doesn't permit (the spec's `Char` production allows only tab/LF/CR among bytes below `0x20`) — it segfaults inside `libQt5Xml` itself. gdb shows the crash never reaches any QET code at all:

```
QDomDocument::setContent(QIODevice*, ...)
<- QETProject::openFile() <- QETProject::QETProject()
```

This is a class of input, not one specific byte — confirmed with three different corrupted files, **identical crash address in gdb across all three**:
- an embedded NUL (`0x00`) in XML whitespace
- an `0x0E` in XML whitespace (found by the harness's own mutation sweep, after the NUL fix, on a completely different seed file)
- an `0x19` inside base64-encoded embedded logo data

**Fix:** a new `QET::isWellFormedXmlByteStream()` (`sources/qet.cpp`) — read the raw bytes first and refuse to hand a stream containing an illegal control character to the parser at all, rather than try to recover from a crash inside a library this code doesn't control.

## Verification

- Both fixes verified against the original repro files: clean rejection (`XmlParsingFailed`, exit 1) or clean resave instead of hang/crash.
- Full-corpus regression: all 23 files in `qet-fix/examples/` still resave cleanly — the byte-stream check does not false-positive on real QET output.
- A 150-iteration adversarial sweep with all 8 mutation strategies active against the fixed build found **zero crashes**.
- Built clean, CMake/Ninja Release, Qt 5.15.18, mold-linked.

## Deliberately not fixed here

Found during validation; listed rather than silently folded in or silently left undocumented.

**`QDomDocument::setContent()` is called the same way at roughly twenty other sites** and likely shares the same crash — none of them are covered by this fix:

`sources/cli_export.cpp`, `sources/titleblocktemplate.cpp`, `sources/qetxml.cpp`, `sources/diagramview.cpp`, `sources/diagramevent/diagrameventaddmacro.cpp`, `sources/import/edz/edzpart.cpp`, `sources/elementtextpattern.cpp`, `sources/ElementsCollection/elementslocation.cpp`, `sources/ElementsCollection/elementstreeview.cpp`, `sources/titleblock/templateview.cpp`, `sources/editor/elementview.cpp`, `sources/editor/ui/qetelementeditor.cpp`. Element loading, macro/title-block loading, EDZ import, and clipboard paste are all plausibly reachable.

**A `DynamicElementTextItem`'s position accepts and persists a non-finite value.** Confirmed: `y="-inf"` survives two consecutive resaves without crashing — lower severity than the two bugs above, since it doesn't reach `Conductor::shape()` the same way an element position does, so it's a silent data-integrity gap rather than a hang. Different parsing path from the one this PR touches.

I'm happy to follow up on either of these if there's interest, but wanted this PR to stay scoped to the two bugs that are actually reproduced and fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)