### PR TITLE
Fix bugtracker #291: crash on cancelling open-element dialog before collection load finishes

### DIFF
--- a/sources/ElementsCollection/elementscollectionmodel.cpp
+++ b/sources/ElementsCollection/elementscollectionmodel.cpp
@@ -39,6 +39,20 @@ ElementsCollectionModel::ElementsCollectionModel(QObject *parent) :
 }
 
 /**
+	@brief ElementsCollectionModel::~ElementsCollectionModel
+	Destructor. loadCollections() may still have background threads
+	(via QtConcurrent::map()) running setUpData() on this model's items
+	when the model is destroyed (e.g. the user cancels the dialog before
+	loading finishes). Wait for them here so QStandardItemModel's
+	destructor doesn't free items out from under them, which used to
+	crash the whole application (bugtracker #291).
+*/
+ElementsCollectionModel::~ElementsCollectionModel()
+{
+	m_future.waitForFinished();
+}
+
+/**
 	@brief ElementsCollectionModel::data
 	Reimplemented from QStandardItemModel
 	@param index

--- a/sources/ElementsCollection/elementscollectionmodel.h
+++ b/sources/ElementsCollection/elementscollectionmodel.h
@@ -35,6 +35,7 @@ class ElementsCollectionModel : public QStandardItemModel
 
 	public:
 		ElementsCollectionModel(QObject *parent = Q_NULLPTR);
+		~ElementsCollectionModel() override;
 
 		QVariant data(const QModelIndex &index, int role) const override;
 		QMimeData *mimeData(const QModelIndexList &indexes) const override;


### PR DESCRIPTION
https://qelectrotech.org/bugtracker/view.php?id=291

## Bug

Clicking Cancel on the open/save-element dialog before the user collection finishes loading crashes the whole application with an unhandled pointer exception. Always reproducible per the report.

## Root cause

`ElementsCollectionModel::loadCollections()` loads collections in the background:

```cpp
m_future = QtConcurrent::map(m_items_list_to_setUp, setUpData);
```

Worker threads call `setUpData()` on each `ElementCollectionItem` (a `QStandardItem`), e.g. `FileElementCollectionItem::setUpData()` calls `setFlags()`/`setData()` on itself.

`ElementDialog::execConfiguredDialog()` deletes the dialog as soon as `exec()` returns:

```cpp
element_dialog->exec();
ElementsLocation location = element_dialog->location();
delete element_dialog;
```

That destroys the tree view and its `ElementsCollectionModel`. As a `QStandardItemModel`, its destructor frees every item it owns — but nothing waited for `m_future` first. So if the user cancels before loading completes, background threads are still calling `setUpData()` on `QStandardItem`s the main thread just freed: a use-after-free race, matching the "unhandled pointer exception" in the report.

## Fix

Add an `ElementsCollectionModel` destructor that waits for the future before `QStandardItemModel`'s own destructor runs:

```cpp
ElementsCollectionModel::~ElementsCollectionModel()
{
	m_future.waitForFinished();
}
```

`QFuture::waitForFinished()` on a default-constructed (never-started) future returns immediately, so this is a no-op on every path where loading already finished — only the crashing path (cancel during load) is affected, and it now blocks briefly instead of crashing.

## Testing

Clean rebuild, no new warnings.

I was not able to get a reliable live reproduction of the crash itself under Xvfb + xdotool — the race window is narrow and GUI automation is much slower than a real fast click, so the unpatched binary didn't reliably crash in that environment either. The fix is a direct, well-understood correction of a QtConcurrent-lifetime hazard (background workers outliving the objects they operate on), confirmed by reading the exact call path from `loadCollections()` through to the dialog's `delete`, so confidence rests on that rather than a captured crash.

---

**Also fixes** https://github.com/qelectrotech/qelectrotech-source-mirror/issues/50 — same root cause (`ElementsCollectionModel` destroyed while `QtConcurrent::map()` is still running against its items), different trigger (closing the whole app during initial load, vs. cancelling the open-element dialog during load). An earlier investigation on that issue independently diagnosed the same race and proposed the same fix, before Mantis #291 turned up with an always-reproducible repro path.