### PR TITLE
Fix bugtracker #312: wire text rotation not preserved on reload

### DIFF
--- a/sources/undocommand/rotatetextscommand.cpp
+++ b/sources/undocommand/rotatetextscommand.cpp
@@ -89,7 +89,7 @@ void RotateTextsCommand::undo()
 	m_anim_group->start();
 	
 	for(ConductorTextItem *cti : m_cond_texts.keys())
-		cti->forceMovedByUser(m_cond_texts.value(cti));
+		cti->forceRotateByUser(m_cond_texts.value(cti));
 }
 
 void RotateTextsCommand::redo()
@@ -101,7 +101,7 @@ void RotateTextsCommand::redo()
 	m_anim_group->start();
 	
 	for(ConductorTextItem *cti : m_cond_texts.keys())
-		cti->forceMovedByUser(true);
+		cti->forceRotateByUser(true);
 }
 
 void RotateTextsCommand::openDialog()


### PR DESCRIPTION
## Bug

https://qelectrotech.org/bugtracker/view.php?id=312

Manually rotating a conductor's number/label text via **Edition > Orienter les textes** (Ctrl+Space) applies correctly on screen, but the rotation is lost the next time the project is reopened — the text reverts to its default orientation.

## Root cause

`RotateTextsCommand::undo()`/`redo()` call `cti->forceMovedByUser(...)` on each selected `ConductorTextItem`, but they should call `cti->forceRotateByUser(...)`. These are two independent user-override flags:

- `moved_by_user_` gates whether `userx`/`usery` get written on save
- `rotate_by_user_` gates whether `rotation` gets written on save (`Conductor::toXml()`, which checks `wasRotatedByUser()`)

The constructor correctly reads `wasRotatedByUser()` into `m_cond_texts` for the undo snapshot, but `undo()`/`redo()` were writing to the wrong flag (`moved_by_user_`) instead. Since `rotate_by_user_` never actually became `true`, `Conductor::toXml()`'s rotation-writing gate never fired, so the rotation attribute was silently dropped on save.

## Fix

Swap both calls to `forceRotateByUser(...)`, matching what the constructor already reads via `wasRotatedByUser()`.

## Verification

- Clean rebuild: 506/506, no new warnings (only the pre-existing unrelated `QGIManager::manage`/`release` deprecation warnings).
- Live-verified under Xvfb that triggering "Orienter les textes" correctly animates and applies rotation to `ConductorTextItem` text via the orientation dialog.
- A full save/close/reopen round-trip on a from-scratch two-element wire was attempted but not completed — synthetic-mouse-event terminal-to-terminal wire drawing proved unreliable in a window-manager-less Xvfb sandbox. Confidence in the fix instead rests on tracing the exact save-gate code path: `Conductor::toXml()` gates purely on `wasRotatedByUser()`, and this change makes `undo()`/`redo()` set that flag correctly, mirroring the already-correct handling of the parallel `moved_by_user_` flag elsewhere in the same class.

🤖 Generated with [Claude Code](https://claude.com/claude-code)