### PR TITLE
Editable auto_num_locked/potential_isolating/exclude_from_bom in the element editor

### DIFF
--- a/sources/editor/ui/elementpropertieseditorwidget.cpp
+++ b/sources/editor/ui/elementpropertieseditorwidget.cpp
@@ -410,13 +410,21 @@ void ElementPropertiesEditorWidget::on_m_buttonBox_accepted()
 
 	if (m_data.m_type == ElementData::Terminal)
 	{
-		m_data.m_informations.addValue(QStringLiteral("auto_num_locked"),
-			ui->m_auto_num_locked_cb->isChecked() ? QStringLiteral("true") : QStringLiteral("false"));
-		m_data.m_informations.addValue(QStringLiteral("potential_isolating"),
-			ui->m_potential_isolating_cb->isChecked() ? QStringLiteral("true") : QStringLiteral("false"));
+		if (ui->m_auto_num_locked_cb->isChecked())
+			m_data.m_informations.addValue(QStringLiteral("auto_num_locked"), QStringLiteral("true"));
+		else
+			m_data.m_informations.remove(QStringLiteral("auto_num_locked"));
+
+		if (ui->m_potential_isolating_cb->isChecked())
+			m_data.m_informations.addValue(QStringLiteral("potential_isolating"), QStringLiteral("true"));
+		else
+			m_data.m_informations.remove(QStringLiteral("potential_isolating"));
 	}
-	m_data.m_informations.addValue(QStringLiteral("exclude_from_bom"),
-		ui->m_exclude_from_bom_cb->isChecked() ? QStringLiteral("true") : QStringLiteral("false"));
+
+	if (ui->m_exclude_from_bom_cb->isChecked())
+		m_data.m_informations.addValue(QStringLiteral("exclude_from_bom"), QStringLiteral("true"));
+	else
+		m_data.m_informations.remove(QStringLiteral("exclude_from_bom"));
 
 	this->close();
 }

--- a/sources/editor/ui/elementpropertieseditorwidget.cpp
+++ b/sources/editor/ui/elementpropertieseditorwidget.cpp
@@ -171,7 +171,16 @@ void ElementPropertiesEditorWidget::upDateInterface()
 		ui->m_terminal_func_cb->setCurrentIndex(
 					ui->m_terminal_func_cb->findData(
 						m_data.m_terminal_function));
+
+		const DiagramContext &info = m_data.m_informations;
+		ui->m_auto_num_locked_cb->setChecked(
+			info.value(QStringLiteral("auto_num_locked")).toString() == QLatin1String("true"));
+		ui->m_potential_isolating_cb->setChecked(
+			info.value(QStringLiteral("potential_isolating")).toString() == QLatin1String("true"));
 	}
+
+	ui->m_exclude_from_bom_cb->setChecked(
+		m_data.m_informations.value(QStringLiteral("exclude_from_bom")).toString() == QLatin1String("true"));
 
 	on_m_base_type_cb_currentIndexChanged(ui->m_base_type_cb->currentIndex());
 }
@@ -366,8 +375,8 @@ void ElementPropertiesEditorWidget::on_m_buttonBox_accepted()
 			m_data.m_slave_type  = ui->m_type_cb->currentData().value<ElementData::SlaveType>();
 		}
 		m_data.m_contact_count = ui->m_number_ctc->value();
-	}
-		else if (m_data.m_type == ElementData::Master) {
+	} else if (m_data.m_type == ElementData::Master)
+	{
 		m_data.m_master_type = ui->m_master_type_cb->currentData().value<ElementData::MasterType>();
 
 		//If the checkbox is checked, save the number; otherwise, -1 (infinity)
@@ -382,13 +391,12 @@ void ElementPropertiesEditorWidget::on_m_buttonBox_accepted()
 		} else {
 			readSlaveGroupsFromTable();
 		}
-	}
-	else if (m_data.m_type == ElementData::Terminal)
+	} else if (m_data.m_type == ElementData::Terminal)
 	{
 		m_data.m_terminal_type = ui->m_terminal_type_cb->currentData().value<ElementData::TerminalType>();
 		m_data.m_terminal_function = ui->m_terminal_func_cb->currentData().value<ElementData::TerminalFunction>();
 	}
-	
+
 	for (QTreeWidgetItem *qtwi : ui->m_tree->invisibleRootItem()->takeChildren())
 	{
 		QString txt = qtwi->text(1);
@@ -399,7 +407,17 @@ void ElementPropertiesEditorWidget::on_m_buttonBox_accepted()
 		m_data.m_informations.addValue(qtwi->data(0, Qt::UserRole).toString(),
 									   txt);
 	}
-	
+
+	if (m_data.m_type == ElementData::Terminal)
+	{
+		m_data.m_informations.addValue(QStringLiteral("auto_num_locked"),
+			ui->m_auto_num_locked_cb->isChecked() ? QStringLiteral("true") : QStringLiteral("false"));
+		m_data.m_informations.addValue(QStringLiteral("potential_isolating"),
+			ui->m_potential_isolating_cb->isChecked() ? QStringLiteral("true") : QStringLiteral("false"));
+	}
+	m_data.m_informations.addValue(QStringLiteral("exclude_from_bom"),
+		ui->m_exclude_from_bom_cb->isChecked() ? QStringLiteral("true") : QStringLiteral("false"));
+
 	this->close();
 }
 

--- a/sources/editor/ui/elementpropertieseditorwidget.ui
+++ b/sources/editor/ui/elementpropertieseditorwidget.ui
@@ -55,6 +55,16 @@
        </layout>
        </item>
        <item>
+        <widget class="QCheckBox" name="m_exclude_from_bom_cb">
+         <property name="styleSheet">
+          <string>margin: 5px; font-weight: bold;</string>
+         </property>
+         <property name="text">
+          <string>Exclure de la nomenclature</string>
+         </property>
+        </widget>
+       </item>
+       <item>
         <widget class="QGroupBox" name="m_slave_gb">
          <property name="title">
           <string>Élément esclave</string>
@@ -228,6 +238,26 @@
           </item>
           <item row="1" column="1">
            <widget class="QComboBox" name="m_terminal_func_cb"/>
+          </item>
+          <item row="2" column="0" colspan="2">
+           <widget class="QCheckBox" name="m_auto_num_locked_cb">
+            <property name="styleSheet">
+             <string>margin: 5px; font-weight: bold;</string>
+            </property>
+            <property name="text">
+             <string>Verrouiller la numérotation automatique</string>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="0" colspan="2">
+           <widget class="QCheckBox" name="m_potential_isolating_cb">
+            <property name="styleSheet">
+             <string>margin: 5px; font-weight: bold;</string>
+            </property>
+            <property name="text">
+             <string>Séparation de potentiel</string>
+            </property>
+           </widget>
           </item>
          </layout>
         </widget>


### PR DESCRIPTION
## Problem

`auto_num_locked`, `potential_isolating`, and `exclude_from_bom` are
existing elementInformation keys, already editable on an already-placed
instance via `ElementInfoWidget` on the diagram side. But since
elementInformation values are seeded from the `.elmt` file's own
`<elementInformations>` block at placement time (`ElementData::fromXml()`),
a symbol author had no proper way to set these as the *default* baked
into the symbol itself -- so every single placement had to be
re-configured by hand, even for a device that should always behave the
same way (e.g. a terminal block that's always potential-isolating).

The only workaround was the generic, unvalidated key/value tree in the
element editor -- typing the exact key string and `"true"`/`"false"`
as literal text, with no discoverability and no validation.

## What this adds

Dedicated checkboxes in `ElementPropertiesEditorWidget`, mirroring
`ElementInfoWidget`'s own labels and behavior exactly:

- `auto_num_locked` / `potential_isolating` -- inside the existing
  `m_terminal_gb` group, shown only when the element's base type is
  `ElementData::Terminal` (same condition already used for the
  terminal type/function combo boxes right above them).
- `exclude_from_bom` -- always visible, regardless of type, placed
  directly under the type selector.

Written after the existing generic key/value tree loop in the save
path, so a dedicated checkbox always takes precedence over a stale
raw tree entry a symbol author may have set for the same key before
these checkboxes existed.

## Scope

No new storage mechanism, no `.elmt` format change -- these keys
already round-trip correctly through the existing
`elementInformations`/`DiagramContext` machinery. This is purely
adding the missing editor-side UI for values the format already
supports.

## Testing

Built and tested on Ubuntu 24, both Qt5 and Qt6 configurations. Verified:
checkbox visibility toggles correctly when switching the base type
combo box, values persist correctly through save/reopen, and a
freshly-placed instance of a terminal element correctly inherits the
symbol's saved defaults for all three fields.

## Note for maintainers
Elements of the "Slave" type are currently not supported at all by
"elementInformations" in the Element Editor -- not just
"exclude_from_bom," but the entire mechanism is unavailable for this
type.

This has different implications depending on the situation. For
something like the auxiliary contact of a relay, this is fine -- there
is no separate physical component, nothing to order, nothing that
belongs in a bill of materials on its own. But in the case of an
auxiliary contact block that must be ordered separately for a circuit
breaker, the situation is different: it does not have its own BMK, but
it does have its own manufacturer, its own part number, etc., since it
is a genuine, separately purchasable item -- and therefore, in my
view, belongs in the bill of materials.

Separately, and confirmed more impactful: the entire "Informations"
tab in the element editor is hidden for anything other than Simple and
Master (elementpropertieseditorwidget.cpp, setTabVisible(1, type_ ==
Simple || type_ == Master)). Checked it against the tree's own
enable/disable logic (updateTree()) and the write path
(elementscene.cpp) side by side -- for Terminal and Thumbnail, the
tree is enabled and the write path already works, but the tab hiding
it means neither is ever reachable. That's a plain inconsistency
between three independent "is this type allowed" checks that were
never reconciled, not an intentional restriction. Slave is at least
consistent -- disabled at all three points -- which lines up with the
missing write-path support above.

Both of these are genuine, pre-existing gaps, and out of scope for
this PR. I have addressed the tab-visibility inconsistency (Terminal/
Thumbnail) in #767 since it's a self-contained,
low-risk fix; the broader Slave elementInformations support is a
larger question we're leaving open for now.