### PR TITLE
Fix bugtracker #248: files passed to a running instance are never opened

### DIFF
--- a/sources/qet.cpp
+++ b/sources/qet.cpp
@@ -544,23 +544,51 @@ QString QET::joinWithSpaces(const QStringList &string_list) {
 	@return La liste des sous-chaines, sans echappement.
 */
 QStringList QET::splitWithSpaces(const QString &string) {
-	// les chaines sont separees par des espaces non echappes
-	// = avec un nombre nul ou pair de backslashes devant
-#if TODO_LIST
-#pragma message("@TODO remove code for QT 5.14 or later")
-#endif
-	QStringList escaped_strings = string.split(QRegularExpression("[^\\]?(?:\\\\)* "),
-#if QT_VERSION < QT_VERSION_CHECK(5, 14, 0)	// ### Qt 6: remove
-						   QString
-#else
-						   Qt
-#endif
-						   ::SkipEmptyParts);
-
+		// Substrings are separated by unescaped spaces; spaces belonging to a
+		// substring are escaped by joinWithSpaces()/escapeSpaces(), which also
+		// escapes the backslash itself. Scanning explicitly rather than
+		// splitting on a regular expression: the previous pattern,
+		// "[^\\]?(?:\\\\)* ", contained an unterminated character class
+		// ("[^\\]" escapes the closing bracket), so QRegularExpression
+		// rejected it as invalid and QString::split() returned an empty list
+		// for *every* input -- silently discarding the file names it was
+		// given.
 	QStringList returned_list;
-	foreach(QString escaped_string, escaped_strings) {
-		returned_list << QET::unescapeSpaces(escaped_string);
+	QString current;
+	bool in_token = false;
+	bool escaped = false;
+
+	for (const QChar &c : string) {
+		if (escaped) {
+				//Whatever follows a backslash is taken literally, so an
+				//escaped space stays inside the current substring.
+			current += c;
+			in_token = true;
+			escaped = false;
+		} else if (c == QLatin1Char('\\')) {
+			escaped = true;
+		} else if (c == QLatin1Char(' ')) {
+			if (in_token) {
+				returned_list << current;
+				current.clear();
+				in_token = false;
+			}
+		} else {
+			current += c;
+			in_token = true;
+		}
 	}
+
+		//A lone trailing backslash is not a valid escape: keep it verbatim
+		//rather than dropping a character.
+	if (escaped) {
+		current += QLatin1Char('\\');
+		in_token = true;
+	}
+	if (in_token) {
+		returned_list << current;
+	}
+
 	return(returned_list);
 }
 

--- a/sources/qetapp.cpp
+++ b/sources/qetapp.cpp
@@ -16,6 +16,7 @@
 	along with QElectroTech.  If not, see <http://www.gnu.org/licenses/>.
 */
 #include "qetapp.h"
+#include <QTimer>
 
 #include "configdialog.h"
 #include "ui/configpage/configpages.h"
@@ -1634,8 +1635,19 @@ void QETApp::receiveMessage(int instanceId, QByteArray message)
 	if (str.startsWith("launched-with-args: "))
 	{
 		QString my_message(str.mid(20));
-		QStringList args_list = QET::splitWithSpaces(my_message);
-		openFiles(QETArguments(args_list));
+		const QStringList args_list = QET::splitWithSpaces(my_message);
+
+			//Deferred on purpose. This slot is invoked straight from the
+			//QLocalSocket readyRead handler that carried the message, and
+			//opening a project spins nested event loops of its own (the
+			//"please wait" dialog, then the backup prompt). Doing that work
+			//here means unwinding back into Qt's socket code long after it
+			//expected us to return, which crashes in
+			//QIODevice::channelReadyRead(). Hand the files to the event loop
+			//instead, so the socket handler completes first.
+		QTimer::singleShot(0, this, [this, args_list]() {
+			openFiles(QETArguments(args_list));
+		});
 	}
 }
 


### PR DESCRIPTION
Fixes <https://qelectrotech.org/bugtracker/view.php?id=248>.

## The bug

Opening a project while QElectroTech is already running does nothing at all. The second process hands its file names to the first one and exits; the first one silently discards them.

The report describes this as happening with spaces in the path, but it turns out not to be limited to that — **no file ever arrives, whatever it is called**. Spaces are just how the reporter happened to notice.

There are two defects on that path, and they have to be fixed together.

## 1. `QET::splitWithSpaces()` never returned anything

It split on `"[^\\]?(?:\\\\)* "`, which as a regular expression is `[^\]?(?:\\)* `. The character class is unterminated — `[^\]` escapes the closing bracket instead of closing the class — so `QRegularExpression` rejects the whole pattern and `QString::split()` returns an **empty list for every input**. Qt has been saying so on stderr all along, once per attempt:

```
QString::split: invalid QRegularExpression object
```

With an empty argument list, `QETArguments` finds no project files and `openFiles()` has nothing to do.

Replaced with an explicit scan that mirrors `joinWithSpaces()` / `escapeSpaces()`: a backslash escapes the next character, an unescaped space separates arguments. No regular expression, so there is nothing to silently get wrong.

## 2. Opening the files from the socket handler crashes

With (1) fixed the files arrive — and QElectroTech segfaults:

```
#1  QIODevice::channelReadyRead(int)
#2  libQt5Network                     <- QLocalSocket read handler
#13 main
```

`QETApp::receiveMessage()` is invoked directly from the `QLocalSocket` `readyRead` handler that carried the message, and opening a project runs nested event loops of its own (the "please wait" dialog, then the backup prompt). Unwinding back into Qt's socket code long afterwards is what crashes.

The open is now deferred to the event loop, so the socket handler completes first.

Fixing only (1) would have traded a silent failure for a crash, which is why both are in one commit.

## Testing

With a project already open, sending a second file to the running instance:

| Case | Before | After |
|---|---|---|
| Path with spaces (`/tmp/qet space dir/my test.qet`) | nothing happens | opens |
| Path without spaces | nothing happens | opens |
| Two files at once, one with spaces | nothing happens | both open |
| Crash on the backup prompt afterwards | n/a (unreachable) | no crash |

No `invalid QRegularExpression` warnings remain. Built against Qt 5.15, Release, no new warnings.

## Note

This also means the single-instance file hand-off has been dead for some time, so anything relying on it (desktop file association, `xdg-open`, passing a file while QET is open) has been silently doing nothing.
