### PR TITLE
Fix bugtracker #306: crash when restoring backup files on startup

### DIFF
--- a/sources/qetdiagrameditor.cpp
+++ b/sources/qetdiagrameditor.cpp
@@ -2101,6 +2101,7 @@ void QETDiagramEditor::openBackupFiles(QList<KAutoSaveFile *> backup_files)
 			}
 			delete project;
 			DialogWaiting::dropInstance();
+			continue;
 		}
 		addProject(project);
 		DialogWaiting::dropInstance();


### PR DESCRIPTION
## Bug

https://qelectrotech.org/bugtracker/view.php?id=306

On startup, QET offers to restore backup/autosave files left over from a previous session. Clicking **Cancel** works fine. Clicking **OK** to actually restore the listed files crashes the application. The same files open fine via File > Open or the OS file explorer. The reporter also noted the restore list keeps growing across sessions.

Related issue #209 (fixed in 2021) was about restore filenames becoming too long due to URL-encoding of the full path — a different, already-fixed problem. This is a distinct crash in the restore/reopen path itself.

## Root cause

`QETDiagramEditor::openBackupFiles()` (`sources/qetdiagrameditor.cpp`):

```cpp
QETProject *project = new QETProject(file, this);
if (project->state() != QETProject::Ok)
{
    if (project -> state() != QETProject::FileOpenDiscard) { ... warning ... }
    delete project;
    DialogWaiting::dropInstance();
}
addProject(project);   // <-- runs unconditionally, even after delete above
DialogWaiting::dropInstance();
```

When a backup project fails to reach `ProjectState::Ok`, `project` is deleted — but there's no `continue`/`else`, so `addProject(project)` still runs on the now-dangling pointer. `addProject()` immediately dereferences it (`new ProjectView(project)`, etc.), producing a use-after-free.

This matches the reported behavior exactly:
- **Cancel** never calls `openBackupFiles()` — it just deletes the stale markers directly (`QETApp::checkBackupFiles()`), so it's unaffected.
- **OK** calls `openBackupFiles()`, which crashes on this UAF whenever *any* listed backup fails to open cleanly.
- Because the crash happens mid-loop, cleanup for that (and any later) backup file in the batch never completes — plausibly explaining why the restore list kept growing across sessions.

## Fix

Add the missing `continue` so a failed project is skipped instead of being passed use-after-free into `addProject()`.

## Verification

- Clean rebuild: only the intended object file recompiled, linked successfully with no errors or warnings.
- I attempted a live repro under Xvfb by crafting a malformed stale-file marker to force `ProjectState != Ok` and clicking OK. However, this local build links against real KDE Frameworks (`BUILD_WITH_KF5=ON`, confirmed via `CMakeCache.txt`) rather than the in-tree `sources/ui/nokde/kautosavefile.cpp` reimplementation I initially targeted — real `KF5::KAutoSaveFile` uses a different stale-marker directory/naming scheme (`~/.local/share/stalefiles/<app>/`) that I wasn't able to reverse-engineer accurately enough in the time available to produce a matching malformed marker.
- Confidence in the fix instead rests on the code itself: this is an unambiguous, textbook use-after-free — the exact object is deleted on the line immediately above the missing `continue` — with a single-line, side-effect-free fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)