### PR TITLE
Fix folio report link picker showing candidates as blank rows

### DIFF
--- a/sources/ui/linksingleelementwidget.cpp
+++ b/sources/ui/linksingleelementwidget.cpp
@@ -85,7 +85,7 @@ LinkSingleElementWidget::LinkSingleElementWidget(Element *elmt,
 		
 		const auto elmt_type{this->m_element->elementData().m_type};
 		if (elmt_type & ElementData::AllReport)
-			settings.setValue(QStringLiteral("link-element-widget/report-state"), qba);
+			settings.setValue(QStringLiteral("link-element-widget/report-state-2"), qba);
 		else if (elmt_type == ElementData::Slave)
 			settings.setValue(QStringLiteral("link-element-widget/slave-state"), qba);
 	});
@@ -304,6 +304,30 @@ void LinkSingleElementWidget::buildTree()
 			QStringList search_list;
 			QStringList str_list;
 			
+				//The folio of the candidate is what identifies it, so it comes first.
+				//The conductor properties below are empty whenever the candidate has
+				//no conductor attached yet, which would otherwise leave the row blank.
+			if (Diagram *diag = elmt->diagram())
+			{
+				if (settings.value(QStringLiteral("genericpanel/folio"), false).toBool())
+				{
+					autonum::sequentialNumbers seq;
+					QString F =autonum::AssignVariables::formulaToLabel(diag->border_and_titleblock.folio(), seq, diag, elmt);
+					str_list << F;
+				}
+				else
+				{
+					str_list << QString::number(diag->folioIndex() + 1);
+				}
+				str_list << diag->convertPosition(elmt->scenePos()).toString();
+				str_list << diag->title();
+			}
+			else
+			{
+				qDebug() << "In method void LinkSingleElementWidget::updateUi(), provided element must be in a diagram";
+				str_list << "" << "" << "";
+			}
+
 			if (!elmt->conductors().isEmpty())
 			{
 				ConductorProperties cp = elmt->conductors().first()->properties();
@@ -325,34 +349,14 @@ void LinkSingleElementWidget::buildTree()
 			}
 			else
 				str_list << "" << "" << "" << "" << "";
-			
-			if (Diagram *diag = elmt->diagram())
-			{
-				if (settings.value(QStringLiteral("genericpanel/folio"), false).toBool())
-				{
-					autonum::sequentialNumbers seq;
-					QString F =autonum::AssignVariables::formulaToLabel(diag->border_and_titleblock.folio(), seq, diag, elmt);
-					str_list << F;
-				}
-				else
-				{
-					str_list << QString::number(diag->folioIndex() + 1);
-				}
-				str_list << diag->convertPosition(elmt->scenePos()).toString();
-				str_list << diag->title();
-			}
-			else
-			{
-				qDebug() << "In method void LinkSingleElementWidget::updateUi(), provided element must be in a diagram";
-			}
-			
+
 			QTreeWidgetItem *qtwi = new QTreeWidgetItem(ui->m_tree_widget, str_list);
 			m_qtwi_elmt_hash.insert(qtwi, elmt);
 			m_qtwi_strl_hash.insert(qtwi, search_list);
 		}
 		
 		QSettings settings;
-		QVariant v = settings.value(QStringLiteral("link-element-widget/report-state"));
+		QVariant v = settings.value(QStringLiteral("link-element-widget/report-state-2"));
 		if(!v.isNull())
 			ui->m_tree_widget->header()->restoreState(v.toByteArray());
 	}
@@ -491,25 +495,25 @@ void LinkSingleElementWidget::setUpHeaderLabels()
 	{
 		if (settings.value(QStringLiteral("genericpanel/folio"), false).toBool())
 		{
-			list << tr("N° de fil")
+			list << tr("Label de folio")
+			     << tr("Position")
+			     << tr("Titre de folio")
+			     << tr("N° de fil")
 			     << tr("Fonction")
 			     << tr("Tension / Protocole")
 			     << tr("Couleur du conducteur")
-			     << tr("Section du conducteur")
-			     << tr("Label de folio")
-			     << tr("Position")
-			     << tr("Titre de folio");
+			     << tr("Section du conducteur");
 		}
 		else
 		{
-			list << tr("N° de fil")
+			list << tr("N° de folio")
+			     << tr("Position")
+			     << tr("Titre de folio")
+			     << tr("N° de fil")
 			     << tr("Fonction")
 			     << tr("Tension / Protocole")
 			     << tr("Couleur du conducteur")
-			     << tr("Section du conducteur")
-			     << tr("N° de folio")
-			     << tr("Position")
-			     << tr("Titre de folio");
+			     << tr("Section du conducteur");
 		}
 	}
 	


### PR DESCRIPTION
Fixes #735.

### Problem

In a report arrow's **Report de folio** tab, a valid candidate arrow was drawn as a completely blank row. The list looked empty, so cross-folio linking appeared impossible — the row was actually there and became visible only once clicked.

`buildTree()` found the candidate correctly (confirmed with temporary instrumentation: `buildTree got 1 candidates` while the UI showed nothing). The cause was purely column order: the `AllReport` branch listed five **conductor** properties first, and `buildTree()` fills all five with empty strings when the candidate has no conductor attached — a perfectly normal state for a freshly placed report arrow. The three columns that identify the candidate (folio, position, folio title) came last and sat off-screen past the horizontal scrollbar.

### Change

Identifying columns first, conductor properties after — matching the `Slave` branch, which already leads with `actualLabel()` and so never shows a blank row.

Two smaller points in the same commit:

- when the candidate has no diagram, three empty strings are appended so the columns stay aligned with the headers instead of shifting left (previously the row was short by three cells);
- the saved header state key becomes `report-state-2`, so a state saved under the old column order isn't restored onto the new one and re-hiding the now-leading columns.

No new translatable strings — the same `tr()` literals, reordered.

### Testing

Built and exercised under Xvfb using the two custom arrow elements attached to bugtracker #256 (`01going_arrow_with_protocol.elmt` / `02coming_arrow.elmt`), with no conductors attached — the case that produced the blank row:

- **Before:** header shown, list visually empty; clicking the blank strip highlighted an invisible row.
- **After:** the row reads `Label de folio: 2/2 | Position: D6`.
- Linking still works end to end — right-click → *Lier l'élément* → Apply, after which the coming arrow's composite text resolves to `2-D6 / ` as expected.

Only the `AllReport` branch is touched; the `Slave` picker is unchanged.