### PR TITLE
Extend terminal numbering dialog with letter numbering and strip selection

### DIFF
--- a/sources/qetdiagrameditor.cpp
+++ b/sources/qetdiagrameditor.cpp
@@ -2799,11 +2799,11 @@ void QETDiagramEditor::generateTerminalBlock()
  * Opens the dialog for automatic terminal numbering and applies the generated undo command.
  */
 void QETDiagramEditor::slot_terminalNumbering() {
-	TerminalNumberingDialog dialog(this);
-	if (dialog.exec() == QDialog::Accepted) {
-		QETProject *project = currentProject();
-		if (!project) return;
+	QETProject *project = currentProject();
+	if (!project) return;
 
+	TerminalNumberingDialog dialog(this, project);
+	if (dialog.exec() == QDialog::Accepted) {
 		// Fetch the generated undo command from the dialog logic
 		QUndoCommand *macro = dialog.getUndoCommand(project);
 

--- a/sources/ui/terminalnumberingdialog.cpp
+++ b/sources/ui/terminalnumberingdialog.cpp
@@ -5,18 +5,57 @@
 #include "../qetgraphicsitem/element.h"
 #include "../undocommand/changeelementinformationcommand.h"
 #include <QUndoCommand>
+#include <QCheckBox>
+#include <QVBoxLayout>
+#include <QSet>
 #include <algorithm>
 
 /**
  * @brief TerminalNumberingDialog::TerminalNumberingDialog
  * Constructor
  * @param parent
+ * @param project Pointer to the current project (used to populate terminal strips)
  */
-TerminalNumberingDialog::TerminalNumberingDialog(QWidget *parent) :
-QDialog(parent),
-ui(new Ui::TerminalNumberingDialog)
+TerminalNumberingDialog::TerminalNumberingDialog(QWidget *parent, QETProject *project) :
+    QDialog(parent),
+    ui(new Ui::TerminalNumberingDialog),
+    m_project(project)
 {
     ui->setupUi(this);
+
+    // Connect radio button to enable/disable the "also number letters" checkbox
+    connect(ui->rb_type_alpha, &QRadioButton::toggled, ui->cb_also_alpha, &QCheckBox::setEnabled);
+
+    // Collect all unique terminal strip prefixes from the project
+    if (m_project) {
+        QSet<QString> prefixes;
+        foreach (Diagram *diagram, m_project->diagrams()) {
+            foreach (QGraphicsItem *qgi, diagram->items()) {
+                if (Element *elmt = qgraphicsitem_cast<Element *>(qgi)) {
+                    if (elmt->elementData().m_type == ElementData::Terminal) {
+                        QString label = elmt->actualLabel();
+                        if (label.isEmpty()) continue;
+                        int colonIndex = label.lastIndexOf(':');
+                        if (colonIndex != -1) {
+                            QString prefix = label.left(colonIndex);
+                            prefixes.insert(prefix);
+                        }
+                    }
+                }
+            }
+        }
+
+        // Sort prefixes alphabetically and create checkboxes
+        QStringList sortedPrefixes = prefixes.values();
+        sortedPrefixes.sort(Qt::CaseInsensitive);
+
+        foreach (const QString &prefix, sortedPrefixes) {
+            QCheckBox *cb = new QCheckBox(prefix);
+            cb->setChecked(true);
+            ui->verticalLayout_strips_content->addWidget(cb);
+            m_stripCheckboxes.insert(prefix, cb);
+        }
+    }
 }
 
 /**
@@ -47,10 +86,36 @@ bool TerminalNumberingDialog::isAlphanumeric() const
 }
 
 /**
+ * @brief TerminalNumberingDialog::alsoNumberLetters
+ * @return true if the "also number letters" checkbox is checked
+ */
+bool TerminalNumberingDialog::alsoNumberLetters() const
+{
+    return ui->cb_also_alpha->isChecked();
+}
+
+/**
+ * @brief TerminalNumberingDialog::excludedStrips
+ * @return List of terminal strip prefixes that should be excluded from numbering
+ */
+QStringList TerminalNumberingDialog::excludedStrips() const
+{
+    QStringList excluded;
+    QMapIterator<QString, QCheckBox*> it(m_stripCheckboxes);
+    while (it.hasNext()) {
+        it.next();
+        if (!it.value()->isChecked()) {
+            excluded.append(it.key());
+        }
+    }
+    return excluded;
+}
+
+/**
  * @brief TerminalNumberingDialog::getUndoCommand
  * Scans the given project for terminals, sorts them according to user preferences
  * (X/Y axis, alphanumeric rules), and generates an undo command containing all label changes.
- * * @param project Pointer to the current QETProject
+ * @param project Pointer to the current QETProject
  * @return QUndoCommand* containing the modifications, or nullptr if no changes are needed.
  */
 QUndoCommand* TerminalNumberingDialog::getUndoCommand(QETProject *project) const {
@@ -58,6 +123,8 @@ QUndoCommand* TerminalNumberingDialog::getUndoCommand(QETProject *project) const
 
     bool axisX = isXAxisPriority();
     bool alpha = isAlphanumeric();
+    bool alsoAlpha = alsoNumberLetters();
+    QStringList excluded = excludedStrips();
 
     // 1. Helper structure to store and sort terminal data
     struct TermInfo {
@@ -96,6 +163,9 @@ QUndoCommand* TerminalNumberingDialog::getUndoCommand(QETProject *project) const
                         prefix = label.left(colonIndex);
                         suffix = label.mid(colonIndex + 1);
                     }
+
+                    // Skip excluded terminal strips
+                    if (excluded.contains(prefix)) continue;
 
                     // If user chose purely numeric, skip terminals with alphabetical suffixes
                     if (!alpha && !suffix.isEmpty()) {
@@ -154,8 +224,13 @@ QUndoCommand* TerminalNumberingDialog::getUndoCommand(QETProject *project) const
             // If it was a number (e.g., "1") or empty, update it with the new counter
             newLabel = ti.prefix + ":" + QString::number(newNum);
         } else {
-            // If it was alphabetical (e.g., "N", "PE"), keep the original text but consume the count!
-            newLabel = ti.prefix + ":" + ti.suffix;
+            // If it was alphabetical (e.g., "N", "PE"), keep the original text
+            // If "also number letters" is enabled, append the counter
+            if (alsoAlpha) {
+                newLabel = ti.prefix + ":" + ti.suffix + QString::number(newNum);
+            } else {
+                newLabel = ti.prefix + ":" + ti.suffix;
+            }
         }
 
         DiagramContext oldInfo = ti.elmt->elementInformations();

--- a/sources/ui/terminalnumberingdialog.cpp
+++ b/sources/ui/terminalnumberingdialog.cpp
@@ -18,8 +18,7 @@
  */
 TerminalNumberingDialog::TerminalNumberingDialog(QWidget *parent, QETProject *project) :
     QDialog(parent),
-    ui(new Ui::TerminalNumberingDialog),
-    m_project(project)
+    ui(new Ui::TerminalNumberingDialog)
 {
     ui->setupUi(this);
 
@@ -27,19 +26,30 @@ TerminalNumberingDialog::TerminalNumberingDialog(QWidget *parent, QETProject *pr
     connect(ui->rb_type_alpha, &QRadioButton::toggled, ui->cb_also_alpha, &QCheckBox::setEnabled);
 
     // Collect all unique terminal strip prefixes from the project
-    if (m_project) {
+    if (project) {
         QSet<QString> prefixes;
-        foreach (Diagram *diagram, m_project->diagrams()) {
+        foreach (Diagram *diagram, project->diagrams()) {
             foreach (QGraphicsItem *qgi, diagram->items()) {
                 if (Element *elmt = qgraphicsitem_cast<Element *>(qgi)) {
                     if (elmt->elementData().m_type == ElementData::Terminal) {
+                        // Ignore locked terminals
+                        DiagramContext info = elmt->elementInformations();
+                        if (info.value(QStringLiteral("auto_num_locked")).toString() == QLatin1String("true")) {
+                            continue;
+                        }
+
                         QString label = elmt->actualLabel();
                         if (label.isEmpty()) continue;
+
+                        // Handle labels with and without colon
                         int colonIndex = label.lastIndexOf(':');
+                        QString prefix;
                         if (colonIndex != -1) {
-                            QString prefix = label.left(colonIndex);
-                            prefixes.insert(prefix);
+                            prefix = label.left(colonIndex);
+                        } else {
+                            prefix = label;
                         }
+                        prefixes.insert(prefix);
                     }
                 }
             }
@@ -224,9 +234,12 @@ QUndoCommand* TerminalNumberingDialog::getUndoCommand(QETProject *project) const
             // If it was a number (e.g., "1") or empty, update it with the new counter
             newLabel = ti.prefix + ":" + QString::number(newNum);
         } else {
-            // If it was alphabetical (e.g., "N", "PE"), keep the original text
-            // If "also number letters" is enabled, append the counter
-            if (alsoAlpha) {
+            // Only append to purely alphabetic suffixes (N, PE), so re-running is a
+            // no-op and already-numbered suffixes (L1, L2, L3) keep their meaning.
+            const bool allLetters = !ti.suffix.isEmpty()
+                    && std::all_of(ti.suffix.cbegin(), ti.suffix.cend(),
+                                   [](QChar c){ return c.isLetter(); });
+            if (alsoAlpha && allLetters) {
                 newLabel = ti.prefix + ":" + ti.suffix + QString::number(newNum);
             } else {
                 newLabel = ti.prefix + ":" + ti.suffix;

--- a/sources/ui/terminalnumberingdialog.h
+++ b/sources/ui/terminalnumberingdialog.h
@@ -21,7 +21,7 @@ class TerminalNumberingDialog : public QDialog
     Q_OBJECT
 
 public:
-    explicit TerminalNumberingDialog(QWidget *parent, QETProject *project);
+    explicit TerminalNumberingDialog(QWidget *parent = nullptr, QETProject *project = nullptr);
     ~TerminalNumberingDialog();
 
     // Getters for the user's choices
@@ -34,7 +34,6 @@ public:
 
 private:
     Ui::TerminalNumberingDialog *ui;
-    QETProject *m_project;
     QMap<QString, QCheckBox*> m_stripCheckboxes;
 };
 

--- a/sources/ui/terminalnumberingdialog.h
+++ b/sources/ui/terminalnumberingdialog.h
@@ -2,9 +2,11 @@
 #define TERMINALNUMBERINGDIALOG_H
 
 #include <QDialog>
+#include <QMap>
 
 class QETProject;
 class QUndoCommand;
+class QCheckBox;
 
 namespace Ui {
     class TerminalNumberingDialog;
@@ -19,17 +21,21 @@ class TerminalNumberingDialog : public QDialog
     Q_OBJECT
 
 public:
-    explicit TerminalNumberingDialog(QWidget *parent = nullptr);
+    explicit TerminalNumberingDialog(QWidget *parent, QETProject *project);
     ~TerminalNumberingDialog();
 
     // Getters for the user's choices
     bool isXAxisPriority() const;
     bool isAlphanumeric() const;
+    bool alsoNumberLetters() const;
+    QStringList excludedStrips() const;
 
     QUndoCommand* getUndoCommand(QETProject *project) const;
 
 private:
     Ui::TerminalNumberingDialog *ui;
+    QETProject *m_project;
+    QMap<QString, QCheckBox*> m_stripCheckboxes;
 };
 
 #endif // TERMINALNUMBERINGDIALOG_H

--- a/sources/ui/terminalnumberingdialog.ui
+++ b/sources/ui/terminalnumberingdialog.ui
@@ -6,8 +6,8 @@
             <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>400</width>
-                <height>300</height>
+                <width>500</width>
+                <height>450</height>
             </rect>
         </property>
         <property name="windowTitle">
@@ -25,56 +25,123 @@
                 </widget>
             </item>
             <item>
-                <widget class="QGroupBox" name="groupBox_axis">
-                    <property name="title">
-                        <string>Priorité des axes</string>
-                    </property>
-                    <layout class="QVBoxLayout" name="verticalLayout_2">
-                        <item>
-                            <widget class="QRadioButton" name="rb_priority_x">
-                                <property name="text">
-                                    <string>Priorité à l'axe X (horizontal)</string>
-                                </property>
-                                <property name="checked">
-                                    <bool>true</bool>
-                                </property>
-                            </widget>
-                        </item>
-                        <item>
-                            <widget class="QRadioButton" name="rb_priority_y">
-                                <property name="text">
-                                    <string>Priorité à l'axe Y (vertical)</string>
-                                </property>
-                            </widget>
-                        </item>
-                    </layout>
-                </widget>
-            </item>
-            <item>
-                <widget class="QGroupBox" name="groupBox_type">
-                    <property name="title">
-                        <string>Type de numérotation</string>
-                    </property>
-                    <layout class="QVBoxLayout" name="verticalLayout_3">
-                        <item>
-                            <widget class="QRadioButton" name="rb_type_num">
-                                <property name="text">
-                                    <string>Numérique uniquement (1, 2, 3...)</string>
-                                </property>
-                                <property name="checked">
-                                    <bool>true</bool>
-                                </property>
-                            </widget>
-                        </item>
-                        <item>
-                            <widget class="QRadioButton" name="rb_type_alpha">
-                                <property name="text">
-                                    <string>Alphanumérique (A, B, C... 1, 2...)</string>
-                                </property>
-                            </widget>
-                        </item>
-                    </layout>
-                </widget>
+                <layout class="QHBoxLayout" name="horizontalLayout_main">
+                    <item>
+                        <layout class="QVBoxLayout" name="verticalLayout_left">
+                            <item>
+                                <widget class="QGroupBox" name="groupBox_axis">
+                                    <property name="title">
+                                        <string>Priorité des axes</string>
+                                    </property>
+                                    <layout class="QVBoxLayout" name="verticalLayout_2">
+                                        <item>
+                                            <widget class="QRadioButton" name="rb_priority_x">
+                                                <property name="text">
+                                                    <string>Priorité à l'axe X (horizontal)</string>
+                                                </property>
+                                                <property name="checked">
+                                                    <bool>true</bool>
+                                                </property>
+                                            </widget>
+                                        </item>
+                                        <item>
+                                            <widget class="QRadioButton" name="rb_priority_y">
+                                                <property name="text">
+                                                    <string>Priorité à l'axe Y (vertical)</string>
+                                                </property>
+                                            </widget>
+                                        </item>
+                                    </layout>
+                                </widget>
+                            </item>
+                            <item>
+                                <widget class="QGroupBox" name="groupBox_type">
+                                    <property name="title">
+                                        <string>Type de numérotation</string>
+                                    </property>
+                                    <layout class="QVBoxLayout" name="verticalLayout_3">
+                                        <item>
+                                            <widget class="QRadioButton" name="rb_type_num">
+                                                <property name="text">
+                                                    <string>Numérique uniquement (1, 2, 3...)</string>
+                                                </property>
+                                                <property name="checked">
+                                                    <bool>true</bool>
+                                                </property>
+                                            </widget>
+                                        </item>
+                                        <item>
+                                            <widget class="QRadioButton" name="rb_type_alpha">
+                                                <property name="text">
+                                                    <string>Alphanumérique (A, B, C... 1, 2...)</string>
+                                                </property>
+                                            </widget>
+                                        </item>
+                                        <item>
+                                            <layout class="QHBoxLayout" name="horizontalLayout_also_alpha">
+                                                <item>
+                                                    <spacer name="spacer_also_alpha">
+                                                        <property name="orientation">
+                                                            <enum>Qt::Horizontal</enum>
+                                                        </property>
+                                                        <property name="sizeType">
+                                                            <enum>QSizePolicy::Fixed</enum>
+                                                        </property>
+                                                        <property name="sizeHint" stdset="0">
+                                                            <size>
+                                                                <width>20</width>
+                                                                <height>0</height>
+                                                            </size>
+                                                        </property>
+                                                    </spacer>
+                                                </item>
+                                                <item>
+                                                    <widget class="QCheckBox" name="cb_also_alpha">
+                                                        <property name="text">
+                                                            <string>Numéroter également les lettres</string>
+                                                        </property>
+                                                        <property name="enabled">
+                                                            <bool>false</bool>
+                                                        </property>
+                                                    </widget>
+                                                </item>
+                                            </layout>
+                                        </item>
+                                    </layout>
+                                </widget>
+                            </item>
+                        </layout>
+                    </item>
+                    <item>
+                        <widget class="QGroupBox" name="groupBox_strips">
+                            <property name="title">
+                                <string>Borniers</string>
+                            </property>
+                            <layout class="QVBoxLayout" name="verticalLayout_strips">
+                                <item>
+                                    <widget class="QLabel" name="label_strips_description">
+                                        <property name="text">
+                                            <string>Décochez les borniers dont la numérotation doit être exclue</string>
+                                        </property>
+                                        <property name="wordWrap">
+                                            <bool>true</bool>
+                                        </property>
+                                    </widget>
+                                </item>
+                                <item>
+                                    <widget class="QScrollArea" name="scrollArea_strips">
+                                        <property name="widgetResizable">
+                                            <bool>true</bool>
+                                        </property>
+                                        <widget class="QWidget" name="scrollAreaWidgetContents_strips">
+                                            <layout class="QVBoxLayout" name="verticalLayout_strips_content"/>
+                                        </widget>
+                                    </widget>
+                                </item>
+                            </layout>
+                        </widget>
+                    </item>
+                </layout>
             </item>
             <item>
                 <spacer name="verticalSpacer">


### PR DESCRIPTION
This PR extends the automatic terminal numbering dialog with two new features:

"Also number letters" option - When alphanumeric numbering is selected, a new checkbox becomes available. When enabled, skipped numbers are appended to letter-based suffixes (e.g., X1:N4, X1:PE5 instead of X1:N, X1:PE).
Terminal strip selection - All unique terminal strip prefixes (the part before :) are now collected and displayed as checkboxes. Users can exclude specific strips from numbering by unchecking them.
Changes
UI (terminalnumberingdialog.ui):

Added "Numéroter également les lettres" checkbox (indented under the alphanumeric radio button)
Added "Borniers" group box on the right side with scrollable checkboxes for each terminal strip
Restructured layout from vertical to horizontal (left: axis priority + numbering type, right: terminal strips)
Dialog size adjusted to 500×450
Logic (terminalnumberingdialog.h/cpp):

Constructor now accepts QETProject* to populate terminal strip checkboxes on dialog open
Added alsoNumberLetters() and excludedStrips() methods
Numbering logic extended: when "also number letters" is enabled, counter is appended to alphabetical suffixes
Excluded terminal strips are skipped during numbering
Integration (qetdiagrameditor.cpp):

Updated slot_terminalNumbering() to pass project to dialog constructor
Behavior
Before:

X1:1, X1:2, X1:3, X1:N, X1:PE → X1:1, X1:2, X1:3, X1:N, X1:PE (N and PE keep original, numbers 4 and 5 are lost)
After (with "also number letters" enabled):

X1:1, X1:2, X1:3, X1:N, X1:PE → X1:1, X1:2, X1:3, X1:N4, X1:PE5