### PR TITLE
Fix bugtracker #238: summary lists folios in the wrong order

### DIFF
--- a/sources/dataBase/ui/summaryquerywidget.cpp
+++ b/sources/dataBase/ui/summaryquerywidget.cpp
@@ -60,28 +60,18 @@ QString SummaryQueryWidget::queryStr() const
 	}
 
 		//Made a string list with the columns (keys) choosen by the user
-	QStringList keys = selectedKeys();
+	const QString column = selectedKeys().join(QStringLiteral(", "));
 
-	QString select ="SELECT ";
-	QString order_by = " ORDER BY ";
-
-	QString column;
-	bool first = true;
-	for (auto key: keys) {
-		if (first) {
-			first = false;
-		} else {
-			column += ", ";
-			order_by +=", ";
-		}
-		column += key;
-		order_by += key;
-	}
-
-	QString from = " FROM project_summary_view";
-
-	QString q(select + column + from + order_by);
-	return q;
+		//Order by the folio's position in the project, never by the displayed
+		//columns. This is a summary -- a table of contents -- so its rows have
+		//to follow the page order. The ORDER BY used to be built from the same
+		//loop as the column list, so the folios came out sorted by whichever
+		//column happened to be first in the list (the title, normally), and
+		//"pos" only took part at all if the user had added the Position column
+		//to the display. There is no sort control in this widget, so that
+		//coupling was not something the user could correct.
+	return QStringLiteral("SELECT ") + column
+			+ QStringLiteral(" FROM project_summary_view ORDER BY pos");
 }
 
 /**


### PR DESCRIPTION
Fixes <https://qelectrotech.org/bugtracker/view.php?id=238>.

## The bug

A project summary is a table of contents, so its rows have to follow the page order. They don't: the folios come out sorted alphabetically by whichever column happens to be first in the table — normally the title.

## Cause

`SummaryQueryWidget::queryStr()` built the `ORDER BY` clause inside the same loop that built the column list, so the two were always identical:

```sql
SELECT title, author FROM project_summary_view ORDER BY title, author
```

The folio's position in the project (the view's `pos` column) only took part in the ordering at all if the user happened to add the **Position** column to the *displayed* columns — and even then only as the first sort key if they moved it to the top.

There is no sort control anywhere in this widget. The only list it offers reorders *displayed* columns, so this was not something a user could correct.

## The fix

Order by `pos`. A user who wants something else can still write their own statement with the **Requête SQL** option, which this doesn't touch.

`setQuery()`, which rebuilds the widget state from a stored query, only parses between `SELECT` and `FROM` and ignores the `ORDER BY` entirely — so saved summary configurations keep working.

## Testing

Two-folio project whose titles sort the opposite way to the pages: **"Zebra" on page 1, "Alpha" on page 2**.

The dialog's SQL preview shows the generated statement directly:

| | generated query |
|---|---|
| before | `SELECT title FROM project_summary_view ORDER BY title` |
| after | `SELECT title, author FROM project_summary_view ORDER BY pos` |

And against that data, the old clause returns the pages in the wrong order:

```
page order in the project:  Zebra(1), Alpha(2), Middle(3)

ORDER BY title  ->  Alpha, Middle, Zebra      <- what a summary showed
ORDER BY pos    ->  Zebra, Alpha, Middle      <- the actual page order
```

Built against Qt 5.15, Release, no new warnings.
