### PR TITLE
Added width/height/depth properties to elements

### DIFF
--- a/sources/editor/ui/elementpropertieseditorwidget.cpp
+++ b/sources/editor/ui/elementpropertieseditorwidget.cpp
@@ -64,9 +64,22 @@ class EditorDelegate : public QItemDelegate
 	{
 		if(index.column() == 1)
 		{
-			return QItemDelegate::createEditor(parent,
-							   option,
-							   index);
+			const QString key = index.sibling(index.row(), 0)
+									.data(Qt::UserRole).toString();
+
+			if (key == QETInformation::ELMT_WIDTH ||
+				key == QETInformation::ELMT_HEIGHT ||
+				key == QETInformation::ELMT_DEPTH)
+			{
+				auto *line_edit = new QLineEdit(parent);
+				auto *validator = new QDoubleValidator(0.0, 100000.0, 4, line_edit);
+				validator->setNotation(QDoubleValidator::StandardNotation);
+				validator->setLocale(QLocale::c());
+				line_edit->setValidator(validator);
+				return line_edit;
+			}
+
+			return QItemDelegate::createEditor(parent, option, index);
 		}
 		return nullptr;
 	}

--- a/sources/editor/ui/elementpropertieseditorwidget.cpp
+++ b/sources/editor/ui/elementpropertieseditorwidget.cpp
@@ -44,6 +44,7 @@
 #include <QSplitter>
 #include <QShortcut>
 #include <QMenu>
+#include <QRegularExpressionValidator>
 
 /**
 	@brief The EditorDelegate class
@@ -69,8 +70,7 @@ class EditorDelegate : public QItemDelegate
 			if (key == QETInformation::ELMT_WIDTH || key == QETInformation::ELMT_HEIGHT || key == QETInformation::ELMT_DEPTH)
 			{
 				auto *line_edit = new QLineEdit(parent);
-				auto *validator = new QRegularExpressionValidator(
-					QETInformation::numericInfoPattern(), line_edit);
+				auto *validator = new QETInformation::NumericInfoValidator(line_edit);
 				line_edit->setValidator(validator);
 				line_edit->setPlaceholderText(tr("ex. 80.5"));
 				line_edit->setToolTip(tr("Nombre décimal avec un point comme séparateur (ex. 80.5)"));

--- a/sources/editor/ui/elementpropertieseditorwidget.cpp
+++ b/sources/editor/ui/elementpropertieseditorwidget.cpp
@@ -20,7 +20,6 @@
 #include "../../qetapp.h"
 #include "../../qetinformation.h"
 #include "ui_elementpropertieseditorwidget.h"
-#include "../../qetinformation.h"
 
 #include <QItemDelegate>
 #include <QComboBox>
@@ -67,15 +66,14 @@ class EditorDelegate : public QItemDelegate
 			const QString key = index.sibling(index.row(), 0)
 									.data(Qt::UserRole).toString();
 
-			if (key == QETInformation::ELMT_WIDTH ||
-				key == QETInformation::ELMT_HEIGHT ||
-				key == QETInformation::ELMT_DEPTH)
+			if (key == QETInformation::ELMT_WIDTH || key == QETInformation::ELMT_HEIGHT || key == QETInformation::ELMT_DEPTH)
 			{
 				auto *line_edit = new QLineEdit(parent);
-				auto *validator = new QDoubleValidator(0.0, 100000.0, 4, line_edit);
-				validator->setNotation(QDoubleValidator::StandardNotation);
-				validator->setLocale(QLocale::c());
+				auto *validator = new QRegularExpressionValidator(
+					QRegularExpression(QStringLiteral(R"(^[0-9]*\.?[0-9]{0,4}$)")), line_edit);
 				line_edit->setValidator(validator);
+				line_edit->setPlaceholderText(tr("ex. 80.5"));
+				line_edit->setToolTip(tr("Nombre décimal avec un point comme séparateur (ex. 80.5)"));
 				return line_edit;
 			}
 

--- a/sources/editor/ui/elementpropertieseditorwidget.cpp
+++ b/sources/editor/ui/elementpropertieseditorwidget.cpp
@@ -70,7 +70,7 @@ class EditorDelegate : public QItemDelegate
 			{
 				auto *line_edit = new QLineEdit(parent);
 				auto *validator = new QRegularExpressionValidator(
-					QRegularExpression(QStringLiteral(R"(^[0-9]*\.?[0-9]{0,4}$)")), line_edit);
+					QETInformation::numericInfoPattern(), line_edit);
 				line_edit->setValidator(validator);
 				line_edit->setPlaceholderText(tr("ex. 80.5"));
 				line_edit->setToolTip(tr("Nombre décimal avec un point comme séparateur (ex. 80.5)"));

--- a/sources/qetinformation.cpp
+++ b/sources/qetinformation.cpp
@@ -229,6 +229,33 @@ QRegularExpression QETInformation::numericInfoPattern()
 }
 
 /**
+	@brief QETInformation::NumericInfoValidator::NumericInfoValidator
+	@param parent
+*/
+QETInformation::NumericInfoValidator::NumericInfoValidator(QObject *parent) :
+	QRegularExpressionValidator(numericInfoPattern(), parent)
+{
+}
+
+/**
+	@brief QETInformation::NumericInfoValidator::validate
+	Rewrites any "," in @a input to "." in place, then delegates to
+	the base class for the actual numericInfoPattern() check. @a pos
+	is left untouched by the rewrite itself -- replacing "," with "."
+	never changes the string's length, so the cursor position the
+	caller already tracked stays correct.
+	@param input the text being validated; may be rewritten
+	@param pos the cursor position within @a input
+	@return the resulting validation state
+*/
+QValidator::State QETInformation::NumericInfoValidator::validate(QString &input, int &pos) const
+{
+	if (input.contains(QLatin1Char(',')))
+		input.replace(QLatin1Char(','), QLatin1Char('.'));
+	return QRegularExpressionValidator::validate(input, pos);
+}
+
+/**
  * @brief QETInformation::infoToVar
  * @param info
  * @return return the string @info prepended by %{ ans appended by }

--- a/sources/qetinformation.cpp
+++ b/sources/qetinformation.cpp
@@ -217,6 +217,18 @@ QString QETInformation::elementInfoToVar(const QString &info)
 }
 
 /**
+ * @brief QETInformation::numericInfoPattern
+ * @return the pattern used to validate numeric elementInformation
+ * fields (currently width/height/depth): digits with an optional "."
+ * as decimal separator, requiring at least one digit overall so a
+ * lone "." can never be a complete, acceptable value on its own.
+ */
+QRegularExpression QETInformation::numericInfoPattern()
+{
+	return QRegularExpression(QStringLiteral(R"(^[0-9]+\.?[0-9]{0,2}$|^[0-9]*\.[0-9]{1,2}$)"));
+}
+
+/**
  * @brief QETInformation::infoToVar
  * @param info
  * @return return the string @info prepended by %{ ans appended by }

--- a/sources/qetinformation.cpp
+++ b/sources/qetinformation.cpp
@@ -225,7 +225,7 @@ QString QETInformation::elementInfoToVar(const QString &info)
  */
 QRegularExpression QETInformation::numericInfoPattern()
 {
-	return QRegularExpression(QStringLiteral(R"(^[0-9]+\.?[0-9]{0,2}$|^[0-9]*\.[0-9]{1,2}$)"));
+	return QRegularExpression(QStringLiteral(R"(^[0-9]+$|^[0-9]*\.[0-9]{1,2}$)"));
 }
 
 /**

--- a/sources/qetinformation.cpp
+++ b/sources/qetinformation.cpp
@@ -153,7 +153,10 @@ QStringList QETInformation::elementInfoKeys()
 						 ELMT_MACHINE_MANUFACTURER_REF,
 						 ELMT_SUPPLIER,
 						 ELMT_QUANTITY,
-						 ELMT_UNITY, 
+						 ELMT_UNITY,
+						 ELMT_WIDTH,
+						 ELMT_HEIGHT,
+						 ELMT_DEPTH,
 						 ELMT_AUX1,
 						 ELMT_DESCRIPTION_AUX1,
 						 ELMT_DESIGNATION_AUX1,
@@ -268,6 +271,9 @@ QString QETInformation::translatedInfoKey(const QString &info)
 	else if (info == ELMT_SUPPLIER)                    return QObject::tr("Fournisseur");
 	else if (info == ELMT_QUANTITY)                    return QObject::tr("Quantité");
 	else if (info == ELMT_UNITY)                       return QObject::tr("Unité");
+	else if (info == ELMT_WIDTH)					   return QObject::tr("Largeur [mm]");
+	else if (info == ELMT_HEIGHT)                      return QObject::tr("Hauteur [mm]");
+	else if (info == ELMT_DEPTH)                       return QObject::tr("Profondeur [mm]");
 	else if (info == ELMT_LOCATION)                    return QObject::tr("Localisation (+)");
 	else if (info == COND_FUNCTION)                    return QObject::tr("Fonction");
 	else if (info == COND_TENSION_PROTOCOL)            return QObject::tr("Tension / Protocole");
@@ -334,6 +340,9 @@ QStringList QETInformation::elementEditorElementInfoKeys()
 						 ELMT_SUPPLIER,
 						 ELMT_QUANTITY,
 						 ELMT_UNITY,
+						 ELMT_WIDTH,
+						 ELMT_HEIGHT,
+						 ELMT_DEPTH,
 						 ELMT_AUX1,
 						 ELMT_DESCRIPTION_AUX1,
 						 ELMT_DESIGNATION_AUX1,

--- a/sources/qetinformation.h
+++ b/sources/qetinformation.h
@@ -20,6 +20,7 @@
 
 #include <QHash>
 #include <QRegularExpression>
+#include <QRegularExpressionValidator>
 #include <QStringList>
 
 /**
@@ -27,10 +28,12 @@
  * element, conductor and diagram.
  * Each information have 3 values :
  * #1 the info key = the key of an information as a QString used in the code
- * (example : label) #2 the info key to variable = the key in form of a
- * variable. This is used by the user to replace a variable by the string of
- * this variable (example : %{label}) #3 the info key translated to the current
- * local (example label in dutch = Betriebsmittelkennzeichen)
+ * (example : label)
+ * #2 the info key to variable = the key in form of a variable. This is used
+ * by the user to replace a variable by the string of this variable
+ * (example : %{label})
+ * #3 the info key translated to the current local (example label in dutch =
+ * Betriebsmittelkennzeichen)
  */
 namespace QETInformation
 {
@@ -161,6 +164,12 @@ namespace QETInformation
 	QString elementInfoToVar(const QString &info);
 
 	QRegularExpression numericInfoPattern();
+	class NumericInfoValidator : public QRegularExpressionValidator
+	{
+	public:
+		explicit NumericInfoValidator(QObject *parent = nullptr);
+		State validate(QString &input, int &pos) const override;
+	};
 
 	QStringList terminalElementInfoKeys();
 

--- a/sources/qetinformation.h
+++ b/sources/qetinformation.h
@@ -18,17 +18,19 @@
 #ifndef QETINFORMATION_H
 #define QETINFORMATION_H
 
-#include <QStringList>
 #include <QHash>
+#include <QRegularExpression>
+#include <QStringList>
 
 /**
  * Inside this namespace you will find all information used in QElectrotech for
  * element, conductor and diagram.
  * Each information have 3 values :
- * #1 the info key = the key of an information as a QString used in the code (example : label)
- * #2 the info key to variable = the key in form of a variable.
- * This is used by the user to replace a variable by the string of this variable (example : %{label})
- * #3 the info key translated to the current local (example label in dutch = Betriebsmittelkennzeichen)
+ * #1 the info key = the key of an information as a QString used in the code
+ * (example : label) #2 the info key to variable = the key in form of a
+ * variable. This is used by the user to replace a variable by the string of
+ * this variable (example : %{label}) #3 the info key translated to the current
+ * local (example label in dutch = Betriebsmittelkennzeichen)
  */
 namespace QETInformation
 {
@@ -157,6 +159,8 @@ namespace QETInformation
 	QStringList elementInfoKeys();
 	QStringList elementEditorElementInfoKeys();
 	QString elementInfoToVar(const QString &info);
+
+	QRegularExpression numericInfoPattern();
 
 	QStringList terminalElementInfoKeys();
 

--- a/sources/qetinformation.h
+++ b/sources/qetinformation.h
@@ -45,6 +45,9 @@ namespace QETInformation
 	static QString ELMT_SUPPLIER                     = "supplier";
 	static QString ELMT_QUANTITY                     = "quantity";
 	static QString ELMT_UNITY                        = "unity";
+	static QString ELMT_WIDTH						 = "width";
+	static QString ELMT_HEIGHT                       = "height";
+	static QString ELMT_DEPTH                        = "depth";
 	static QString ELMT_PLANT                        = "plant";
 	static QString ELMT_LOCATION                     = "location";
 	static QString ELMT_AUX1                         = "auxiliary1";

--- a/sources/ui/elementinfopartwidget.cpp
+++ b/sources/ui/elementinfopartwidget.cpp
@@ -47,8 +47,7 @@ ElementInfoPartWidget::ElementInfoPartWidget(
 
 	if (key_ == QETInformation::ELMT_WIDTH || key_ == QETInformation::ELMT_HEIGHT || key_ == QETInformation::ELMT_DEPTH)
 	{
-		auto *validator = new QRegularExpressionValidator(
-			QETInformation::numericInfoPattern(), ui->line_edit);
+		auto *validator = new QETInformation::NumericInfoValidator(ui->line_edit);
 		ui->line_edit->setValidator(validator);
 		ui->line_edit->setPlaceholderText(tr("ex. 80.5"));
 		ui->line_edit->setToolTip(tr("Nombre décimal avec un point comme séparateur (ex. 80.5)"));
@@ -76,6 +75,15 @@ ElementInfoPartWidget::~ElementInfoPartWidget()
 QString ElementInfoPartWidget::text() const
 {
 	return (ui->line_edit->text());
+}
+
+/**
+	@brief ElementInfoPartWidget::hasAcceptableInput
+	@return whether the line edit's current text satisfies its validator
+*/
+bool ElementInfoPartWidget::hasAcceptableInput() const
+{
+	return ui->line_edit->hasAcceptableInput();
 }
 
 /**

--- a/sources/ui/elementinfopartwidget.cpp
+++ b/sources/ui/elementinfopartwidget.cpp
@@ -45,7 +45,7 @@ ElementInfoPartWidget::ElementInfoPartWidget(
 	ui->label_->setText(translated_key);
 	ui->m_erase_text->setVisible(false);
 
-	if (key == QETInformation::ELMT_WIDTH || key == QETInformation::ELMT_HEIGHT || key == QETInformation::ELMT_DEPTH)
+	if (key_ == QETInformation::ELMT_WIDTH || key_ == QETInformation::ELMT_HEIGHT || key_ == QETInformation::ELMT_DEPTH)
 	{
 		auto *validator = new QRegularExpressionValidator(
 			QRegularExpression(QStringLiteral(R"(^[0-9]*\.?[0-9]{0,4}$)")), ui->line_edit);

--- a/sources/ui/elementinfopartwidget.cpp
+++ b/sources/ui/elementinfopartwidget.cpp
@@ -48,7 +48,7 @@ ElementInfoPartWidget::ElementInfoPartWidget(
 	if (key_ == QETInformation::ELMT_WIDTH || key_ == QETInformation::ELMT_HEIGHT || key_ == QETInformation::ELMT_DEPTH)
 	{
 		auto *validator = new QRegularExpressionValidator(
-			QRegularExpression(QStringLiteral(R"(^[0-9]*\.?[0-9]{0,4}$)")), ui->line_edit);
+			QETInformation::numericInfoPattern(), ui->line_edit);
 		ui->line_edit->setValidator(validator);
 		ui->line_edit->setPlaceholderText(tr("ex. 80.5"));
 		ui->line_edit->setToolTip(tr("Nombre décimal avec un point comme séparateur (ex. 80.5)"));

--- a/sources/ui/elementinfopartwidget.cpp
+++ b/sources/ui/elementinfopartwidget.cpp
@@ -18,7 +18,9 @@
 #include "elementinfopartwidget.h"
 
 #include "../SearchAndReplace/searchandreplaceworker.h"
+#include "../qetinformation.h"
 #include "ui_elementinfopartwidget.h"
+#include <QRegularExpressionValidator>
 
 #include <utility>
 
@@ -42,6 +44,15 @@ ElementInfoPartWidget::ElementInfoPartWidget(
 	ui->setupUi(this);
 	ui->label_->setText(translated_key);
 	ui->m_erase_text->setVisible(false);
+
+	if (key == QETInformation::ELMT_WIDTH || key == QETInformation::ELMT_HEIGHT || key == QETInformation::ELMT_DEPTH)
+	{
+		auto *validator = new QRegularExpressionValidator(
+			QRegularExpression(QStringLiteral(R"(^[0-9]*\.?[0-9]{0,4}$)")), ui->line_edit);
+		ui->line_edit->setValidator(validator);
+		ui->line_edit->setPlaceholderText(tr("ex. 80.5"));
+		ui->line_edit->setToolTip(tr("Nombre décimal avec un point comme séparateur (ex. 80.5)"));
+	}
 
 	connect(ui->line_edit, &QLineEdit::textEdited,
 		this, &ElementInfoPartWidget::textEdited);

--- a/sources/ui/elementinfopartwidget.h
+++ b/sources/ui/elementinfopartwidget.h
@@ -41,9 +41,9 @@ class ElementInfoPartWidget : public QWidget
 			QWidget *parent = nullptr);
 		~ElementInfoPartWidget() override;
 
-		QString key () const
-{return key_;}
+		QString key () const {return key_;}
 		QString text () const;
+		bool hasAcceptableInput() const;
 		void setText (const QString &);
 		void setPlaceHolderText (const QString &text);
 		void setFocusTolineEdit();

--- a/sources/ui/elementinfowidget.cpp
+++ b/sources/ui/elementinfowidget.cpp
@@ -387,6 +387,9 @@ DiagramContext ElementInfoWidget::currentInfo() const
 
 	for (const auto &eipw : std::as_const(m_eipw_list))
 	{
+		if (!eipw->hasAcceptableInput())
+			continue;
+
 		//add value only if they're something to store
 		if (!eipw->text().isEmpty())
 		{


### PR DESCRIPTION
First step towards #410 (panel layout / disposition drawing support) —
see my comment there for the full proposal. Splitting the work into
small, independently useful pieces; this one just adds the data model.

## What this adds

Three new elementInformation keys: `width`, `height`, `depth`, all in
mm. Same pattern as the existing manufacturer/manufacturer_reference
fields — set once per element definition, since physical dimensions
belong to the device type, not the placed instance.

## Validation

Input is restricted to plain decimal numbers in both places these
fields are edited: the information tree's `EditorDelegate`
(`elementpropertieseditorwidget.cpp`, which already special-cases
column 1 for inline editing) and the selection properties dock
(`ElementInfoPartWidget`, used when editing a placed instance).

Validation is a `QRegularExpressionValidator` against
`QETInformation::numericInfoPattern()`, shared by both call sites:
digits with an optional "." as decimal separator, at least one digit
required overall so a lone "." can't be committed as a value, up to 2
decimal places. Using a fixed pattern rather than `QDoubleValidator`
sidesteps locale entirely — "." is a literal character in the regex,
not something Qt substitutes based on the UI language — so any later
consumer doing math with these values gets a single, predictable
format to parse without locale handling.

## Scope

Deliberately minimal:
- No UI beyond the existing information tree and selection properties
  dock — no new dialog.
- No unit conversion / unit picker — mm is a fixed convention for now,
  documented in the field label ("Largeur [mm]" etc.) rather than
  stored as separate data. See the discussion on #410 for why a
  per-element unit field was intentionally left out at this stage.
- No consumer of these values yet — that's the disposition editor
  itself, proposed as follow-up work.

## Testing

Verified on Ubuntu 24, Qt 5 builds: fields appear
correctly labelled in both the element editor's information tree and
the selection properties dock, non-numeric input (including a lone
".") is rejected at the keystroke level in both, and values round-trip
correctly through save/reload:

```xml
<elementInformation name="width" show="1">80</elementInformation>
<elementInformation name="height" show="1">119.8</elementInformation>
<elementInformation name="depth" show="1">71.5</elementInformation>
```