### PR TITLE
Dialogs remember their size/position; drop a hardcoded light-mode color

### DIFF
--- a/sources/ElementsCollection/ui/renamedialog.cpp
+++ b/sources/ElementsCollection/ui/renamedialog.cpp
@@ -20,12 +20,14 @@
 #include <QDate>
 #include "ui_renamedialog.h"
 
+#include "../../qet.h"
 RenameDialog::RenameDialog(QString path, QWidget *parent) :
 	QDialog(parent),
 	ui(new Ui::RenameDialog),
 	m_path(std::move(path))
 {
 	ui->setupUi(this);
+	QET::trackDialogGeometry(this);
 	m_name = m_path.split("/").last();
 	if (m_name.endsWith(".elmt")) m_name.remove(".elmt");
 	ui->m_label->setText(tr("L'élément « %1 » existe déjà. Que souhaitez-vous faire ?").arg(m_path));

--- a/sources/NameList/ui/namelistdialog.cpp
+++ b/sources/NameList/ui/namelistdialog.cpp
@@ -19,6 +19,7 @@
 #include "ui_namelistdialog.h"
 #include "namelistwidget.h"
 
+#include "../../qet.h"
 #include <QPushButton>
 #include <QMessageBox>
 
@@ -27,6 +28,7 @@ NameListDialog::NameListDialog(QWidget *parent) :
 	ui(new Ui::NameListDialog)
 {
 	ui->setupUi(this);
+	QET::trackDialogGeometry(this);
 
 	m_namelist_widget = new NameListWidget(this);
 	ui->m_main_layout->insertWidget(1, m_namelist_widget);

--- a/sources/PropertiesEditor/propertieseditordialog.h
+++ b/sources/PropertiesEditor/propertieseditordialog.h
@@ -18,6 +18,8 @@
 #ifndef PROPERTIESEDITORDIALOG_H
 #define PROPERTIESEDITORDIALOG_H
 
+#include "../qet.h"
+
 #include <QDialog>
 #include <QDialogButtonBox>
 #include <QVBoxLayout>
@@ -61,6 +63,14 @@ class PropertiesEditorDialog : public QDialog
 						| QDialogButtonBox::Reset,
 						this);
 			vlayout->addWidget(button_box);
+
+				// Keyed on the wrapped editor's own class, not this
+				// dialog's -- every instantiation of this constructor
+				// template is the same PropertiesEditorDialog class,
+				// so using its class name here would have every kind
+				// of wrapped editor (conductor properties, element
+				// properties, ...) fight over one saved size.
+			QET::trackDialogGeometry(this, editor->metaObject()->className());
 
 			//Setup connection between button box and the editor
 			connect(button_box,

--- a/sources/SearchAndReplace/ui/replaceadvanceddialog.cpp
+++ b/sources/SearchAndReplace/ui/replaceadvanceddialog.cpp
@@ -21,6 +21,7 @@
 #include "../../qetinformation.h"
 #include "ui_replaceadvanceddialog.h"
 
+#include "../../qet.h"
 #include <QAbstractButton>
 
 /**
@@ -33,6 +34,7 @@ replaceAdvancedDialog::replaceAdvancedDialog(advancedReplaceStruct advanced, QWi
 	ui(new Ui::replaceAdvancedDialog)
 {
 	ui->setupUi(this);
+	QET::trackDialogGeometry(this);
 	
 	connect(ui->m_button_box, &QDialogButtonBox::clicked, [this](QAbstractButton *button_) {
 		this->done(ui->m_button_box->buttonRole(button_));

--- a/sources/SearchAndReplace/ui/replaceconductordialog.cpp
+++ b/sources/SearchAndReplace/ui/replaceconductordialog.cpp
@@ -20,6 +20,7 @@
 #include "../searchandreplaceworker.h"
 #include "ui_replaceconductordialog.h"
 
+#include "../../qet.h"
 #include <QColorDialog>
 #include <QPainter>
 
@@ -37,6 +38,7 @@ ReplaceConductorDialog::ReplaceConductorDialog(
 	ui(new Ui::ReplaceConductorDialog)
 {
 	ui->setupUi(this);
+	QET::trackDialogGeometry(this);
 	initWidget();
 	setProperties(properties);
 }

--- a/sources/SearchAndReplace/ui/replaceelementdialog.cpp
+++ b/sources/SearchAndReplace/ui/replaceelementdialog.cpp
@@ -24,6 +24,7 @@
 #include "replaceelementdialog.h"
 #include "ui_replaceelementdialog.h"
 
+#include "../../qet.h"
 #include <QAbstractButton>
 
 ReplaceElementDialog::ReplaceElementDialog(DiagramContext context, QWidget *parent) :
@@ -31,6 +32,7 @@ ReplaceElementDialog::ReplaceElementDialog(DiagramContext context, QWidget *pare
 	ui(new Ui::ReplaceElementDialog)
 {
 	ui->setupUi(this);
+	QET::trackDialogGeometry(this);
 	buildWidget();
 	setContext(context);
 }

--- a/sources/SearchAndReplace/ui/replacefoliowidget.cpp
+++ b/sources/SearchAndReplace/ui/replacefoliowidget.cpp
@@ -18,6 +18,7 @@
 #include "replacefoliowidget.h"
 
 #include "../../ui/diagramcontextwidget.h"
+#include "../../qet.h"
 #include "../searchandreplaceworker.h"
 #include "ui_replacefoliowidget.h"
 
@@ -132,6 +133,8 @@ ReplaceFolioDialog::ReplaceFolioDialog(QWidget *parent) :
 	{
 		this->done(m_button_box->buttonRole(button_));
 	});
+
+	QET::trackDialogGeometry(this);
 }
 
 ReplaceFolioDialog::~ReplaceFolioDialog()

--- a/sources/TerminalStrip/ui/addterminalstripitemdialog.cpp
+++ b/sources/TerminalStrip/ui/addterminalstripitemdialog.cpp
@@ -23,6 +23,7 @@
 #include "../GraphicsItem/terminalstripitem.h"
 #include "../../diagram.h"
 
+#include "../../qet.h"
 void AddTerminalStripItemDialog::openDialog(Diagram *diagram, QWidget *parent)
 {
 	AddTerminalStripItemDialog d(diagram->project(), parent);
@@ -46,6 +47,7 @@ AddTerminalStripItemDialog::AddTerminalStripItemDialog(QETProject *project, QWid
 	ui{new Ui::AddTerminalStripItemDialog}
 {
 	ui->setupUi(this);
+	QET::trackDialogGeometry(this);
 	fillComboBox();
 }
 

--- a/sources/TerminalStrip/ui/terminalstripcreatordialog.cpp
+++ b/sources/TerminalStrip/ui/terminalstripcreatordialog.cpp
@@ -20,6 +20,7 @@
 #include "../terminalstrip.h"
 #include "../../qetproject.h"
 
+#include "../../qet.h"
 /**
  * @brief TerminalStripCreatorDialog::TerminalStripCreatorDialog
  * @param project : Project to add a new terminal strip
@@ -31,6 +32,7 @@ TerminalStripCreatorDialog::TerminalStripCreatorDialog(QETProject *project, QWid
 	m_project(project)
 {
 	ui->setupUi(this);
+	QET::trackDialogGeometry(this);
 }
 
 /**

--- a/sources/configdialog.cpp
+++ b/sources/configdialog.cpp
@@ -19,6 +19,7 @@
 #include "configdialog.h"
 #include "ui/configpage/configpages.h"
 #include "qetapp.h"
+#include "qet.h"
 
 #include "machine_info.h"
 
@@ -90,6 +91,8 @@ ConfigDialog::ConfigDialog(QWidget *parent) : QDialog(parent) {
 		setWindowFlags(Qt::Sheet);
 	}
 #endif
+
+	QET::trackDialogGeometry(this);
 }
 
 /// Destructeur

--- a/sources/editor/ui/elementpropertieseditorwidget.cpp
+++ b/sources/editor/ui/elementpropertieseditorwidget.cpp
@@ -22,6 +22,7 @@
 #include "ui_elementpropertieseditorwidget.h"
 #include "../../qetinformation.h"
 
+#include "../../qet.h"
 #include <QItemDelegate>
 #include <QComboBox>
 #include <QSpinBox>
@@ -83,6 +84,7 @@ ElementPropertiesEditorWidget::ElementPropertiesEditorWidget(ElementData data, Q
 	m_data(data)
 {
 	ui->setupUi(this);
+	QET::trackDialogGeometry(this);
 	setUpInterface();
 	upDateInterface();
 }

--- a/sources/elementdialog.cpp
+++ b/sources/elementdialog.cpp
@@ -19,6 +19,7 @@
 
 #include "ElementsCollection/elementcollectionitem.h"
 #include "ElementsCollection/elementscollectionmodel.h"
+#include "qet.h"
 #include "qetapp.h"
 #include "qetmessagebox.h"
 #include "qfilenameedit.h"
@@ -40,6 +41,7 @@ ElementDialog::ElementDialog(uint mode, QWidget *parent) :
 {
 	setUpWidget();
 	setUpConnection();
+	QET::trackDialogGeometry(this);
 }
 
 /**

--- a/sources/elementscategoryeditor.cpp
+++ b/sources/elementscategoryeditor.cpp
@@ -41,6 +41,7 @@ ElementsCategoryEditor::ElementsCategoryEditor(const ElementsLocation &location,
 	m_location(location)
 {
 	setUpWidget();
+	QET::trackDialogGeometry(this);
 
 	if (m_location.isElement()) {
 		QET::QetMessageBox::warning(this,

--- a/sources/exportdialog.cpp
+++ b/sources/exportdialog.cpp
@@ -21,6 +21,7 @@
 #include "createdxf.h"
 #include "exportpropertieswidget.h"
 #include "factory/elementpicturefactory.h"
+#include "qet.h"
 #include "qetgraphicsitem/ViewItem/qetgraphicstableitem.h"
 #include "qetgraphicsitem/conductor.h"
 #include "qetgraphicsitem/conductortextitem.h"
@@ -105,6 +106,8 @@ ExportDialog::ExportDialog(
 	
 	// ajustement des extensions des fichiers
 	slot_changeFilesExtension(true);
+
+	QET::trackDialogGeometry(this);
 }
 
 /**

--- a/sources/factory/ui/addtabledialog.cpp
+++ b/sources/factory/ui/addtabledialog.cpp
@@ -22,6 +22,7 @@
 #include "../../utils/qetutils.h"
 #include "ui_addtabledialog.h"
 
+#include "../../qet.h"
 #include <QFontDialog>
 
 /**
@@ -35,6 +36,7 @@ AddTableDialog::AddTableDialog(QWidget *content_widget, QWidget *parent) :
 	ui(new Ui::AddTableDialog)
 {
 	ui->setupUi(this);
+	QET::trackDialogGeometry(this);
 	ui->m_header_font_pb->setText(m_header_font.family());
 	ui->m_table_font_pb->setText(m_table_font.family());
 	m_content_widget = content_widget;

--- a/sources/logging/ui/diagnosticsreportdialog.cpp
+++ b/sources/logging/ui/diagnosticsreportdialog.cpp
@@ -17,6 +17,7 @@
 */
 #include "diagnosticsreportdialog.h"
 
+#include "../../qet.h"
 #include "../../qetmessagebox.h"
 
 #include <QDialogButtonBox>
@@ -63,6 +64,8 @@ DiagnosticsReportDialog::DiagnosticsReportDialog(
 	// holds a QString copy but we save the original UTF-8 bytes to avoid
 	// any round-trip surprises.
 	setProperty("qet_report_content", content);
+
+	QET::trackDialogGeometry(this);
 }
 
 void DiagnosticsReportDialog::saveToFile()

--- a/sources/qet.cpp
+++ b/sources/qet.cpp
@@ -22,8 +22,10 @@
 #include <limits>
 #include <QGraphicsSceneContextMenuEvent>
 #include <QAction>
+#include <QDialog>
 #include <QFileInfo>
 #include <QSaveFile>
+#include <QSettings>
 #include <QTextStream>
 #include <QRegularExpression>
 #include <QActionGroup>
@@ -250,6 +252,27 @@ bool QET::attributeIsAReal(
 	if (!ok) return(false);
 	if (reel != nullptr) *reel = tmp;
 	return(true);
+}
+
+/**
+	@brief QET::trackDialogGeometry
+	@see the declaration in qet.h for the rationale.
+*/
+void QET::trackDialogGeometry(QDialog *dialog, const QString &key)
+{
+	const QString settings_key = QStringLiteral("dialoggeometry/%1").arg(
+		key.isEmpty() ? QString::fromLatin1(dialog->metaObject()->className()) : key);
+
+	QSettings settings;
+	const QVariant geometry = settings.value(settings_key);
+	if (geometry.isValid()) {
+		dialog->restoreGeometry(geometry.toByteArray());
+	}
+
+	QObject::connect(dialog, &QDialog::finished, dialog, [dialog, settings_key]() {
+		QSettings settings;
+		settings.setValue(settings_key, dialog->saveGeometry());
+	});
 }
 
 /**

--- a/sources/qet.h
+++ b/sources/qet.h
@@ -23,6 +23,7 @@
 #include <QObject>
 
 class QActionGroup;
+class QDialog;
 /**
 	This file provides useful functions and enums that may be used from
 	anywhere else within the QElectroTech application.
@@ -185,6 +186,18 @@ namespace QET {
 	bool writeToFile (QDomDocument &xml_doc, QFile *file, QString *error_message = nullptr);
 	bool eachStrIsEqual (const QStringList &qsl);
 	QActionGroup *depthActionGroup(QObject *parent = nullptr);
+
+		/**
+			Restore a dialog's last-used size/position from QSettings, and
+			save it back whenever the dialog closes (accepted, rejected, or
+			via the window's close button). @a key identifies the dialog in
+			QSettings; defaults to the dialog's class name, which is enough
+			to distinguish dialogs one-to-one -- pass an explicit @a key for
+			a dialog class reused for several different kinds of content
+			(e.g. a generic properties-editor wrapper), so each kind gets
+			its own remembered size instead of fighting over one entry.
+		*/
+	void trackDialogGeometry(QDialog *dialog, const QString &key = QString());
 }
 
 Q_DECLARE_METATYPE(QET::DepthOption)

--- a/sources/richtext/richtexteditor.cpp
+++ b/sources/richtext/richtexteditor.cpp
@@ -48,6 +48,7 @@
 #include "richtexteditor_p.h"
 #include "ui_addlinkdialog.h"
 #include "../shortcutmanager.h"
+#include "../qet.h"
 
 //#include <QtDesigner/QDesignerFormEditorInterface>
 
@@ -233,6 +234,7 @@ AddLinkDialog::AddLinkDialog(RichTextEditor *editor, QWidget *parent) :
 	m_ui(new Ui::AddLinkDialog)
 {
 	m_ui->setupUi(this);
+	QET::trackDialogGeometry(this);
 
 	setWindowFlags(windowFlags() & ~Qt::WindowContextHelpButtonHint);
 
@@ -815,6 +817,7 @@ RichTextEditorDialog::RichTextEditorDialog(QWidget *parent)  :
 
 	m_editor->setFocus();
 
+	QET::trackDialogGeometry(this);
 }
 
 RichTextEditorDialog::~RichTextEditorDialog()

--- a/sources/titleblock/dimensionwidget.cpp
+++ b/sources/titleblock/dimensionwidget.cpp
@@ -17,6 +17,8 @@
 */
 #include "dimensionwidget.h"
 
+#include "../qet.h"
+
 /**
 	Constructor
 	@param complete True for this dialog to show the radio buttons that allow
@@ -31,6 +33,7 @@ TitleBlockDimensionWidget::TitleBlockDimensionWidget(bool complete, QWidget *par
 {
 	initWidgets();
 	initLayouts();
+	QET::trackDialogGeometry(this);
 }
 
 /**

--- a/sources/ui/aboutqetdialog.cpp
+++ b/sources/ui/aboutqetdialog.cpp
@@ -34,6 +34,7 @@ AboutQETDialog::AboutQETDialog(QWidget *parent) :
 	ui(new Ui::AboutQETDialog)
 {
 	ui->setupUi(this);
+	QET::trackDialogGeometry(this);
 	setAbout();
 	setAuthors();
 	setTranslators();

--- a/sources/ui/alignmenttextdialog.cpp
+++ b/sources/ui/alignmenttextdialog.cpp
@@ -20,11 +20,13 @@
 #include "../qetgraphicsitem/dynamicelementtextitem.h"
 #include "ui_alignmenttextdialog.h"
 
+#include "../qet.h"
 AlignmentTextDialog::AlignmentTextDialog(Qt::Alignment alignment, QWidget *parent) :
 	QDialog(parent),
 	ui(new Ui::AlignmentTextDialog)
 {
 	ui->setupUi(this);
+	QET::trackDialogGeometry(this);
 	
 	if(alignment == (Qt::AlignTop|Qt::AlignLeft))
 		ui->top_left->setChecked(true);

--- a/sources/ui/bomexportdialog.cpp
+++ b/sources/ui/bomexportdialog.cpp
@@ -23,6 +23,7 @@
 #include "../qetproject.h"
 #include "ui_bomexportdialog.h"
 
+#include "../qet.h"
 #include <QMessageBox>
 #include <QSqlError>
 #include <QSqlRecord>
@@ -38,6 +39,7 @@ BOMExportDialog::BOMExportDialog(QETProject *project, QWidget *parent) :
 	m_project(project)
 {
 	ui->setupUi(this);
+	QET::trackDialogGeometry(this);
 
 	m_query_widget = new ElementQueryWidget(this);
 	ui->m_main_layout->insertWidget(0, m_query_widget);

--- a/sources/ui/compositetexteditdialog.cpp
+++ b/sources/ui/compositetexteditdialog.cpp
@@ -5,6 +5,7 @@
 #include "../qetgraphicsitem/dynamicelementtextitem.h"
 #include "../qetgraphicsitem/element.h"
 #include "../qetinformation.h"
+#include "../qet.h"
 #include "ui_compositetexteditdialog.h"
 
 #include <utility>
@@ -15,6 +16,7 @@ CompositeTextEditDialog::CompositeTextEditDialog(DynamicElementTextItem *text, Q
 	m_text(text)
 {
 	ui->setupUi(this);
+	QET::trackDialogGeometry(this);
 	m_default_text = m_text->compositeText();
 	ui->m_plain_text_edit->setPlainText(m_default_text);
 	ui->m_plain_text_edit->setPlaceholderText(tr("Entrée votre texte composé ici, en vous aidant des variables disponible"));
@@ -31,6 +33,7 @@ CompositeTextEditDialog::CompositeTextEditDialog(QString text, bool report, QWid
 	ui(new Ui::CompositeTextEditDialog)
 {
 	ui->setupUi(this);
+	QET::trackDialogGeometry(this);
 	m_default_text = std::move(text);
 	ui->m_plain_text_edit->setPlainText(m_default_text);
 	ui->m_plain_text_edit->setPlaceholderText(tr("Entrée votre texte composé ici, en vous aidant des variables disponible"));

--- a/sources/ui/conductorpropertiesdialog.cpp
+++ b/sources/ui/conductorpropertiesdialog.cpp
@@ -24,6 +24,7 @@
 #include "conductorpropertieswidget.h"
 #include "ui_conductorpropertiesdialog.h"
 
+#include "../qet.h"
 /**
 	@brief ConductorPropertiesDialog::ConductorPropertiesDialog
 	Constructor
@@ -36,6 +37,7 @@ ConductorPropertiesDialog::ConductorPropertiesDialog(
 	ui(new Ui::ConductorPropertiesDialog)
 {
 	ui->setupUi(this);
+	QET::trackDialogGeometry(this);
 	m_cpw = new ConductorPropertiesWidget(conductor->properties());
 	m_cpw -> setHiddenOneTextPerFolio(true);
 	m_cpw->setHiddenAvailableAutonum(true);

--- a/sources/ui/contactgroupselectiondialog.cpp
+++ b/sources/ui/contactgroupselectiondialog.cpp
@@ -17,6 +17,8 @@
 */
 #include "contactgroupselectiondialog.h"
 
+#include "../qet.h"
+
 #include <QVBoxLayout>
 #include <QHBoxLayout>
 #include <QTableWidget>
@@ -207,6 +209,8 @@ ContactGroupSelectionDialog::ContactGroupSelectionDialog(
 			accept();
 		}
 	});
+
+	QET::trackDialogGeometry(this);
 }
 
 int ContactGroupSelectionDialog::selectedIndex() const

--- a/sources/ui/diagrampropertiesdialog.cpp
+++ b/sources/ui/diagrampropertiesdialog.cpp
@@ -89,6 +89,8 @@ DiagramPropertiesDialog::DiagramPropertiesDialog(Diagram *diagram, QWidget *pare
 	vlayout.addLayout(glayout);
 	vlayout.addWidget(&boutons);
 
+	QET::trackDialogGeometry(this);
+
 	// if dialog is accepted
 	if (this -> exec() == QDialog::Accepted && !diagram_is_read_only)
 	{

--- a/sources/ui/dialogwaiting.cpp
+++ b/sources/ui/dialogwaiting.cpp
@@ -18,6 +18,7 @@
 
 #include "dialogwaiting.h"
 #include "ui_dialogwaiting.h"
+#include "../qet.h"
 #include <QPushButton>
 
 
@@ -31,6 +32,7 @@ DialogWaiting::DialogWaiting(QWidget *parent) :
 	ui(new Ui::DialogWaiting)
 {
 	ui->setupUi(this);
+	QET::trackDialogGeometry(this);
 	setTitle(  "..." );
 	setDetail( "..." );
 }

--- a/sources/ui/formulaassistantdialog.cpp
+++ b/sources/ui/formulaassistantdialog.cpp
@@ -18,6 +18,7 @@
 #include "formulaassistantdialog.h"
 #include "ui_formulaassistantdialog.h"
 
+#include "../qet.h"
 #include <QPushButton>
 
 FormulaAssistantDialog::FormulaAssistantDialog(QWidget *parent) :
@@ -25,6 +26,7 @@ FormulaAssistantDialog::FormulaAssistantDialog(QWidget *parent) :
 	ui(new Ui::FormulaAssistantDialog)
 {
 	ui->setupUi(this);
+	QET::trackDialogGeometry(this);
 }
 
 FormulaAssistantDialog::~FormulaAssistantDialog()

--- a/sources/ui/importelementdialog.cpp
+++ b/sources/ui/importelementdialog.cpp
@@ -17,6 +17,7 @@
 */
 #include "importelementdialog.h"
 #include "ui_importelementdialog.h"
+#include "../qet.h"
 #include <QButtonGroup>
 
 ImportElementDialog::ImportElementDialog(QWidget *parent) :
@@ -24,6 +25,7 @@ ImportElementDialog::ImportElementDialog(QWidget *parent) :
 	ui(new Ui::ImportElementDialog)
 {
 	ui->setupUi(this);
+	QET::trackDialogGeometry(this);
 	setUpWidget();
 }
 

--- a/sources/ui/importelementtextpatterndialog.cpp
+++ b/sources/ui/importelementtextpatterndialog.cpp
@@ -18,10 +18,12 @@
 #include "importelementtextpatterndialog.h"
 #include "ui_importelementtextpatterndialog.h"
 
+#include "../qet.h"
 ImportElementTextPatternDialog::ImportElementTextPatternDialog(QWidget *parent) :
 	QDialog(parent),
 	ui(new Ui::ImportElementTextPatternDialog) {
 	ui->setupUi(this);
+	QET::trackDialogGeometry(this);
 }
 
 ImportElementTextPatternDialog::~ImportElementTextPatternDialog()

--- a/sources/ui/jumptoelementdialog.cpp
+++ b/sources/ui/jumptoelementdialog.cpp
@@ -18,6 +18,7 @@
 #include "jumptoelementdialog.h"
 
 #include "../diagram.h"
+#include "../qet.h"
 #include "../qetgraphicsitem/element.h"
 
 #include <QEvent>
@@ -56,6 +57,8 @@ JumpToElementDialog::JumpToElementDialog(Diagram *diagram, QWidget *parent) :
 	buildCandidates();
 	updateFilteredList(QString());
 	m_filter_edit->setFocus();
+
+	QET::trackDialogGeometry(this);
 }
 
 JumpToElementDialog::~JumpToElementDialog()

--- a/sources/ui/marginseditdialog.cpp
+++ b/sources/ui/marginseditdialog.cpp
@@ -18,6 +18,7 @@
 #include "marginseditdialog.h"
 #include "ui_marginseditdialog.h"
 
+#include "../qet.h"
 #include <QScopedPointer>
 
 MarginsEditDialog::MarginsEditDialog(QMargins margins, QWidget *parent) :
@@ -25,6 +26,7 @@ MarginsEditDialog::MarginsEditDialog(QMargins margins, QWidget *parent) :
 	ui(new Ui::MarginsEditDialog)
 {
 	ui->setupUi(this);
+	QET::trackDialogGeometry(this);
 	ui->m_top_sb->setValue(margins.top());
 	ui->m_left_sb->setValue(margins.left());
 	ui->m_right_sb->setValue(margins.right());

--- a/sources/ui/masterpropertieswidget.cpp
+++ b/sources/ui/masterpropertieswidget.cpp
@@ -572,7 +572,6 @@ void MasterPropertiesWidget::updateUi()
 			// Type combo (read-only — type is defined in the editor)
 			auto *type_cb = new QComboBox(m_plc_table);
 			type_cb->setEnabled(false);
-			type_cb->setStyleSheet("QComboBox { background-color: #f0f0f0; }");
 			QStringList plc_types = ElementData::plcIOTypeList();
 			for (int t = 0; t < plc_types.size(); ++t) {
 				type_cb->addItem(plc_types.at(t), t);

--- a/sources/ui/multipastedialog.cpp
+++ b/sources/ui/multipastedialog.cpp
@@ -26,6 +26,7 @@
 #include "../qetgraphicsitem/conductor.h"
 #include "../ui_multipastedialog.h"
 
+#include "../qet.h"
 #include <QHash>
 #include <QSettings>
 
@@ -35,6 +36,7 @@ MultiPasteDialog::MultiPasteDialog(Diagram *diagram, QWidget *parent) :
 	m_diagram(diagram)
 {
 	ui->setupUi(this);
+	QET::trackDialogGeometry(this);
 
 	connect(ui->m_x_sb, static_cast<void (QSpinBox::*)(int)>(&QSpinBox::valueChanged), this, &MultiPasteDialog::updatePreview);
 	connect(ui->m_y_sb, static_cast<void (QSpinBox::*)(int)>(&QSpinBox::valueChanged), this, &MultiPasteDialog::updatePreview);

--- a/sources/ui/potentialselectordialog.cpp
+++ b/sources/ui/potentialselectordialog.cpp
@@ -19,6 +19,7 @@
 #include "potentialselectordialog.h"
 
 #include "../QPropertyUndoCommand/qpropertyundocommand.h"
+#include "../qet.h"
 #include "../autoNum/assignvariables.h"
 #include "../diagram.h"
 #include "../qetgraphicsitem/conductor.h"
@@ -270,6 +271,7 @@ PotentialSelectorDialog::PotentialSelectorDialog(Conductor *conductor,
 	m_parent_undo(parent_undo)
 {
 	ui->setupUi(this);
+	QET::trackDialogGeometry(this);
 	m_potential_selector = new NewConductorPotentialSelector(conductor);
 	buildWidget();
 }
@@ -292,6 +294,7 @@ PotentialSelectorDialog::PotentialSelectorDialog(Element *report,
 	m_parent_undo(parent_undo)
 {
 	ui->setupUi(this);
+	QET::trackDialogGeometry(this);
 	m_potential_selector = new LinkReportPotentialSelector(report);
 	buildWidget();
 }

--- a/sources/ui/terminalnumberingdialog.cpp
+++ b/sources/ui/terminalnumberingdialog.cpp
@@ -4,6 +4,7 @@
 #include "../diagram.h"
 #include "../qetgraphicsitem/element.h"
 #include "../undocommand/changeelementinformationcommand.h"
+#include "../qet.h"
 #include <QUndoCommand>
 #include <algorithm>
 
@@ -17,6 +18,7 @@ QDialog(parent),
 ui(new Ui::TerminalNumberingDialog)
 {
     ui->setupUi(this);
+    QET::trackDialogGeometry(this);
 }
 
 /**

--- a/sources/ui/thirdpartybinaryinstalldialog.cpp
+++ b/sources/ui/thirdpartybinaryinstalldialog.cpp
@@ -18,6 +18,7 @@
 #include "thirdpartybinaryinstalldialog.h"
 #include "ui_thirdpartybinaryinstalldialog.h"
 
+#include "../qet.h"
 #include <QDialogButtonBox>
 #include <QPushButton>
 #include <QDesktopServices>
@@ -32,6 +33,7 @@ ThirdPartyBinaryInstallDialog::ThirdPartyBinaryInstallDialog(const QString &text
 	ui{new Ui::ThirdPartyBinaryInstallDialog}
 {
 	ui->setupUi(this);
+	QET::trackDialogGeometry(this);
 	ui->m_label->setText(text);
 
 	connect(ui->m_download_pb, &QPushButton::clicked, [downloadLink](){


### PR DESCRIPTION
Small UI-polish PR from a broader windows/controls audit (main window + ~35 dialogs), not a full "modernization" — most of the app held up well (HiDPI already handled properly, no forced style/palette, 21/23 dialogs already use `QDialogButtonBox` correctly). Two concrete, low-risk findings survived that audit:

## 1. Dialogs don't remember their size or position

`QETElementEditor`, `QETDiagramEditor` and `QETTemplateEditor` already persist geometry via `QSettings`. None of the ~35 modal `QDialog` subclasses did — resize "Search and Replace" or "Diagram properties" to see more of its content, and it's back to the default size the next time you open it, every session.

Added `QET::trackDialogGeometry()` (`sources/qet.h`/`qet.cpp`), one call per dialog constructor, following the exact `restoreGeometry()`/`saveGeometry()` pattern already used by the three editors above — keyed by class name by default. `PropertiesEditorDialog` (a single class templated over several unrelated wrapped editors — conductor properties, element properties, etc.) gets an explicit key per wrapped editor type, so they don't all fight over one saved size.

Deliberately not touched: `BackupDialog`, which `setFixedSize()`s itself — a small fixed Yes/No confirmation prompt has no meaningful size to remember.

**Verification**: full Release build (504/504, no new warnings). Also verified the restore/save round-trip directly against `qet.cpp` in a small standalone Qt program outside the main build — saved a 600×400 geometry, then confirmed a fresh dialog defaulting to 200×150 picked up the saved 600×400 after the tracking call, in the same order the real fixes use (explicit default `resize()`/`setMinimumSize()` first, tracking call after, so a restored size correctly wins over a hardcoded default). Three of the ~35 constructors needed care rather than a mechanical insertion: `RichTextEditorDialog` and `AddLinkDialog` are hand-built with no `setupUi()` anchor (and share a file with an unrelated class, `RichTextEditor`, that does have one — easy to insert in the wrong constructor by grepping alone), `ReplaceFolioDialog` similarly shares a file with `ReplaceFolioWidget`, and `DiagramPropertiesDialog` calls `exec()` on itself from inside its own constructor, so the tracking call has to land *before* that call rather than at the end.

## 2. Hardcoded light-gray background breaks under a dark palette

`masterpropertieswidget.cpp` set an inline `background-color: #f0f0f0` on the disabled PLC-IO type combo box. Qt already renders disabled widgets correctly without help; the hardcoded light color just shows as a bright box in an otherwise dark dialog under a dark OS theme. Dropped the stylesheet.

---

A third finding from the same audit — a permanently-`setHidden(true)` button in `ReplaceConductorDialog` that looked like dead code from the `.cpp` alone — turned out to be a deliberate mechanism once I checked the `.ui`'s own Designer-level signal/slot connections: several controls are wired to call `click()` on it (which doesn't require visibility) purely to share one `updatePreview()` trigger point. Dropped that one from this PR since it isn't actually a bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RPBnuxsg8T9Ndy8nHyUSu9