### PR TITLE
Fix crash changing dynamic text color and confirming with Enter (bugtracker #323)

### DIFF
--- a/sources/ui/dynamicelementtextmodel.cpp
+++ b/sources/ui/dynamicelementtextmodel.cpp
@@ -36,6 +36,7 @@
 #include <QHash>
 #include <QModelIndex>
 #include <QStandardItem>
+#include <QTimer>
 #include <QUndoCommand>
 
 static int src_txt_row   = 0;
@@ -1595,6 +1596,15 @@ DynamicTextItemDelegate::DynamicTextItemDelegate(QObject *parent) :
 	QStyledItemDelegate(parent)
 {}
 
+void DynamicTextItemDelegate::commitAndCloseDeferred(QWidget *editor) const
+{
+	auto *self = const_cast<DynamicTextItemDelegate *>(this);
+	QTimer::singleShot(0, self, [self, editor]() {
+		emit self->commitData(editor);
+		emit self->closeEditor(editor);
+	});
+}
+
 QWidget *DynamicTextItemDelegate::createEditor(
 		QWidget *parent,
 		const QStyleOptionViewItem &option,
@@ -1682,6 +1692,7 @@ QWidget *DynamicTextItemDelegate::createEditor(
 				w->setProperty("ok", ok);
 			}
 			w->setObjectName("font_dialog");
+			commitAndCloseDeferred(w);
 			return w;
 		}
 		case DynamicElementTextModel::color:
@@ -1716,6 +1727,7 @@ QWidget *DynamicTextItemDelegate::createEditor(
 				w->setProperty("ok", true);
 			}
 			w->setObjectName("color_dialog");
+			commitAndCloseDeferred(w);
 			return w;
 		}
 		case DynamicElementTextModel::pos:

--- a/sources/ui/dynamicelementtextmodel.cpp
+++ b/sources/ui/dynamicelementtextmodel.cpp
@@ -1686,9 +1686,37 @@ QWidget *DynamicTextItemDelegate::createEditor(
 		}
 		case DynamicElementTextModel::color:
 		{
-			QColorDialog *cd = new QColorDialog(index.data(Qt::EditRole).value<QColor>(), parent);
-			cd->setObjectName("color_dialog");
-			return cd;
+				/* Like the font case above: run the dialog synchronously via
+				 * its static convenience function and stash the result on a
+				 * plain placeholder widget, rather than handing back the
+				 * QColorDialog itself as the item view's "editor".
+				 *
+				 * The item view's own Enter/Escape handling (the base
+				 * QStyledItemDelegate::eventFilter(), since "color_dialog"
+				 * isn't one of the objectNames special-cased in this
+				 * delegate's own eventFilter() above) treats whatever
+				 * createEditor() returned as a small inline editor it
+				 * commits and destroys directly on a key press. A QColorDialog
+				 * is not that: on Windows it can hand off to the native
+				 * color picker, whose own accept/close path then races the
+				 * view's -- pressing Enter fired both, one tearing down an
+				 * object the other was still using (case #323 on the bug
+				 * tracker: "QObject::installEventFilter(): Cannot filter
+				 * events for objects in a different thread" immediately
+				 * followed by a segfault; clicking the dialog's own OK
+				 * button with the mouse didn't reach the view's key
+				 * handling, so it didn't crash). Resolving the dialog
+				 * before returning removes the second, competing teardown
+				 * path entirely. */
+			QColor color = QColorDialog::getColor(index.data(Qt::EditRole).value<QColor>(), parent);
+			QWidget *w = new QWidget(parent);
+			if (color.isValid())
+			{
+				w->setProperty("color", color);
+				w->setProperty("ok", true);
+			}
+			w->setObjectName("color_dialog");
+			return w;
 		}
 		case DynamicElementTextModel::pos:
 		{
@@ -1788,15 +1816,15 @@ void DynamicTextItemDelegate::setModelData(
 			{
 				if(QStandardItem *qsi = qsim->itemFromIndex(index))
 				{
-					QColorDialog *cd = static_cast<QColorDialog *> (editor);
-					if (cd->result() == QDialog::Accepted)
+					if (editor->property("ok").toBool() == true)
 					{
-						qsi->setData(cd->selectedColor(), Qt::EditRole);
-						qsi->setData(cd->selectedColor(), Qt::ForegroundRole);
+						QColor color = editor->property("color").value<QColor>();
+						qsi->setData(color, Qt::EditRole);
+						qsi->setData(color, Qt::ForegroundRole);
 					}
 					return;
 				}
-				
+
 			}
 		}
 		else if (editor->objectName() == "info_text")

--- a/sources/ui/dynamicelementtextmodel.h
+++ b/sources/ui/dynamicelementtextmodel.h
@@ -155,6 +155,21 @@ class DynamicTextItemDelegate : public QStyledItemDelegate
 
 	private:
 	QStringList availableInfo(DynamicElementTextItem *deti) const;
+		/**
+			@brief commitAndCloseDeferred
+			Schedule commitData()/closeEditor() for @a editor on the next
+			event loop iteration. For editors resolved synchronously inside
+			createEditor() (font/color, both run their picker dialog before
+			returning) there is no user interaction left to drive the base
+			QStyledItemDelegate::eventFilter()'s usual Enter/focus-out commit
+			path, so without this the value sits picked-but-uncommitted
+			until something unrelated (e.g. clicking elsewhere) happens to
+			trigger it. Deferred rather than called immediately: the view
+			only registers the widget createEditor() returns as "the active
+			editor" *after* createEditor() itself returns, so emitting here
+			would target an editor the view doesn't know about yet.
+		*/
+	void commitAndCloseDeferred(QWidget *editor) const;
 };
 
 #endif // DYNAMICELEMENTTEXTMODEL_H


### PR DESCRIPTION
Fixes https://qelectrotech.org/bugtracker/view.php?id=323 — "Crash on change label color". Reported crash: changing a dynamic text's color and confirming with **Enter** segfaults; confirming with the mouse on the dialog's own OK button does not. Reported on Windows 11 and Debian, with `QObject::installEventFilter(): Cannot filter events for objects in a different thread` immediately before the crash.

## Root cause

`DynamicTextItemDelegate::createEditor()`'s `color` case constructs a `QColorDialog` and returns it directly as the item view's editor widget for that cell:

```cpp
case DynamicElementTextModel::color:
{
    QColorDialog *cd = new QColorDialog(index.data(Qt::EditRole).value<QColor>(), parent);
    cd->setObjectName("color_dialog");
    return cd;
}
```

Every other case in this function returns a small inline widget appropriate for an item-view editor (`QSpinBox`, `QComboBox`, ...). The `font` case right above it needs a full picker too, and does it the safe way — call the blocking static `QFontDialog::getFont()`, then return a plain placeholder `QWidget` with the result stashed on it:

```cpp
case DynamicElementTextModel::font:
{
    bool ok;
    QFont font = QFontDialog::getFont(&ok, index.data(Qt::UserRole+2).value<QFont>(), parent);
    QWidget *w = new QWidget(parent);
    if (ok) { w->setFont(font); w->setProperty("ok", ok); }
    w->setObjectName("font_dialog");
    return w;
}
```

`color` didn't follow that pattern. `"color_dialog"` isn't one of the objectNames this delegate's own `eventFilter()` special-cases (the "commit on every keystroke" hack list, or the combo-box `FocusIn` list), so Enter on it falls through to the base `QStyledItemDelegate::eventFilter()`, which treats whatever `createEditor()` returned as an ordinary small editor to commit-and-destroy on Enter — racing the `QColorDialog`'s own internal OK-button accept/close path, which on Windows can hand off to the native color picker. Clicking OK with the mouse doesn't go through the same view-level key-press handling, which is consistent with the report that only Enter crashes.

## Verification

Structural: built a standalone Qt program that constructs a bare `QStandardItemModel` + `QTreeView` with the real `DynamicTextItemDelegate` and drives it through `QAbstractItemView::edit()` exactly as the real view does. Confirmed the *old* code's `QColorDialog` editor is a **child widget of the view's viewport**, not a top-level window (a search of `QApplication::topLevelWidgets()` never found it; only a search of the viewport's children did) — i.e. concretely not being used as a dialog is meant to be used, independent of whether this Linux/Xvfb environment reproduces the exact native-dialog-thread segfault from the report.

End-to-end with the fix: same harness, but now the `QColorDialog` **is** found among top-level widgets (proper popup behavior). Clicked its real OK button, confirmed the picked color landed on the placeholder widget's stashed properties, sent the editor a synthetic Enter keypress (the exact trigger from the bug report), and confirmed the final value committed to the model matches the picked color. No crash, clean exit.

Also did a full Release build (333/333, CMake/Ninja, Qt 5.15.18) — no new warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RPBnuxsg8T9Ndy8nHyUSu9