### PR TITLE
Fix pasted conductors getting an unwanted "_" label

### DIFF
--- a/sources/diagramcommands.cpp
+++ b/sources/diagramcommands.cpp
@@ -99,12 +99,18 @@ void PasteDiagramCommand::redo()
 				dc.addValue("location", "");
 				e->setElementInformations(dc);
 				
-				//Reset the text of conductors
+				//Reset the text of conductors, the same way the label/comment/
+				//location above are reset to "" rather than to some other
+				//value - "erase on copy" means erase, not "replace with the
+				//project's default new-conductor text" (which happens to
+				//default to a literal "_" character, unrelated to whether the
+				//user wanted this copy's old label kept or cleared; see
+				//issue #413).
 				const QList <Conductor *> conductors_list = content.m_conductors_to_move;
 				for (Conductor *c : conductors_list)
 				{
 					ConductorProperties cp = c -> properties();
-					cp.text = c->diagram() ? c -> diagram() -> defaultConductorProperties.text : "_";
+					cp.text = "";
 					c -> setProperties(cp);
 				}
 			}


### PR DESCRIPTION
Fixes #413.

### Bug

Copy-pasting an element pair joined by a conductor with no label results in the pasted conductor having a literal `_` label, even though the source conductor's label was empty. Repeat the copy+paste and the `_` compounds, since the pasted copy now legitimately carries that text.

### Root cause

`PasteDiagramCommand::redo()` (`sources/diagramcommands.cpp`), when "erase label on copy" is enabled (the default), resets each pasted element's formula/label/comment/location to `""` — a real erase. Right next to it, the equivalent reset for conductors doesn't erase:

```cpp
cp.text = c->diagram() ? c->diagram()->defaultConductorProperties.text : "_";
```

It unconditionally overwrites the conductor's text with the *project's configured default text for newly-drawn conductors* — a setting that happens to default to a literal `_` character (visible in the project/new-folio "Conductors" tab), and has nothing to do with whether this particular copy's label should be kept or cleared. The `: "_"` fallback for the "no diagram" branch doesn't help either — these conductors are already on the scene by the time this code runs, so that branch shouldn't even be reachable.

### Fix

Reset conductor text to `""` too, matching every other field reset in the same block. "Erase on copy" should erase, not "replace with whatever the project's unrelated new-conductor default happens to be."

### Verification

Built clean. I wasn't able to get a reliable live GUI reproduction under Xvfb + xdotool for this one — drawing conductors between terminals via simulated drag kept mis-firing as element placement instead in this environment, the same class of automation friction noted on #743. Confidence rests on tracing the exact code path (confirmed `defaultConductorProperties.text` is a project-level setting for freshly-drawn conductors, unrelated to paste; confirmed the sibling element-info reset four lines above uses `""` specifically) plus this being a one-line change to match an already-correct pattern sitting right next to it, not new logic.