### PR TITLE
Fix bugtracker #238: table of contents pages in wrong order

### DIFF
--- a/sources/dataBase/ui/summaryquerywidget.cpp
+++ b/sources/dataBase/ui/summaryquerywidget.cpp
@@ -63,7 +63,6 @@ QString SummaryQueryWidget::queryStr() const
 	QStringList keys = selectedKeys();
 
 	QString select ="SELECT ";
-	QString order_by = " ORDER BY ";
 
 	QString column;
 	bool first = true;
@@ -72,11 +71,24 @@ QString SummaryQueryWidget::queryStr() const
 			first = false;
 		} else {
 			column += ", ";
-			order_by +=", ";
 		}
 		column += key;
-		order_by += key;
 	}
+
+		// Always sort by folio position first, regardless of which columns
+		// the user chose to display (and regardless of where "pos" falls
+		// among them, if at all): the summary/table of contents should
+		// follow the actual folio order by default. Previously the ORDER
+		// BY clause only ever contained the user's chosen display columns
+		// in their chosen order, so a report was left completely unsorted
+		// by position unless the user happened to both add "Position" as
+		// a column AND place it first (bugtracker #238).
+	QStringList order_by_terms;
+	order_by_terms << "pos";
+	for (auto key: keys) {
+		if (key != "pos") order_by_terms << key;
+	}
+	QString order_by = " ORDER BY " + order_by_terms.join(", ");
 
 	QString from = " FROM project_summary_view";
 


### PR DESCRIPTION
## Bug

https://qelectrotech.org/bugtracker/view.php?id=238

The summary/table of contents report displays pages in the wrong order.

## Root cause

`SummaryQueryWidget::queryStr()` (`sources/dataBase/ui/summaryquerywidget.cpp`) built the SQL `ORDER BY` clause purely from whichever columns the user chose to *display* in the report, in the order they picked them. "Position" (`pos`, the folio's actual position in the project) is just one of many optional display columns, defaulting to not selected — so a report was left completely unordered by folio position unless the user happened to both add "Position" as a displayed column **and** place it first among their chosen columns.

This exactly matches the forum diagnosis linked from the bug report ([viewtopic.php?pid=13910](https://qelectrotech.org/forum/viewtopic.php?pid=13910#p13910)): *"When you set the position to column 1, the order works"* — because the `ORDER BY` clause mirrored the display-column order, so `pos` had to be both present and first to get correct sorting, which nothing in the UI suggested or required.

## Fix

Always sort by `pos` (a genuine column of `project_summary_view` — see `projectDataBase::createSummaryView()`) as the primary sort key, regardless of which columns the user chose to display or in what order — with the user's chosen display columns still applied as secondary sort keys for ties, same as before. The `SELECT` column list (what's actually shown) is left untouched.

## Verification

- Clean rebuild: only the intended object file recompiled, linked successfully.
- Wrote a standalone test of the query-building logic covering: display columns not including `pos`, `pos` chosen first, `pos` chosen in the middle, `pos` chosen alone, and no columns chosen — all produced correct SQL with `pos` as the primary `ORDER BY` term, proper comma placement, and no duplicate `pos` term when the user had already selected it themselves.
- **Not verified**: an actual generated table-of-contents report's visual row order in the running application — constructing a multi-folio project with a custom summary query configuration was out of scope for the time available, given the SQL-generation logic itself was already precisely verified in isolation, and `pos` was confirmed to genuinely exist in the underlying view.

🤖 Generated with [Claude Code](https://claude.com/claude-code)