### PR TITLE
Change element editor coordinates display

### DIFF
--- a/sources/editor/elementscene.cpp
+++ b/sources/editor/elementscene.cpp
@@ -121,7 +121,7 @@ void ElementScene::mouseMoveEvent(QGraphicsSceneMouseEvent *e)
 {
 	if (m_event_interface) {
 		if (m_event_interface -> mouseMoveEvent(e)) {
-			emit mouseMoved(e -> scenePos());
+			emit mouseMoved(snapToGrid(e->scenePos()));
 			if (m_event_interface->isFinish()) {
 				delete m_event_interface;
 				m_event_interface = nullptr;

--- a/sources/editor/ui/qetelementeditor.cpp
+++ b/sources/editor/ui/qetelementeditor.cpp
@@ -55,6 +55,7 @@
 #include <QActionGroup>
 #include <QFileDialog>
 #include <QSvgGenerator>
+#include <QHBoxLayout>
 
 /**
  * @brief QETElementEditor::QETElementEditor
@@ -1200,7 +1201,18 @@ void QETElementEditor::initGui()
 		//Live cursor position readout, in the same scene coordinates as the parts' X/Y properties
 	m_position_label = new QLabel(this);
 	m_position_label->setMinimumWidth(120);
-	statusBar()->addPermanentWidget(m_position_label);
+	
+	// Layout
+	QHBoxLayout *coordDisplayLayout = new QHBoxLayout();
+	coordDisplayLayout->setContentsMargins(0, 0, 0, 0);
+	coordDisplayLayout->addWidget(m_position_label);
+	coordDisplayLayout->addStretch();
+	// Widget
+	QWidget *coordDisplay = new QWidget;
+	coordDisplay->setLayout(coordDisplayLayout);
+	
+	statusBar()->addPermanentWidget(coordDisplay);
+	
 	connect(m_elmt_scene, &ElementScene::mouseMoved, this, [this](const QPointF &pos) {
 		m_position_label->setText(tr("X: %1  Y: %2")
 			.arg(pos.x(), 0, 'f', 1)


### PR DESCRIPTION
Commit: Change live cursor-coordinate readout on running ESEvent
During an ES event in the element editor (e.g., drawing a line), the coordinates for the coordinate display are not formatted using 'snapToGrid'. As a result, the coordinates of the help cross do not match the displayed coordinates. The signal for transmitting the coordinates has been moved to the `updateHelpCross` function within the event interface. Therfore, position formatted with 'snapToGrid' is used for the display across all events.

Commit:  move  element editor coord display to center of statusar
The coordinate display has been moved to the center of the status bar because it is more easily visible there than in the bottom-right corner.