### PR TITLE
Fix invisible element icons on dark themes in two dialogs missed by the earlier fix (bugtracker #335)

### DIFF
--- a/sources/elementdialog.cpp
+++ b/sources/elementdialog.cpp
@@ -19,6 +19,7 @@
 
 #include "ElementsCollection/elementcollectionitem.h"
 #include "ElementsCollection/elementscollectionmodel.h"
+#include "ElementsCollection/elementstreeview.h"
 #include "qetapp.h"
 #include "qetmessagebox.h"
 #include "qfilenameedit.h"
@@ -88,7 +89,7 @@ void ElementDialog::setUpWidget()
 	layout->addWidget(new QLabel(label_));
 
 
-	m_tree_view = new QTreeView(this);
+	m_tree_view = new ElementsTreeView(this);
 
 	m_model = new ElementsCollectionModel(m_tree_view);
 

--- a/sources/newelementwizard.cpp
+++ b/sources/newelementwizard.cpp
@@ -19,6 +19,7 @@
 
 #include "ElementsCollection/elementcollectionitem.h"
 #include "ElementsCollection/elementscollectionmodel.h"
+#include "ElementsCollection/elementstreeview.h"
 #include "NameList/ui/namelistwidget.h"
 #include "editor/ui/qetelementeditor.h"
 #include "qetmessagebox.h"
@@ -85,7 +86,7 @@ QWizardPage *NewElementWizard::buildStep1()
 	page -> setSubTitle(tr("Sélectionnez une catégorie dans laquelle enregistrer le nouvel élément.", "wizard page subtitle"));
 	QVBoxLayout *layout = new QVBoxLayout();
 
-	m_tree_view = new QTreeView(this);
+	m_tree_view = new ElementsTreeView(this);
 
 	m_model = new ElementsCollectionModel(m_tree_view);
 	m_model->hideElement();


### PR DESCRIPTION
Relates to https://qelectrotech.org/bugtracker/view.php?id=335 — "Element library icons are black and almost invisible on dark OS themes" (KDE Plasma / Fedora 43, dark theme).

## This turns out to already be mostly fixed

The main elements panel (`ElementsCollectionWidget`) already forces a fixed light palette on its tree views via `ElementsTreeView`, in a fix that landed on master in two parts: `a8e2a7acf` (the palette itself) and `bb61dde81` (applying it to the viewport too, since `QAbstractItemView` paints rows via the viewport's palette, not the view's own). Element icons are rendered with colors read straight from each `.elmt` file — almost always black linework, matching printed-schematic convention — onto a transparent background, so any view showing them needs to stay light regardless of the OS/desktop theme.

`ElementsTreeView`'s own class doc already says exactly this:

> This class must be used when the tree view have an ElementsCollectionModel as model.

But two other dialogs display the exact same `ElementsCollectionModel` and were still using a plain `QTreeView`, missing that fix:

- `ElementDialog` (`sources/elementdialog.cpp`) — the Open/Save Element, Open/Save Category, and Save Template dialog.
- `NewElementWizard` (`sources/newelementwizard.cpp`) — the parent-category picker on step 1 of the New Element Wizard.

Same model, same black-on-transparent icons, same invisibility problem on a dark theme.

## Fix

Swap `new QTreeView(this)` for `new ElementsTreeView(this)` in both — a two-line change per file (the class swap plus its include), matching the main panel and the class's own documented contract. No other behavior changes: `ElementsTreeView` only additionally overrides `startDrag()` for a nicer drag pixmap, inert unless drag-out is enabled.

## Verification

Full Release build (504/504, CMake/Ninja, Qt 5.15.18) — no new warnings.

Also built a standalone Qt program showing the real `ElementDialog` under a forced dark `QPalette` (simulating a dark OS theme — neither this build environment nor QET itself forces a palette either way, so I had to construct one to actually observe the failure mode). Screenshots stepping down through nested collection categories (Electric → IEC 60617 → Conductors and connecting devices, 4 levels deep) confirm the tree view keeps its white background against the dark dialog chrome around it, the same as the already-fixed main panel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RPBnuxsg8T9Ndy8nHyUSu9