### PR TITLE
Fix nameless "false" row in the element Informations panel

### DIFF
--- a/sources/ui/elementinfowidget.cpp
+++ b/sources/ui/elementinfowidget.cpp
@@ -204,6 +204,14 @@ void ElementInfoWidget::buildInterface()
 		keys = QETInformation::elementInfoKeys();
 	}
 
+		//"exclude_from_bom" is part of elementInfoKeys() because the project
+		//database builds the element_info table from that list, but it is not
+		//a free-text property: it already has its own check box below. Without
+		//this it also gets a generic edit row, and since translatedInfoKey()
+		//has no entry for it that row carries no label at all - an anonymous
+		//line that currentInfo() then fills with "true"/"false".
+	keys.removeAll(QStringLiteral("exclude_from_bom"));
+
 	for (auto str : keys)
 	{
 		ElementInfoPartWidget *eipw = new ElementInfoPartWidget(str, QETInformation::translatedInfoKey(str), this);


### PR DESCRIPTION
Fixes the issue @plc-user reported on #642: an edit line with no label that fills itself with `false` as soon as you edit a property.

### Cause

`"exclude_from_bom"` is in `QETInformation::elementInfoKeys()` — it has to be, because `projectdatabase.cpp` builds the `element_info` table from that list (six call sites), and `elementquerywidget.cpp` reads the key. But it is not a free-text property: `ElementInfoWidget` already gives it a dedicated **"Exclure de la nomenclature"** check box.

`buildInterface()` creates one `ElementInfoPartWidget` per key in that list, so the key also gets a *second*, generic edit row:

```cpp
for (auto str : keys)
{
    ElementInfoPartWidget *eipw = new ElementInfoPartWidget(str, QETInformation::translatedInfoKey(str), this);
```

and `translatedInfoKey()` has no case for it, falling through to `else return QString();` — hence a row with **no label at all**.

`currentInfo()` then writes the key unconditionally:

```cpp
if (m_exclude_from_bom_cb) {
    info_.addValue(QStringLiteral("exclude_from_bom"), m_exclude_from_bom_cb->isChecked() ? "true" : "false");
}
```

so the moment anything is edited, `updateUi()` refills that anonymous row with `false`. That is exactly the two screenshots in the report.

### Change

One line: drop the key from the list `buildInterface()` iterates, with a comment explaining why it is in `elementInfoKeys()` but must not get a row.

Deliberately *not* removed from `elementInfoKeys()` — that would drop the database column and break the BOM-exclusion feature it backs.

Nothing else changes: the check box is still the only way to set it, `currentInfo()` still writes it exactly as before (the check-box block always ran after the row loop and overwrote it anyway, so the stored value is identical), and `predefinedKeys()` already excluded it from the custom-property rows.

### Note on origin

This is **not** a regression from #642. Both ingredients are present in master before that merge — verified against `14ef848c4`, the merge's first parent: `exclude_from_bom` was already in `elementInfoKeys()`, and the unconditional write was already at `elementinfowidget.cpp:327`. #642 only added the custom-property rows below, which is what drew attention to the panel.

### Testing

Built clean. With the patch, the Informations panel for a placed element now ends at "Réf. croisée PLC" followed directly by the "Ajouter une propriété personnalisée" button, with no anonymous row; the "Exclure de la nomenclature" check box still appears and still works. The before state is the screenshots in the report.