### PR TITLE
Scroll the diagram view to the selected search hit (bugtracker #309)

### DIFF
--- a/sources/SearchAndReplace/ui/searchandreplacewidget.cpp
+++ b/sources/SearchAndReplace/ui/searchandreplacewidget.cpp
@@ -1020,6 +1020,7 @@ void SearchAndReplaceWidget::on_m_tree_widget_currentItemChanged(
 		{
 			m_highlighted_element = elmt;
 			elmt.data()->setHighlighted(true);
+			elmt.data()->ensureVisible();
 		}
 	}
 	else if (m_text_hash.contains(current))
@@ -1029,6 +1030,7 @@ void SearchAndReplaceWidget::on_m_tree_widget_currentItemChanged(
 		{
 			text.data()->setSelected(true);
 			m_last_selected = text;
+			text.data()->ensureVisible();
 		}
 	}
 	else if (m_conductor_hash.contains(current))
@@ -1038,6 +1040,7 @@ void SearchAndReplaceWidget::on_m_tree_widget_currentItemChanged(
 		{
 			cond.data()->setSelected(true);
 			m_last_selected = cond;
+			cond.data()->ensureVisible();
 		}
 	}
 


### PR DESCRIPTION
Fixes https://qelectrotech.org/bugtracker/view.php?id=309 — "Not focusing diagram view on search hit". Selecting a result from the Search/Replace hit list highlights the matching element, but on a diagram too large to fit the current view, the view itself never scrolls — the highlighted element can be entirely off-screen with no indication of where it went. The reporter pinpointed the exact spot (`searchandreplacewidget.cpp:1022`) and suggested repositioning the view's scrollbars directly.

## Fix

`SearchAndReplaceWidget::on_m_tree_widget_currentItemChanged()` already calls `setHighlighted()`/`setSelected()` on the matched element, text, or conductor when a hit is selected — it just never brings it into view. Added a `QGraphicsItem::ensureVisible()` call alongside each of the three existing highlight/select calls.

Used `ensureVisible()` rather than computing scrollbar positions by hand as suggested: it scrolls every view showing the diagram automatically, works correctly if the same folio happens to be open in more than one window, and needs no lookup of which `QGraphicsView` the widget is attached to (it doesn't currently hold one). This mirrors `JumpToElementDialog::activateCurrentItem()`, which solves the identical "scroll to reveal a matched item" problem for the Ctrl+G jump-to-element feature — the only existing precedent for this anywhere in the codebase.

## Verification

Built and ran the app under Xvfb, zoomed into one corner of an example diagram until it needed scrollbars, then searched for text appearing on two different elements ("Offset null", both op-amp offset-null pins). Selecting each result scrolled the view to a different part of the diagram, bringing the matched element's highlight circle into the visible area each time. Full Release build, no new warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RPBnuxsg8T9Ndy8nHyUSu9