### PR TITLE
Don't drop files handed to a starting instance while the backup prompts are up

### DIFF
--- a/sources/qet.cpp
+++ b/sources/qet.cpp
@@ -544,23 +544,51 @@ QString QET::joinWithSpaces(const QStringList &string_list) {
 	@return La liste des sous-chaines, sans echappement.
 */
 QStringList QET::splitWithSpaces(const QString &string) {
-	// les chaines sont separees par des espaces non echappes
-	// = avec un nombre nul ou pair de backslashes devant
-#if TODO_LIST
-#pragma message("@TODO remove code for QT 5.14 or later")
-#endif
-	QStringList escaped_strings = string.split(QRegularExpression("[^\\]?(?:\\\\)* "),
-#if QT_VERSION < QT_VERSION_CHECK(5, 14, 0)	// ### Qt 6: remove
-						   QString
-#else
-						   Qt
-#endif
-						   ::SkipEmptyParts);
-
+		// Substrings are separated by unescaped spaces; spaces belonging to a
+		// substring are escaped by joinWithSpaces()/escapeSpaces(), which also
+		// escapes the backslash itself. Scanning explicitly rather than
+		// splitting on a regular expression: the previous pattern,
+		// "[^\\]?(?:\\\\)* ", contained an unterminated character class
+		// ("[^\\]" escapes the closing bracket), so QRegularExpression
+		// rejected it as invalid and QString::split() returned an empty list
+		// for *every* input -- silently discarding the file names it was
+		// given.
 	QStringList returned_list;
-	foreach(QString escaped_string, escaped_strings) {
-		returned_list << QET::unescapeSpaces(escaped_string);
+	QString current;
+	bool in_token = false;
+	bool escaped = false;
+
+	for (const QChar &c : string) {
+		if (escaped) {
+				//Whatever follows a backslash is taken literally, so an
+				//escaped space stays inside the current substring.
+			current += c;
+			in_token = true;
+			escaped = false;
+		} else if (c == QLatin1Char('\\')) {
+			escaped = true;
+		} else if (c == QLatin1Char(' ')) {
+			if (in_token) {
+				returned_list << current;
+				current.clear();
+				in_token = false;
+			}
+		} else {
+			current += c;
+			in_token = true;
+		}
 	}
+
+		//A lone trailing backslash is not a valid escape: keep it verbatim
+		//rather than dropping a character.
+	if (escaped) {
+		current += QLatin1Char('\\');
+		in_token = true;
+	}
+	if (in_token) {
+		returned_list << current;
+	}
+
 	return(returned_list);
 }
 

--- a/sources/qetapp.cpp
+++ b/sources/qetapp.cpp
@@ -16,6 +16,7 @@
 	along with QElectroTech.  If not, see <http://www.gnu.org/licenses/>.
 */
 #include "qetapp.h"
+#include <QTimer>
 
 #include "configdialog.h"
 #include "ui/configpage/configpages.h"
@@ -1634,8 +1635,19 @@ void QETApp::receiveMessage(int instanceId, QByteArray message)
 	if (str.startsWith("launched-with-args: "))
 	{
 		QString my_message(str.mid(20));
-		QStringList args_list = QET::splitWithSpaces(my_message);
-		openFiles(QETArguments(args_list));
+		const QStringList args_list = QET::splitWithSpaces(my_message);
+
+			//Deferred on purpose. This slot is invoked straight from the
+			//QLocalSocket readyRead handler that carried the message, and
+			//opening a project spins nested event loops of its own (the
+			//"please wait" dialog, then the backup prompt). Doing that work
+			//here means unwinding back into Qt's socket code long after it
+			//expected us to return, which crashes in
+			//QIODevice::channelReadyRead(). Hand the files to the event loop
+			//instead, so the socket handler completes first.
+		QTimer::singleShot(0, this, [this, args_list]() {
+			openFiles(QETArguments(args_list));
+		});
 	}
 }
 

--- a/sources/qetapp.cpp
+++ b/sources/qetapp.cpp
@@ -161,7 +161,16 @@ QETApp::QETApp() :
 		m_splash_screen -> hide();
 	}
 
-	checkBackupFiles();
+		//Deferred so this constructor returns before the prompts appear.
+		//checkBackupFiles() opens modal dialogs, and main() still has work to
+		//do once we return -- in particular connecting
+		//SingleApplication::receivedMessage to receiveMessage(). While those
+		//prompts were up that connection did not exist yet, so a file handed
+		//to the already-running instance during start-up was accepted by the
+		//socket and then dropped on the floor.
+	QMetaObject::invokeMethod(this, [this]() {
+		checkBackupFiles();
+	}, Qt::QueuedConnection);
 }
 
 /**


### PR DESCRIPTION
> **Depends on #728.** This branch is built on top of it, so the diff shown here includes that commit. Review #728 first; this PR adds one commit on top (`sources/qetapp.cpp`, +10/-1).

## The bug

`QETApp`'s constructor ends with `checkBackupFiles()`, which opens modal dialogs — the "restore these files?" prompt, and the crash-report offer. Those dialogs run their own event loop, so **the constructor does not return until the user answers them**.

`main()` still has work to do at that point. In particular, a few lines later:

```cpp
QObject::connect(&app, &SingleApplication::receivedMessage,
                 &qetapp, &QETApp::receiveMessage);
```

While the prompts are up, that connection does not exist yet. A second instance launched during that window — double-clicking a project, or `xdg-open`, while the first copy is still asking about restore files — hands its file names over, SingleApplication accepts and delivers them, and **nothing is listening**. The message is discarded, the second process has already exited, and the file is silently lost.

## The fix

Defer `checkBackupFiles()` to the event loop so the constructor returns promptly. `main()` finishes wiring up, and the prompts appear immediately afterwards exactly as before. `checkBackupFiles()` is called from this one place only.

## Testing

With a stale restore file present, sending a project to the running instance *while the restore prompt is displayed*:

| | Before | After |
|---|---|---|
| File sent during the prompt | dropped — never appeared, even after answering the prompt | opens |
| Restore prompt still shown and working | yes | yes |
| Backup prompt still shown and working | yes | yes |

Built against Qt 5.15, Release, no new warnings.

## Why it is separate from #728

This is only *observable* once #728 is in — before that, no file passed to a running instance was opened under any circumstances, so the window described here was invisible. They are independent defects on the same path, kept as separate commits.
