### PR TITLE
Fix print window clipping diagram when titleblock on right edge is hidden

### DIFF
--- a/sources/bordertitleblock.h
+++ b/sources/bordertitleblock.h
@@ -73,7 +73,7 @@ class BorderTitleBlock : public QObject
 			return(rows_count_ * rows_height_); }
 		/// @return la rows header width, in pixels
 		qreal rowsHeaderWidth() const { return(rows_header_width_); }
-		// @return the edge where title block is docked
+		/// @return the edge where title block is docked
 		Qt::Edge titleBlockEdge() const { return(m_edge); }
 	
 		// border - title block = diagram

--- a/sources/bordertitleblock.h
+++ b/sources/bordertitleblock.h
@@ -94,6 +94,9 @@ class BorderTitleBlock : public QObject
 
 		QRectF titleBlockRect () const;
 
+                // @return the edge where title block is docked
+                Qt::Edge titleBlockEdge() const { return(m_edge); }
+
 		DiagramContext titleblockInformation() const;
 	private:
 		QRectF titleBlockRectForQPainter () const;

--- a/sources/bordertitleblock.h
+++ b/sources/bordertitleblock.h
@@ -73,6 +73,8 @@ class BorderTitleBlock : public QObject
 			return(rows_count_ * rows_height_); }
 		/// @return la rows header width, in pixels
 		qreal rowsHeaderWidth() const { return(rows_header_width_); }
+		// @return the edge where title block is docked
+		Qt::Edge titleBlockEdge() const { return(m_edge); }
 	
 		// border - title block = diagram
 		/**
@@ -93,9 +95,6 @@ class BorderTitleBlock : public QObject
 			return(rowsTotalHeight() + columnsHeaderHeight()); }
 
 		QRectF titleBlockRect () const;
-
-                // @return the edge where title block is docked
-                Qt::Edge titleBlockEdge() const { return(m_edge); }
 
 		DiagramContext titleblockInformation() const;
 	private:

--- a/sources/print/projectprintwindow.cpp
+++ b/sources/print/projectprintwindow.cpp
@@ -450,9 +450,13 @@ QRect ProjectPrintWindow::diagramRect(Diagram *diagram, const ExportProperties &
 {
 	auto diagram_rect = diagram->border_and_titleblock.borderAndTitleBlockRect();
 	if (!option.draw_titleblock) {
-		auto titleblock_height = diagram->border_and_titleblock.titleBlockRect().height();
-		diagram_rect.setHeight(diagram_rect.height() - titleblock_height);
-	}
+                auto tbt_rect = diagram->border_and_titleblock.titleBlockRect();
+                if (diagram->border_and_titleblock.titleBlockEdge() == Qt::BottomEdge)
+                        diagram_rect.setHeight(diagram_rect.height() - tbt_rect.height());
+                else
+                        diagram_rect.setWidth(diagram_rect.width() - tbt_rect.width());
+        }
+
 
 		//Adjust the border of diagram to 1px (width of the line)
 	diagram_rect.adjust(0,0,1,1);

--- a/sources/print/projectprintwindow.cpp
+++ b/sources/print/projectprintwindow.cpp
@@ -450,12 +450,12 @@ QRect ProjectPrintWindow::diagramRect(Diagram *diagram, const ExportProperties &
 {
 	auto diagram_rect = diagram->border_and_titleblock.borderAndTitleBlockRect();
 	if (!option.draw_titleblock) {
-			auto tbt_rect = diagram->border_and_titleblock.titleBlockRect();
-			if (diagram->border_and_titleblock.titleBlockEdge() == Qt::BottomEdge)
-					diagram_rect.setHeight(diagram_rect.height() - tbt_rect.height());
-			else
-					diagram_rect.setWidth(diagram_rect.width() - tbt_rect.width());
-        }
+		auto titleblock_rect = diagram->border_and_titleblock.titleBlockRect();
+		if (diagram->border_and_titleblock.titleBlockEdge() == Qt::BottomEdge)
+			diagram_rect.setHeight(diagram_rect.height() - titleblock_rect.height());
+		else
+			diagram_rect.setWidth(diagram_rect.width() - titleblock_rect.width());
+	}
 
 		//Adjust the border of diagram to 1px (width of the line)
 	diagram_rect.adjust(0,0,1,1);

--- a/sources/print/projectprintwindow.cpp
+++ b/sources/print/projectprintwindow.cpp
@@ -450,13 +450,12 @@ QRect ProjectPrintWindow::diagramRect(Diagram *diagram, const ExportProperties &
 {
 	auto diagram_rect = diagram->border_and_titleblock.borderAndTitleBlockRect();
 	if (!option.draw_titleblock) {
-                auto tbt_rect = diagram->border_and_titleblock.titleBlockRect();
-                if (diagram->border_and_titleblock.titleBlockEdge() == Qt::BottomEdge)
-                        diagram_rect.setHeight(diagram_rect.height() - tbt_rect.height());
-                else
-                        diagram_rect.setWidth(diagram_rect.width() - tbt_rect.width());
+			auto tbt_rect = diagram->border_and_titleblock.titleBlockRect();
+			if (diagram->border_and_titleblock.titleBlockEdge() == Qt::BottomEdge)
+					diagram_rect.setHeight(diagram_rect.height() - tbt_rect.height());
+			else
+					diagram_rect.setWidth(diagram_rect.width() - tbt_rect.width());
         }
-
 
 		//Adjust the border of diagram to 1px (width of the line)
 	diagram_rect.adjust(0,0,1,1);


### PR DESCRIPTION
When the titleblock is docked on the right edge, diagramRect() always
subtracted titleBlockRect().height() from the printable height. For a
right-edge titleblock this height equals the full diagram height, so the
print area collapsed to zero and the schematic vanished, leaving only the
border and column/row headers.

Query the docked edge via BorderTitleBlock::titleBlockEdge() and subtract
the dimension that actually carries the titleblock extension: height for a
bottom-edge titleblock, width for a right-edge one.