### PR TITLE
Fix-PLC-Warnings

### DIFF
--- a/sources/editor/ui/elementpropertieseditorwidget.cpp
+++ b/sources/editor/ui/elementpropertieseditorwidget.cpp
@@ -474,9 +474,6 @@ void ElementPropertiesEditorWidget::populateSlaveGroupsTable()
 	int row_count = ui->max_slaves_checkbox->isChecked()
 		? ui->max_slaves_spinbox->value() : 0;
 
-	// If we have existing groups, use their count (up to max_slaves)
-	int existing_groups = m_data.m_slave_contact_groups.size();
-
 	// Adjust the groups list to match the spinbox value
 	while (m_data.m_slave_contact_groups.size() < row_count) {
 		ElementData::SlaveContactGroup group;
@@ -1160,6 +1157,7 @@ void ElementPropertiesEditorWidget::plcAddRow()
 void ElementPropertiesEditorWidget::plcTerminalCountChanged(int row, int count)
 {
 	Q_UNUSED(row)
+	Q_UNUSED(count)
 	if (!m_plc_terminal_table)
 		return;
 

--- a/sources/qetgraphicsitem/crossrefitem.cpp
+++ b/sources/qetgraphicsitem/crossrefitem.cpp
@@ -1455,7 +1455,6 @@ void CrossRefItem::drawAsPlcTable(QPainter &painter)
 	painter.drawRect(bg_rect);
 
 	// Draw header row
-	qreal x_offset = 0;
 
 	for (int block = 0; block < block_count; ++block) {
 		qreal block_x = block * (col_widths.value(visible_cols.first(), 30) * visible_cols.size() + 3);

--- a/sources/ui/masterpropertieswidget.cpp
+++ b/sources/ui/masterpropertieswidget.cpp
@@ -1034,7 +1034,7 @@ void MasterPropertiesWidget::plcUpdateDisplaySettings()
 
 		// Preserve terminal data by looking up original IO via address
 		if (addr_to_orig_idx.contains(io.address)) {
-			const auto &orig_io = ed.plcMasterData().ios.at(addr_to_orig_idx.value(io.address));
+			const auto orig_io = ed.plcMasterData().ios.at(addr_to_orig_idx.value(io.address));
 			io.terminalCount = orig_io.terminalCount;
 			io.terminals = orig_io.terminals;
 		}


### PR DESCRIPTION
https://qelectrotech.org/forum/viewtopic.php?pid=23153#p23153

Fix: Missing b = true in PLC query branch
File: sources/dataBase/ui/elementquerywidget.cpp

The PLC checkbox branch in queryStr() was missing the b = true; statement that every other checkbox branch sets after appending its OR clause. Currently harmless since PLC is the last condition, but would silently produce a malformed WHERE clause if another filter is ever added after it.

Fix: Dangling reference warning
File: sources/ui/masterpropertieswidget.cpp

const auto &orig_io = ed.plcMasterData().ios.at(...) bound a const reference to a temporary returned by plcMasterData(). The temporary is destroyed at the end of the expression, leaving a dangling reference (undefined behavior). Changed to const auto orig_io (value copy).

Fix: Unused variable x_offset
File: sources/qetgraphicsitem/crossrefitem.cpp

Removed unused qreal x_offset = 0; declaration in drawAsPlcTable().

Fix: Unused variable existing_groups
File: sources/editor/ui/elementpropertieseditorwidget.cpp

Removed unused int existing_groups = m_data.m_slave_contact_groups.size(); in populateSlaveGroupsTable().

Fix: Unused parameter count
File: sources/editor/ui/elementpropertieseditorwidget.cpp

Added Q_UNUSED(count) in plcTerminalCountChanged(int row, int count) to suppress the unused parameter warning.