### PR TITLE
Cancel the collection-loading map before waiting on it in ~ElementsCollectionModel

### DIFF
--- a/sources/ElementsCollection/elementscollectionmodel.cpp
+++ b/sources/ElementsCollection/elementscollectionmodel.cpp
@@ -39,6 +39,22 @@ ElementsCollectionModel::ElementsCollectionModel(QObject *parent) :
 }
 
 /**
+	@brief ElementsCollectionModel::~ElementsCollectionModel
+	loadCollections() kicks off QtConcurrent::map() over this model's own
+	item tree without ever cancelling/waiting for it. If the model (and the
+	items it owns) get destroyed while that background pass is still
+	running -- e.g. the "Open Element" dialog is cancelled before loading
+	finishes -- worker threads keep dereferencing the freed items. Cancel
+	and wait here so no worker thread can still be touching an item once
+	QStandardItemModel's own destructor starts tearing down the tree.
+*/
+ElementsCollectionModel::~ElementsCollectionModel()
+{
+	m_future.cancel();
+	m_future.waitForFinished();
+}
+
+/**
 	@brief ElementsCollectionModel::data
 	Reimplemented from QStandardItemModel
 	@param index

--- a/sources/ElementsCollection/elementscollectionmodel.h
+++ b/sources/ElementsCollection/elementscollectionmodel.h
@@ -35,6 +35,7 @@ class ElementsCollectionModel : public QStandardItemModel
 
 	public:
 		ElementsCollectionModel(QObject *parent = Q_NULLPTR);
+		~ElementsCollectionModel() override;
 
 		QVariant data(const QModelIndex &index, int role) const override;
 		QMimeData *mimeData(const QModelIndexList &indexes) const override;


### PR DESCRIPTION
**Reopened and rescoped — the crash this PR was named after is already fixed.**

`39ac5716c` (merged 14 Aug) added `m_future.waitForFinished()` to `~ElementsCollectionModel()`, which is what stops the worker threads dereferencing freed items. Bugtracker #291 is closed by that, not by this. The original title and description no longer describe anything real, so both are rewritten.

What is left here is one line: `m_future.cancel()` before the wait.

Without it, the wait runs the whole queued `QtConcurrent::map()` to completion, so cancelling the open-element dialog blocks until every remaining item has been processed — on a large collection, a visible hang on the button pressed precisely to stop the work. `cancel()` drops the not-yet-started items so the wait is short.

Net change against master is that one line plus the comment explaining it.

Merged master in (the branch was 8 days behind and conflicting). Builds clean, ctest 12/12.

**Not measured:** the responsiveness gain is reasoned from `QFuture` semantics, not timed here. If you would rather see numbers before taking it, say so and I will A/B the dialog-cancel latency against a large collection.