### PR TITLE
Fix slave contact groups being trimmed to one when reopening element properties

### DIFF
--- a/sources/editor/ui/elementpropertieseditorwidget.cpp
+++ b/sources/editor/ui/elementpropertieseditorwidget.cpp
@@ -452,6 +452,9 @@ void ElementPropertiesEditorWidget::on_m_slave_groups_checkbox_toggled(bool chec
 
 	if (checked && !ui->max_slaves_checkbox->isChecked()) {
 		ui->max_slaves_checkbox->setChecked(true);
+		if (!m_data.m_slave_contact_groups.isEmpty()) {
+			ui->max_slaves_spinbox->setValue(m_data.m_slave_contact_groups.size());
+		}
 	}
 
 	if (checked) {


### PR DESCRIPTION
https://qelectrotech.org/bugtracker/view.php?id=339

Summary: When editing a Master element's properties, enabling the "Define slave elements" checkbox without first checking the "Define max slaves" checkbox caused the slave contact groups list to be trimmed to a single entry upon reopening the dialog.

The root cause was in on_m_slave_groups_checkbox_toggled: when toggling the slave groups checkbox on, it forced the max_slaves checkbox on but did not update the spinbox value. The spinbox retained its default value of 1 (from the UI minimum), so populateSlaveGroupsTable() would trim all loaded groups down to one.

The fix sets the spinbox value to the current number of existing groups when the slave groups checkbox forces the max_slaves checkbox on.