### PR TITLE
Fix bugtracker #307: QET file type description bad encoding

### DIFF
--- a/build-aux/windows/QET64.nsi
+++ b/build-aux/windows/QET64.nsi
@@ -1,4 +1,4 @@
-; this file is part of installer for QElectroTech
+﻿; this file is part of installer for QElectroTech
 ; Copyright (C)2015 QElectroTech Team <scorpio@qelectrotech.org>
 ;
 ; This program is free software; you can redistribute it and/or
@@ -34,6 +34,13 @@
 ;--------------------------------
 ; NSIS 3 requires SetCompressor BEFORE any Section or Function
 SetCompressor /FINAL /SOLID lzma
+
+; This script is saved as UTF-8 with a BOM. Without an explicit BOM, NSIS
+; falls back to interpreting non-ASCII literals (e.g. the accented registry
+; strings below) using the system ANSI codepage instead of UTF-8, which
+; double-encodes them into mojibake (bug #307). Unicode is NSIS 3's default,
+; but is declared here explicitly so this doesn't silently regress.
+Unicode true
 
 ;--------------------------------
 ; Includes
@@ -315,7 +322,7 @@ Section ""
     WriteRegStr   HKEY_CLASSES_ROOT "Applications\qelectrotech.exe\shell\open\command" "" \
         '"$final_qet_exe" "%1"'
     WriteRegStr   HKEY_CLASSES_ROOT ".qet"                                              "" "qet_diagram_file"
-    WriteRegStr   HKEY_CLASSES_ROOT "qet_diagram_file"                                  "" "Diagram QET"
+    WriteRegStr   HKEY_CLASSES_ROOT "qet_diagram_file"                                  "" "Schéma QET"
     WriteRegDWORD HKEY_CLASSES_ROOT "qet_diagram_file"                                  "EditFlags"    0x00000000
     WriteRegDWORD HKEY_CLASSES_ROOT "qet_diagram_file"                                  "BrowserFlags" 0x00000008
     WriteRegStr   HKEY_CLASSES_ROOT "qet_diagram_file\DefaultIcon"                      "" "$final_project_ico"
@@ -323,7 +330,7 @@ Section ""
 
     ; File associations - .elmt
     WriteRegStr   HKEY_CLASSES_ROOT ".elmt"                                             "" "qet_element_file"
-    WriteRegStr   HKEY_CLASSES_ROOT "qet_element_file"                                  "" "Element QET"
+    WriteRegStr   HKEY_CLASSES_ROOT "qet_element_file"                                  "" "Élément QET"
     WriteRegDWORD HKEY_CLASSES_ROOT "qet_element_file"                                  "EditFlags"    0x00000000
     WriteRegDWORD HKEY_CLASSES_ROOT "qet_element_file"                                  "BrowserFlags" 0x00000008
     WriteRegStr   HKEY_CLASSES_ROOT "qet_element_file\DefaultIcon"                      "" "$final_element_ico"


### PR DESCRIPTION
## Bug

https://qelectrotech.org/bugtracker/view.php?id=307

Windows file-type descriptions for `.qet`/`.elmt` files show up mojibake-corrupted in Explorer/regedit — "Schéma QET" renders as "SchÃ©ma QET" and "Élément QET" as "Ã‰lÃ©ment QET".

## Root cause

`build-aux/windows/QET64.nsi` writes these descriptions via `WriteRegStr` with the correct accented French text. The `.nsi` source was saved as UTF-8 **without a byte-order mark** and had no explicit `Unicode true` declaration. NSIS's encoding auto-detection for scripts without a BOM can fall back to the system ANSI codepage for short, mostly-ASCII literals like these — the two UTF-8 bytes of `é` get read as two separate CP1252 characters (`Ã` + `©`), producing the classic double-encoded mojibake once written into the (Unicode) registry value.

Git history shows this was hit before: commit `9fceb6f00` restored the correctly-encoded accented strings, which is exactly what triggered the mojibake reports. Commit `e9e2ea5b0` ("Try to fix bug #307") then worked around the *symptom* by replacing the strings with plain-ASCII English ("Diagram QET" / "Element QET") — avoiding the corruption, but silently dropping the original French wording rather than fixing the underlying encoding problem. That workaround is the current state on `master`.

## Fix

Per NSIS's own documented guidance for scripts containing non-ASCII literals:
- Save `QET64.nsi` as UTF-8 **with a BOM**.
- Add an explicit `Unicode true` declaration (this is already NSIS 3's default, but stating it makes the encoding contract explicit rather than relying on an implicit default that could change).
- Restore the original `"Schéma QET"` / `"Élément QET"` strings.

## Verification

- Compiled with `makensis` (NSIS 3.10, installed locally via `apt`). The compiler log changed from silently defaulting to ANSI-ambiguous parsing to explicitly reporting:
  ```
  Processing script file: "QET64.nsi" (UTF8)
  ```
  and the build completes cleanly, producing an `x86-unicode` installer.
- No encoding-related warnings. The only warnings present are `7010: ... no files found` for payload directories (`elements/`, `lang/`, `fonts/`, etc.) that aren't populated in this stripped source checkout — those are supplied by the real CI build and are unrelated to this change.
- I was **not** able to verify the installed registry values actually render correctly in a real Windows File Explorer/regedit, since no Windows or Wine environment is available in this sandbox. Confidence rests on NSIS's documented BOM-based source-encoding detection, and on the compiler's own encoding-mode log line reflecting the fix (previously ambiguous/ANSI-defaultable, now explicitly UTF-8).

🤖 Generated with [Claude Code](https://claude.com/claude-code)