### PR TITLE
Fix "use current date" preset lost unless the Folio tab is active on save (bugtracker #308)

### DIFF
--- a/sources/ui/titleblockpropertieswidget.cpp
+++ b/sources/ui/titleblockpropertieswidget.cpp
@@ -194,7 +194,16 @@ TitleBlockProperties TitleBlockPropertiesWidget::properties() const
 		prop.useDate = TitleBlockProperties::UseDateValue;
 		prop.date = ui->m_date_edit->date();
 	}
-	else if (ui->m_current_date_rb->isVisible() && ui->m_current_date_rb->isChecked()) {
+	else if (!ui->m_current_date_rb->isHidden() && ui->m_current_date_rb->isChecked()) {
+			/* isVisible() (unlike isHidden()) also depends on the whole
+			 * ancestor chain being visible, not just this widget's own
+			 * state -- inside a QTabWidget page (both the New Project and
+			 * Project Properties dialogs embed this widget in one), it's
+			 * false whenever this isn't the active tab, silently dropping
+			 * "current date" back to the useDate/date default (no date)
+			 * even though the radio button is still checked underneath.
+			 * isHidden() mirrors the read side's own check in initDialog(),
+			 * and isn't affected by an ancestor tab switch. */
 		prop.useDate = TitleBlockProperties::CurrentDate;
 		prop.date = QDate::currentDate();
 	}
@@ -237,7 +246,16 @@ TitleBlockProperties TitleBlockPropertiesWidget::propertiesAutoNum(
 		prop.useDate = TitleBlockProperties::UseDateValue;
 		prop.date = ui->m_date_edit->date();
 	}
-	else if (ui->m_current_date_rb->isVisible() && ui->m_current_date_rb->isChecked()) {
+	else if (!ui->m_current_date_rb->isHidden() && ui->m_current_date_rb->isChecked()) {
+			/* isVisible() (unlike isHidden()) also depends on the whole
+			 * ancestor chain being visible, not just this widget's own
+			 * state -- inside a QTabWidget page (both the New Project and
+			 * Project Properties dialogs embed this widget in one), it's
+			 * false whenever this isn't the active tab, silently dropping
+			 * "current date" back to the useDate/date default (no date)
+			 * even though the radio button is still checked underneath.
+			 * isHidden() mirrors the read side's own check in initDialog(),
+			 * and isn't affected by an ancestor tab switch. */
 		prop.useDate = TitleBlockProperties::CurrentDate;
 		prop.date = QDate::currentDate();
 	}


### PR DESCRIPTION
Fixes https://qelectrotech.org/bugtracker/view.php?id=308 — "Preset for date is not saved". A follow-up comment on the report pinpointed the exact trigger: the setting falls back to "No date" unless the folio tab remains active when saving settings, and the same happens in Project Properties.

## Root cause

`TitleBlockPropertiesWidget::properties()` — and its near-duplicate sibling `propertiesAutoNum()`, copy-pasted with the identical bug — reads the date radio buttons like this:

```cpp
else if (ui->m_current_date_rb->isVisible() && ui->m_current_date_rb->isChecked()) {
	prop.useDate = TitleBlockProperties::CurrentDate;
	prop.date = QDate::currentDate();
}
```

Both the New Project settings page and the Project Properties dialog embed this widget as one page of a `QTabWidget` (`NewDiagramPage`, in `configpage/configpages.cpp` — `ProjectPropertiesDialog` reuses the same class). `QWidget::isVisible()` depends on the *whole ancestor chain* being visible, not just the widget's own state. Switch to any other tab (Conducteur, Reports, ...) before clicking OK/Apply, and this radio button's `isVisible()` goes false — even though it's still checked underneath — so all three `if`/`else if` branches fall through. The function returns a default-constructed `TitleBlockProperties` for the date fields (`useDate = UseDateValue`, `date = QDate()`, i.e. "no date"), matching exactly what was reported.

## Fix

Use `isHidden()` instead, which reflects only this widget's own explicit state and isn't affected by an ancestor tab switch. This actually mirrors the *read* side's own check a few lines above in the same file — `setProperties()`/`initDialog()` already gates on `!ui->m_current_date_rb->isHidden()` for the identical "is the current-date option even offered here" question. The save side had just copy-pasted the wrong widget-state query.

## Verification

Wrote a standalone Qt program that constructs the real `NewDiagramPage`, checks "current date", switches the page's internal `QTabWidget` away from Folio to Conducteur (reproducing the report's exact trigger), calls `applyConf()`, and reads back the resulting `QSettings` value. Against the original code this saves `date="null"`; with the fix, under the identical scenario and identical tab switch, it saves `date="now"` — confirmed both ways by building and running the test against each version of the file in turn.

Also did a full Release build (504/504, CMake/Ninja, Qt 5.15.18) — no new warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RPBnuxsg8T9Ndy8nHyUSu9