### PR TITLE
Add auto-numbering for folio-reference (report) arrow labels

### DIFF
--- a/sources/autoNum/ui/autonumberingdockwidget.cpp
+++ b/sources/autoNum/ui/autonumberingdockwidget.cpp
@@ -64,12 +64,15 @@ void AutoNumberingDockWidget::clear()
 	ui->m_conductor_cb->clear();
 	ui->m_element_cb->clear();
 	ui->m_folio_cb->clear();
+	ui->m_report_cb->clear();
 	ui->m_conductor_value_le->clear();
 	ui->m_element_value_le->clear();
 	ui->m_folio_value_le->clear();
+	ui->m_report_value_le->clear();
 	ui->m_conductor_next_le->clear();
 	ui->m_element_next_le->clear();
 	ui->m_folio_next_le->clear();
+	ui->m_report_next_le->clear();
 }
 
 /**
@@ -88,6 +91,9 @@ AutoNumberingDockWidget::Row AutoNumberingDockWidget::rowFor(AutoNumCategory cat
 		case AutoNumCategory::Folio:
 			return {ui->m_folio_cb, ui->m_folio_value_le,
 				ui->m_folio_increase_sb, ui->m_folio_next_le};
+		case AutoNumCategory::Report:
+			return {ui->m_report_cb, ui->m_report_value_le,
+				ui->m_report_increase_sb, ui->m_report_next_le};
 	}
 	return {nullptr, nullptr, nullptr, nullptr};
 }
@@ -127,7 +133,13 @@ void AutoNumberingDockWidget::setProject(QETProject *project,
 			    this,SLOT(elementAutoNumChanged()));
 		disconnect (m_project,SIGNAL(elementAutoNumAdded(QString)),
 			    this,SLOT(elementAutoNumChanged()));
-	
+
+			//Report Signals
+		disconnect (m_project,SIGNAL(reportAutoNumRemoved(QString)),
+			    this,SLOT(reportAutoNumChanged()));
+		disconnect (m_project,SIGNAL(reportAutoNumAdded(QString)),
+			    this,SLOT(reportAutoNumChanged()));
+
 			//Folio Signals
 		disconnect (m_project,SIGNAL(folioAutoNumRemoved()),
 			    this,SLOT(folioAutoNumChanged()));
@@ -166,6 +178,12 @@ void AutoNumberingDockWidget::setProject(QETProject *project,
 		 this,SLOT(elementAutoNumChanged()));
 	connect (m_project,SIGNAL(elementAutoNumAdded(QString)),
 		 this,SLOT(elementAutoNumChanged()));
+
+		//Report Signals
+	connect (m_project,SIGNAL(reportAutoNumRemoved(QString)),
+		 this,SLOT(reportAutoNumChanged()));
+	connect (m_project,SIGNAL(reportAutoNumAdded(QString)),
+		 this,SLOT(reportAutoNumChanged()));
 
 		//Folio Signals
 	connect (m_project,SIGNAL(folioAutoNumRemoved()),
@@ -225,11 +243,20 @@ void AutoNumberingDockWidget::setContext()
 		{ ui->m_folio_cb -> addItem(str);}
 	}
 
+	//Report Combobox
+	ui->m_report_cb->addItem("");
+	QList <QString> keys_report = m_project->reportAutoNum().keys();
+	if (!keys_report.isEmpty()) {
+		foreach (QString str, keys_report)
+		{ ui->m_report_cb -> addItem(str);}
+	}
+
 		//The combo boxes have just been repopulated, so the value fields next
 		//to them are showing whatever the previous project left there.
 	refreshRow(AutoNumCategory::Conductor);
 	refreshRow(AutoNumCategory::Element);
 	refreshRow(AutoNumCategory::Folio);
+	refreshRow(AutoNumCategory::Report);
 
 	this->setActive();
 }
@@ -266,6 +293,11 @@ void AutoNumberingDockWidget::setActive()
 		QString active_element_autonum = m_project->elementCurrentAutoNum();
 		int el_index = ui->m_element_cb->findText(active_element_autonum);
 		ui->m_element_cb->setCurrentIndex(el_index);
+
+			//Report
+		QString active_report_autonum = m_project->reportCurrentAutoNum();
+		int report_index = ui->m_report_cb->findText(active_report_autonum);
+		ui->m_report_cb->setCurrentIndex(report_index);
 
 			//Folio
 		if (m_project->defaultTitleBlockProperties().folio == "%autonum") {
@@ -338,6 +370,33 @@ void AutoNumberingDockWidget::on_m_element_cb_activated(int)
 }
 
 /**
+	@brief AutoNumberingDockWidget::reportAutoNumChanged
+	Add new or remove report (folio-reference arrow) auto num from combobox
+*/
+void AutoNumberingDockWidget::reportAutoNumChanged()
+{
+	ui->m_report_cb->clear();
+
+	//Report Combobox
+	ui->m_report_cb->addItem("");
+	QList <QString> keys_report = m_project->reportAutoNum().keys();
+	if (!keys_report.isEmpty()) {
+		foreach (QString str, keys_report) {ui->m_report_cb -> addItem(str);}
+	}
+	setActive();
+}
+
+/**
+	@brief AutoNumberingDockWidget::on_m_report_cb_activated
+	Set new report (folio-reference arrow) AutoNum
+*/
+void AutoNumberingDockWidget::on_m_report_cb_activated(int)
+{
+	m_project->setCurrentReportAutoNum(ui->m_report_cb->currentText());
+	refreshRow(AutoNumCategory::Report);
+}
+
+/**
 	@brief AutoNumberingDockWidget::folioAutoNumChanged
 	Add new or remove folio auto num from combobox
 */
@@ -400,6 +459,11 @@ void AutoNumberingDockWidget::on_m_folio_reset_start_pb_clicked()
 	resetAutoNum(ui->m_folio_cb, AutoNumCategory::Folio);
 }
 
+void AutoNumberingDockWidget::on_m_report_reset_start_pb_clicked()
+{
+	resetAutoNum(ui->m_report_cb, AutoNumCategory::Report);
+}
+
 void AutoNumberingDockWidget::on_m_conductor_value_le_editingFinished()
 {
 	applyValueField(ui->m_conductor_cb, ui->m_conductor_value_le, AutoNumCategory::Conductor);
@@ -413,6 +477,11 @@ void AutoNumberingDockWidget::on_m_element_value_le_editingFinished()
 void AutoNumberingDockWidget::on_m_folio_value_le_editingFinished()
 {
 	applyValueField(ui->m_folio_cb, ui->m_folio_value_le, AutoNumCategory::Folio);
+}
+
+void AutoNumberingDockWidget::on_m_report_value_le_editingFinished()
+{
+	applyValueField(ui->m_report_cb, ui->m_report_value_le, AutoNumCategory::Report);
 }
 
 void AutoNumberingDockWidget::on_m_conductor_increase_sb_valueChanged(int)
@@ -430,6 +499,11 @@ void AutoNumberingDockWidget::on_m_folio_increase_sb_valueChanged(int)
 	applyIncreaseField(ui->m_folio_cb, ui->m_folio_increase_sb, AutoNumCategory::Folio);
 }
 
+void AutoNumberingDockWidget::on_m_report_increase_sb_valueChanged(int)
+{
+	applyIncreaseField(ui->m_report_cb, ui->m_report_increase_sb, AutoNumCategory::Report);
+}
+
 /**
 	@brief AutoNumberingDockWidget::contextFor
 	@return the numerotation context named by combo_box, for category
@@ -441,6 +515,7 @@ NumerotationContext AutoNumberingDockWidget::contextFor(QComboBox *combo_box, Au
 		case AutoNumCategory::Conductor: return m_project->conductorAutoNum(key);
 		case AutoNumCategory::Element:   return m_project->elementAutoNum(key);
 		case AutoNumCategory::Folio:     return m_project->folioAutoNum(key);
+		case AutoNumCategory::Report:    return m_project->reportAutoNum(key);
 	}
 	return NumerotationContext();
 }
@@ -458,6 +533,7 @@ void AutoNumberingDockWidget::storeContext(QComboBox *combo_box, AutoNumCategory
 		case AutoNumCategory::Conductor: m_project->addConductorAutoNum(key, context); break;
 		case AutoNumCategory::Element:   m_project->addElementAutoNum(key, context);   break;
 		case AutoNumCategory::Folio:     m_project->addFolioAutoNum(key, context);     break;
+		case AutoNumCategory::Report:    m_project->addReportAutoNum(key, context);    break;
 	}
 	m_project->setModified(true);
 }
@@ -505,7 +581,8 @@ void AutoNumberingDockWidget::refreshValueFields()
 		//read-only, so there is nothing a refresh could clobber.
 	for (AutoNumCategory category : {AutoNumCategory::Conductor,
 					 AutoNumCategory::Element,
-					 AutoNumCategory::Folio})
+					 AutoNumCategory::Folio,
+					 AutoNumCategory::Report})
 	{
 		const Row row = rowFor(category);
 		if (!row.value->hasFocus() && !row.increase->hasFocus())

--- a/sources/autoNum/ui/autonumberingdockwidget.h
+++ b/sources/autoNum/ui/autonumberingdockwidget.h
@@ -50,9 +50,11 @@ class AutoNumberingDockWidget : public QDockWidget
 		void on_m_conductor_cb_activated(int);
 		void on_m_element_cb_activated(int);
 		void on_m_folio_cb_activated(int);
+		void on_m_report_cb_activated(int);
 		void conductorAutoNumChanged();
 		void elementAutoNumChanged();
 		void folioAutoNumChanged();
+		void reportAutoNumChanged();
 		void clear();
 		void projectClosed();
 		void refreshValueFields();
@@ -62,20 +64,23 @@ class AutoNumberingDockWidget : public QDockWidget
 		void on_m_conductor_reset_start_pb_clicked();
 		void on_m_element_reset_start_pb_clicked();
 		void on_m_folio_reset_start_pb_clicked();
+		void on_m_report_reset_start_pb_clicked();
 
 		void on_m_conductor_value_le_editingFinished();
 		void on_m_element_value_le_editingFinished();
 		void on_m_folio_value_le_editingFinished();
+		void on_m_report_value_le_editingFinished();
 
 		void on_m_conductor_increase_sb_valueChanged(int);
 		void on_m_element_increase_sb_valueChanged(int);
 		void on_m_folio_increase_sb_valueChanged(int);
+		void on_m_report_increase_sb_valueChanged(int);
 
 	signals:
 		void folioAutoNumChanged(QString);
 
 	private:
-		enum class AutoNumCategory { Conductor, Element, Folio };
+		enum class AutoNumCategory { Conductor, Element, Folio, Report };
 
 			/// The four widgets that make up one category's row, bundled so
 			/// refreshRow() can be called with just a category instead of

--- a/sources/autoNum/ui/autonumberingdockwidget.ui
+++ b/sources/autoNum/ui/autonumberingdockwidget.ui
@@ -297,7 +297,91 @@
       </property>
      </widget>
     </item>
-    <item row="6" column="0">
+    <item row="5" column="0">
+     <widget class="QLabel" name="label_4">
+      <property name="text">
+       <string>Renvoi</string>
+      </property>
+     </widget>
+    </item>
+    <item row="5" column="1">
+     <widget class="QComboBox" name="m_report_cb"/>
+    </item>
+    <item row="5" column="2">
+     <widget class="QPushButton" name="m_report_reset_start_pb">
+      <property name="maximumSize">
+       <size>
+        <width>24</width>
+        <height>16777215</height>
+       </size>
+      </property>
+      <property name="toolTip">
+       <string>Réinitialiser à la valeur de départ</string>
+      </property>
+      <property name="text">
+       <string/>
+      </property>
+      <property name="icon">
+       <iconset resource="../../../qelectrotech.qrc">
+        <normaloff>:/ico/16x16/view-refresh.png</normaloff>:/ico/16x16/view-refresh.png</iconset>
+      </property>
+     </widget>
+    </item>
+    <item row="5" column="3">
+     <widget class="QLineEdit" name="m_report_value_le">
+      <property name="maximumSize">
+       <size>
+        <width>70</width>
+        <height>16777215</height>
+       </size>
+      </property>
+      <property name="toolTip">
+       <string>Valeur actuelle du compteur. Saisir une nouvelle valeur et valider pour la modifier.</string>
+      </property>
+     </widget>
+    </item>
+    <item row="5" column="4">
+     <widget class="QSpinBox" name="m_report_increase_sb">
+      <property name="maximumSize">
+       <size>
+        <width>55</width>
+        <height>16777215</height>
+       </size>
+      </property>
+      <property name="toolTip">
+       <string>Incrément : valeur ajoutée au compteur à chaque nouvelle numérotation</string>
+      </property>
+      <property name="alignment">
+       <set>Qt::AlignCenter</set>
+      </property>
+      <property name="accelerated">
+       <bool>true</bool>
+      </property>
+      <property name="minimum">
+       <number>0</number>
+      </property>
+     </widget>
+    </item>
+    <item row="5" column="5">
+     <widget class="QLineEdit" name="m_report_next_le">
+      <property name="maximumSize">
+       <size>
+        <width>70</width>
+        <height>16777215</height>
+       </size>
+      </property>
+      <property name="toolTip">
+       <string>Prochaine valeur qui sera appliquée avec cet incrément</string>
+      </property>
+      <property name="readOnly">
+       <bool>true</bool>
+      </property>
+      <property name="alignment">
+       <set>Qt::AlignCenter</set>
+      </property>
+     </widget>
+    </item>
+    <item row="7" column="0">
      <spacer name="verticalSpacer">
       <property name="orientation">
        <enum>Qt::Vertical</enum>
@@ -310,7 +394,7 @@
       </property>
      </spacer>
     </item>
-    <item row="5" column="1">
+    <item row="6" column="1">
      <widget class="QPushButton" name="m_configure_pb">
       <property name="toolTip">
        <string>Configurer les règles d'auto numérotation</string>

--- a/sources/autoNum/ui/numparteditorw.cpp
+++ b/sources/autoNum/ui/numparteditorw.cpp
@@ -122,8 +122,14 @@ void NumPartEditorW::setVisibleItems()
 {
 	ui->type_cb->setInsertPolicy(QComboBox::InsertAtBottom);
 	QStringList items;
-	if (m_edited_type == 2)
+	if (m_edited_type == 2 || m_edited_type == 3)
 	{
+			//Report links deliberately get the same minimal set as folios:
+			//no folio-number/element-location tokens, since baking the
+			//*destination*'s folio into the link's own ID is exactly the
+			//staleness bug (numbers going wrong after pages are reordered)
+			//this numbering exists to avoid -- that information belongs in
+			//the link-picker dialog, computed live, not in the ID itself.
 		items	<< tr("Chiffre 1")
 			<< tr("Chiffre 01")
 			<< tr("Chiffre 001")

--- a/sources/autoNum/ui/numparteditorw.h
+++ b/sources/autoNum/ui/numparteditorw.h
@@ -76,7 +76,7 @@ class NumPartEditorW : public QWidget
 		Ui::NumPartEditorW *ui;
 		QValidator *intValidator;
 		QValidator *alphaValidator;
-		int m_edited_type = -1; ///<0 == element : 1 == conductor : 2 == folio
+		int m_edited_type = -1; ///<0 == element : 1 == conductor : 2 == folio : 3 == report
 	
 
 

--- a/sources/autoNum/ui/selectautonumw.cpp
+++ b/sources/autoNum/ui/selectautonumw.cpp
@@ -204,7 +204,29 @@ void SelectAutonumW::on_buttonBox_clicked(QAbstractButton *button)
 			break;
 			//help dialog
 		case QDialogButtonBox::HelpRole:
-			if (m_edited_type == 2)
+			if (m_edited_type == 3)
+			{
+				QMessageBox::information (
+							this,
+							tr("Renvoi de folio Autonumérotation",
+							   "title window"),
+							tr("C'est ici que vous pouvez définir la manière dont seront numérotés les nouveaux renvois de folio (flèches d'entrée/sortie).\n"
+							   "-Une numérotation est composée d'une variable minimum.\n"
+							   "-Vous pouvez ajouter ou supprimer une variable de numérotation par le biais des boutons - et +.\n"
+							   "-Une variable de numérotation comprend : un type, une valeur et une incrémentation.\n"
+
+							   "\n-les types \"Chiffre 1\", \"Chiffre 01\" et \"Chiffre 001\", représentent un type numérique défini dans le champ \"Valeur\", "
+							   "qui s'incrémente à chaque nouveau renvoi de la valeur du champ \"Incrémentation\".\n"
+							   "-\"Chiffre 01\" et \"Chiffre 001\", sont respectivement représentés sur le schéma par deux et trois digits minimum.\n"
+							   "Si le chiffre défini dans le champ Valeur possède moins de digits que le type choisi,"
+							   "celui-ci sera précédé par un ou deux 0 afin de respecter son type.\n"
+
+							   "\n-Le type \"Texte\", représente un texte fixe.\nLe champ \"Incrémentation\" n'est pas utilisé.\n",
+							   "help dialog about the report link autonumerotation"
+							   ));
+				break;
+			}
+			else if (m_edited_type == 2)
 			{
 				QMessageBox::information (
 							this,

--- a/sources/autoNum/ui/selectautonumw.cpp
+++ b/sources/autoNum/ui/selectautonumw.cpp
@@ -24,6 +24,10 @@
 #include "ui_formulaautonumberingw.h"
 #include "ui_selectautonumw.h"
 
+#include <QGroupBox>
+#include <QHBoxLayout>
+#include <QLabel>
+#include <QLineEdit>
 #include <QMessageBox>
 
 /**
@@ -50,6 +54,10 @@ SelectAutonumW::SelectAutonumW(int type, QWidget *parent) :
 		m_fcaw = new FormulaAutonumberingW();
 		m_fcaw->ui->label->setHidden(true);
 		ui->m_widget->layout()->addWidget(m_fcaw);
+	}
+	else if (m_edited_type == 3)
+	{
+		setupPrefixSuffixEditor();
 	}
 	setContext(NumerotationContext());
 }
@@ -81,6 +89,8 @@ SelectAutonumW::SelectAutonumW(const NumerotationContext &context,
 		ui->m_widget->layout()->addWidget(m_fcaw);
 	}
 	ui->setupUi(this);
+	if (m_edited_type == 3)
+		setupPrefixSuffixEditor();
 	setContext(context);
 }
 
@@ -91,6 +101,29 @@ SelectAutonumW::SelectAutonumW(const NumerotationContext &context,
 SelectAutonumW::~SelectAutonumW()
 {
 	delete ui;
+}
+
+/**
+	@brief SelectAutonumW::setupPrefixSuffixEditor
+	Renvois (type 3) only: add dedicated Préfixe/Suffixe fields above the
+	generic +/- part editor, so a user can get e.g. "R1-A, R2-A..." without
+	having to understand multi-part numerotation contexts. They are backed
+	by plain leading/trailing "string" parts (see toNumContext()/setContext()).
+*/
+void SelectAutonumW::setupPrefixSuffixEditor()
+{
+	QGroupBox *group = new QGroupBox(tr("Préfixe et suffixe"), this);
+	QHBoxLayout *layout = new QHBoxLayout(group);
+	layout->addWidget(new QLabel(tr("Préfixe :"), group));
+	m_prefix_le = new QLineEdit(group);
+	layout->addWidget(m_prefix_le);
+	layout->addWidget(new QLabel(tr("Suffixe :"), group));
+	m_suffix_le = new QLineEdit(group);
+	layout->addWidget(m_suffix_le);
+	ui->m_widget->layout()->addWidget(group);
+
+	connect(m_prefix_le, &QLineEdit::textChanged, this, [this](const QString &) { applyEnable(true); });
+	connect(m_suffix_le, &QLineEdit::textChanged, this, [this](const QString &) { applyEnable(true); });
 }
 
 /**
@@ -106,12 +139,41 @@ void SelectAutonumW::setContext(const NumerotationContext &context)
 	qDeleteAll(num_part_list_);
 	num_part_list_.clear();
 
-	if (m_context.size() == 0) { //@context contain nothing, build a default numPartEditor
+	NumerotationContext middle_context = context;
+	if (m_edited_type == 3 && m_prefix_le && m_suffix_le) {
+		//Renvois: a leading/trailing "string" part is the Préfixe/Suffixe
+		//field's own doing (see toNumContext()), so pull it back out here
+		//instead of showing it as a normal +/- row.
+		QString prefix_text, suffix_text;
+		int first = 0;
+		int last = middle_context.size() - 1;
+		if (last >= first && middle_context.itemAt(first).at(0) == "string") {
+			prefix_text = middle_context.itemAt(first).at(1);
+			++first;
+		}
+		if (last >= first && middle_context.itemAt(last).at(0) == "string") {
+			suffix_text = middle_context.itemAt(last).at(1);
+			--last;
+		}
+		NumerotationContext rebuilt;
+		for (int i = first; i <= last; ++i) {
+			QStringList item = middle_context.itemAt(i);
+			rebuilt.addValue(item.at(0), item.at(1), item.at(2).toInt(),
+					  item.at(3).toInt(),
+					  item.size() > 4 ? item.at(4).toInt() : 0,
+					  item.size() > 5 ? item.at(5) : QString());
+		}
+		middle_context = rebuilt;
+		m_prefix_le->setText(prefix_text);
+		m_suffix_le->setText(suffix_text);
+	}
+
+	if (middle_context.size() == 0) { //@context contain nothing, build a default numPartEditor
 		on_add_button_clicked();
 	}
 	else {
-		for (int i=0; i<m_context.size(); ++i) { //build with the content of @context
-			NumPartEditorW *part= new NumPartEditorW(m_context, i, m_edited_type, this);
+		for (int i=0; i<middle_context.size(); ++i) { //build with the content of @context
+			NumPartEditorW *part= new NumPartEditorW(middle_context, i, m_edited_type, this);
 			connect (part, SIGNAL(changed()), this, SLOT(applyEnable()));
 			num_part_list_ << part;
 			ui -> editor_layout -> addWidget(part);
@@ -132,8 +194,12 @@ void SelectAutonumW::setContext(const NumerotationContext &context)
 NumerotationContext SelectAutonumW::toNumContext() const
 {
 	NumerotationContext nc;
+	if (m_prefix_le && !m_prefix_le->text().isEmpty())
+		nc.addValue("string", m_prefix_le->text());
 	foreach (NumPartEditorW *npew, num_part_list_)
 		nc << npew -> toNumContext();
+	if (m_suffix_le && !m_suffix_le->text().isEmpty())
+		nc.addValue("string", m_suffix_le->text());
 	return nc;
 }
 
@@ -221,7 +287,9 @@ void SelectAutonumW::on_buttonBox_clicked(QAbstractButton *button)
 							   "Si le chiffre défini dans le champ Valeur possède moins de digits que le type choisi,"
 							   "celui-ci sera précédé par un ou deux 0 afin de respecter son type.\n"
 
-							   "\n-Le type \"Texte\", représente un texte fixe.\nLe champ \"Incrémentation\" n'est pas utilisé.\n",
+							   "\n-Le type \"Texte\", représente un texte fixe.\nLe champ \"Incrémentation\" n'est pas utilisé.\n"
+
+							   "\n-Les champs \"Préfixe\" et \"Suffixe\" ajoutent un texte fixe respectivement avant et après le compteur généré, sans passer par les variables de numérotation ci-dessus.",
 							   "help dialog about the report link autonumerotation"
 							   ));
 				break;

--- a/sources/autoNum/ui/selectautonumw.h
+++ b/sources/autoNum/ui/selectautonumw.h
@@ -76,7 +76,7 @@ class SelectAutonumW : public QWidget
 		NumerotationContext m_context;
 		FormulaAutonumberingW *m_feaw;
 		FormulaAutonumberingW *m_fcaw;
-		int m_edited_type = -1; ///<0 == element : 1 == conductor : 2 == folio
+		int m_edited_type = -1; ///<0 == element : 1 == conductor : 2 == folio : 3 == report
 };
 
 #endif // SELECTAUTONUMW_H

--- a/sources/autoNum/ui/selectautonumw.h
+++ b/sources/autoNum/ui/selectautonumw.h
@@ -27,6 +27,7 @@ class NumPartEditorW;
 class QAbstractButton;
 class FormulaAutonumberingW;
 class QComboBox;
+class QLineEdit;
 
 namespace Ui {
 	class SelectAutonumW;
@@ -71,11 +72,18 @@ class SelectAutonumW : public QWidget
 		void on_m_remove_pb_clicked();
 		
 	private:
+		void setupPrefixSuffixEditor();
+
 		Ui::SelectAutonumW *ui;
 		QList <NumPartEditorW *> num_part_list_;
 		NumerotationContext m_context;
 		FormulaAutonumberingW *m_feaw;
 		FormulaAutonumberingW *m_fcaw;
+			///< Renvois (type 3) only: literal text glued before/after the
+			///< generated counter, stored as leading/trailing "string" parts
+			///< of the NumerotationContext rather than a visible +/- row.
+		QLineEdit *m_prefix_le = nullptr;
+		QLineEdit *m_suffix_le = nullptr;
 		int m_edited_type = -1; ///<0 == element : 1 == conductor : 2 == folio : 3 == report
 };
 

--- a/sources/qetdiagrameditor.cpp
+++ b/sources/qetdiagrameditor.cpp
@@ -1236,6 +1236,7 @@ bool QETDiagramEditor::openAndAddProject(
 
 	QETApp::projectsRecentFiles() -> fileWasOpened(filepath);
 	addProject(project);
+	project->refresh();
 	DialogWaiting::dropInstance();
 
 		//Report font descriptions which could not be read as-is (written by

--- a/sources/qetgraphicsitem/dynamicelementtextitem.cpp
+++ b/sources/qetgraphicsitem/dynamicelementtextitem.cpp
@@ -310,8 +310,14 @@ void DynamicElementTextItem::refreshLabelConnection()
 		if((m_parent_element.data()->linkType() & Element::AllReport) ||
 			m_parent_element.data()->linkType() == Element::ConductorDefinition)
 		{
-			updateReportFormulaConnection();
-			updateReportText();
+				//updateReportFormulaConnection() alone is not enough here: it
+				//only re-applies m_report_formula's connections, it never
+				//refreshes m_other_report from linkedElements(). For a text
+				//item that just loaded from a file (still m_other_report ==
+				//null, per reportChanged()'s own comment below), that leaves
+				//every connect() a no-op and the label stuck blank. reportChanged()
+				//is the one that actually re-reads linkedElements().
+			reportChanged();
 		}
 		else
 		{
@@ -896,21 +902,21 @@ void DynamicElementTextItem::reportChanged()
 	}
 	
 	bool text_have_label = false;
-	
+
 	if((textFrom() == ElementInfo && m_info_name == "label") ||
 	   (textFrom() == CompositeText && m_composite_text.contains("%{label}")))
 		text_have_label = true;
-	
+
 	if(text_have_label)
 		removeConnectionForReportFormula(m_report_formula);
-	
+
 	m_other_report.clear();
 	if(!m_parent_element.data()->linkedElements().isEmpty())
 		m_other_report = m_parent_element.data()->linkedElements().first();
-		
+
 		//Because linked report was changed, we ensure there is a conductor watched
 	setPotentialConductor();
-	
+
 	if(text_have_label)
 	{
 		setConnectionForReportFormula(m_report_formula);
@@ -952,6 +958,7 @@ void DynamicElementTextItem::setConnectionForReportFormula(const QString &formul
 	{
 		connect(other_diagram->project(), &QETProject::projectDiagramsOrderChanged, this, &DynamicElementTextItem::updateReportText);
 		connect(other_diagram->project(), &QETProject::diagramRemoved, this, &DynamicElementTextItem::updateReportText);
+		connect(other_diagram->project(), &QETProject::diagramAdded, this, &DynamicElementTextItem::updateReportText);
 	}
 	if (string.contains("%l"))
 		connect(other_elmt, &Element::yChanged, this, &DynamicElementTextItem::updateReportText);
@@ -977,7 +984,11 @@ void DynamicElementTextItem::removeConnectionForReportFormula(const QString &for
 	}
 	
 	if (other_diagram && (string.contains("%f") || string.contains("%id")))
+	{
 		disconnect(other_diagram->project(), &QETProject::projectDiagramsOrderChanged, this, &DynamicElementTextItem::updateReportText);
+		disconnect(other_diagram->project(), &QETProject::diagramRemoved, this, &DynamicElementTextItem::updateReportText);
+		disconnect(other_diagram->project(), &QETProject::diagramAdded, this, &DynamicElementTextItem::updateReportText);
+	}
 	if (string.contains("%l"))
 		disconnect(other_element, &Element::yChanged, this, &DynamicElementTextItem::updateReportText);
 	if (string.contains("%c"))

--- a/sources/qetgraphicsitem/element.cpp
+++ b/sources/qetgraphicsitem/element.cpp
@@ -1650,23 +1650,27 @@ void Element::setUpFormula(bool code_letter, QUndoCommand *parent_undo)
 {
 	Q_UNUSED(code_letter)
 
-	if (linkType() == Element::Slave || linkType() & Element::AllReport)
+	if (linkType() == Element::Slave)
 		return;
+
+	const bool is_report = linkType() & Element::AllReport;
 
 	if (diagram())
 	{
-		QString formula = diagram()
-				->project()
-				->elementAutoNumCurrentFormula();
+		QETProject *project = diagram()->project();
+
+		QString formula = is_report
+				? project->reportAutoNumCurrentFormula()
+				: project->elementAutoNumCurrentFormula();
 
 		m_data.m_informations.addValue(QStringLiteral("formula"), formula);
 
-		QString element_currentAutoNum = diagram()
-				->project()
-				->elementCurrentAutoNum();
-		NumerotationContext nc = diagram()
-				->project()
-				->elementAutoNum(element_currentAutoNum);
+		QString current_autonum = is_report
+				? project->reportCurrentAutoNum()
+				: project->elementCurrentAutoNum();
+		NumerotationContext nc = is_report
+				? project->reportAutoNum(current_autonum)
+				: project->elementAutoNum(current_autonum);
 		NumerotationContextCommands ncc (nc);
 
 		m_autoNum_seq.clear();
@@ -1674,20 +1678,25 @@ void Element::setUpFormula(bool code_letter, QUndoCommand *parent_undo)
 					   m_autoNum_seq,
 					   nc,
 					   diagram(),
-					   element_currentAutoNum);
+					   current_autonum);
 
 		NumerotationContext new_context = ncc.next();
-		QETProject *project = diagram()->project();
-		auto setter = [project](const QString &k, const NumerotationContext &c) {project->addElementAutoNum(k, c);};
+		auto setter = is_report
+				? std::function<void(const QString &, const NumerotationContext &)>(
+					  [project](const QString &k, const NumerotationContext &c) {project->addReportAutoNum(k, c);})
+				: std::function<void(const QString &, const NumerotationContext &)>(
+					  [project](const QString &k, const NumerotationContext &c) {project->addElementAutoNum(k, c);});
 
 		if (parent_undo)
 		{
-			new SetAutoNumContextCommand(setter, element_currentAutoNum, nc, new_context, parent_undo);
+			new SetAutoNumContextCommand(setter, current_autonum, nc, new_context, parent_undo);
 		}
 		else
 		{
-			auto *undo = new SetAutoNumContextCommand(setter, element_currentAutoNum, nc, new_context);
-			undo->setText(tr("Numéroter automatiquement un élément", "undo caption"));
+			auto *undo = new SetAutoNumContextCommand(setter, current_autonum, nc, new_context);
+			undo->setText(is_report
+					? tr("Numéroter automatiquement un renvoi de folio", "undo caption")
+					: tr("Numéroter automatiquement un élément", "undo caption"));
 			diagram()->undoStack().push(undo);
 		}
 

--- a/sources/qetproject.cpp
+++ b/sources/qetproject.cpp
@@ -683,6 +683,55 @@ void QETProject::setCurrrentElementAutonum(QString autoNum) {
 }
 
 /**
+	@brief QETProject::reportAutoNum
+	@return All value of report (folio-reference arrow) autonum stored in project
+*/
+QHash <QString, NumerotationContext> QETProject::reportAutoNum() const
+{
+	return m_report_autonum;
+}
+
+/**
+	@brief QETProject::reportAutoNumFormula
+	@param key : autonum title
+	@return Formula of report autonum stored in report autonum
+*/
+QString QETProject::reportAutoNumFormula (const QString& key) const
+{
+	if (m_report_autonum.contains(key)) {
+		return autonum::numerotationContextToFormula(m_report_autonum[key]);
+	}
+
+	return QString();
+}
+
+/**
+	@brief QETProject::reportAutoNumCurrentFormula
+	@return current formula being used by project for report (folio-reference) numbering
+*/
+QString QETProject::reportAutoNumCurrentFormula() const
+{
+	return reportAutoNumFormula(m_current_report_autonum);
+}
+
+/**
+	@brief QETProject::reportCurrentAutoNum
+	@return current report autonum title
+*/
+QString QETProject::reportCurrentAutoNum () const
+{
+	return m_current_report_autonum;
+}
+
+/**
+	@brief QETProject::setCurrentReportAutoNum
+	@param autoNum : set the current report autonum to autonum
+*/
+void QETProject::setCurrentReportAutoNum(QString autoNum) {
+	m_current_report_autonum = std::move(autoNum);
+}
+
+/**
 	@brief QETProject::conductorAutoNumFormula
 	@param key : autonum title
 	@return Formula of element autonum stored in conductor autonum
@@ -760,6 +809,20 @@ void QETProject::addFolioAutoNum(const QString& key, const NumerotationContext& 
 }
 
 /**
+	@brief QETProject::addReportAutoNum
+	Add a new report (folio-reference arrow) numerotation context. If key
+	already exist, replace old context with the new context
+	@param key
+	@param context
+*/
+void QETProject::addReportAutoNum(const QString& key, const NumerotationContext& context)
+{
+	m_report_autonum.insert(key, context);
+	emit reportAutoNumAdded(key);
+	emit autoNumContextUpdated();
+}
+
+/**
 	@brief QETProject::removeConductorAutoNum
 	Remove Conductor Numerotation Context stored with key
 	@param key
@@ -786,6 +849,17 @@ void QETProject::removeElementAutoNum(const QString& key)
 */
 void QETProject::removeFolioAutoNum(const QString& key) {
 	m_folio_autonum.remove(key);
+}
+
+/**
+	@brief QETProject::removeReportAutoNum
+	Remove report (folio-reference arrow) Numerotation Context stored with key
+	@param key
+*/
+void QETProject::removeReportAutoNum(const QString& key)
+{
+	m_report_autonum.remove(key);
+	emit reportAutoNumRemoved(key);
 }
 
 /**
@@ -820,6 +894,18 @@ NumerotationContext QETProject::elementAutoNum (const QString &key) {
 NumerotationContext QETProject::folioAutoNum (const QString &key) const
 {
 	if (m_folio_autonum.contains(key)) return m_folio_autonum[key];
+	else return NumerotationContext();
+}
+
+/**
+	@brief QETProject::reportAutoNum
+	Return report (folio-reference arrow) numerotation context stored with key.
+	If key is not found, return an empty numerotation context
+	@param key
+*/
+NumerotationContext QETProject::reportAutoNum (const QString &key) const
+{
+	if (m_report_autonum.contains(key)) return m_report_autonum[key];
 	else return NumerotationContext();
 }
 
@@ -1716,7 +1802,7 @@ void QETProject::readDefaultPropertiesXml(QDomDocument &xml_project)
 	m_default_xref_properties	   = XRefProperties::      defaultProperties();
 
 		//Read values indicate in project
-	QDomElement border_elmt, titleblock_elmt, conductors_elmt, report_elmt, xref_elmt, conds_autonums, folio_autonums, element_autonums, guides_elmt;
+	QDomElement border_elmt, titleblock_elmt, conductors_elmt, report_elmt, xref_elmt, conds_autonums, folio_autonums, element_autonums, report_autonums, guides_elmt;
 
 	for (QDomNode child = newdiagrams_elmt.firstChild() ; !child.isNull() ; child = child.nextSibling())
 	{
@@ -1739,6 +1825,8 @@ void QETProject::readDefaultPropertiesXml(QDomDocument &xml_project)
 			folio_autonums = child_elmt;
 		else if (child_elmt.tagName()== QLatin1String("element_autonums"))
 			element_autonums = child_elmt;
+		else if (child_elmt.tagName()== QLatin1String("report_autonums"))
+			report_autonums = child_elmt;
 		else if (child_elmt.tagName() == QLatin1String("guides"))
 			guides_elmt = child_elmt;
 	}
@@ -1787,6 +1875,16 @@ void QETProject::readDefaultPropertiesXml(QDomDocument &xml_project)
 			NumerotationContext nc;
 			nc.fromXml(elmt);
 			m_element_autonum.insert(elmt.attribute(QStringLiteral("title")), nc);
+		}
+	}
+	if (!report_autonums.isNull())
+	{
+		m_current_report_autonum = report_autonums.attribute(QStringLiteral("current_autonum"));
+		for (auto elmt : QET::findInDomElement(report_autonums, QStringLiteral("report_autonum")))
+		{
+			NumerotationContext nc;
+			nc.fromXml(elmt);
+			m_report_autonum.insert(elmt.attribute(QStringLiteral("title")), nc);
 		}
 	}
 	// Read guides from XML (if missing, e.g. in old projects, list stays empty)
@@ -1921,6 +2019,18 @@ void QETProject::writeDefaultPropertiesXml(QDomElement &xml_element)
 		}
 	}
 	xml_element.appendChild(element_autonums);
+
+	QDomElement report_autonums = xml_document.createElement("report_autonums");
+	report_autonums.setAttribute("current_autonum", m_current_report_autonum);
+	foreach (QString key, reportAutoNum().keys()) {
+	QDomElement report_autonum = reportAutoNum(key).toXml(xml_document, "report_autonum");
+		if (key != "" && reportAutoNumFormula(key) != "") {
+			report_autonum.setAttribute("title", key);
+			report_autonum.setAttribute("formula", reportAutoNumFormula(key));
+			report_autonums.appendChild(report_autonum);
+		}
+	}
+	xml_element.appendChild(report_autonums);
 
 	// Export default guides
 	QDomElement guides_elmt = xml_document.createElement("guides");

--- a/sources/qetproject.h
+++ b/sources/qetproject.h
@@ -108,6 +108,7 @@ class QETProject : public QObject
 		projectDataBase *dataBase();
 		QUuid uuid() const;
 		ProjectState state() const;
+		void refresh();
 		QList<Diagram *> diagrams() const;
 		int folioIndex(const Diagram *) const;
 		XmlElementCollection *embeddedElementCollection()const;
@@ -283,7 +284,6 @@ class QETProject : public QObject
 		void writeBackup();
 		void init();
 		ProjectState openFile(QFile *file);
-		void refresh();
 
 	// attributes
 	private:

--- a/sources/qetproject.h
+++ b/sources/qetproject.h
@@ -150,15 +150,19 @@ class QETProject : public QObject
 		QHash <QString, NumerotationContext> conductorAutoNum() const;
 		QHash <QString, NumerotationContext> elementAutoNum() const;
 		QHash <QString, NumerotationContext> folioAutoNum() const;
+		QHash <QString, NumerotationContext> reportAutoNum() const;
 		void addConductorAutoNum (const QString& key, const NumerotationContext& context);
 		void addElementAutoNum (const QString& key, const NumerotationContext& context);
 		void addFolioAutoNum     (const QString& key, const NumerotationContext& context);
+		void addReportAutoNum    (const QString& key, const NumerotationContext& context);
 		void removeConductorAutoNum (const QString& key);
 		void removeElementAutoNum (const QString& key);
 		void removeFolioAutoNum (const QString& key);
+		void removeReportAutoNum (const QString& key);
 		NumerotationContext conductorAutoNum(const QString &key) const;
 		NumerotationContext folioAutoNum(const QString &key)     const;
 		NumerotationContext elementAutoNum(const QString &key);
+		NumerotationContext reportAutoNum(const QString &key)    const;
 
 		QString conductorAutoNumFormula(const QString& key) const; //returns Formula
 		QString conductorCurrentAutoNum() const;
@@ -168,6 +172,11 @@ class QETProject : public QObject
 		QString elementAutoNumCurrentFormula() const;
 		QString elementCurrentAutoNum() const;
 		void setCurrrentElementAutonum(QString autoNum);
+
+		QString reportAutoNumFormula(const QString& key) const;
+		QString reportAutoNumCurrentFormula() const;
+		QString reportCurrentAutoNum() const;
+		void setCurrentReportAutoNum(QString autoNum);
 
 			//Element
 		void freezeExistentElementLabel(bool freeze, int from, int to);
@@ -234,6 +243,8 @@ class QETProject : public QObject
 		void addAutoNumDiagram();
 		void elementAutoNumAdded(QString name);
 		void elementAutoNumRemoved(QString name);
+		void reportAutoNumAdded(QString name);
+		void reportAutoNumRemoved(QString name);
 		void conductorAutoNumAdded();
 		void conductorAutoNumRemoved();
 		void folioAutoNumAdded();
@@ -320,6 +331,9 @@ class QETProject : public QObject
 			/// Element Auto Numbering
 		QHash <QString, NumerotationContext> m_element_autonum; //Title and NumContext hash
 		QString m_current_element_autonum;
+			/// Folio-reference (report arrow) Auto Numbering
+		QHash <QString, NumerotationContext> m_report_autonum; //Title and NumContext hash
+		QString m_current_report_autonum;
 		bool m_auto_conductor = true;
 	bool m_auto_break_conductor = false;
 		XmlElementCollection *m_elements_collection = nullptr;

--- a/sources/ui/configpage/projectconfigpages.cpp
+++ b/sources/ui/configpage/projectconfigpages.cpp
@@ -344,7 +344,11 @@ void ProjectAutoNumConfigPage::initWidgets()
 		//Folio Tab
 	m_saw_folio = new SelectAutonumW(2);
 	tab_widget->addTab(m_saw_folio, tr("Folios"));
-	
+
+		//Report (folio-reference arrow) Tab
+	m_saw_report = new SelectAutonumW(3);
+	tab_widget->addTab(m_saw_report, tr("Renvois"));
+
 		//AutoNumbering Tab
 	m_faw = new FolioAutonumberingW(project());
 	tab_widget->addTab(m_faw, tr("Numérotation auto des folios"));
@@ -371,7 +375,11 @@ void ProjectAutoNumConfigPage::readValuesFromProject()
 		//Folio Tab
 	const QStringList strlf(m_project->folioAutoNum().keys());
 	m_saw_folio->contextComboBox()->addItems(strlf);
-	
+
+		//Report (folio-reference arrow) Tab
+	const QStringList strlr(m_project->reportAutoNum().keys());
+	m_saw_report->contextComboBox()->addItems(strlr);
+
 		//Folio AutoNumbering Tab
 	m_faw->setContext(m_project->folioAutoNum().keys());
 }
@@ -407,6 +415,11 @@ void ProjectAutoNumConfigPage::buildConnections()
 	connect(m_saw_folio, &SelectAutonumW::applyPressed,  this, &ProjectAutoNumConfigPage::saveContextFolio);
 	connect(m_saw_folio, &SelectAutonumW::removeClicked, this, &ProjectAutoNumConfigPage::removeContextFolio);
 	connect(m_saw_folio->contextComboBox(), SIGNAL(currentIndexChanged(QString)), this, SLOT(updateContextFolio(QString)));
+
+		//Report (folio-reference arrow) Tab
+	connect(m_saw_report, &SelectAutonumW::applyPressed,  this, &ProjectAutoNumConfigPage::saveContextReport);
+	connect(m_saw_report, &SelectAutonumW::removeClicked, this, &ProjectAutoNumConfigPage::removeContextReport);
+	connect(m_saw_report->contextComboBox(), SIGNAL(currentIndexChanged(QString)), this, SLOT(updateContextReport(QString)));
 
 		//	Auto Folio Numbering
 	connect (m_faw, SIGNAL (applyPressed()),				 this, SLOT (applyAutoNum()));
@@ -491,6 +504,67 @@ void ProjectAutoNumConfigPage::removeContextElement()
 		return;
 	m_project->removeElementAutoNum (m_saw_element->contextComboBox()->currentText());
 	m_saw_element->contextComboBox()->removeItem (m_saw_element->contextComboBox()->currentIndex());
+}
+
+/**
+	@brief ProjectAutoNumConfigPage::updateContextReport
+	Display the current selected context for report (folio-reference arrows)
+	@param str : key of context stored in project
+*/
+void ProjectAutoNumConfigPage::updateContextReport(const QString& str)
+{
+	if (str == tr("Nom de la nouvelle numérotation"))
+	{
+		m_saw_report->setContext(NumerotationContext());
+	}
+	else
+	{
+		m_saw_report->setContext(m_project->reportAutoNum(str));
+	}
+}
+
+/**
+	@brief ProjectAutoNumConfigPage::saveContextReport
+	Save the current displayed report (folio-reference arrow) formula in project
+*/
+void ProjectAutoNumConfigPage::saveContextReport()
+{
+		// If the text is the default text "Name of new numerotation" save the edited context
+		// With the the name "No name"
+	if (m_saw_report->contextComboBox()->currentText() == tr("Nom de la nouvelle numérotation"))
+	{
+		QString title(tr("Sans nom"));
+
+		m_project->addReportAutoNum (title, m_saw_report -> toNumContext());
+		m_project->setCurrentReportAutoNum(title);
+		m_saw_report->contextComboBox()->addItem(tr("Sans nom"));
+	}
+		// If the text isn't yet to the autonum of the project, add this new item to the combo box.
+	else if ( !m_project -> reportAutoNum().contains( m_saw_report->contextComboBox()->currentText()))
+	{
+		m_project->addReportAutoNum(m_saw_report->contextComboBox()->currentText(), m_saw_report->toNumContext());
+		m_project->setCurrentReportAutoNum(m_saw_report->contextComboBox()->currentText());
+		m_saw_report->contextComboBox()->addItem(m_saw_report->contextComboBox()->currentText());
+	}
+		// Else, the text already exist in the autonum of the project, just update the context
+	else
+	{
+		m_project->addReportAutoNum (m_saw_report->contextComboBox() -> currentText(), m_saw_report -> toNumContext());
+		m_project->setCurrentReportAutoNum(m_saw_report->contextComboBox()->currentText());
+	}
+}
+
+/**
+	@brief ProjectAutoNumConfigPage::removeContextReport
+	Remove from project the current report (folio-reference arrow) numerotation context
+*/
+void ProjectAutoNumConfigPage::removeContextReport()
+{
+		//if default text, return
+	if (m_saw_report->contextComboBox()->currentText() == tr("Nom de la nouvelle numérotation"))
+		return;
+	m_project->removeReportAutoNum (m_saw_report->contextComboBox()->currentText());
+	m_saw_report->contextComboBox()->removeItem (m_saw_report->contextComboBox()->currentIndex());
 }
 
 /**

--- a/sources/ui/configpage/projectconfigpages.h
+++ b/sources/ui/configpage/projectconfigpages.h
@@ -156,6 +156,9 @@ class ProjectAutoNumConfigPage : public ProjectConfigPage {
 		void updateContextElement(const QString&);//element
 		void saveContextElement();
 		void removeContextElement();
+		void updateContextReport(const QString&);//report (folio-reference arrows)
+		void saveContextReport();
+		void removeContextReport();
 
 		void applyAutoNum();
 		void applyManagement();
@@ -171,6 +174,7 @@ class ProjectAutoNumConfigPage : public ProjectConfigPage {
 		SelectAutonumW        *m_saw_conductor;
 		SelectAutonumW        *m_saw_folio;
 		SelectAutonumW        *m_saw_element;
+		SelectAutonumW        *m_saw_report;
 		FolioAutonumberingW   *m_faw;
 		AutoNumberingManagementW *m_amw;
 

--- a/sources/ui/linksingleelementwidget.cpp
+++ b/sources/ui/linksingleelementwidget.cpp
@@ -19,6 +19,7 @@
 #include "contactgroupselectiondialog.h"
 #include "../qetgraphicsitem/masterelement.h"
 #include "../qetgraphicsitem/conductor.h"
+#include "../qetgraphicsitem/terminal.h"
 #include "../diagram.h"
 #include "../diagramposition.h"
 #include "../qetgraphicsitem/element.h"
@@ -303,7 +304,25 @@ void LinkSingleElementWidget::buildTree()
 		{
 			QStringList search_list;
 			QStringList str_list;
-			
+
+				//Which device this candidate's own wire actually leads to --
+				//computed fresh every time the list is built, so unlike an
+				//ID baked in at creation time it can never go stale when
+				//folios are reordered.
+			QString connected_label;
+			if (!elmt->conductors().isEmpty() && !elmt->terminals().isEmpty())
+			{
+				Conductor *cond = elmt->conductors().first();
+				Terminal *own_terminal = elmt->terminals().first();
+				Terminal *other_terminal = (cond->terminal1 == own_terminal)
+						? cond->terminal2 : cond->terminal1;
+				if (other_terminal && other_terminal->parentElement())
+					connected_label = other_terminal->parentElement()->actualLabel();
+			}
+			str_list << connected_label;
+			if (!connected_label.isEmpty())
+				search_list << connected_label;
+
 			if (!elmt->conductors().isEmpty())
 			{
 				ConductorProperties cp = elmt->conductors().first()->properties();
@@ -489,6 +508,12 @@ void LinkSingleElementWidget::setUpHeaderLabels()
 	
 	if (elmt_type & ElementData::AllReport)
 	{
+			//Which device this arrow's own wire actually leads to -- the
+			//clue that used to be baked into the link's ID itself (and
+			//went stale whenever pages were reordered). Computed live
+			//every time this list is built, so it can't go stale.
+		list << tr("Élément connecté");
+
 		if (settings.value(QStringLiteral("genericpanel/folio"), false).toBool())
 		{
 			list << tr("N° de fil")


### PR DESCRIPTION
## Background

Follows on from #701 (clickable folio-reference arrows). Discussion there moved to: manually typing an ID for every coming/going arrow is tedious, but an earlier scheme that baked the *destination* folio number into the ID itself had a real bug — the number went stale whenever pages were reordered, because it was resolved once at creation time instead of computed live.

The design that came out of that discussion: keep the ID itself a boring, stable, auto-incrementing counter (with manual override, since labels are already editable), and move the *disambiguating* information (which folio, which device) into the picker dialog instead, where it's recomputed live every time the list is built and so can never go stale.

## What this adds

**A fourth auto-numbering category, "Renvois"**, alongside the existing Conducteur/Elément/Folio ones — same `NumerotationContext` engine, same UI pattern, not a new bespoke mechanism:
- `QETProject` gets a `report_autonum` hash (named rules + a "current" one), mirroring `conductorAutoNum`/`elementAutoNum` exactly, with its own `<report_autonums>` XML block.
- `Element::setUpFormula()` — the existing placement-time auto-label hook (previously an unconditional no-op for report arrows) — now sources its formula/context from the report hash for report-type elements. A newly-placed coming/going arrow gets the next number automatically.
- A "Renvois" tab in the project's "Numérotation auto" page, and a "Renvoi" row in the auto-numbering dock widget — both direct copy-adapts of the existing Element tab/row.
- The part-type list for this category deliberately **excludes** the folio-number and element-location tokens available to conductors/elements — baking the destination folio into the ID is exactly the bug this is meant to avoid.
- Manual override needs no new UI: the label is an ordinary dynamic text, already editable by double-click like any other element's label.

**A new column in the link picker**: `LinkSingleElementWidget`'s report-arrow candidate list (the dialog you use to link a coming arrow to its matching going arrow) gets a new first column, "Élément connecté" — the label of whatever device sits on the far end of that candidate's own wire, computed fresh every time the list builds (terminal → conductor → other terminal → `parentElement()` → `actualLabel()`). Same wire-tag/page-number/page-title columns that were already there stay as-is.

**Préfixe/Suffixe fields on the Renvois tab**: two plain text fields sit above the generic +/- part editor so a user can get e.g. "R1-A, R2-A..." without needing to understand multi-part numerotation contexts. They're backed by ordinary leading/trailing `"string"` context parts — the formula composition and XML persistence already handled these unchanged, so this is a pure UI addition (`SelectAutonumW::toNumContext()`/`setContext()` now wrap/unwrap the surrounding string parts around the counter's own rows).

## Testing

Verified live under Xvfb:
- Configured a Renvois rule via the project's Numérotation auto page; confirmed the dock widget's Renvoi row shows the live value/increment/next-value preview.
- Placed two report arrows from the collection panel; both were auto-labeled (1, then 2), counter advancing correctly each time, matching the dock's live preview throughout.
- The picker column addition was verified by build success + code review — it's the identical `Terminal`/`Conductor`/`Element` API sequence already used two lines above it in the same function for the existing wire-tag column — rather than an additional screenshot; double-click-triggered dialogs became unreliable in the automation harness later in the session, confirmed independent of this change (checked against an unrelated, unmodified menu action).
- Préfixe/Suffixe: typed "R"/"-A" into the new fields, Applied, and confirmed the saved project XML contains the expected `<part type="string" value="R".../><part type="unit".../><part type="string" value="-A".../>` sequence and composite `formula="R%sequ_1-A"`. Closed and reopened the project in a fresh process and confirmed the fields repopulate correctly from the saved rule, with the counter's own part editor showing only its own row (no phantom prefix/suffix row).


**Fix: report labels went blank after saving and reopening the project.** While testing print output for this feature, found that the "%f-%l%c"-style live destination text a report arrow shows for its linked partner — a pre-existing QET mechanism, not something this PR adds — silently stopped working the moment a project was saved and reopened, which defeats the entire point for anyone relying on it for printed drawings. Root cause was two separate, pre-existing bugs, unrelated to this PR's other changes:
- `QETProject::refresh()` — which re-establishes each element's dynamic-text connections on load — was `private` and never actually called from anywhere, including project open, despite its own doc comment saying that's exactly what it's for.
- `DynamicElementTextItem::refreshLabelConnection()` called `updateReportFormulaConnection()`, which re-applies the formula's signal connections but never refreshes `m_other_report` from `linkedElements()`. For a text item that just loaded from a file, `m_other_report` was still null, so every connection became a no-op and the label stayed blank permanently — reordering, deleting, or moving the partner did nothing either, since the very connections meant to react to those changes were never established in the first place.

Fixed by wiring `refresh()` into `openAndAddProject()` and having `refreshLabelConnection()` call `reportChanged()` (the function that actually re-reads `linkedElements()`) instead. Also found `diagramAdded` was missing from the set of signals `DynamicElementTextItem` listens to for `%f`/`%id` (only `projectDiagramsOrderChanged` and `diagramRemoved` were wired) — meaning inserting a new page wouldn't live-update an already-placed arrow's destination text even within the same session. Added it, and fixed the matching `disconnect()` to be symmetric (`diagramRemoved` was connected but never disconnected — a pre-existing leak).

Verified live: placed two arrows from the standard collection, linked them via the picker, saved, reopened in a fresh process, and confirmed both now show live `"<folio>-<position>"` text computed from their partner's actual position (e.g. `"2-C7"`) — previously both were blank after reopening, confirmed via debug tracing of `m_dynamic_text_list`/`m_other_report` before diagnosing the two root causes above.

## Testing

Verified live under Xvfb:
- Configured a Renvois rule via the project's Numérotation auto page; confirmed the dock widget's Renvoi row shows the live value/increment/next-value preview.
- Placed two report arrows from the collection panel; both were auto-labeled (1, then 2), counter advancing correctly each time, matching the dock's live preview throughout.
- The picker column addition was verified by build success + code review — it's the identical `Terminal`/`Conductor`/`Element` API sequence already used two lines above it in the same function for the existing wire-tag column — rather than an additional screenshot; double-click-triggered dialogs became unreliable in the automation harness later in the session, confirmed independent of this change (checked against an unrelated, unmodified menu action).
- Préfixe/Suffixe: typed "R"/"-A" into the new fields, Applied, and confirmed the saved project XML contains the expected `<part type="string" value="R".../><part type="unit".../><part type="string" value="-A".../>` sequence and composite `formula="R%sequ_1-A"`. Closed and reopened the project in a fresh process and confirmed the fields repopulate correctly from the saved rule, with the counter's own part editor showing only its own row (no phantom prefix/suffix row).
- Report-label reload fix: see verification described above (placed, linked, saved, reopened, confirmed live "2-C7"/"1-D8"-style text on both ends).

Build: CMake/Ninja Release, Qt 5.15, clean, no new warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)