### PR TITLE
Add a non-interactive mode so headless runs cannot block on a modal

### DIFF
--- a/sources/main.cpp
+++ b/sources/main.cpp
@@ -127,6 +127,11 @@ QGuiApplication::setHighDpiScaleFactorRoundingPolicy(QetSettings::hdpiScaleFacto
 			// runs on a background thread referencing the project and races the
 			// process exit (intermittent segfault in QET::writeToFile).
 			QETProject::setBackupEnabled(false);
+			// Nobody is watching a headless run, so a modal prompt has no way
+			// to be answered and blocks the process forever. Suppress them:
+			// QET::QetMessageBox reports the question on stderr and returns
+			// the caller's default instead of opening a dialog.
+			QET::setInteractive(false);
 			return CLIExport::run(export_app.arguments());
 		}
 	}

--- a/sources/qet.cpp
+++ b/sources/qet.cpp
@@ -713,6 +713,30 @@ bool QET::eachStrIsEqual(const QStringList &qsl) {
 	@param c QetCollection value to convert
 	@return The QetCollection enum value converted to a QString
 */
+namespace {
+		/// @see QET::setInteractive
+	bool interactive_mode = true;
+}
+
+/**
+	@brief QET::setInteractive
+	@param interactive : false to suppress every blocking user prompt.
+	Set once, early, from the headless command-line path.
+*/
+void QET::setInteractive(bool interactive)
+{
+	interactive_mode = interactive;
+}
+
+/**
+	@brief QET::isInteractive
+	@return true when there is a user available to answer a prompt.
+*/
+bool QET::isInteractive()
+{
+	return interactive_mode;
+}
+
 QString QET::qetCollectionToString(const QET::QetCollection &c)
 {
 	switch (c)

--- a/sources/qet.h
+++ b/sources/qet.h
@@ -155,7 +155,21 @@ namespace QET {
 
 	QString qetCollectionToString (const QetCollection &c);
 	QetCollection qetCollectionFromString (const QString &str);
-	
+
+		/**
+			Interactive mode. True by default; set false for headless runs
+			(the command-line export path in main.cpp).
+
+			When false, the QET::QetMessageBox helpers do not open a dialog:
+			they report the question on stderr and return immediately. There
+			is nobody to answer a modal in a headless run, so any that opens
+			blocks the process forever -- a whole class of "the CLI hangs"
+			bugs. Query it before any other blocking prompt you add.
+		*/
+	void setInteractive(bool interactive);
+	bool isInteractive();
+
+
 	bool lineContainsPoint(const QLineF &, const QPointF &);
 	bool orthogonalProjection(const QPointF &, const QLineF &, QPointF * = nullptr);
 	bool attributeIsAnInteger(const QDomElement &, const QString& , int * = nullptr);

--- a/sources/qetmessagebox.cpp
+++ b/sources/qetmessagebox.cpp
@@ -17,6 +17,36 @@
 */
 #include "qetmessagebox.h"
 
+#include <QDebug>
+
+#include "qet.h"
+
+namespace {
+	/**
+		Answer a message box without a user.
+
+		In a headless run (QET::isInteractive() == false) there is nobody to
+		click a button, so opening the dialog would block the process forever.
+		Report the question on stderr instead and hand back @p defaultButton.
+
+		A call site that has not specified a default gets QMessageBox::NoButton,
+		which is deliberate: almost every caller is written as "if the user
+		chose the abort option, abort", so NoButton means the operation carries
+		on unchanged. Pass an explicit default wherever a specific unattended
+		answer is wanted.
+	*/
+	QMessageBox::StandardButton answerWithoutUser(
+			const char *level,
+			const QString &title,
+			const QString &text,
+			QMessageBox::StandardButton defaultButton)
+	{
+		qWarning().noquote() << QStringLiteral("%1 (headless, no user to ask): %2 -- %3")
+								.arg(QString::fromLatin1(level), title, text);
+		return defaultButton;
+	}
+}
+
 /**
 	@see Documentation Qt pour QMessageBox::critical
 */
@@ -27,6 +57,9 @@ QMessageBox::StandardButton QET::QetMessageBox::critical (
 		QMessageBox::StandardButtons buttons,
 		QMessageBox::StandardButton defaultButton)
 {
+	if (!QET::isInteractive())
+		return answerWithoutUser("critical", title, text, defaultButton);
+
 #ifdef Q_OS_MACOS
 	QMessageBox message_box(
 				QMessageBox::Critical,
@@ -59,6 +92,9 @@ QMessageBox::StandardButton QET::QetMessageBox::information(
 		QMessageBox::StandardButtons buttons,
 		QMessageBox::StandardButton defaultButton)
 {
+	if (!QET::isInteractive())
+		return answerWithoutUser("information", title, text, defaultButton);
+
 #ifdef Q_OS_MACOS
 	QMessageBox message_box(
 				QMessageBox::Information,
@@ -91,6 +127,9 @@ QMessageBox::StandardButton QET::QetMessageBox::question (
 		QMessageBox::StandardButtons buttons,
 		QMessageBox::StandardButton defaultButton)
 {
+	if (!QET::isInteractive())
+		return answerWithoutUser("question", title, text, defaultButton);
+
 #ifdef Q_OS_MACOS
 	QMessageBox message_box(
 				QMessageBox::Question,
@@ -123,6 +162,9 @@ QMessageBox::StandardButton QET::QetMessageBox::warning (
 		QMessageBox::StandardButtons buttons,
 		QMessageBox::StandardButton defaultButton)
 {
+	if (!QET::isInteractive())
+		return answerWithoutUser("warning", title, text, defaultButton);
+
 #ifdef Q_OS_MACOS
 	QMessageBox message_box(
 				QMessageBox::Warning,

--- a/sources/qetproject.cpp
+++ b/sources/qetproject.cpp
@@ -1228,7 +1228,7 @@ ElementsLocation QETProject::importElement(ElementsLocation &location)
 				// Warn if the new element introduces slave contact groups
 				QDomElement new_kind = location.xml().firstChildElement("kindInformations");
 				if (!new_kind.firstChildElement("slaveContactGroups").isNull()) {
-					QMessageBox::StandardButton answer = QMessageBox::warning(nullptr,
+					QMessageBox::StandardButton answer = QET::QetMessageBox::warning(nullptr,
 						tr("Système de contacts modifié"),
 						tr("Le nouvel élément définit des groupes de contacts esclaves.\n"
 						   "Les éléments esclaves existants ne seront pas automatiquement "


### PR DESCRIPTION
A modal dialog opened during a headless run has nobody to answer it, so the process blocks forever.

This is a recurring **class** of bug rather than a one-off. Two of my own open PRs each fix a single instance of it:

- #661 — command-line tools hanging on a modal message box
- #737 — headless CLI hanging on version-incompatible projects

and the next prompt someone adds to a load path reintroduces it. **This PR is intended to supersede both** — I am happy to close them if you prefer this approach.

### What it does

Adds `QET::setInteractive()` / `QET::isInteractive()`, mirroring the existing `QETProject::setBackupEnabled()` pattern, set `false` from `main.cpp`'s command-line branch. The four `QET::QetMessageBox` helpers consult it: when non-interactive they report the question on stderr and return the caller's `defaultButton` instead of opening a dialog.

That covers the **59 existing `QET::QetMessageBox` call sites at once**, including both version-compatibility prompts in `QETProject::readProjectXml()` that #737 addresses individually. It also routes the one raw `QMessageBox::warning` on the element-load path through the wrapper.

### The default-answer rule

A caller that passes no default gets `QMessageBox::NoButton`, deliberately.

Nearly every call site is written as *"if the user chose the abort option, abort"* — so `NoButton` means the operation proceeds unchanged, which is the safe direction and needs no per-site guesswork about what to auto-answer. The two `readProjectXml` prompts are exactly this shape (`if (ret == QMessageBox::Cancel) discard`), so they now proceed as Open, matching #737's intent without a bespoke fix.

Call sites wanting a specific unattended answer pass an explicit default, as several already do.

### Verification

`examples/schema_indus.qet` is version 0.3 and previously hung **every** CLI verb forever:

| verb | before | after |
|---|---|---|
| `--info` | HUNG (60 s timeout) | ok |
| `--resave` | HUNG | ok |
| `--export-bom` / `-nets` / `-links` | HUNG | ok |
| `--export-pdf` / `-svg` / `-png` | HUNG | ok |

with the suppressed prompt reported on stderr:

```
warning (headless, no user to ask): Avertissement -- Le projet que vous tentez
d'ouvrir est partiellement compatible avec votre version 0.100.1 ...
```

Controls: a normal project (`examples/741.qet`) round-trips with its conductor count unchanged, and the GUI still shows its dialogs — interactive mode is the default and only the CLI branch turns it off. Verified under Xvfb.

### Not covered, on purpose

This handles **confirmation** dialogs, which have a sensible unattended answer. It does not help **parameter-gathering** dialogs — ones whose whole purpose is to obtain a value with no default. Suppressing those just yields "cancelled". Those need the parameter lifted into the API instead; #752 does that for `RotateTextsCommand`. There are very few of them.
