### PR TITLE
Fix bugtracker #251: title block template with slash in name fails silently

### DIFF
--- a/sources/titleblock/qettemplateeditor.cpp
+++ b/sources/titleblock/qettemplateeditor.cpp
@@ -776,7 +776,20 @@ bool QETTitleBlockTemplateEditor::saveAs(const TitleBlockTemplateLocation &locat
 	elmt.setAttribute("name", location.name());
 	doc.appendChild(elmt);
 
-	collection -> setTemplateXmlDescription(location.name(), elmt);
+	if (!collection -> setTemplateXmlDescription(location.name(), elmt)) {
+			// Report the failure instead of marking the template "saved"
+			// regardless (bugtracker #251) -- this return value used to
+			// be discarded here.
+		QET::QetMessageBox::critical(
+			this,
+			tr("Erreur", "message box title"),
+			tr(
+				"Impossible d'enregistrer le modèle « %1 ».",
+				"message box content - %1 is a title block template name"
+			).arg(location.name())
+		);
+		return(false);
+	}
 
 	opened_from_file_ = false;
 	location_ = location;
@@ -879,6 +892,21 @@ bool QETTitleBlockTemplateEditor::saveAs()
 	);
 	if (location.isValid()) {
 		return(saveAs(location));
+	}
+	if (!location.name().isEmpty()) {
+			// The name was rejected (e.g. contains a path separator or
+			// other filesystem-reserved character) rather than the user
+			// cancelling the dialog -- say so instead of silently doing
+			// nothing (bugtracker #251).
+		QET::QetMessageBox::critical(
+			this,
+			tr("Erreur", "message box title"),
+			tr(
+				"Le nom « %1 » n'est pas valide : il ne doit pas contenir "
+				"les caractères suivants : \\ / : * ? \" < > |",
+				"message box content - %1 is the rejected template name"
+			).arg(location.name())
+		);
 	}
 	return(false);
 }

--- a/sources/titleblock/templatelocation.cpp
+++ b/sources/titleblock/templatelocation.cpp
@@ -92,7 +92,13 @@ void TitleBlockTemplateLocation::setName(const QString &name) {
 */
 bool TitleBlockTemplateLocation::isValid() const
 {
-	return(!name_.isEmpty());
+	// The name becomes (part of) a filename on disk (see
+	// TitleBlockTemplatesFilesCollection::toFileName()). A name containing
+	// a path separator or another filesystem-reserved character silently
+	// fails to save instead of erroring, because it turns into an
+	// unintended subpath rather than a plain filename (bugtracker #251).
+	static const QRegularExpression invalid_chars_re(QStringLiteral("[\\\\/:*?\"<>|]"));
+	return(!name_.isEmpty() && !name_.contains(invalid_chars_re));
 }
 
 /**


### PR DESCRIPTION
## Bug

https://qelectrotech.org/bugtracker/view.php?id=251

Saving a new user title block template with a name containing a slash silently fails — no file is created, and no error is shown to the user.

## Root cause

The entered name is turned directly into a filename (`TitleBlockTemplatesFilesCollection::toFileName()`), so a name like `foo/bar` becomes the path `foo/bar.titleblock`. Since `foo/` essentially never exists as a directory, the write fails — but that failure was never surfaced:

- `TitleBlockTemplateLocation::isValid()` only checked for an empty name, so an invalid name still counted as "valid" and got passed through to save.
- `QETTitleBlockTemplateEditor::saveAs(const TitleBlockTemplateLocation&)` discarded the `bool` result of `setTemplateXmlDescription()` and unconditionally returned `true`, marking the undo stack clean as if the save had actually succeeded.

## Fix

- `isValid()` now also rejects names containing `\ / : * ? " < > |` — the character set that's actually unsafe once the name becomes a filename.
- `saveAs()` (the no-arg entry point that asks the user for a location) now shows a clear error dialog when the entered name is rejected, distinguishing "user cancelled" (`location.name()` empty) from "name was invalid" (non-empty but rejected by `isValid()`).
- `saveAs(location)` now checks `setTemplateXmlDescription()`'s return value and shows an error dialog instead of reporting false success, covering any future/other write failure too, not just this one.

## Verification

- Clean rebuild: only the intended files recompiled, linked successfully.
- Live-tested under Xvfb:
  - Creating a new template and using "Enregistrer sous" with the name `foo/bar` now shows: *"Le nom « foo/bar » n'est pas valide : il ne doit pas contenir les caractères suivants : \ / : * ? " < > |"* instead of silently doing nothing.
  - Reopening the save-as dialog afterward showed the name field correctly empty — nothing was partially written.
  - Saving again with a valid name (`mytemplate_valid`) completed with no error dialog, and the resulting `mytemplate_valid.titleblock` file was confirmed present on disk in the user's title-block collection directory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)