### PR TITLE
Fix bugtracker #296: cross-reference text overlaps element label by default

### DIFF
--- a/sources/properties/xrefproperties.cpp
+++ b/sources/properties/xrefproperties.cpp
@@ -90,7 +90,7 @@ void XRefProperties::fromSettings(const QSettings &settings,
 	m_slave_label = settings.value(prefix % "slave_label", "(%f-%l%c)").toString();
 
 	QMetaEnum var = QMetaEnum::fromType<Qt::Alignment>();
-	m_xref_pos = Qt::AlignmentFlag(var.keyToValue((settings.value(prefix % "xrefpos").toString()).toStdString().data()));
+	m_xref_pos = Qt::AlignmentFlag(var.keyToValue((settings.value(prefix % "xrefpos", "AlignBottom").toString()).toStdString().data()));
 
 	for (QString key : m_prefix_keys) {
 		m_prefix.insert(key, settings.value(prefix + key % "prefix").toString());


### PR DESCRIPTION
## Bug

https://qelectrotech.org/bugtracker/view.php?id=296

Dynamically-generated cross-reference text for master/slave-linked elements (e.g. magneto-thermal circuit breaker, thermal relay NC) overlaps the element's own label by default, making the reference unreadable. The reporter found a manual workaround: in **Project Properties > New Folio/Cross Referencing > "Organ of protection"**, explicitly setting alignment to "Bottom" fixes it — but this requires per-project manual reconfiguration rather than working out of the box.

## Root cause

`XRefProperties::fromSettings()` (`sources/properties/xrefproperties.cpp`) reads the `xrefpos` `QSettings` key with **no default value**:

```cpp
m_xref_pos = Qt::AlignmentFlag(var.keyToValue((settings.value(prefix % "xrefpos").toString()).toStdString().data()));
```

On a fresh install/project, that key doesn't exist yet, so `settings.value(...)` returns an empty `QVariant`, `.toString()` yields `""`, and `QMetaEnum::keyToValue("")` returns `-1` (invalid). That `-1` is cast directly into `m_xref_pos` as `Qt::AlignmentFlag(-1)` — garbage — even though `XRefProperties`'s own default constructor documents the intended default as `Qt::AlignBottom`.

This explains the reported symptom: the cross-reference text renders at an undefined position and collides with the label. The reporter's manual workaround (setting alignment to "Bottom") sidesteps the bug precisely by writing a valid `"AlignBottom"` string into `QSettings`, which `fromSettings()` then reads back correctly on every subsequent load — but only because they'd already saved it once.

## Fix

Supply `"AlignBottom"` as the fallback default for the `QSettings` read, matching both the constructor's documented default and the reporter's working manual configuration.

## Verification

- Clean rebuild: only the intended object file recompiled, linked successfully.
- Wrote a small standalone `QMetaEnum` test program confirming the exact failure mechanism:
  - `keyToValue("")` → `-1`, `ok=false` (the pre-fix behavior)
  - `keyToValue("AlignBottom")` → `64` (`== Qt::AlignBottom`), `ok=true` (the post-fix behavior)
- **Not verified**: a live before/after visual comparison of rendered cross-reference text position on an actual magneto-thermal/thermal-relay diagram — that would require constructing a multi-folio project with linked master/slave elements and comparing label geometry, which was out of scope for the time available. Confidence rests on the `QMetaEnum` mechanism being unambiguous (confirmed above) and the fix being a one-line default-value correction with no other code path affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)