### PR TITLE
Fix bugtracker #270: Save As on Snap produces file with no .qet extension

### DIFF
--- a/sources/projectview.cpp
+++ b/sources/projectview.cpp
@@ -345,11 +345,19 @@ QString ProjectView::askUserForFilePath(bool assign) {
 	// if no filepath is provided, return an empty string
 	if (filepath.isEmpty()) return(filepath);
 
-	// if the name does not end with the .qet extension and we're _not_ using xdg-desktop-portal, append it
-	bool usesPortal = 
-		qEnvironmentVariableIsSet("FLATPAK_ID") || 
-		qEnvironmentVariableIsSet("SNAP_NAME");
-	if (!filepath.endsWith(".qet", Qt::CaseInsensitive) && !usesPortal) filepath += ".qet";
+	// Ensure the path ends with exactly one .qet extension, regardless of
+	// whether the active file dialog already appended one. Whether it does
+	// depends on which backend actually shows the dialog (Qt's own vs. the
+	// xdg-desktop-portal used by sandboxed Snap/Flatpak builds), and that
+	// isn't reliably predictable from environment variables alone -- an
+	// earlier attempt at that (only appending when *not* Snap/Flatpak,
+	// assuming the portal always appends it) left Snap saves with no
+	// extension at all whenever the portal didn't (bugtracker #270).
+	// Stripping any existing suffix first and re-appending it once is
+	// correct either way.
+	if (filepath.endsWith(".qet", Qt::CaseInsensitive))
+		filepath.chop(4);
+	filepath += ".qet";
 
 	if (assign) {
 		// assign the provided filepath to the currently edited project


### PR DESCRIPTION
## Bug

https://qelectrotech.org/bugtracker/view.php?id=270

On the Snap-packaged build (Ubuntu 22.04), using Save As saves the file without a `.qet` extension.

## Root cause

`ProjectView::askUserForFilePath()` (`sources/projectview.cpp`) only appended `.qet` when neither `FLATPAK_ID` nor `SNAP_NAME` was set:

```cpp
bool usesPortal = 
    qEnvironmentVariableIsSet("FLATPAK_ID") || 
    qEnvironmentVariableIsSet("SNAP_NAME");
if (!filepath.endsWith(".qet", Qt::CaseInsensitive) && !usesPortal) filepath += ".qet";
```

This was a deliberate 2022 change, on the assumption that the `xdg-desktop-portal` file dialog used by sandboxed Snap/Flatpak builds always appends the selected filter's extension itself, so appending again would double it (`.qet.qet`). In practice, on the reporter's Snap setup the portal dialog does **not** append it, so this environment-based skip left Save As producing a file with no extension at all — exactly the reported bug.

Portal behavior isn't something QET controls or can reliably predict from environment variables — it depends on the desktop's actual portal implementation and version, which can vary.

## Fix

Stop guessing per-environment. Normalize unconditionally: strip any existing `.qet` suffix (case-insensitive) and re-append exactly one. This is correct regardless of whether the dialog already added the extension:

```cpp
if (filepath.endsWith(".qet", Qt::CaseInsensitive))
    filepath.chop(4);
filepath += ".qet";
```

## Verification

- Clean rebuild: only the intended object file recompiled, linked successfully.
- Wrote a standalone test of the normalization logic covering: no extension, already has extension, uppercase extension, and a literal dot in the base filename (e.g. `my.project`) — all four produced exactly one correct `.qet` suffix, with no double-extension and no missing extension.
- **Not verified**: the actual Snap-sandboxed portal dialog behavior itself — building and running the Snap package under a real portal environment is outside what's practical to set up in this sandbox. Confidence rests on the fix removing environment-guessing entirely in favor of unconditional, dialog-implementation-agnostic normalization, which is correct regardless of what the underlying dialog does.

🤖 Generated with [Claude Code](https://claude.com/claude-code)