### PR TITLE
Fix bugtracker #333: selecting several dynamic texts overwrites their colours

### DIFF
--- a/sources/editor/ui/dynamictextfieldeditor.cpp
+++ b/sources/editor/ui/dynamictextfieldeditor.cpp
@@ -31,6 +31,7 @@
 #include <QColorDialog>
 #include <QGraphicsItem>
 #include <QPointer>
+#include <QSignalBlocker>
 
 DynamicTextFieldEditor::DynamicTextFieldEditor(QETElementEditor *editor,
 											   PartDynamicTextField *text_field,
@@ -143,7 +144,18 @@ void DynamicTextFieldEditor::updateForm()
 		ui->m_rotation_point_center_cb->setChecked(m_text_field.data()->rotationPointCenter());
 #ifdef BUILD_WITHOUT_KF5
 #else
-		m_color_kpb -> setColor(m_text_field.data() -> color());
+			//Block signals while loading the colour into the button.
+			//KColorButton::changed fires on a programmatic setColor() as well
+			//as on user interaction, and m_color_kpb_changed() applies the new
+			//colour to *every* selected part -- so merely showing the first
+			//part's colour would overwrite the colour of all the others.
+			//The other widgets above are immune because they are wired to
+			//user-only signals (editingFinished, clicked), which setValue()
+			//and setChecked() do not emit.
+		{
+			const QSignalBlocker blocker(m_color_kpb);
+			m_color_kpb -> setColor(m_text_field.data() -> color());
+		}
 #endif
 		ui -> m_width_sb -> setValue(m_text_field.data() -> textWidth());
 		ui -> m_font_pb -> setText(m_text_field -> font().family());


### PR DESCRIPTION
Fixes <https://qelectrotech.org/bugtracker/view.php?id=333>.

## The bug

Selecting more than one dynamic text field in the element editor silently replaces every selected field's colour with the colour of the first one. Nothing is clicked — merely extending the selection destroys the other fields' colours, and the change is pushed onto the undo stack as if the user had asked for it.

## Cause

`DynamicTextFieldEditor::updateForm()` loads the current part's colour into the colour button:

```cpp
m_color_kpb -> setColor(m_text_field.data() -> color());
```

`KColorButton::changed` is emitted for a programmatic `setColor()` exactly as it is for user interaction, and it is connected to `m_color_kpb_changed()`, which applies the new colour to **every** part in `m_parts`. So simply *displaying* the first part's colour writes that colour to all the others.

Every other widget in `updateForm()` is immune, because each is wired to a user-only signal — `on_m_x_sb_editingFinished()`, `on_m_frame_cb_clicked()` — and `setValue()` / `setChecked()` do not emit those. The colour button is the one control whose signal cannot distinguish "user picked a colour" from "the form is being populated".

This also explains the reporter's observation that it happened when rubber-band selecting bottom-to-top but not top-to-bottom: the write only occurs when the first part's colour differs from what the button already shows, which depends on selection order.

## The fix

Block the button's signals while loading the value, so the form can display a colour without writing it back. One statement, and it restores the convention the rest of the function already follows.

## Testing

Element editor, with an element containing two dynamic texts — one red, one blue:

1. **Before the fix** — select the red text, then ctrl-click the blue text: the blue text turns red. Reproduced on screen.
2. **After the fix** — same sequence: both keep their colours.
3. **Regression** — with both texts selected, deliberately choosing a new colour with the button still applies it to all selected texts, as intended.

Built against Qt 5.15, Release, no new warnings.
