### PR TITLE
Make folio-referencing arrows clickable and show link state

### DIFF
--- a/sources/qetgraphicsitem/element.h
+++ b/sources/qetgraphicsitem/element.h
@@ -217,11 +217,11 @@ class Element : public QetGraphicsItem
 	protected:
 		void drawAxes(QPainter *, const QStyleOptionGraphicsItem *);
 		void setSize(int, int);
-
-	private:
 		void drawHighlight(
 				QPainter *,
 				const QStyleOptionGraphicsItem *);
+
+	private:
 		bool buildFromXml(const QDomElement &, int * = nullptr);
 		bool parseElement(const QDomElement &dom);
 		bool parseInput(const QDomElement &dom_element);

--- a/sources/qetgraphicsitem/reportelement.cpp
+++ b/sources/qetgraphicsitem/reportelement.cpp
@@ -24,6 +24,10 @@
 #include "../qetproject.h"
 #include "dynamicelementtextitem.h"
 
+#include <QGraphicsSceneMouseEvent>
+#include <QGraphicsView>
+#include <QMessageBox>
+
 ReportElement::ReportElement(const ElementsLocation &location, const QString& link_type,QGraphicsItem *qgi, int *state) :
 	Element(location, qgi, state,
 			link_type == "next_report"? Element::NextReport : Element::PreviousReport),
@@ -102,4 +106,78 @@ void ReportElement::unlinkAllElements()
 void ReportElement::unlinkElement(Element *elmt) {
 	Q_UNUSED (elmt);
 	unlinkAllElements();
+}
+
+/**
+	@brief ReportElement::paint
+	Draw the same blue halo already used elsewhere in QET to mean "linked"
+	(Element::drawHighlight(), normally a transient hover effect) whenever
+	this arrow actually resolves to a matching element on another folio --
+	a persistent, hyperlink-like "this link is live" indicator instead of
+	only showing on hover.
+	@param painter
+	@param options
+	@param widget
+*/
+void ReportElement::paint(
+		QPainter *painter,
+		const QStyleOptionGraphicsItem *options,
+		QWidget *widget)
+{
+	if (!isFree())
+		drawHighlight(painter, options);
+	Element::paint(painter, options, widget);
+}
+
+/**
+	@brief ReportElement::mouseDoubleClickEvent
+	When this report arrow is linked, jump to the folio holding its
+	counterpart and select it there, so double-clicking an arrow follows it
+	like a hyperlink instead of requiring the user to hunt for the matching
+	folio by hand.
+
+	When it isn't linked yet, fall back to the inherited
+	QetGraphicsItem::mouseDoubleClickEvent() behaviour (open the properties
+	dialog) exactly as before -- that dialog's "Folio referencing" tab is
+	the only way to create the link in the first place, so double-click
+	must keep reaching it until a link actually exists to follow.
+
+	A link that resolves to a connected_elements entry but whose target no
+	longer has a diagram (its folio, or the element itself, was deleted
+	after linking) is reported with a small popup instead of silently
+	doing nothing.
+	@param event
+*/
+void ReportElement::mouseDoubleClickEvent(QGraphicsSceneMouseEvent *event)
+{
+	if (isFree() || connected_elements.isEmpty())
+	{
+		QetGraphicsItem::mouseDoubleClickEvent(event);
+		return;
+	}
+
+	event->accept();
+
+	Element *linked_element = connected_elements.first();
+	Diagram *linked_diagram = linked_element->diagram();
+	if (!linked_diagram)
+	{
+		QWidget *parent_widget = (diagram() && diagram()->views().size())
+				? diagram()->views().at(0)
+				: nullptr;
+		QMessageBox::information(
+					parent_widget,
+					tr("Lien de renvoi de folio"),
+					tr("L'élément relié à ce renvoi n'existe plus."));
+		return;
+	}
+
+	linked_diagram->showMe();
+	if (linked_diagram->views().size())
+	{
+		QGraphicsView *view = linked_diagram->views().at(0);
+		linked_diagram->clearSelection();
+		linked_element->setSelected(true);
+		view->centerOn(linked_element);
+	}
 }

--- a/sources/qetgraphicsitem/reportelement.h
+++ b/sources/qetgraphicsitem/reportelement.h
@@ -39,7 +39,14 @@ class ReportElement : public Element
 		void linkToElement(Element *) override;
 		void unlinkAllElements() override;
 		void unlinkElement(Element *elmt) override;
-		
+
+	protected:
+		void mouseDoubleClickEvent(QGraphicsSceneMouseEvent *) override;
+		void paint(
+				QPainter *,
+				const QStyleOptionGraphicsItem *,
+				QWidget *) override;
+
 	private:
 		int m_inverse_report;
 };


### PR DESCRIPTION
## What this adds

Coming/going arrows (`previous_report`/`next_report` elements, used for wire references between folios) already carried an in-memory link to their counterpart on another folio, but there was no way to *act* on that link and no visual cue that it existed.

- **Double-click a linked arrow** to jump straight to the linked folio, with the counterpart selected and centered.
- **Double-click an unlinked arrow** still opens the properties dialog, exactly as before — that dialog's "Folio referencing" tab is the only way to create the link in the first place, so this path can't be given up.
- **A dangling link** (the linked element was deleted after linking) shows a small popup instead of silently doing nothing.
- **Linked arrows get a persistent blue halo** — the same radial-gradient highlight `Element::drawHighlight()` already draws transiently on hover for linked elements elsewhere in QET, now shown continuously on report arrows whenever they resolve to a real counterpart, so an active link reads visually the way a hyperlink does.

## Implementation

- `ReportElement::mouseDoubleClickEvent()` — new override. Falls back to the inherited `QetGraphicsItem::mouseDoubleClickEvent()` (properties dialog) when `isFree()`; otherwise resolves `connected_elements.first()`, calls `Diagram::showMe()` to switch folio tabs, then selects and centers the target.
- `ReportElement::paint()` — new override. Calls the now-`protected` `Element::drawHighlight()` before the normal paint when `!isFree()`.
- `Element::drawHighlight()` moved from `private` to `protected` so `ReportElement` can reuse it instead of duplicating the gradient-drawing code.

## Testing

Verified live under Xvfb with a hand-built two-folio project containing a linked coming/going arrow pair:
- Halo renders on both linked arrows.
- Double-clicking the coming arrow switches to the linked folio and selects/centers the going arrow.
- Double-clicking a still-unlinked arrow opens the properties dialog unchanged (checked twice, no regression from the new override).

Build: CMake/Ninja Release, Qt 5.15, clean incremental rebuild, no new warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)