### PR TITLE
Export slave cross-reference labels to DXF

### DIFF
--- a/sources/exportdialog.cpp
+++ b/sources/exportdialog.cpp
@@ -472,6 +472,10 @@ void ExportDialog::generateDxf(
 	QList<Conductor *> list_conductors;
 	QList<DiagramTextItem *> list_texts;
 	QList<DiagramImageItem *> list_images;
+		//Slave cross-reference labels. They hang off a DynamicElementTextItem
+		//as plain QGraphicsTextItem children, so neither cast below picks them
+		//up and they were missing from the DXF entirely.
+	QList<QGraphicsTextItem *> list_xref_texts;
 	QList<QLineF *> list_lines;
 	QList<QRectF *> list_rectangles;
 	//QList<QRectF *> list_ellipses;
@@ -493,6 +497,9 @@ void ExportDialog::generateDxf(
 			list_shapes << dii;
 		} else if (DynamicElementTextItem *deti = qgraphicsitem_cast<DynamicElementTextItem *>(qgi)) {
 			list_texts << deti;
+			if (QGraphicsTextItem *xref = deti->slaveXrefItem()) {
+				list_xref_texts << xref;
+			}
 		} else if (QetGraphicsTableItem *gti = qgraphicsitem_cast<QetGraphicsTableItem *>(qgi)) {
 			list_tables << gti;
 		}
@@ -683,6 +690,42 @@ void ExportDialog::generateDxf(
 		foreach (QString line, lines) {
 			if (line.size() > 0 && line != "_" )
 				Createdxf::drawText(file_path, line, QPointF(x, y), fontSize, 360-angle, Createdxf::dxfColor(dti->color()), 0.72 );
+			x += offset * xdir;
+			y -= offset * ydir;
+		}
+	}
+
+	//Draw the slave cross-reference labels
+	for (QGraphicsTextItem *xref : std::as_const(list_xref_texts))
+	{
+		qreal fontSize = xref->font().pointSizeF();
+		if (fontSize < 0)
+			fontSize = xref->font().pixelSize();
+
+		qreal angle = xref->rotation();
+		QGraphicsItem *parent = xref->parentItem();
+		while (parent) {
+			angle += parent->rotation();
+			parent = parent->parentItem();
+		}
+
+		qreal angler = angle * M_PI/180;
+		int xdir = -sin(angler);
+		int ydir = -cos(angler);
+		qreal x = xref->scenePos().x()
+				+ xdir * fontSize * 1.8
+				- ydir * fontSize;
+		qreal y = xref->scenePos().y()
+				- ydir * fontSize * 1.8
+				- xdir * fontSize * 0.9;
+
+		const QStringList lines = xref->toPlainText().split('\n');
+		const qreal offset = fontSize * 1.6;
+		for (const QString &line : lines) {
+			if (line.size() > 0 && line != QLatin1String("_")) {
+				Createdxf::drawText(file_path, line, QPointF(x, y), fontSize,
+									360-angle, Createdxf::dxfColor(xref->defaultTextColor()), 0.72);
+			}
 			x += offset * xdir;
 			y -= offset * ydir;
 		}


### PR DESCRIPTION
Addresses part of what @scorpio810 asked for on #718 — cross-references in the DXF export, from the forum report at https://qelectrotech.org/forum/viewtopic.php?id=2481 ("les références croisées n'apparaissent pas dans le dxf").

### Cause

`ExportDialog::generateDxf()` walks the scene and collects items by cast. A slave element's cross-reference label — the `(6-G15)` pointing back to its master — is a plain **`QGraphicsTextItem`** created as a child of a `DynamicElementTextItem` (`dynamicelementtextitem.cpp:1375`). It is neither an `IndependentTextItem` nor a `DynamicElementTextItem`, so it matched no branch in the walker and was silently dropped.

Nothing was wrong with the label; it was simply never collected.

### Change

Collect it through the existing public `DynamicElementTextItem::slaveXrefItem()` accessor, and draw it with the same placement, rotation-accumulation and multi-line handling as the other text items — using `defaultTextColor()`, since a bare `QGraphicsTextItem` has no `DiagramTextItem::color()`.

### Measurements

`examples/industrial.qet`, all 50 folios, compared against the PDF export (which renders the whole scene, so it shows what *should* be there):

| | before | after | PDF |
|---|---|---|---|
| slave xrefs `(n-Xn)` | 0 | **41** | 41 |
| folio/position strings | 317 | 358 | 403 |

The slave cross-references now match the PDF exactly.

### What this does not cover

Two clarifications on the original request:

**Folio reports already export.** I checked before changing anything — the 317 folio/position strings present in the unmodified DXF are the folio-report texts. They are `DynamicElementTextItem`s and were already collected. So that half of the request appears to be already satisfied; if something specific is still missing there, a sample project would help.

**The master-side cross-reference table is still missing** — the remaining 403 − 358 = 45 strings. That is drawn by `CrossRefItem`, a `QGraphicsObject` that paints itself with custom `QPainter` code in three modes (`drawAsCross`, `drawAsContacts`, `drawAsPlcTable`) including contact symbols and rules. Giving it a faithful DXF representation means reproducing that drawing as DXF primitives, which is a substantially larger job than this and worth doing separately — possibly better solved generically with a DXF-writing paint device than per-item. Happy to take it on if you want it.