### PR TITLE
Fix bugtracker #335: element icons invisible on dark themes

### DIFF
--- a/sources/factory/elementpicturefactory.cpp
+++ b/sources/factory/elementpicturefactory.cpp
@@ -99,7 +99,14 @@ QPixmap ElementPictureFactory::pixmap(const ElementsLocation &location)
 		int hsy = qMin(doc.document_element().attribute("hotspot_y").as_int(), h);
 
 		QPixmap pix(w, h);
-		pix.fill(QColor(255, 255, 255, 0));
+			//Element definitions almost always draw with a hardcoded black
+			//stroke color, on the assumption of the white diagram sheet they
+			//are normally placed on. A transparent background here makes
+			//that stroke disappear against a dark widget/tree-view background
+			//(bugtracker #335). Give it an opaque white background instead -
+			//exactly what the element already assumes visually, in every
+			//context this pixmap is used (tree icons, drag icon, previews).
+		pix.fill(Qt::white);
 
 		QPainter painter(&pix);
 		painter.setRenderHint(QPainter::Antialiasing, true);


### PR DESCRIPTION
https://qelectrotech.org/bugtracker/view.php?id=335

## Bug

Element library icons render with a fully transparent background. Element definitions almost always hardcode a black stroke color, on the assumption of the white diagram sheet they are normally drawn on. Against a dark widget/tree-view background (e.g. KDE Plasma dark theme), that black stroke disappears entirely — reported as icons being "black and almost invisible". scorpio810_mantis linked this to the same recurring family as #231, #247, #267.

## Fix

`ElementPictureFactory::pixmap()` is the single shared point every consumer of these icons goes through — the collection tree (via `ElementsCollectionCache` → `Element::pixmap()`), the master/slave properties tree, the element properties preview panel, and the drag icon. Changed its background fill from fully transparent to opaque white — exactly what the element already visually assumes in every context this pixmap is used, so it's correct regardless of the surrounding widget's palette.

```cpp
-		pix.fill(QColor(255, 255, 255, 0));
+		pix.fill(Qt::white);
```

## Testing

Built both variants and compared under Xvfb using a simple, decisive visual test: select the tree row (giving it a highlighted/colored background) and look at what shows immediately around the icon's glyph.

- **Before:** the icon's background matches the row's selection color — confirms it's transparent, so on an unselected dark row the black strokes have nothing to stand out against.
- **After:** a solid white square is visible behind the glyph regardless of the row's background color.

## Note on the on-disk pixmap cache

`ElementsCollectionCache` (`~/.local/share/QElectroTech/QElectroTech/elements_cache.sqlite`) persists rendered PNGs across runs, keyed only on path+uuid with no version-based invalidation. Existing cached entries predate this fix and will keep their transparent background until regenerated (e.g. after the source `.elmt` changes, or the cache is cleared). That's an existing characteristic of the cache, not something introduced here — worth knowing if a user reports the fix "not working" until their cache is cleared, but out of scope to change in this PR.