### PR TITLE
PLC terminal names: fix transfer to slaves and display in properties widgets

### DIFF
--- a/sources/properties/elementdata.h
+++ b/sources/properties/elementdata.h
@@ -99,6 +99,19 @@ class ElementData : public PropertiesInterface
 			int terminalCount = 1;    ///< Number of terminals for this IO (1-4)
 			QStringList terminals;    ///< Terminal values T1, T2, ... (size = terminalCount)
 
+			/**
+			 * @brief Return terminal labels, generating defaults (T1, T2...) if empty
+			 */
+			QStringList effectiveTerminals() const {
+				if (!terminals.isEmpty())
+					return terminals;
+				int count = qMax(terminalCount, 1);
+				QStringList defaults;
+				for (int i = 0; i < count && i < 4; ++i)
+					defaults << QStringLiteral("T%1").arg(i + 1);
+				return defaults;
+			}
+
 			bool operator==(const PlcIO &other) const {
 				return type == other.type
 					&& address == other.address

--- a/sources/qetgraphicsitem/element.cpp
+++ b/sources/qetgraphicsitem/element.cpp
@@ -38,6 +38,15 @@
 #include "dynamicelementtextitem.h"
 #include "elementtextitemgroup.h"
 #include "iostream"
+
+#include <QCollator>
+
+static const QString plcTerminalKeys[] = {
+	QETInformation::ELMT_PLC_T1,
+	QETInformation::ELMT_PLC_T2,
+	QETInformation::ELMT_PLC_T3,
+	QETInformation::ELMT_PLC_T4
+};
 #include "../qetxml.h"
 #include "../qetversion.h"
 #include "qgraphicsitemutility.h"
@@ -1511,13 +1520,7 @@ void Element::setElementData(ElementData data)
 					{
 						QString val = (t < io.terminals.size())
 							? io.terminals.at(t) : QString();
-						ctx.addValue(
-							QStringList({
-								QETInformation::ELMT_PLC_T1,
-								QETInformation::ELMT_PLC_T2,
-								QETInformation::ELMT_PLC_T3,
-								QETInformation::ELMT_PLC_T4
-							}).at(t), val);
+						ctx.addValue(plcTerminalKeys[t], val);
 					}
 					slave->setElementInformations(ctx);
 

--- a/sources/qetgraphicsitem/terminal.cpp
+++ b/sources/qetgraphicsitem/terminal.cpp
@@ -823,17 +823,15 @@ QUuid Terminal::uuid() const
 QString Terminal::name() const
 {
 	if (d->m_use_master_label && parent_element_) {
-		// Find the master element in the slave's linked elements
 		for (Element *elmt : parent_element_->linkedElements()) {
 			if (elmt->linkType() == Element::Master) {
 				int group_idx = elmt->groupIndexForElement(parent_element_);
 				if (group_idx >= 0) {
-					// For PLC masters, use io.terminals as labels
 					if (elmt->elementData().m_master_type == ElementData::PLC) {
 						const auto &plc_data = elmt->elementData().plcMasterData();
 						if (group_idx < plc_data.ios.size()) {
 							int label_idx = d->m_master_label_index;
-							const QStringList &labels = plc_data.ios.at(group_idx).terminals;
+							const QStringList labels = plc_data.ios.at(group_idx).effectiveTerminals();
 							if (label_idx >= 0 && label_idx < labels.size()) {
 								return labels.at(label_idx);
 							}

--- a/sources/ui/masterpropertieswidget.cpp
+++ b/sources/ui/masterpropertieswidget.cpp
@@ -979,14 +979,7 @@ void MasterPropertiesWidget::plcUpdateDisplaySettings()
 	ElementData::PlcMasterData plc_data = ed.plcMasterData();
 	plc_data.ios.clear();
 
-	// Build address -> original IO lookup to correctly reattach terminal data
-	// after row reorder (move up/down) or row removal
-	QHash<QString, int> addr_to_orig_idx;
-	for (int i = 0; i < ed.plcMasterData().ios.size(); ++i) {
-		addr_to_orig_idx[ed.plcMasterData().ios.at(i).address] = i;
-	}
-
-	// Read IOs from table, preserving terminal data from original IOs
+	// Read IOs from table, preserving terminal data from original IOs by row index
 	for (int row = 0; row < m_plc_table->rowCount(); ++row) {
 		ElementData::PlcIO io;
 
@@ -1010,9 +1003,12 @@ void MasterPropertiesWidget::plcUpdateDisplaySettings()
 		if (crossref_item)
 			io.crossRef = crossref_item->text();
 
-		// Preserve terminal data by looking up original IO via address
-		if (addr_to_orig_idx.contains(io.address)) {
-			const auto orig_io = ed.plcMasterData().ios.at(addr_to_orig_idx.value(io.address));
+		// Preserve terminal data by matching row index directly.
+		// This avoids address-based lookup which fails when all addresses
+		// are empty (common in PLC masters) — a hash collision would cause
+		// only the last IO's terminals to be used for all rows.
+		if (row < ed.plcMasterData().ios.size()) {
+			const auto &orig_io = ed.plcMasterData().ios.at(row);
 			io.terminalCount = orig_io.terminalCount;
 			io.terminals = orig_io.terminals;
 		}

--- a/sources/ui/masterpropertieswidget.cpp
+++ b/sources/ui/masterpropertieswidget.cpp
@@ -525,10 +525,10 @@ void MasterPropertiesWidget::updateUi()
 
 			// Table
 			m_plc_table = new QTableWidget(m_plc_widget);
-			m_plc_table->setColumnCount(5);
+			m_plc_table->setColumnCount(6);
 			m_plc_table->setHorizontalHeaderLabels({
 				tr("Type"), tr("Adresse"), tr("Fonction"),
-				tr("Commentaire"), tr("Réf. croisée")
+				tr("Commentaire"), tr("Réf. croisée"), tr("Bornes")
 			});
 			m_plc_table->horizontalHeader()->setSectionResizeMode(QHeaderView::Stretch);
 			m_plc_table->setSelectionBehavior(QAbstractItemView::SelectItems);
@@ -592,6 +592,11 @@ void MasterPropertiesWidget::updateUi()
 			auto *crossref_item = new QTableWidgetItem(io.crossRef);
 			crossref_item->setFlags(crossref_item->flags() & ~Qt::ItemIsEditable);
 			m_plc_table->setItem(row, 4, crossref_item);
+
+			// Anschlüsse (read-only)
+			auto *terminals_item = new QTableWidgetItem(io.terminals.join(QStringLiteral(", ")));
+			terminals_item->setFlags(terminals_item->flags() & ~Qt::ItemIsEditable);
+			m_plc_table->setItem(row, 5, terminals_item);
 		}
 
 		m_plc_table->blockSignals(false);
@@ -806,23 +811,7 @@ void MasterPropertiesWidget::setCellFromValue(int row, int col, const QString &v
 		}
 	}
 	else if (col == 5) {
-		// Terminal count spinbox
-		auto *tc_sb = qobject_cast<QSpinBox*>(m_plc_table->cellWidget(row, col));
-		if (!tc_sb) {
-			tc_sb = new QSpinBox(m_plc_table);
-			tc_sb->setMinimum(1);
-			tc_sb->setMaximum(4);
-			m_plc_table->setCellWidget(row, col, tc_sb);
-			connect(tc_sb, QOverload<int>::of(&QSpinBox::valueChanged),
-				this, [this, row](int) { plcIOCellChanged(row, 5); });
-		}
-		bool ok;
-		int v = val.toInt(&ok);
-		if (ok && v >= 1 && v <= 4)
-			tc_sb->setValue(v);
-	}
-	else if (col == 6) {
-		// CrossRef - read-only
+		// Anschlüsse (read-only)
 		auto *item = new QTableWidgetItem(val);
 		item->setFlags(item->flags() & ~Qt::ItemIsEditable);
 		m_plc_table->setItem(row, col, item);
@@ -860,17 +849,10 @@ void MasterPropertiesWidget::plcAddRow()
 	m_plc_table->setItem(row, 3, new QTableWidgetItem());
 	m_plc_table->setItem(row, 4, new QTableWidgetItem());
 
-	auto *tc_sb = new QSpinBox(m_plc_table);
-	tc_sb->setMinimum(1);
-	tc_sb->setMaximum(4);
-	tc_sb->setValue(1);
-	m_plc_table->setCellWidget(row, 5, tc_sb);
-	connect(tc_sb, QOverload<int>::of(&QSpinBox::valueChanged),
-		this, [this, row](int) { plcIOCellChanged(row, 5); });
-
-	auto *crossref_item = new QTableWidgetItem();
-	crossref_item->setFlags(crossref_item->flags() & ~Qt::ItemIsEditable);
-	m_plc_table->setItem(row, 6, crossref_item);
+	// Anschlüsse (read-only)
+	auto *terminals_item = new QTableWidgetItem();
+	terminals_item->setFlags(terminals_item->flags() & ~Qt::ItemIsEditable);
+	m_plc_table->setItem(row, 5, terminals_item);
 }
 
 /**

--- a/sources/ui/plclinkwidget.cpp
+++ b/sources/ui/plclinkwidget.cpp
@@ -65,7 +65,7 @@ PlcLinkWidget::PlcLinkWidget(Element *elmt, QWidget *parent)
 	m_tree_widget = new QTreeWidget(this);
 	m_tree_widget->setHeaderLabels({
 		tr("Label"), tr("Type"), tr("Adresse"),
-		tr("Fonction"), tr("Commentaire"), tr("Anschlüsse")
+		tr("Fonction"), tr("Commentaire"), tr("Bornes")
 	});
 	m_tree_widget->setRootIsDecorated(true);
 	m_tree_widget->setIndentation(20);
@@ -225,8 +225,8 @@ void PlcLinkWidget::buildPlcTree()
 			child_item->setText(3, io.functionText);
 			child_item->setText(4, io.comment);
 
-			// Terminal count
-			child_item->setText(5, QString::number(io.terminalCount));
+			// Terminal names
+			child_item->setText(5, io.terminals.join(QStringLiteral(", ")));
 
 			PlcIoEntry entry;
 			entry.master = elmt;

--- a/sources/undocommand/linkelementcommand.cpp
+++ b/sources/undocommand/linkelementcommand.cpp
@@ -31,6 +31,16 @@
 #include "../autoNum/assignvariables.h"
 #include "../autoNum/numerotationcontextcommands.h"
 
+#include <algorithm>
+#include <QCollator>
+
+static const QString plcTerminalKeys[] = {
+	QETInformation::ELMT_PLC_T1,
+	QETInformation::ELMT_PLC_T2,
+	QETInformation::ELMT_PLC_T3,
+	QETInformation::ELMT_PLC_T4
+};
+
 /**
 	@brief Get the cross-ref text for a slave element using XRefProperties formula
 	@param master the PLC master element
@@ -408,15 +418,16 @@ void LinkElementCommand::makeLink(const QList<Element *> &element_list)
 					// Set master labels on slave terminals
 					if (elmt->elementData().m_master_type == ElementData::PLC)
 					{
-						// For PLC masters, use io.terminals as labels
 						const auto &plc_data = elmt->elementData().plcMasterData();
 						if (group_idx < plc_data.ios.size())
 						{
-							const QStringList &labels = plc_data.ios.at(group_idx).terminals;
+							const QStringList labels = plc_data.ios.at(group_idx).effectiveTerminals();
 							QList<Terminal *> slave_terms = m_element->terminals();
+							QCollator collator;
+							collator.setNumericMode(true);
 							std::sort(slave_terms.begin(), slave_terms.end(),
-								[](Terminal *a, Terminal *b) {
-									return a->baseName() < b->baseName();
+								[&collator](Terminal *a, Terminal *b) {
+									return collator.compare(a->baseName(), b->baseName()) < 0;
 								});
 							for (int i = 0; i < slave_terms.size(); ++i)
 							{
@@ -426,6 +437,29 @@ void LinkElementCommand::makeLink(const QList<Element *> &element_list)
 									slave_terms.at(i)->setMasterLabelIndex(i);
 								}
 							}
+
+							// Populate PLC variables on the slave
+							const auto &io = plc_data.ios.at(group_idx);
+							DiagramContext ctx = m_element->elementInformations();
+							ctx.addValue(QETInformation::ELMT_PLC_TYPE,
+								ElementData::translatedPlcIOType(io.type));
+							ctx.addValue(QETInformation::ELMT_PLC_ADDRESS, io.address);
+							ctx.addValue(QETInformation::ELMT_PLC_FUNCTION, io.functionText);
+							ctx.addValue(QETInformation::ELMT_PLC_COMMENT, io.comment);
+							ctx.addValue(QETInformation::ELMT_PLC_CROSSREF,
+								plcCrossRefText(elmt, m_element));
+							ctx.addValue(QETInformation::ELMT_LABEL,
+								elmt->actualLabel());
+							ctx.addValue(QETInformation::ELMT_PLC_TC,
+								QString::number(io.terminalCount));
+							const QStringList eff_terms = io.effectiveTerminals();
+							for (int t = 0; t < io.terminalCount && t < 4; ++t)
+							{
+								QString val = (t < eff_terms.size())
+									? eff_terms.at(t) : QString();
+								ctx.addValue(plcTerminalKeys[t], val);
+							}
+							m_element->setElementInformations(ctx);
 						}
 					}
 					else
@@ -435,9 +469,11 @@ void LinkElementCommand::makeLink(const QList<Element *> &element_list)
 						{
 							const QStringList &labels = groups.at(group_idx).labels;
 							QList<Terminal *> slave_terms = m_element->terminals();
+							QCollator collator;
+							collator.setNumericMode(true);
 							std::sort(slave_terms.begin(), slave_terms.end(),
-								[](Terminal *a, Terminal *b) {
-									return a->baseName() < b->baseName();
+								[&collator](Terminal *a, Terminal *b) {
+									return collator.compare(a->baseName(), b->baseName()) < 0;
 								});
 							for (int i = 0; i < slave_terms.size(); ++i)
 							{
@@ -447,41 +483,6 @@ void LinkElementCommand::makeLink(const QList<Element *> &element_list)
 									slave_terms.at(i)->setMasterLabelIndex(i);
 								}
 							}
-						}
-					}
-
-					// Populate PLC variables on the slave if master is PLC type
-					if (elmt->elementData().m_master_type == ElementData::PLC)
-					{
-						const auto &plc_data = elmt->elementData().plcMasterData();
-						if (group_idx < plc_data.ios.size())
-						{
-						const auto &io = plc_data.ios.at(group_idx);
-						DiagramContext ctx = m_element->elementInformations();
-						ctx.addValue(QETInformation::ELMT_PLC_TYPE,
-							ElementData::translatedPlcIOType(io.type));
-						ctx.addValue(QETInformation::ELMT_PLC_ADDRESS, io.address);
-						ctx.addValue(QETInformation::ELMT_PLC_FUNCTION, io.functionText);
-						ctx.addValue(QETInformation::ELMT_PLC_COMMENT, io.comment);
-						ctx.addValue(QETInformation::ELMT_PLC_CROSSREF,
-							plcCrossRefText(elmt, m_element));
-						ctx.addValue(QETInformation::ELMT_LABEL,
-							elmt->actualLabel());
-						ctx.addValue(QETInformation::ELMT_PLC_TC,
-							QString::number(io.terminalCount));
-						for (int t = 0; t < io.terminalCount && t < 4; ++t)
-						{
-							QString val = (t < io.terminals.size())
-								? io.terminals.at(t) : QString();
-							ctx.addValue(
-								QStringList({
-									QETInformation::ELMT_PLC_T1,
-									QETInformation::ELMT_PLC_T2,
-									QETInformation::ELMT_PLC_T3,
-									QETInformation::ELMT_PLC_T4
-								}).at(t), val);
-						}
-						m_element->setElementInformations(ctx);
 						}
 					}
 
@@ -507,11 +508,13 @@ void LinkElementCommand::makeLink(const QList<Element *> &element_list)
 					const auto &plc_data = m_element->elementData().plcMasterData();
 					if (group_idx < plc_data.ios.size())
 					{
-						const QStringList &labels = plc_data.ios.at(group_idx).terminals;
+						const QStringList labels = plc_data.ios.at(group_idx).effectiveTerminals();
 						QList<Terminal *> slave_terms = slave->terminals();
+						QCollator collator;
+						collator.setNumericMode(true);
 						std::sort(slave_terms.begin(), slave_terms.end(),
-							[](Terminal *a, Terminal *b) {
-								return a->baseName() < b->baseName();
+							[&collator](Terminal *a, Terminal *b) {
+								return collator.compare(a->baseName(), b->baseName()) < 0;
 							});
 						for (int i = 0; i < slave_terms.size(); ++i)
 						{
@@ -530,9 +533,11 @@ void LinkElementCommand::makeLink(const QList<Element *> &element_list)
 					{
 						const QStringList &labels = groups.at(group_idx).labels;
 						QList<Terminal *> slave_terms = slave->terminals();
+						QCollator collator;
+						collator.setNumericMode(true);
 						std::sort(slave_terms.begin(), slave_terms.end(),
-							[](Terminal *a, Terminal *b) {
-								return a->name() < b->name();
+							[&collator](Terminal *a, Terminal *b) {
+								return collator.compare(a->baseName(), b->baseName()) < 0;
 							});
 						for (int i = 0; i < slave_terms.size(); ++i)
 						{
@@ -564,17 +569,12 @@ void LinkElementCommand::makeLink(const QList<Element *> &element_list)
 							m_element->actualLabel());
 						ctx.addValue(QETInformation::ELMT_PLC_TC,
 							QString::number(io.terminalCount));
+						const QStringList eff_terms = io.effectiveTerminals();
 						for (int t = 0; t < io.terminalCount && t < 4; ++t)
 						{
-							QString val = (t < io.terminals.size())
-								? io.terminals.at(t) : QString();
-							ctx.addValue(
-								QStringList({
-									QETInformation::ELMT_PLC_T1,
-									QETInformation::ELMT_PLC_T2,
-									QETInformation::ELMT_PLC_T3,
-									QETInformation::ELMT_PLC_T4
-								}).at(t), val);
+							QString val = (t < eff_terms.size())
+								? eff_terms.at(t) : QString();
+							ctx.addValue(plcTerminalKeys[t], val);
 						}
 						slave->setElementInformations(ctx);
 					}

--- a/sources/undocommand/linkelementcommand.cpp
+++ b/sources/undocommand/linkelementcommand.cpp
@@ -502,22 +502,45 @@ void LinkElementCommand::makeLink(const QList<Element *> &element_list)
 				m_element->setGroupIndexForElement(slave, group_idx);
 
 				// Set master labels on slave terminals
-				const auto &groups = m_element->elementData().m_slave_contact_groups;
-				if (group_idx < groups.size())
+				if (m_element->elementData().m_master_type == ElementData::PLC)
 				{
-					const QStringList &labels = groups.at(group_idx).labels;
-					QList<Terminal *> slave_terms = slave->terminals();
-					// Sort terminals by name (T1, T2, T3...) to match label order
-					std::sort(slave_terms.begin(), slave_terms.end(),
-						[](Terminal *a, Terminal *b) {
-							return a->name() < b->name();
-						});
-					for (int i = 0; i < slave_terms.size(); ++i)
+					const auto &plc_data = m_element->elementData().plcMasterData();
+					if (group_idx < plc_data.ios.size())
 					{
-						if (i < labels.size())
+						const QStringList &labels = plc_data.ios.at(group_idx).terminals;
+						QList<Terminal *> slave_terms = slave->terminals();
+						std::sort(slave_terms.begin(), slave_terms.end(),
+							[](Terminal *a, Terminal *b) {
+								return a->baseName() < b->baseName();
+							});
+						for (int i = 0; i < slave_terms.size(); ++i)
 						{
-							slave_terms.at(i)->setUseMasterLabel(true);
-							slave_terms.at(i)->setMasterLabelIndex(i);
+							if (i < labels.size())
+							{
+								slave_terms.at(i)->setUseMasterLabel(true);
+								slave_terms.at(i)->setMasterLabelIndex(i);
+							}
+						}
+					}
+				}
+				else
+				{
+					const auto &groups = m_element->elementData().m_slave_contact_groups;
+					if (group_idx < groups.size())
+					{
+						const QStringList &labels = groups.at(group_idx).labels;
+						QList<Terminal *> slave_terms = slave->terminals();
+						std::sort(slave_terms.begin(), slave_terms.end(),
+							[](Terminal *a, Terminal *b) {
+								return a->name() < b->name();
+							});
+						for (int i = 0; i < slave_terms.size(); ++i)
+						{
+							if (i < labels.size())
+							{
+								slave_terms.at(i)->setUseMasterLabel(true);
+								slave_terms.at(i)->setMasterLabelIndex(i);
+							}
 						}
 					}
 				}
@@ -539,6 +562,20 @@ void LinkElementCommand::makeLink(const QList<Element *> &element_list)
 							plcCrossRefText(m_element, slave));
 						ctx.addValue(QETInformation::ELMT_LABEL,
 							m_element->actualLabel());
+						ctx.addValue(QETInformation::ELMT_PLC_TC,
+							QString::number(io.terminalCount));
+						for (int t = 0; t < io.terminalCount && t < 4; ++t)
+						{
+							QString val = (t < io.terminals.size())
+								? io.terminals.at(t) : QString();
+							ctx.addValue(
+								QStringList({
+									QETInformation::ELMT_PLC_T1,
+									QETInformation::ELMT_PLC_T2,
+									QETInformation::ELMT_PLC_T3,
+									QETInformation::ELMT_PLC_T4
+								}).at(t), val);
+						}
 						slave->setElementInformations(ctx);
 					}
 				}


### PR DESCRIPTION
Bug Fix - PLC terminal labels not transferred from Master to Slave

When linking a PLC Slave to a PLC Master from the Master side (m_element->linkType() == Element::Master), the terminal labels (Anschlüsse) defined in PlcIO.terminals were never propagated to the slave. The code unconditionally used m_slave_contact_groups for terminal labels, which is empty for PLC masters. Additionally, ELMT_PLC_TC and ELMT_PLC_T1..T4 were missing from the Master-case PLC variable propagation.

Fixed in sources/undocommand/linkelementcommand.cpp by:

Branching on m_master_type == PLC to use plcMasterData().ios[group_idx].terminals for PLC masters
Adding the missing ELMT_PLC_TC and ELMT_PLC_T1..T4 values to the slave's DiagramContext
Feature - Display PLC terminal names in properties widgets

PLC terminal names defined in the element editor were not visible in the schematic editor's GUI. Added a read-only "Bornes" column to both:

MasterPropertiesWidget - shows comma-separated terminal names when editing a PLC Master's properties
PlcLinkWidget - shows actual terminal names instead of just the count when connecting a Slave to a Master