### PR TITLE
Fix bugtracker #281: new-part wizard's element editor opens behind main window

### DIFF
--- a/sources/newelementwizard.cpp
+++ b/sources/newelementwizard.cpp
@@ -252,4 +252,10 @@ void NewElementWizard::createNewElement()
 	loc_.addToPath(m_chosen_file);
 	edit_new_element -> setLocation(loc_);
 	edit_new_element -> show();
+		// Without this, the just-closed wizard can leave the main window
+		// as the active/key window (bugtracker #281, reported on macOS):
+		// the new editor is created and shown, but stays behind the main
+		// window and doesn't surface in the Dock/Windows menu.
+	edit_new_element -> raise();
+	edit_new_element -> activateWindow();
 }


### PR DESCRIPTION
## Bug

https://qelectrotech.org/bugtracker/view.php?id=281

On macOS, using the "create new part" wizard for the user library appears to do nothing after clicking "Done" — no new part shows up. An admin later found the element editor actually *does* open, but behind the main window, and doesn't appear in the Dock's window list or the app's Windows menu.

## Root cause

`NewElementWizard::createNewElement()` (`sources/newelementwizard.cpp`) creates and `show()`s a `QETElementEditor` for the newly-created part, but never calls `raise()`/`activateWindow()`. On macOS, the just-closed wizard (a modal sheet/child of the main window) apparently leaves the main window as the active/key window, so the new editor is created and shown but stays behind it — and since it's neither key nor frontmost, it also never surfaces in the Dock or Windows menu. This matches the report precisely: the wizard "does nothing" because its actual result is invisible.

## Fix

Explicitly call `raise()` and `activateWindow()` on the new editor after `show()`, matching the pattern already used elsewhere in the codebase (`QETApp::openElementLocations()`'s already-open-editor branch does the same for a different scenario).

## Verification

- Clean rebuild: only the intended object file recompiled, linked successfully.
- Ran the full wizard flow live under Xvfb on Linux (right-click user collection → "Nouvel élément" → through all 3 steps → Finish) and confirmed the element editor opens correctly with a blank new part, no regression in the flow.
- **Not verified**: the actual reported symptom is macOS-specific window-manager behavior (key/frontmost window handling, Dock registration), which can't be reproduced or confirmed in this Linux/Xvfb sandbox — no macOS or Wine-with-Cocoa environment is available here. `raise()`/`activateWindow()` are the standard cross-platform Qt calls for exactly this class of problem, and match existing precedent in this codebase, so confidence rests on that rather than a macOS-side confirmation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)