### PR TITLE
Fix real_font_size_ desyncing from the actual font in PartText

### DIFF
--- a/sources/editor/graphicspart/parttext.cpp
+++ b/sources/editor/graphicspart/parttext.cpp
@@ -440,6 +440,14 @@ void PartText::setFont(const QFont &font) {
 		// at a different spot after save/reopen (the position recomputes from
 		// the saved font on load). See #158.
 		adjustItemPosition();
+		// Keep real_font_size_ in sync with the actual font. It's the base
+		// size startUserTransformation()/handleUserTransformation() scale
+		// from when the user drags a resize handle, and flip() also reads it
+		// to reposition the item. Left stale here, either one computes from
+		// whatever size the item had when it was first created, ignoring any
+		// size set since (toolbar, property editor, or loaded from XML) -
+		// found investigating #158.
+		real_font_size_ = font.pointSize();
 		emit fontChanged(font);
 	}
 }


### PR DESCRIPTION
Follow-up to #158 / #501. While investigating that position bug, I flagged this as a separate, unrelated finding in the issue thread and said I'd send a small PR for it — this is that.

### Bug

`PartText::setFont()` never updated `real_font_size_`, so it stays frozen at whatever size the item was constructed with (the default, since `PartText`'s constructor is what sets it initially).

That field isn't cosmetic — two other operations depend on it:

- `startUserTransformation()`/`handleUserTransformation()` use it as the base size when scaling the font as the user drags a resize handle. If it's stale, dragging a handle after changing the size via the toolbar (or loading a file with a non-default size) scales from the wrong starting point — the resulting size has nothing to do with what's visibly on screen.
- `flip()` reads it directly to compute the repositioning offset, so a stale value also mis-positions the item on flip.

### Fix

Update `real_font_size_` inside `setFont()` — the same place #501 already re-runs `adjustItemPosition()` for the same reason (font changed, keep everything that depends on it in sync):

```cpp
real_font_size_ = font.pointSize();
```

`fromXml()` already routes both its `size` and `font` attribute branches through `setFont()`, so loaded elements pick this up for free — no separate handling needed there.

### Verification

Built with a temporary instrumented log (before/after values printed on every `setFont()` call), then in the actual element editor typed a size into the font-size field three times in one session: `9 -> 4 -> 48`.

```
before= 9   newfont= 9    (construction)
before= 9   newfont= 4
before= 4   newfont= 48
```

Each call's `before=` exactly matches the *previous* call's `after=` — confirming `real_font_size_` now tracks every change instead of freezing at `9`. Instrumentation removed before committing; final diff is the one-line fix plus a comment.