### PR TITLE
Draft: fast element insertion — all four phases from #676

### DIFF
--- a/cmake/qet_compilation_vars.cmake
+++ b/cmake/qet_compilation_vars.cmake
@@ -411,6 +411,8 @@ set(QET_SRC_FILES
   ${QET_DIR}/sources/ElementsCollection/elementcollectionitem.h
   ${QET_DIR}/sources/ElementsCollection/elementscollectionmodel.cpp
   ${QET_DIR}/sources/ElementsCollection/elementscollectionmodel.h
+  ${QET_DIR}/sources/ElementsCollection/elementpickerpopup.cpp
+  ${QET_DIR}/sources/ElementsCollection/elementpickerpopup.h
   ${QET_DIR}/sources/ElementsCollection/elementscollectionwidget.cpp
   ${QET_DIR}/sources/ElementsCollection/elementscollectionwidget.h
   ${QET_DIR}/sources/ElementsCollection/elementslocation.cpp

--- a/sources/ElementsCollection/elementpickerpopup.cpp
+++ b/sources/ElementsCollection/elementpickerpopup.cpp
@@ -1,0 +1,323 @@
+/*
+	Copyright 2006-2026 The QElectroTech Team
+	This file is part of QElectroTech.
+
+	QElectroTech is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 2 of the License, or
+	(at your option) any later version.
+
+	QElectroTech is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with QElectroTech. If not, see <http://www.gnu.org/licenses/>.
+*/
+#include "elementpickerpopup.h"
+
+#include "elementscollectionwidget.h"
+
+#include <QGuiApplication>
+#include <QKeyEvent>
+#include <QLabel>
+#include <QLineEdit>
+#include <QListView>
+#include <QScreen>
+#include <QStandardItemModel>
+#include <QTimer>
+#include <QVBoxLayout>
+#include <QDir>
+#include <QFileInfo>
+#include <QSettings>
+
+#include "../qetapp.h"
+#include "elementslocation.h"
+
+/**
+	@brief ElementPickerPopup::ElementPickerPopup
+	@param source : the collection widget whose model the search runs against
+	@param parent
+*/
+ElementPickerPopup::ElementPickerPopup(ElementsCollectionWidget *source,
+				       QWidget *parent) :
+	QFrame(parent, Qt::Popup),
+	m_source(source)
+{
+	setFrameShape(QFrame::StyledPanel);
+	setFrameShadow(QFrame::Raised);
+	setMinimumWidth(340);
+
+	auto *layout = new QVBoxLayout(this);
+	layout->setContentsMargins(6, 6, 6, 6);
+	layout->setSpacing(4);
+
+	m_search = new QLineEdit(this);
+	m_search->setPlaceholderText(tr("Rechercher un élément…"));
+	m_search->setClearButtonEnabled(true);
+
+	m_model = new QStandardItemModel(this);
+	m_view = new QListView(this);
+	m_view->setModel(m_model);
+	m_view->setIconSize(QSize(40, 40));
+	m_view->setVerticalScrollMode(QAbstractItemView::ScrollPerPixel);
+	m_view->setEditTriggers(QAbstractItemView::NoEditTriggers);
+	m_view->setMinimumHeight(260);
+
+	m_hint = new QLabel(tr("Entrée pour insérer · Échap pour fermer"), this);
+	m_hint->setEnabled(false);
+
+	layout->addWidget(m_search);
+	layout->addWidget(m_view);
+	layout->addWidget(m_hint);
+
+		//Search as you type, on the same 500ms idle the dock uses -- the
+		//collection is large enough that filtering on every keystroke is
+		//noticeable.
+	auto *timer = new QTimer(this);
+	timer->setSingleShot(true);
+	timer->setInterval(300);
+	connect(m_search, &QLineEdit::textChanged, this,
+		[timer]() { timer->start(); });
+	connect(timer, &QTimer::timeout, this, &ElementPickerPopup::runSearch);
+
+	connect(m_view, &QListView::doubleClicked, this,
+		[this](const QModelIndex &) { chooseCurrent(); });
+}
+
+/**
+	@brief ElementPickerPopup::popUpAt
+	Show the picker at @a global_pos, kept on screen, with the search field
+	focused and any previous query cleared.
+	@param global_pos
+*/
+void ElementPickerPopup::popUpAt(const QPoint &global_pos)
+{
+	m_search->clear();
+	m_model->clear();
+	showPalette();
+
+	adjustSize();
+	QPoint pos = global_pos;
+
+		//Keep it fully on the screen the cursor is on: opening at the cursor
+		//near a right or bottom edge would otherwise push it off.
+	if (QScreen *screen = QGuiApplication::screenAt(global_pos)) {
+		const QRect avail = screen->availableGeometry();
+		pos.setX(qBound(avail.left(),
+				pos.x(), avail.right() - width()));
+		pos.setY(qBound(avail.top(),
+				pos.y(), avail.bottom() - height()));
+	}
+
+	move(pos);
+	show();
+	m_search->setFocus();
+}
+
+/**
+	@brief ElementPickerPopup::runSearch
+*/
+void ElementPickerPopup::runSearch()
+{
+	m_model->clear();
+	if (!m_source) {
+		return;
+	}
+
+	if (m_search->text().isEmpty()) {
+		showPalette();
+		return;
+	}
+
+	m_palette_mode = false;
+	m_view->setViewMode(QListView::ListMode);
+	m_view->setGridSize(QSize());
+	m_view->setIconSize(QSize(40, 40));
+
+	const QVector<ElementSearchHit> hits = m_source->rankedSearch(m_search->text());
+	for (const ElementSearchHit &hit : hits)
+	{
+		auto *item = new QStandardItem(hit.name);
+		item->setIcon(hit.icon);
+		item->setEditable(false);
+		item->setToolTip(hit.folder);
+		item->setData(hit.path, Qt::UserRole + 2);
+		m_model->appendRow(item);
+	}
+
+		//Preselect the best hit so Enter works straight from the search field
+		//without arrowing down first -- that is the whole point of the popup.
+	if (m_model->rowCount()) {
+		m_view->setCurrentIndex(m_model->index(0, 0));
+	}
+	m_hint->setText(hits.isEmpty()
+			? tr("Aucun résultat")
+			: tr("Entrée pour insérer · Échap pour fermer"));
+}
+
+/**
+	@brief ElementPickerPopup::chooseCurrent
+	Emit the highlighted element and close.
+*/
+void ElementPickerPopup::chooseCurrent()
+{
+	const QModelIndex index = m_view->currentIndex();
+	if (!index.isValid()) {
+		return;
+	}
+	const QString path = index.data(Qt::UserRole + 2).toString();
+	if (path.isEmpty()) {
+		return;
+	}
+
+	ElementsLocation location(path);
+	if (!location.exist()) {
+		return;
+	}
+
+		//Close before emitting: placement mode wants the focus, and a popup
+		//still up would keep the grab.
+	hide();
+	emit elementChosen(location);
+}
+
+/**
+	@brief ElementPickerPopup::keyPressEvent
+	Drive the list from the search field, so the hands never leave the
+	keyboard: Up/Down move the selection, Enter places, Esc closes.
+	@param event
+*/
+void ElementPickerPopup::keyPressEvent(QKeyEvent *event)
+{
+	switch (event->key())
+	{
+		case Qt::Key_Escape:
+			hide();
+			return;
+		case Qt::Key_Return:
+		case Qt::Key_Enter:
+			chooseCurrent();
+			return;
+		case Qt::Key_Down:
+		case Qt::Key_Up:
+		case Qt::Key_PageDown:
+		case Qt::Key_PageUp:
+			if (m_model->rowCount()) {
+					//Forwarded rather than focus-switched, so typing carries
+					//on going to the search field.
+				QCoreApplication::sendEvent(m_view, event);
+				return;
+			}
+			break;
+		default:
+			break;
+	}
+	QFrame::keyPressEvent(event);
+}
+
+/**
+	@brief ElementPickerPopup::showPalette
+	With an empty search field, show the quick palette as an icon grid.
+
+	The palette is a folder, not a config file. QET already has a user-owned,
+	drag-populated, icon-rendering collection -- so a palette is just a
+	directory whose subfolders are categories and whose contents are entries.
+	That gives set-up (drag into the folder), ordering (the 01_/02_ filename
+	convention the shipped collection already uses), team sharing
+	(companyElementsDir) and version control for free, with no schema, parser,
+	merge rules or "reset to defaults" to build or maintain.
+
+	Only the path lives in QSettings, defaulting to the user's custom
+	collection.
+*/
+void ElementPickerPopup::showPalette()
+{
+	m_palette_mode = true;
+	m_model->clear();
+
+	m_view->setViewMode(QListView::IconMode);
+	m_view->setIconSize(QSize(48, 48));
+	m_view->setGridSize(QSize(92, 84));
+	m_view->setResizeMode(QListView::Adjust);
+	m_view->setWordWrap(true);
+	m_view->setMovement(QListView::Static);
+
+	QSettings settings;
+	const QString path = settings.value(
+		QStringLiteral("elementscollection/palette-path"),
+		QETApp::customElementsDir()).toString();
+
+	const int count = loadPaletteDir(path, QString(), 0);
+
+	if (!count) {
+		m_hint->setText(
+			tr("Palette vide — glissez des éléments dans votre collection "
+			   "personnelle, ou tapez pour rechercher"));
+	} else {
+		m_hint->setText(tr("Entrée pour insérer · Échap pour fermer"));
+		m_view->setCurrentIndex(m_model->index(0, 0));
+	}
+}
+
+/**
+	@brief ElementPickerPopup::loadPaletteDir
+	Add every .elmt under @a dir_path to the grid, recursing into subfolders.
+	@param dir_path
+	@param prefix : folder path so far, shown as the entry's tooltip
+	@param depth : recursion guard -- a palette is a shortlist, and the whole
+	shipped collection would not be usable as a grid anyway
+	@return how many entries were added
+*/
+int ElementPickerPopup::loadPaletteDir(const QString &dir_path,
+				       const QString &prefix, int depth)
+{
+	if (depth > 3) {
+		return 0;
+	}
+	QDir dir(dir_path);
+	if (!dir.exists()) {
+		return 0;
+	}
+
+	int added = 0;
+		//Sorted by name, which is what makes the 01_/02_ filename convention
+		//work as the ordering mechanism.
+	const QFileInfoList entries = dir.entryInfoList(
+		QDir::Files | QDir::Dirs | QDir::NoDotAndDotDot, QDir::Name);
+
+	for (const QFileInfo &info : entries)
+	{
+		if (info.isDir()) {
+			added += loadPaletteDir(info.absoluteFilePath(),
+						prefix.isEmpty()
+							? info.fileName()
+							: prefix + QStringLiteral(" / ")
+								+ info.fileName(),
+						depth + 1);
+			continue;
+		}
+		if (info.suffix().compare(QStringLiteral("elmt"),
+					  Qt::CaseInsensitive) != 0) {
+			continue;
+		}
+
+		ElementsLocation location(info.absoluteFilePath());
+		if (!location.exist()) {
+			continue;
+		}
+
+		auto *item = new QStandardItem(location.name().isEmpty()
+						       ? info.completeBaseName()
+						       : location.name());
+		item->setIcon(location.icon());
+		item->setEditable(false);
+		item->setToolTip(prefix.isEmpty() ? info.completeBaseName() : prefix);
+		item->setData(info.absoluteFilePath(), Qt::UserRole + 2);
+		item->setTextAlignment(Qt::AlignHCenter | Qt::AlignTop);
+		m_model->appendRow(item);
+		++added;
+	}
+	return added;
+}

--- a/sources/ElementsCollection/elementpickerpopup.h
+++ b/sources/ElementsCollection/elementpickerpopup.h
@@ -1,0 +1,76 @@
+/*
+	Copyright 2006-2026 The QElectroTech Team
+	This file is part of QElectroTech.
+
+	QElectroTech is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 2 of the License, or
+	(at your option) any later version.
+
+	QElectroTech is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with QElectroTech. If not, see <http://www.gnu.org/licenses/>.
+*/
+#ifndef ELEMENTPICKERPOPUP_H
+#define ELEMENTPICKERPOPUP_H
+
+#include "elementslocation.h"
+
+#include <QFrame>
+
+class ElementsCollectionWidget;
+class QLineEdit;
+class QListView;
+class QStandardItemModel;
+class QLabel;
+
+/**
+	@brief A cursor-anchored element picker.
+
+	Opens where the mouse is, focused on its search field: type to filter,
+	Enter to place, Esc to close. It is a recall tool, as opposed to the
+	Collections dock, which is a browsing tool.
+
+	It deliberately does not build its own ElementsCollectionModel. Loading the
+	collection is already the slow part of startup and a second copy would
+	double it, so the picker asks the dock's widget to run the query -- see
+	ElementsCollectionWidget::rankedSearch(). That also means the two always
+	agree on results and ranking.
+*/
+class ElementPickerPopup : public QFrame
+{
+	Q_OBJECT
+
+	public:
+		explicit ElementPickerPopup(ElementsCollectionWidget *source,
+					    QWidget *parent = nullptr);
+
+		void popUpAt(const QPoint &global_pos);
+
+	signals:
+			/// Emitted when the user picks an element; the popup has closed
+		void elementChosen(const ElementsLocation &location);
+
+	protected:
+		void keyPressEvent(QKeyEvent *event) override;
+
+	private:
+		void runSearch();
+		void chooseCurrent();
+		void showPalette();
+		int loadPaletteDir(const QString &dir_path, const QString &prefix,
+				   int depth);
+
+		ElementsCollectionWidget *m_source = nullptr;
+		QLineEdit *m_search = nullptr;
+		QListView *m_view = nullptr;
+		QStandardItemModel *m_model = nullptr;
+		QLabel *m_hint = nullptr;
+		bool m_palette_mode = true;
+};
+
+#endif // ELEMENTPICKERPOPUP_H

--- a/sources/ElementsCollection/elementscollectionwidget.cpp
+++ b/sources/ElementsCollection/elementscollectionwidget.cpp
@@ -35,6 +35,8 @@
 
 #include <QCheckBox>
 #include <QDesktopServices>
+#include <QSettings>
+#include <QShortcut>
 #include <QDialog>
 #include <QDialogButtonBox>
 #include <QFileDialog>
@@ -266,15 +268,7 @@ void ElementsCollectionWidget::setUpConnection()
 		this, &ElementsCollectionWidget::dirProperties);
 
 	connect(m_tree_view, &QTreeView::doubleClicked,
-			[this](const QModelIndex &index)
-			{
-				this->m_index_at_context_menu = index ;
-				ElementCollectionItem *eci = elementCollectionItemForIndex(index);
-				if (eci && eci->collectionPath().endsWith(".qetmak")) {
-					return; // Do nothing on double click for macros
-				}
-				this->editElement();
-			});
+			[this](const QModelIndex &index) { this->activateIndex(index); });
 
 	connect(m_tree_view, &QTreeView::entered,
 		[this] (const QModelIndex &index) {
@@ -284,19 +278,23 @@ void ElementsCollectionWidget::setUpConnection()
 			qde->statusBar()->showMessage(eci->localName());
 	});
 
+		//Enter on the highlighted item does the same as a double click, so a
+		//run of elements can be placed without leaving the keyboard. Bound as
+		//a shortcut on the view rather than by reimplementing keyPressEvent,
+		//which would mean subclassing ElementsTreeView for one key.
+	for (const auto key : {Qt::Key_Return, Qt::Key_Enter}) {
+		auto *sc = new QShortcut(QKeySequence(key), m_tree_view);
+		sc->setContext(Qt::WidgetShortcut);
+		connect(sc, &QShortcut::activated, this, [this]() {
+			this->activateIndex(m_tree_view->currentIndex());
+		});
+	}
+
 	connect(m_macros_tree_view, &QTreeView::customContextMenuRequested,
 			this, &ElementsCollectionWidget::customContextMenu);
 
 	connect(m_macros_tree_view, &QTreeView::doubleClicked,
-			[this](const QModelIndex &index)
-			{
-				this->m_index_at_context_menu = index ;
-				ElementCollectionItem *eci = elementCollectionItemForIndex(index);
-				if (eci && eci->collectionPath().endsWith(".qetmak")) {
-					return; // Do nothing on double click for macros
-				}
-				this->editElement();
-			});
+			[this](const QModelIndex &index) { this->activateIndex(index); });
 
 	connect(m_macros_tree_view, &QTreeView::entered,
 		[this] (const QModelIndex &index) {
@@ -403,6 +401,60 @@ void ElementsCollectionWidget::openDir()
 		QDesktopServices::openUrl(QUrl("file:///" + static_cast<XmlProjectElementCollectionItem*>(eci)->project()->currentDir()));
 #endif
 
+}
+
+/**
+	@brief ElementsCollectionWidget::activateIndex
+	What a double click (or Enter) on @a index does.
+
+	Historically this opened the element editor, which is the slowest action
+	available on a symbol you are most likely about to place. Placing is now
+	the default and editing has moved to the context menu, where it already
+	was. The old behaviour is preserved behind a preference for anyone who
+	relies on it.
+	@param index
+*/
+void ElementsCollectionWidget::activateIndex(const QModelIndex &index)
+{
+	m_index_at_context_menu = index;
+
+	ElementCollectionItem *eci = elementCollectionItemForIndex(index);
+	if (!eci) {
+		return;
+	}
+	//Macros are placed, never edited, and were already skipped here.
+	const bool is_macro = eci->collectionPath().endsWith(".qetmak");
+
+	QSettings settings;
+	const bool insert = settings.value(
+		QStringLiteral("elementscollection/double-click-inserts"), true).toBool();
+
+	if (insert) {
+		insertCurrentElement();
+		return;
+	}
+	if (!is_macro) {
+		editElement();
+	}
+}
+
+/**
+	@brief ElementsCollectionWidget::insertCurrentElement
+	Ask for the current item to be placed on the folio.
+*/
+void ElementsCollectionWidget::insertCurrentElement()
+{
+	ElementCollectionItem *eci =
+		elementCollectionItemForIndex(m_index_at_context_menu);
+	if (!(eci && eci->isElement())) {
+		return;
+	}
+
+	ElementsLocation location(eci->collectionPath());
+	if (!location.exist()) {
+		return;
+	}
+	emit insertElementRequested(location);
 }
 
 /**

--- a/sources/ElementsCollection/elementscollectionwidget.cpp
+++ b/sources/ElementsCollection/elementscollectionwidget.cpp
@@ -1081,6 +1081,80 @@ void ElementsCollectionWidget::search()
 }
 
 /**
+	@brief ElementsCollectionWidget::rankedSearch
+	Run the collection search for @a text and return the hits already ordered.
+
+	Shared with the picker popup, which needs the same results but cannot hold
+	model indexes -- its list is not backed by the collection model. Keeping
+	the query here also means the popup does not build a second
+	ElementsCollectionModel, which would double an already slow startup.
+	@param text : search text, "+" separating terms as in the dock
+	@return ranked hits, best first
+*/
+QVector<ElementSearchHit> ElementsCollectionWidget::rankedSearch(const QString &text)
+{
+	QVector<ElementSearchHit> out;
+	if (!m_model || text.size() < 3) {
+		return out;
+	}
+
+#if QT_VERSION < QT_VERSION_CHECK(5, 14, 0)	// ### Qt 6: remove
+	const QStringList terms = text.split("+", QString::SkipEmptyParts);
+#else
+	const QStringList terms = text.split("+", Qt::SkipEmptyParts);
+#endif
+	QModelIndexList matches;
+	for (const QString &t : terms) {
+		matches << m_model->match(m_model->index(0, 0),
+					  Qt::UserRole + 1,
+					  QVariant(t),
+					  -1,
+					  Qt::MatchContains | Qt::MatchRecursive);
+	}
+
+	const QString needle = terms.value(0).toLower();
+	QVector<QPair<int, ElementSearchHit>> scored;
+	QSet<QString> seen;
+
+	for (const QModelIndex &index : matches)
+	{
+		ElementCollectionItem *eci = elementCollectionItemForIndex(index);
+		if (!(eci && eci->isElement())) {
+			continue;
+		}
+		const QString path = eci->collectionPath();
+		if (path.isEmpty() || seen.contains(path)) {
+			continue;
+		}
+		seen.insert(path);
+
+		ElementSearchHit hit;
+		hit.path = path;
+		hit.name = index.data(Qt::DisplayRole).toString();
+		hit.icon = qvariant_cast<QIcon>(index.data(Qt::DecorationRole));
+		QStringList parts;
+		for (QModelIndex p = index.parent(); p.isValid(); p = p.parent()) {
+			parts.prepend(p.data(Qt::DisplayRole).toString());
+		}
+		hit.folder = parts.join(QStringLiteral(" / "));
+
+		const QString hay = index.data(Qt::UserRole + 1).toString().toLower();
+		scored.append({rankMatch(needle, hit.name, hay), hit});
+	}
+
+	std::stable_sort(scored.begin(), scored.end(),
+			 [](const QPair<int, ElementSearchHit> &a,
+			    const QPair<int, ElementSearchHit> &b) {
+				 return a.first > b.first;
+			 });
+	out.reserve(scored.size());
+	for (const auto &p : scored) {
+		out.append(p.second);
+	}
+	return out;
+}
+
+/**
 	@brief ElementsCollectionWidget::rankMatch
 	Score a hit so the list can be ordered by how well it matches.
 

--- a/sources/ElementsCollection/elementscollectionwidget.cpp
+++ b/sources/ElementsCollection/elementscollectionwidget.cpp
@@ -37,6 +37,10 @@
 #include <QDesktopServices>
 #include <QSettings>
 #include <QShortcut>
+#include <QListView>
+#include <QStandardItemModel>
+#include <QSet>
+#include <algorithm>
 #include <QDialog>
 #include <QDialogButtonBox>
 #include <QFileDialog>
@@ -219,8 +223,25 @@ void ElementsCollectionWidget::setUpWidget()
 	m_tab_widget->addTab(m_tree_view, tr("Collections"));
 	m_tab_widget->addTab(m_macros_tree_view, tr("Modèles"));
 
+		//Flat ranked search results.
+		//The tree search hides non-matching rows, so hits stay scattered
+		//through five levels of expanded folders -- searching "diode" leaves
+		//you scrolling a tree to find them. This shows the same matches as a
+		//ranked list instead, and takes the tab widget's place while a search
+		//is active.
+	m_search_model = new QStandardItemModel(this);
+	m_search_results = new QListView(this);
+	m_search_results->setModel(m_search_model);
+	m_search_results->setIconSize(QSize(50, 50));
+	m_search_results->setUniformItemSizes(false);
+	m_search_results->setVerticalScrollMode(QAbstractItemView::ScrollPerPixel);
+	m_search_results->setContextMenuPolicy(Qt::CustomContextMenu);
+	m_search_results->setMouseTracking(true);
+	m_search_results->hide();
+
 	m_main_vlayout->addWidget(m_search_field);
 	m_main_vlayout->addWidget(m_tab_widget);
+	m_main_vlayout->addWidget(m_search_results);
 
 	m_progress_bar = new QProgressBar(this);
 	m_progress_bar->setFormat(QObject::tr("chargement %p% (%v sur %m)"));
@@ -289,6 +310,41 @@ void ElementsCollectionWidget::setUpConnection()
 			this->activateIndex(m_tree_view->currentIndex());
 		});
 	}
+
+		//The flat results list carries the collection path directly, so it
+		//does not go through activateIndex() -- there is no tree index behind
+		//a row to look an ElementCollectionItem up from.
+	auto place_from_results = [this](const QModelIndex &index) {
+		const QString path = index.data(Qt::UserRole + 2).toString();
+		if (path.isEmpty()) {
+			return;
+		}
+		ElementsLocation location(path);
+		if (location.exist()) {
+			emit insertElementRequested(location);
+		}
+	};
+	connect(m_search_results, &QListView::doubleClicked, this, place_from_results);
+	for (const auto key : {Qt::Key_Return, Qt::Key_Enter}) {
+		auto *sc = new QShortcut(QKeySequence(key), m_search_results);
+		sc->setContext(Qt::WidgetShortcut);
+		connect(sc, &QShortcut::activated, this, [this, place_from_results]() {
+			place_from_results(m_search_results->currentIndex());
+		});
+	}
+		//Down from the search field moves into the results, so the whole
+		//type-then-place run happens without touching the mouse.
+	auto *to_results = new QShortcut(QKeySequence(Qt::Key_Down), m_search_field);
+	to_results->setContext(Qt::WidgetShortcut);
+	connect(to_results, &QShortcut::activated, this, [this]() {
+		if (!m_search_results->isVisible() || !m_search_model->rowCount()) {
+			return;
+		}
+		m_search_results->setFocus();
+		if (!m_search_results->currentIndex().isValid()) {
+			m_search_results->setCurrentIndex(m_search_model->index(0, 0));
+		}
+	});
 
 	connect(m_macros_tree_view, &QTreeView::customContextMenuRequested,
 			this, &ElementsCollectionWidget::customContextMenu);
@@ -974,6 +1030,7 @@ void ElementsCollectionWidget::search()
 		//Reset the search
 	if (text.isEmpty())
 	{
+		clearFlatResults();
 		QModelIndex current_index = m_tree_view->currentIndex();
 		m_tree_view->reset();
 
@@ -1000,7 +1057,6 @@ void ElementsCollectionWidget::search()
 		return;
 	}
 
-	hideCollection(true);
 #if QT_VERSION < QT_VERSION_CHECK(5, 14, 0)	// ### Qt 6: remove
 	const QStringList text_list = text.split("+", QString::SkipEmptyParts);
 #else
@@ -1021,8 +1077,114 @@ void ElementsCollectionWidget::search()
 						  | Qt::MatchRecursive);
 	}
 
-	for(QModelIndex index : match_index)
-		showAndExpandItem(index);
+	showFlatResults(match_index, text_list.value(0));
+}
+
+/**
+	@brief ElementsCollectionWidget::rankMatch
+	Score a hit so the list can be ordered by how well it matches.
+
+	The tree search treats every hit equally, which is fine when they stay in
+	place but useless in a ranked list: typing "diode" should not put an
+	element whose *description* mentions diodes above one actually called
+	"Diode". Name beats element-info field, earlier beats later, shorter beats
+	longer.
+	@param needle : lower-cased search text
+	@param name : the element's display name
+	@param haystack : the full indexed string (name + every info field)
+	@return a score, higher is better
+*/
+int ElementsCollectionWidget::rankMatch(const QString &needle,
+					const QString &name,
+					const QString &haystack)
+{
+	const QString n = name.toLower();
+	int score = 0;
+
+	if (n == needle) {
+		score = 1000;
+	} else if (n.startsWith(needle)) {
+		score = 800;
+	} else if (n.contains(needle)) {
+		score = 600 - qMin(n.indexOf(needle), 99);
+	} else if (haystack.contains(needle)) {
+			//Matched only on an info field -- manufacturer, reference,
+			//description. Still a real hit, just a weaker one.
+		score = 300;
+	}
+		//Among equally-placed hits prefer the shorter name: "Diode" over
+		//"Diode Zener bidirectional".
+	return score - qMin(n.size(), 99);
+}
+
+/**
+	@brief ElementsCollectionWidget::showFlatResults
+	Replace the tree with a ranked flat list of @a matches.
+	@param matches : indexes returned by the model search
+	@param needle : the search text, for ranking
+*/
+void ElementsCollectionWidget::showFlatResults(const QModelIndexList &matches,
+					       const QString &needle)
+{
+	m_search_model->clear();
+
+	const QString lower = needle.toLower();
+	QVector<QPair<int, QStandardItem *>> scored;
+	QSet<QString> seen;
+
+	for (const QModelIndex &index : matches)
+	{
+		ElementCollectionItem *eci = elementCollectionItemForIndex(index);
+		if (!(eci && eci->isElement())) {
+			continue;
+		}
+		const QString path = eci->collectionPath();
+			//match() is run once per "+"-separated term, so the same element
+			//can arrive several times.
+		if (path.isEmpty() || seen.contains(path)) {
+			continue;
+		}
+		seen.insert(path);
+
+		const QString name = index.data(Qt::DisplayRole).toString();
+		const QString hay = index.data(Qt::UserRole + 1).toString().toLower();
+
+		auto *item = new QStandardItem(name);
+		item->setIcon(qvariant_cast<QIcon>(index.data(Qt::DecorationRole)));
+		item->setEditable(false);
+			//Where it lives, so two similarly-named symbols are tellable apart
+		QStringList parts;
+		for (QModelIndex p = index.parent(); p.isValid(); p = p.parent()) {
+			parts.prepend(p.data(Qt::DisplayRole).toString());
+		}
+		item->setToolTip(parts.join(QStringLiteral(" / ")));
+		item->setData(path, Qt::UserRole + 2);
+
+		scored.append({rankMatch(lower, name, hay), item});
+	}
+
+	std::stable_sort(scored.begin(), scored.end(),
+			 [](const QPair<int, QStandardItem *> &a,
+			    const QPair<int, QStandardItem *> &b) {
+				 return a.first > b.first;
+			 });
+	for (const auto &p : scored) {
+		m_search_model->appendRow(p.second);
+	}
+
+	m_tab_widget->hide();
+	m_search_results->show();
+}
+
+/**
+	@brief ElementsCollectionWidget::clearFlatResults
+	Put the tree back when the search field is emptied.
+*/
+void ElementsCollectionWidget::clearFlatResults()
+{
+	m_search_model->clear();
+	m_search_results->hide();
+	m_tab_widget->show();
 }
 
 /**

--- a/sources/ElementsCollection/elementscollectionwidget.h
+++ b/sources/ElementsCollection/elementscollectionwidget.h
@@ -46,6 +46,20 @@ class ElementsTreeView;
 class QListView;
 class QStandardItemModel;
 
+/**
+	@brief One ranked hit from a collection search.
+	Carries everything a result row needs, so a consumer does not have to hold
+	a model index -- which matters for the picker popup, whose list is not
+	backed by the collection model.
+*/
+struct ElementSearchHit
+{
+	QString path;    ///< collection path, enough to build an ElementsLocation
+	QString name;    ///< display name
+	QString folder;  ///< where it lives, for disambiguation
+	QIcon icon;
+};
+
 class ElementsCollectionWidget : public QWidget
 {
 	Q_OBJECT
@@ -59,6 +73,7 @@ class ElementsCollectionWidget : public QWidget
 		void removeProject (QETProject *project);
 		void highlightUnusedElement();
 		void setCurrentLocation(const ElementsLocation &location);
+		QVector<ElementSearchHit> rankedSearch(const QString &text);
 
 	protected:
 		void leaveEvent(QEvent *event) override;

--- a/sources/ElementsCollection/elementscollectionwidget.h
+++ b/sources/ElementsCollection/elementscollectionwidget.h
@@ -43,6 +43,9 @@ class ElementsTreeView;
 	and all action needed to use this widget.
 	This is the element collection widget used in the diagram editor.
 */
+class QListView;
+class QStandardItemModel;
+
 class ElementsCollectionWidget : public QWidget
 {
 	Q_OBJECT
@@ -101,6 +104,10 @@ class ElementsCollectionWidget : public QWidget
 	private:
 		void locationWasSaved(const ElementsLocation& location);
 		void activateIndex(const QModelIndex &index);
+		void showFlatResults(const QModelIndexList &matches, const QString &needle);
+		void clearFlatResults();
+		static int rankMatch(const QString &needle, const QString &name,
+				     const QString &haystack);
 
 
 	private:
@@ -112,6 +119,9 @@ class ElementsCollectionWidget : public QWidget
 		ElementsTreeView *m_tree_view;
 		ElementsTreeView *m_macros_tree_view = nullptr;
 		QTabWidget *m_tab_widget = nullptr;
+			/// Flat ranked results, shown in place of the tree while searching
+		QListView *m_search_results = nullptr;
+		QStandardItemModel *m_search_model = nullptr;
 		QVBoxLayout *m_main_vlayout;
 		QMenu *m_context_menu;
 		QModelIndex m_index_at_context_menu;

--- a/sources/ElementsCollection/elementscollectionwidget.h
+++ b/sources/ElementsCollection/elementscollectionwidget.h
@@ -86,9 +86,21 @@ class ElementsCollectionWidget : public QWidget
 	public slots:
 		void reload();
 		void loadingFinished();
+		void insertCurrentElement();
+
+	signals:
+		/**
+			Emitted when the user asks for an element to be placed on the
+			current folio. Whoever hosts this widget decides which view
+			receives it -- the dock is inside a diagram editor, but the
+			picker popup is not, so the widget must not reach for an
+			ancestor editor itself.
+		*/
+		void insertElementRequested(const ElementsLocation &location);
 
 	private:
 		void locationWasSaved(const ElementsLocation& location);
+		void activateIndex(const QModelIndex &index);
 
 
 	private:

--- a/sources/diagramview.cpp
+++ b/sources/diagramview.cpp
@@ -217,14 +217,71 @@ void DiagramView::handleElementDrop(QDropEvent *event)
 	drop_pos = event->position();
 	#endif
 
+	startElementPlacement(location, drop_pos);
+}
+
+/**
+	@brief DiagramView::startElementPlacement
+	Enter the interactive placement mode for @a location, with the pending
+	element starting at @a scene_pos.
+
+	This is the mode where the element follows the cursor on the grid, a left
+	click drops a copy, Space rotates it and the element stays loaded so a run
+	of identical symbols can be placed with successive clicks.
+
+	Split out of handleElementDrop() so that placement is reachable without a
+	drag: the mode itself was always general, it simply had no caller other
+	than the end of a drop.
+	@param location : the element or macro to place
+	@param scene_pos : where the pending element first appears, in scene
+	coordinates
+	@return true if the placement mode was entered
+*/
+bool DiagramView::startElementPlacement(const ElementsLocation &location,
+					const QPointF &scene_pos)
+{
+	if (!diagram() || !(location.isElement() && location.exist())) {
+		return false;
+	}
+	if (diagram()->isReadOnly()) {
+		return false;
+	}
+
 	if (location.path().endsWith(".qetmak")) {
-		diagram()->setEventInterface(new DiagramEventAddMacro(location, diagram(), drop_pos));
+		diagram()->setEventInterface(
+			new DiagramEventAddMacro(location, diagram(), scene_pos));
 	} else {
-		diagram()->setEventInterface(new DiagramEventAddElement(location, diagram(), drop_pos));
+			//DiagramEventAddElement takes a non-const reference, so it needs
+			//an lvalue it may modify. Copying keeps the caller's location
+			//untouched -- QETDiagramEditor stores the same one for
+			//"insert last element".
+		ElementsLocation loc(location);
+		diagram()->setEventInterface(
+			new DiagramEventAddElement(loc, diagram(), scene_pos));
 	}
 
 	//Set focus to the view to get event
 	this->setFocus();
+	return true;
+}
+
+/**
+	@brief DiagramView::defaultPlacementPos
+	@return where a pending element should appear when placement was not
+	started by a drop, so there is no cursor position to use.
+
+	The cursor is used when it is over the view -- picking up a placement where
+	the user is already looking -- and the centre of the visible area
+	otherwise.
+*/
+QPointF DiagramView::defaultPlacementPos() const
+{
+	const QPoint local = mapFromGlobal(QCursor::pos());
+	if (viewport() && viewport()->rect().contains(local)) {
+		return mapToScene(local);
+	}
+	return mapToScene(viewport() ? viewport()->rect().center()
+				     : rect().center());
 }
 
 /**

--- a/sources/diagramview.h
+++ b/sources/diagramview.h
@@ -72,6 +72,9 @@ class DiagramView : public QGraphicsView
 		void setEventInterface (DVEventInterface *event_interface);
 		QList<QAction *> contextMenuActions() const;
 	
+		bool startElementPlacement(const ElementsLocation &location,
+					   const QPointF &scene_pos);
+		QPointF defaultPlacementPos() const;
 	protected:
 		void mouseDoubleClickEvent(QMouseEvent *) override;
 		void contextMenuEvent(QContextMenuEvent *) override;
@@ -92,7 +95,6 @@ class DiagramView : public QGraphicsView
 		virtual bool switchToSelectionModeIfNeeded(QInputEvent *e);
 		virtual bool isCtrlShifting(QInputEvent *);
 		virtual bool selectedItemHasFocus();
-	
 	private:
 		void handleElementDrop(QDropEvent *);
 		void handleTitleBlockDrop(QDropEvent *);

--- a/sources/qetdiagrameditor.cpp
+++ b/sources/qetdiagrameditor.cpp
@@ -18,6 +18,7 @@
 #include "qetdiagrameditor.h"
 #include <QCoreApplication>
 #include "ElementsCollection/elementscollectionwidget.h"
+#include "ElementsCollection/elementpickerpopup.h"
 #include "QWidgetAnimation/qwidgetanimation.h"
 #include "autoNum/ui/autonumberingdockwidget.h"
 #include "conductornumexport.h"
@@ -665,6 +666,22 @@ void QETDiagramEditor::setUpActions()
 	connect(m_insert_last_element, &QAction::triggered,
 		this, &QETDiagramEditor::insertLastElement);
 	addAction(m_insert_last_element);
+
+		//Cursor-anchored picker. Insert is unbound anywhere in the tree and
+		//reads correctly for the action, which keeps A free for the far more
+		//frequent "place the same symbol again".
+	m_show_element_picker = new QAction(QET::Icons::ElementNew,
+					    tr("Insérer un élément…"), this);
+	m_show_element_picker->setStatusTip(
+		tr("Ouvre le sélecteur d'éléments à la position du curseur",
+		   "status bar tip"));
+	m_show_element_picker->setData("show_element_picker");
+	ShortcutManager::instance().registerAction(
+		m_show_element_picker, "diagrameditor.show_element_picker",
+		tr("Éditeur de schémas"), Qt::Key_Insert);
+	connect(m_show_element_picker, &QAction::triggered,
+		this, &QETDiagramEditor::showElementPicker);
+	addAction(m_show_element_picker);
 
 	m_delete_selection->setStatusTip( tr("Enlève les éléments sélectionnés du folio", "status bar tip"));
 	m_rotate_selection->setStatusTip( tr("Pivote les éléments et textes sélectionnés", "status bar tip"));
@@ -1700,6 +1717,17 @@ void QETDiagramEditor::slot_updateActions()
 	m_draw_grid->                   setEnabled(opened_diagram);
 	m_draw_guides->                 setEnabled(opened_diagram);
 
+		//Placement needs somewhere to place onto. Both were doing nothing
+		//silently with no folio open, which reads as a broken shortcut rather
+		//than an unavailable one.
+	if (m_show_element_picker) {
+		m_show_element_picker->setEnabled(editable_project && opened_diagram);
+	}
+	if (m_insert_last_element) {
+		m_insert_last_element->setEnabled(editable_project && opened_diagram
+						  && m_last_inserted_element.isElement());
+	}
+
 		//Project menu
 	m_project_edit_properties     -> setEnabled(opened_project);
 	m_project_add_diagram         -> setEnabled(editable_project);
@@ -2682,6 +2710,29 @@ void QETDiagramEditor::insertLastElement()
 		return;
 	}
 	insertElementFromCollection(m_last_inserted_element);
+}
+
+/**
+	@brief QETDiagramEditor::showElementPicker
+	Open the element picker where the mouse is.
+
+	Built lazily: most sessions of the diagram editor never open it, and it
+	holds a list view and a model of its own.
+*/
+void QETDiagramEditor::showElementPicker()
+{
+	if (!currentDiagramView()) {
+		return;
+	}
+
+	if (!m_element_picker)
+	{
+		m_element_picker = new ElementPickerPopup(m_element_collection_widget,
+							  this);
+		connect(m_element_picker, &ElementPickerPopup::elementChosen,
+			this, &QETDiagramEditor::insertElementFromCollection);
+	}
+	m_element_picker->popUpAt(QCursor::pos());
 }
 
 /**

--- a/sources/qetdiagrameditor.cpp
+++ b/sources/qetdiagrameditor.cpp
@@ -215,6 +215,13 @@ void QETDiagramEditor::setUpElementsCollectionWidget()
 	m_qdw_elmt_collection->setWidget(m_element_collection_widget);
 	m_element_collection_widget->expandFirstItems();
 
+		//The widget does not know which view should receive the element -- it
+		//is also used by the picker popup, which has no editor ancestor -- so
+		//the host decides.
+	connect(m_element_collection_widget,
+		&ElementsCollectionWidget::insertElementRequested,
+		this, &QETDiagramEditor::insertElementFromCollection);
+
 	addDockWidget(Qt::RightDockWidgetArea, m_qdw_elmt_collection);
 }
 
@@ -638,6 +645,26 @@ void QETDiagramEditor::setUpActions()
 	ShortcutManager::instance().registerAction(m_rotate_selection, "diagrameditor.rotate_selection", tr("Éditeur de schémas"), Qt::Key_Space);
 	ShortcutManager::instance().registerAction(m_rotate_texts, "diagrameditor.rotate_texts", tr("Éditeur de schémas"), Qt::CTRL | Qt::Key_Space);
 	ShortcutManager::instance().registerAction(m_edit_selection, "diagrameditor.edit_selection", tr("Éditeur de schémas"), Qt::CTRL | Qt::Key_E);
+
+		//Re-enter placement mode with the element placed last. Bare A rather
+		//than Space: Space already rotates the pending element *inside*
+		//placement mode (diagrameventaddelement.cpp), and is taken three times
+		//over in this editor besides. A matches KiCad's add-symbol key and
+		//reads correctly in the source language ("Ajouter"). ShortcutManager
+		//makes it a default, not a commitment -- it appears in the Shortcuts
+		//preference page like every other binding.
+	m_insert_last_element = new QAction(QET::Icons::ElementNew,
+					    tr("Insérer le dernier élément"), this);
+	m_insert_last_element->setStatusTip(
+		tr("Replace le dernier élément inséré", "status bar tip"));
+	m_insert_last_element->setData("insert_last_element");
+	m_insert_last_element->setEnabled(false);
+	ShortcutManager::instance().registerAction(
+		m_insert_last_element, "diagrameditor.insert_last_element",
+		tr("Éditeur de schémas"), Qt::Key_A);
+	connect(m_insert_last_element, &QAction::triggered,
+		this, &QETDiagramEditor::insertLastElement);
+	addAction(m_insert_last_element);
 
 	m_delete_selection->setStatusTip( tr("Enlève les éléments sélectionnés du folio", "status bar tip"));
 	m_rotate_selection->setStatusTip( tr("Pivote les éléments et textes sélectionnés", "status bar tip"));
@@ -2614,6 +2641,48 @@ void QETDiagramEditor::selectionChanged()
 		m_selection_properties_editor->setDiagram(dv->diagram());
 }
 
+
+/**
+	@brief QETDiagramEditor::insertElementFromCollection
+	Place @a location on the current folio using the interactive placement
+	mode -- the same mode a drag and drop ends in, entered without the drag.
+	@param location
+*/
+void QETDiagramEditor::insertElementFromCollection(const ElementsLocation &location)
+{
+	DiagramView *dv = currentDiagramView();
+	if (!dv) {
+		return;
+	}
+
+	if (!dv->startElementPlacement(location, dv->defaultPlacementPos())) {
+		return;
+	}
+
+		//Remembered for "insert last element". Macros are excluded: the
+		//placement mode for them is a different class and re-entering it from
+		//a shortcut has not been thought through.
+	if (!location.path().endsWith(QLatin1String(".qetmak"))) {
+		m_last_inserted_element = location;
+		if (m_insert_last_element) {
+			m_insert_last_element->setEnabled(true);
+		}
+	}
+}
+
+/**
+	@brief QETDiagramEditor::insertLastElement
+	Re-enter placement mode with the element placed most recently, so a run of
+	the same symbol can be dropped without returning to the collection.
+*/
+void QETDiagramEditor::insertLastElement()
+{
+	if (!m_last_inserted_element.isElement()
+	    || !m_last_inserted_element.exist()) {
+		return;
+	}
+	insertElementFromCollection(m_last_inserted_element);
+}
 
 /**
 	@brief QETDiagramEditor::generateTerminalBlock

--- a/sources/qetdiagrameditor.h
+++ b/sources/qetdiagrameditor.h
@@ -122,6 +122,8 @@ class QETDiagramEditor : public QETMainWindow
 		void slot_updatePasteAction();
 		void slot_updateWindowsMenu();
 		void slot_updateAutoNumDock();
+		void insertElementFromCollection(const ElementsLocation &location);
+		void insertLastElement();
 		void generateTerminalBlock();
 		void setWindowedMode();
 		void setTabbedMode();
@@ -238,6 +240,9 @@ class QETDiagramEditor : public QETMainWindow
 		*qdw_undo; /// Dock for the undo list
 
 		ElementsCollectionWidget *m_element_collection_widget;
+			/// Last element placed from the collection, for "insert last"
+		ElementsLocation m_last_inserted_element;
+		QAction *m_insert_last_element = nullptr;
 			
 		DiagramPropertiesEditorDockWidget *m_selection_properties_editor;
 			/// Elements panel

--- a/sources/qetdiagrameditor.h
+++ b/sources/qetdiagrameditor.h
@@ -41,6 +41,7 @@ class ElementsLocation;
 class RecentFiles;
 class DiagramPropertiesEditorDockWidget;
 class ElementsCollectionWidget;
+class ElementPickerPopup;
 class AutoNumberingDockWidget;
 class TerminalNumberingDialog;
 
@@ -124,6 +125,7 @@ class QETDiagramEditor : public QETMainWindow
 		void slot_updateAutoNumDock();
 		void insertElementFromCollection(const ElementsLocation &location);
 		void insertLastElement();
+		void showElementPicker();
 		void generateTerminalBlock();
 		void setWindowedMode();
 		void setTabbedMode();
@@ -243,6 +245,8 @@ class QETDiagramEditor : public QETMainWindow
 			/// Last element placed from the collection, for "insert last"
 		ElementsLocation m_last_inserted_element;
 		QAction *m_insert_last_element = nullptr;
+		QAction *m_show_element_picker = nullptr;
+		ElementPickerPopup *m_element_picker = nullptr;
 			
 		DiagramPropertiesEditorDockWidget *m_selection_properties_editor;
 			/// Elements panel

--- a/sources/ui/configpage/generalconfigurationpage.cpp
+++ b/sources/ui/configpage/generalconfigurationpage.cpp
@@ -68,6 +68,9 @@ GeneralConfigurationPage::GeneralConfigurationPage(QWidget *parent) :
 #endif
 	ui->grid_startup_cb->setChecked(settings.value("diagrameditor/grid_display_startup", true).toBool());
 	ui->guides_startup_cb->setChecked(settings.value("diagrameditor/guides_display_startup", false).toBool());
+		//Stored as "inserts" but presented as "edits", so the default (insert)
+		//is the unchecked state -- a preference reads better as an opt-out.
+	ui->m_collection_dblclick_edits->setChecked(!settings.value("elementscollection/double-click-inserts", true).toBool());
 	ui->DiagramEditor_xGrid_sb->setValue(settings.value("diagrameditor/Xgrid", 10).toInt());
 	ui->DiagramEditor_yGrid_sb->setValue(settings.value("diagrameditor/Ygrid", 10).toInt());
 	ui->DiagramEditor_xKeyGrid_sb->setValue(settings.value("diagrameditor/key_Xgrid", 10).toInt());
@@ -245,6 +248,7 @@ void GeneralConfigurationPage::applyConf()
 
 	settings.setValue("diagrameditor/grid_display_startup", ui->grid_startup_cb->isChecked());
 	settings.setValue("diagrameditor/guides_display_startup", ui->guides_startup_cb->isChecked());
+	settings.setValue("elementscollection/double-click-inserts", !ui->m_collection_dblclick_edits->isChecked());
 		//Grid step and key navigation
 	settings.setValue("diagrameditor/Xgrid", ui->DiagramEditor_xGrid_sb->value());
 	settings.setValue("diagrameditor/Ygrid", ui->DiagramEditor_yGrid_sb->value());

--- a/sources/ui/configpage/generalconfigurationpage.ui
+++ b/sources/ui/configpage/generalconfigurationpage.ui
@@ -67,6 +67,16 @@
         </widget>
        </item>
        <item>
+        <widget class="QCheckBox" name="m_collection_dblclick_edits">
+         <property name="toolTip">
+          <string>Par défaut, un double-clic insère l'élément sur le folio ; l'édition reste accessible par le menu contextuel.</string>
+         </property>
+         <property name="text">
+          <string>Double-cliquer dans la collection ouvre l'éditeur d'élément au lieu de l'insérer</string>
+         </property>
+        </widget>
+       </item>
+       <item>
         <widget class="QCheckBox" name="guides_startup_cb">
          <property name="text">
           <string>Afficher les guides par défaut (appliqué au prochain lancement)</string>


### PR DESCRIPTION
**Draft** — the questions in #676 are still open, and two of them change what this should look like. Opened so the behaviour can be tried rather than argued from a description.

Builds all four phases from #676. Three commits, each self-contained and useful alone; **the first can be cherry-picked on its own** if only Phase 1 is wanted.

## Phase 1 — reach the placement mode without a drag (`716ced5`)

`DiagramEventAddElement` is already a good interactive placement mode — ghost on the grid, left click drops, Space rotates, the element stays loaded, commits through `AddGraphicsObjectCommand` so undo behaves. It had **one caller in the whole tree**, inside `DiagramView::handleElementDrop()`, so the only way to reach it was to finish a drag.

- `DiagramView::startElementPlacement()` split out of `handleElementDrop()`; `defaultPlacementPos()` uses the cursor when it is over the view, the centre of the visible area otherwise.
- `ElementsCollectionWidget` emits `insertElementRequested()` on double click or Enter. It deliberately does **not** reach for an ancestor editor the way the status-bar hint does — the picker has no editor ancestor, so the host connects the signal.
- `QETDiagramEditor` places it and remembers it, which gives **"Insérer le dernier élément"** on `A`.

`A` rather than `Space`: Space already rotates the pending element *inside* placement mode (`diagrameventaddelement.cpp:174`) and is taken three more times in this editor.

**Answering question 1 in #676**: double click inserts by default, with a preference to restore the editor (`elementscollection/double-click-inserts`), worded in Configuration as an opt-out so the default is the unchecked box. Editing stays on the context menu where it already was.

## Phase 2 — flat ranked results (`16409b7`)

The tree search hides non-matching rows, so hits stay scattered. Searching `diode` against the shipped collection leaves you looking at five levels of expanded tree with the first visible hit being *Avalanche diode bidirectional*.

Same matches, shown as a ranked flat list. No new index — this ranks what `match()` already returns against `Qt::UserRole+1`.

```
exact name       1000     name contains   600 - match position
starts with       800     info field only 300
                        minus the name length
```

`diode` now returns: **Diode**, diode-tube, Diodes Module Pilot Wire, Photodiode.

## Phases 3 & 4 — cursor picker and folder palette (`a7cd955`)

`Insert` opens a picker where the mouse is. Empty field shows a quick palette as an icon grid; type to search everything; Enter places; Esc closes.

**The model is not hoisted to a `QETApp` singleton.** #676's Phase 3 proposes that, but **question 2 asks permission for it and nobody has answered**, and it touches loading code several people have worked on. It also turns out not to be needed: the picker builds no model at all, it asks the dock's widget via the new `ElementsCollectionWidget::rankedSearch()` — extracted from Phase 2 so both share one implementation. No second model, no doubled startup, and the two cannot disagree on ranking. If the singleton is wanted later, nothing here blocks it.

**The palette is a folder** — subfolders are categories, contents are entries. Set-up is dragging into it, ordering is the `01_`/`02_` convention already used by the shipped collection, sharing is `companyElementsDir()`. Only the path is in `QSettings`, defaulting to the custom collection. No schema, parser, merge rules or "reset to defaults".

Also fixed: both new actions did nothing silently with no folio open — now enabled from `slot_updateActions()` like every other placement action.

## Verified live

Under Xvfb against `examples/741.qet` with the shipped collection, not just compiled:

- Search `diode` → double-click a result → ghost follows the cursor grid-snapped; **no element editor opens**
- `Insert` over the folio → picker at the cursor → type `relay` → ranked list, best hit preselected
- `Insert` with an empty field → palette icon grid with thumbnails → `Enter` → chosen element in placement mode

Builds clean, CMake/Ninja Release, Qt 5.15, no new warnings in the touched files.

## Still open

**Question 3 in #676 is unanswered and Phase 4 rests on it** — the folder-as-palette design assumes people already curate folders in their custom collection. If that is not how they actually work, the palette grid is the part to reconsider; Phases 1–3 do not depend on it.

The `Insert` and `A` defaults are `ShortcutManager` registrations, so they are defaults rather than commitments and appear in the Shortcuts preference page.

Discussion: #676

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fq6v5jnifdpcwCoPocrp6e
