### PR TITLE
Take the modal dialog out of RotateTextsCommand's constructor

### DIFF
--- a/sources/qetdiagrameditor.cpp
+++ b/sources/qetdiagrameditor.cpp
@@ -1631,7 +1631,18 @@ void QETDiagramEditor::selectionGroupTriggered(QAction *action)
 			diagram->undoStack().push(c);
 	}
 	else if (value == "rotate_selected_text")
-		diagram->undoStack().push(new RotateTextsCommand(diagram));
+	{
+			//Ask for the angle first, then build the command: the command
+			//itself no longer opens a dialog. Guarding on the selection keeps
+			//the previous behaviour of showing no dialog when there is
+			//nothing to rotate.
+		if (RotateTextsCommand::hasSelectedTexts(diagram))
+		{
+			qreal rotation = 0;
+			if (RotateTextsCommand::askRotation(rotation))
+				diagram->undoStack().push(new RotateTextsCommand(diagram, rotation));
+		}
+	}
 	else if (value == "find_selected_element" && currentElement())
 		findElementInPanel(currentElement()->location());
 	else if (value == "edit_selected_element")

--- a/sources/undocommand/rotatetextscommand.cpp
+++ b/sources/undocommand/rotatetextscommand.cpp
@@ -26,14 +26,33 @@
 #include "../qtextorientationspinboxwidget.h"
 
 /**
+	@brief RotateTextsCommand::hasSelectedTexts
+	@param diagram
+	@return true if @p diagram has at least one selected text or text group.
+	Lets a caller decide whether to ask the user for an angle at all, keeping
+	the previous behaviour where no dialog appeared for an empty selection.
+*/
+bool RotateTextsCommand::hasSelectedTexts(Diagram *diagram)
+{
+	if(!diagram)
+		return false;
+
+	DiagramContent dc(diagram);
+	return (!dc.selectedTexts().isEmpty() || !dc.selectedTextsGroup().isEmpty());
+}
+
+/**
 	@brief RotateTextsCommand::RotateTextsCommand
 	@param diagram : Apply the rotation to the selected texts and group of texts
-	of diagram at construction time. 
+	of diagram at construction time.
+	@param rotation : the angle to apply, in degrees. Obtain it from
+	askRotation() for interactive use; pass it directly from a test or script.
 	@param parent : undo parent
 */
-RotateTextsCommand::RotateTextsCommand(Diagram *diagram, QUndoCommand *parent) :
+RotateTextsCommand::RotateTextsCommand(Diagram *diagram, qreal rotation, QUndoCommand *parent) :
 QUndoCommand(parent),
-m_diagram(diagram)
+m_diagram(diagram),
+m_rotation(rotation)
 {
 	DiagramContent dc(m_diagram);
 	QList <DiagramTextItem *> texts_list;
@@ -53,8 +72,6 @@ m_diagram(diagram)
 	
 	if(texts_list.count() || groups_list.count())
 	{
-		openDialog();
-		
 		QString text;
 		if(texts_list.count())
 			text.append(QObject::tr("Pivoter %1 textes").arg(texts_list.count()));
@@ -85,9 +102,15 @@ void RotateTextsCommand::undo()
 	if(m_diagram)
 		m_diagram.data()->showMe();
 	
+		//Nothing was selected at construction time: there is no animation to
+		//run. QUndoStack::push() calls redo() before it discards an obsolete
+		//command, so this has to be survivable rather than assumed away.
+	if(!m_anim_group)
+		return;
+
 	m_anim_group->setDirection(QAnimationGroup::Backward);
 	m_anim_group->start();
-	
+
 	for(ConductorTextItem *cti : m_cond_texts.keys())
 		cti->forceRotateByUser(m_cond_texts.value(cti));
 }
@@ -97,14 +120,28 @@ void RotateTextsCommand::redo()
 	if(m_diagram)
 		m_diagram.data()->showMe();
 	
+	if(!m_anim_group)
+		return;
+
 	m_anim_group->setDirection(QAnimationGroup::Forward);
 	m_anim_group->start();
-	
+
 	for(ConductorTextItem *cti : m_cond_texts.keys())
 		cti->forceRotateByUser(true);
 }
 
-void RotateTextsCommand::openDialog()
+/**
+	@brief RotateTextsCommand::askRotation
+	Ask the user for an orientation.
+	@param rotation : set to the chosen angle when the dialog is accepted,
+	left untouched otherwise.
+	@return true if the user accepted, false if they cancelled.
+
+	Deliberately static and separate from the command: a QUndoCommand that
+	blocks on a modal in its constructor cannot be built by a test, a script,
+	or any headless caller.
+*/
+bool RotateTextsCommand::askRotation(qreal &rotation)
 {
 		//Open the dialog
 	QDialog ori_text_dialog;
@@ -129,10 +166,11 @@ void RotateTextsCommand::openDialog()
 	layout_v.addStretch();
 	layout_v.addWidget(&buttons);
 	
-	if (ori_text_dialog.exec() == QDialog::Accepted)
-		m_rotation = ori_widget->orientation();
-	else
-		setObsolete(true);
+	if (ori_text_dialog.exec() != QDialog::Accepted)
+		return false;
+
+	rotation = ori_widget->orientation();
+	return true;
 }
 
 void RotateTextsCommand::setupAnimation(QObject *target, const QByteArray &propertyName, const QVariant& start, const QVariant& end)

--- a/sources/undocommand/rotatetextscommand.h
+++ b/sources/undocommand/rotatetextscommand.h
@@ -28,19 +28,38 @@ class QParallelAnimationGroup;
 
 /**
 	@brief The RotateTextsCommand class
-	Open a dialog for edit the rotation of the current selected texts and texts group in diagram.
-	Just instantiate this undo command and push it in a QUndoStack.
+	Apply @p rotation to the currently selected texts and texts group of a
+	diagram. Just instantiate this undo command and push it in a QUndoStack.
+
+	This command does not ask the user for anything: obtaining the angle is the
+	caller's job, via the askRotation() helper below. Keeping the dialog out of
+	the constructor is what makes the command usable outside an interactive
+	session — from a test harness, a regression sweep, or a script — and stops
+	a headless caller from blocking forever on a modal nobody can answer.
+
+	Typical interactive use:
+	@code
+	if (RotateTextsCommand::hasSelectedTexts(diagram)) {
+		qreal rotation = 0;
+		if (RotateTextsCommand::askRotation(rotation))
+			diagram->undoStack().push(new RotateTextsCommand(diagram, rotation));
+	}
+	@endcode
 */
 class RotateTextsCommand : public QUndoCommand
 {
 	public:
-		RotateTextsCommand(Diagram *diagram, QUndoCommand *parent=nullptr);
+		RotateTextsCommand(Diagram *diagram, qreal rotation, QUndoCommand *parent=nullptr);
+
+			/// @return true if @p diagram has at least one selected text or text group to rotate.
+		static bool hasSelectedTexts(Diagram *diagram);
+			/// Open the orientation dialog. @return true and set @p rotation if accepted, false if cancelled.
+		static bool askRotation(qreal &rotation);
 
 		void undo() override;
 		void redo() override;
 
 	private:
-		void openDialog();
 		void setupAnimation(QObject *target, const QByteArray &propertyName, const QVariant& start, const QVariant& end);
 
 	private:


### PR DESCRIPTION
`RotateTextsCommand` called `QDialog::exec()` from **inside its constructor**, so the command could not be built without a human answering a dialog.

That made it untestable headlessly and undrivable from any script or test harness — and it is why my own #312 fix (PR #707) shipped with its save/reload round-trip unverified: the symptom could not be reproduced without a GUI, and driving the GUI for it did not work.

### What changed

The command now takes the angle as a parameter and asks nothing. Two statics carry the interactive half:

```cpp
static bool hasSelectedTexts(Diagram *diagram);   // anything to rotate?
static bool askRotation(qreal &rotation);         // dialog; false if cancelled
```

The single call site in `QETDiagramEditor` asks first, then builds the command.

`askRotation()` deliberately stays in this class rather than moving to the caller: it keeps the `QObject` `tr()` context, so existing translations of *"Orienter les textes sélectionnés"* are not invalidated.

### User-visible behaviour is unchanged

Same dialog, same title, same widget, and still no dialog when the selection is empty. Verified by running the built binary under Xvfb: select all → <kbd>Ctrl</kbd>+<kbd>Space</kbd> → the orientation dialog opens as before.

### Also fixes a latent null dereference

When nothing is selected, the constructor calls `setObsolete(true)` without ever creating `m_anim_group`. `QUndoStack::push()` calls `redo()` **before** it discards an obsolete command, which dereferences a null pointer. Unreachable today only because the action is disabled on an empty selection. `undo()`/`redo()` now guard.

### Verification — bugtracker #312 reproduced and fixed under test, for the first time

With the command finally constructible headlessly, I drove it through a scratch scripted-editing hook (not part of this PR) against `examples/741.qet` — 67 conductors, single folio, `rotation` attributes stripped first — and counted what got written on save:

| build | conductors with `rotation` | with `userx` |
|---|---|---|
| PR #707 applied (`forceRotateByUser`) | **67** | 0 |
| PR #707 reverted (`forceMovedByUser`) | **0** | **67** |

The reverted build writes no rotation at all — lost on reload, exactly bugtracker #312. The fixed build writes all 67.

It also surfaced a **second symptom of that bug** that had gone unnoticed: because the buggy code called `forceMovedByUser(true)`, it did not merely drop the rotation, it spuriously marked every text as manually positioned, writing `userx`/`usery`. Projects saved by an affected build carry position pins the user never set, and #707 does not remove them. Flagging it here rather than acting on it — I have not assessed whether that warrants a migration.

### Note for scripted callers

The rotation *value* is applied through `QPropertyAnimation`, which needs a spinning event loop. Headless, the flag is set and the attribute written, but the value stays at its pre-animation figure. Fine for the save gate; a scripted caller wanting the angle actually applied would need the animation completed or bypassed. Not addressed here.

### Testing

- Clean build, no new warnings.
- Interactive path verified under Xvfb as described above.
- Headless A/B as tabulated above.
