### PR TITLE
Fix PDF export truncating project filenames at the first dot

### DIFF
--- a/sources/print/projectprintwindow.cpp
+++ b/sources/print/projectprintwindow.cpp
@@ -108,7 +108,7 @@ QString ProjectPrintWindow::docName(QETProject *project)
 {
 	QString doc_name;
 	if (!project->filePath().isEmpty()) {
-		doc_name = QFileInfo(project->filePath()).baseName();
+		doc_name = QFileInfo(project->filePath()).completeBaseName();
 	} else if (!project->title().isEmpty()) {
 		doc_name = project->title();
 		doc_name = QET::stringToFileName(doc_name);


### PR DESCRIPTION
Fixes the bug reported on the forum: https://qelectrotech.org/forum/viewtopic.php?id=3005

## Problem

A project named e.g. `Mon_projet.avec_un_point.qet` exported to PDF as `Mon_projet.pdf` — everything after the first `.` in the filename was silently dropped. Reporter's exact words: *"if the name is for example 'Mon_projet.avec_un_point.qet' it is exported to PDF as 'Mon_projet.pdf'"*.

## Root cause

`ProjectPrintWindow::docName()` (`sources/print/projectprintwindow.cpp:111`) used `QFileInfo::baseName()`, which returns the filename up to the **first** `.` rather than stripping only the final suffix. `docName()` feeds both the PDF print job's `setOutputFileName()` and the `QFileDialog::getSaveFileName` default in `exportToPDF()`, so the truncation showed up as the actual exported file's name, not just a dialog suggestion.

`sources/exportdialog.cpp`'s SVG/PNG/DXF export path already uses the correct `QFileInfo::completeBaseName()` (strips only the last suffix) — this fix brings the PDF/print path in line with that existing, correct pattern already used elsewhere in the codebase, rather than introducing a new approach.

## Fix

One-line change: `.baseName()` → `.completeBaseName()`.

## Testing

Verified the exact before/after behavior with a standalone `QFileInfo` test:
- `baseName()` on `"Mon_projet.avec_un_point.qet"` → `"Mon_projet"` (the bug)
- `completeBaseName()` on the same input → `"Mon_projet.avec_un_point"` (correct)

Clean incremental build, no new warnings/errors.