### PR TITLE
Fix headless CLI hanging forever on version-incompatible projects

### DIFF
--- a/sources/main.cpp
+++ b/sources/main.cpp
@@ -249,6 +249,10 @@ QGuiApplication::setHighDpiScaleFactorRoundingPolicy(QetSettings::hdpiScaleFacto
 			// runs on a background thread referencing the project and races the
 			// process exit (intermittent segfault in QET::writeToFile).
 			QETProject::setBackupEnabled(false);
+			// No blocking prompts either: readProjectXml() asks the user what
+			// to do about version-incompatible projects, and with nobody to
+			// answer, the modal hangs the process instead of exporting.
+			QETProject::setInteractive(false);
 			return CLIExport::run(export_app.arguments());
 		}
 	}

--- a/sources/qetproject.cpp
+++ b/sources/qetproject.cpp
@@ -46,10 +46,16 @@
 static int BACKUP_INTERVAL = 1200000; //interval in ms of backup = 20min
 
 bool QETProject::m_backup_enabled = true;
+bool QETProject::m_interactive = true;
 
 void QETProject::setBackupEnabled(bool enabled)
 {
 	m_backup_enabled = enabled;
+}
+
+void QETProject::setInteractive(bool interactive)
+{
+	m_interactive = interactive;
 }
 
 /**
@@ -1439,7 +1445,19 @@ void QETProject::readProjectXml(QDomDocument &xml_project)
 		m_project_qet_version = QetVersion::fromXmlAttribute(root_elmt);
 		if (!m_project_qet_version.isNull())
 		{
-			if (QetVersion::currentVersion() < m_project_qet_version)
+			if (QetVersion::currentVersion() < m_project_qet_version
+				&& !m_interactive)
+			{
+					//Nobody can answer a modal in a headless run: report the
+					//mismatch and carry on as if the user had chosen Open.
+				qWarning().noquote()
+					<< QStringLiteral("Warning: '%1' was saved with QElectroTech %2, "
+									  "newer than this build (%3); opening it anyway.")
+					   .arg(m_file_path,
+							root_elmt.attribute(QStringLiteral("version")),
+							QetVersion::currentVersion().toString());
+			}
+			else if (QetVersion::currentVersion() < m_project_qet_version)
 			{
 				int ret = QET::QetMessageBox::warning(
 							nullptr,
@@ -1466,7 +1484,17 @@ void QETProject::readProjectXml(QDomDocument &xml_project)
 
 				//Since QElectrotech 0.9 the compatibility with project made with
 				//Qet 0.6 or lower is break;
-			if (m_project_qet_version <= QetVersion::versionZeroDotSix())
+			if (m_project_qet_version <= QetVersion::versionZeroDotSix()
+				&& !m_interactive)
+			{
+				qWarning().noquote()
+					<< QStringLiteral("Warning: '%1' was saved with QElectroTech %2 and is only "
+									  "partially compatible with this build (%3); opening it anyway.")
+					   .arg(m_file_path,
+							m_project_qet_version.toString(),
+							QetVersion::currentVersion().toString());
+			}
+			else if (m_project_qet_version <= QetVersion::versionZeroDotSix())
 			{
 				auto ret = QET::QetMessageBox::warning(
 							nullptr,

--- a/sources/qetproject.h
+++ b/sources/qetproject.h
@@ -125,6 +125,12 @@ class QETProject : public QObject
 		/// process can destroy the project before the write finishes (crash).
 		static void setBackupEnabled(bool enabled);
 
+		/// Enable/disable blocking user prompts raised while a project is being
+		/// read.  Disabled by the headless CLI: readProjectXml() asks the user
+		/// what to do about version-incompatible projects, and with no one to
+		/// answer, the modal blocks the process forever instead of exporting.
+		static void setInteractive(bool interactive);
+
 			///DEFAULT PROPERTIES
 		BorderProperties defaultBorderProperties() const;
 		void             setDefaultBorderProperties(const BorderProperties &);
@@ -275,6 +281,7 @@ class QETProject : public QObject
 	private:
 			/// When false, writeBackup() is a no-op (set by the headless CLI)
 		static bool m_backup_enabled;
+		static bool m_interactive;
 			/// File path this project is saved to
 		QString m_file_path;
 			/// Current state of the project


### PR DESCRIPTION
### Problem

`QETProject::readProjectXml()` raises two blocking `QMessageBox` prompts while parsing a project: one when it was saved by a newer QElectroTech than the running build, and one when it was saved by 0.6 or older. Both ask the user whether to open anyway.

In a headless CLI run there is nobody to answer, so the modal never returns and the process hangs until it is killed. Because the prompt fires during *load*, before any export work starts, **every** CLI mode is affected.

The shipped example `examples/schema_indus.qet` (`version="0.3"`) reproduces it. All eight of these hang indefinitely on current master:

```
--info  --export-bom  --export-nets  --export-links
--export-cables  --export-wires  --resave  --export-pdf
```

I found this by running every example project through every CLI mode with a 120s timeout — that one project accounted for 8 timeouts, the only hangs in 185 runs.

### Change

Add `QETProject::setInteractive()`, mirroring the existing `setBackupEnabled()` pattern, and disable interactivity in `main.cpp`'s CLI branch right next to the `setBackupEnabled(false)` call already there for the same class of reason.

With interactivity off, both cases report the version mismatch on stderr via `qWarning()` and continue as if the user had chosen Open, so the export still happens and the reason is visible in the log:

```
Warning: '.../examples/schema_indus.qet' was saved with QElectroTech 0.3 and is only
partially compatible with this build (0.100.1); opening it anyway.
```

The GUI path is untouched — both prompts still appear when a project is opened interactively.

### Testing

On `examples/schema_indus.qet`, all eight modes went from hitting the 120s timeout to completing in under a second, with valid output (`--info` reports 48 elements / 69 conductors, `--export-pdf` writes a 21 KB PDF).

Regression check: opened the same project in the GUI and confirmed the "Avertissement" dialog still appears as before.