### PR TITLE
Fix bugtracker #275: element properties window stuck centered on macOS

### DIFF
--- a/sources/PropertiesEditor/propertieseditordialog.h
+++ b/sources/PropertiesEditor/propertieseditordialog.h
@@ -46,6 +46,18 @@ class PropertiesEditorDialog : public QDialog
 		PropertiesEditorDialog(T editor, QWidget *parent = nullptr) :
 		QDialog (parent)
 		{
+			// Without this, a QWidget-modal QDialog with a parent falls
+			// back to macOS's automatic sheet presentation, which some
+			// Qt/Cocoa versions render stuck centered on screen and
+			// non-draggable rather than as a proper attached sheet
+			// (bugtracker #275). Other dialogs in this codebase already
+			// opt in explicitly (see ElementDialog, DiagramPropertiesDialog)
+			// -- this one was missing it.
+			setWindowModality(Qt::WindowModal);
+#ifdef Q_OS_MACOS
+			setWindowFlags(Qt::Sheet);
+#endif
+
 			//Set dialog title
 			setWindowTitle(editor->title());
 			// Reparent the editor,


### PR DESCRIPTION
## Bug

https://qelectrotech.org/bugtracker/view.php?id=275

On macOS, double-clicking a placed element (or right-click > "Éditer l'élément") opens its properties dialog permanently centered on screen — it can't be dragged, and resizing changes both sides symmetrically. Linux works fine, with a normal draggable dialog.

## Root cause

`Element::editProperty()` (`sources/qetgraphicsitem/element.cpp`) constructs a `PropertiesEditorDialog` with a real parent (`QApplication::activeWindow()`) and `Qt::WindowModal`. On macOS, a `QDialog` with both a parent and window-modality set falls back to Cocoa's automatic "sheet" presentation. Without an explicit `Qt::Sheet` flag, some Qt/Cocoa versions render this stuck centered and non-draggable rather than as a proper attached, movable sheet — matching the report exactly.

Two other dialogs in this codebase already explicitly opt into the correct behavior for this exact reason — `ElementDialog::setUpWidget()` and `DiagramPropertiesDialog`'s setup both do:

```cpp
setWindowModality(Qt::WindowModal);
#ifdef Q_OS_MACOS
    setWindowFlags(Qt::Sheet);
#endif
```

`PropertiesEditorDialog` — the shared dialog class used for editing `Element`, `QetShapeItem`, and `DiagramImageItem` properties, all reached via double-click on a diagram item — had neither this opt-in nor an opt-out, so it likely fell into the unpolished automatic-sheet path.

## Fix

Apply the same `setWindowModality()`/`Q_OS_MACOS` `Qt::Sheet` pattern already used by the other two dialogs, directly in `PropertiesEditorDialog`'s constructor — fixing all three call sites at once (element, shape, and image property editing), since they share this one dialog class.

## Verification

- Clean rebuild: all three call sites (`element.cpp`, `qetshapeitem.cpp`, `diagramimageitem.cpp`) recompiled and linked successfully with no errors or warnings.
- **Not verified**: the actual reported symptom is macOS/Cocoa-specific window presentation, which can't be reproduced or confirmed in this Linux/Xvfb sandbox — no macOS environment is available here. Confidence rests on the identical fix pattern already being established (and presumably working) for two other dialogs in this codebase facing the exact same problem.

🤖 Generated with [Claude Code](https://claude.com/claude-code)