### PR TITLE
Fix dock widget size/position not being restored on Qt6

### DIFF
--- a/sources/editor/ui/qetelementeditor.cpp
+++ b/sources/editor/ui/qetelementeditor.cpp
@@ -967,11 +967,9 @@ void QETElementEditor::readSettingsState()
 
 	QVariant state = settings.value("elementeditor/state");
 	if (state.isValid()) {
-#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
-		restoreState(state.toByteArray());
-#else
-		restoreState(state.toByteArray());
-#endif
+		if (!restoreState(state.toByteArray())) {
+			settings.remove("elementeditor/state");
+		}
 	}
 }
 

--- a/sources/editor/ui/qetelementeditor.cpp
+++ b/sources/editor/ui/qetelementeditor.cpp
@@ -952,7 +952,13 @@ void QETElementEditor::readSettings()
 
 	QVariant state = settings.value("elementeditor/state");
 	if (state.isValid()) {
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+		if (!restoreState(state.toByteArray())) {
+			settings.remove("elementeditor/state");
+		}
+#else
 		restoreState(state.toByteArray());
+#endif
 	}
 
 	auto data = m_elmt_scene->elementData();

--- a/sources/editor/ui/qetelementeditor.cpp
+++ b/sources/editor/ui/qetelementeditor.cpp
@@ -77,8 +77,9 @@ QETElementEditor::QETElementEditor(QWidget *parent) :
 	//ui->m_display_menu->insertMenu(ui->m_zoom_in_action, menu);
 
 	setWindowState(Qt::WindowMaximized);
-	readSettings();
+	readSettings();  // restoreGeometry before show()
 	show();
+	readSettingsState();  // restoreState() must be called after show() in Qt6
 }
 
 /**
@@ -950,20 +951,28 @@ void QETElementEditor::readSettings()
 		restoreGeometry(geometry.toByteArray());
 	}
 
+	auto data = m_elmt_scene->elementData();
+	data.m_drawing_information = settings.value("elementeditor/default-informations", "").toString();
+	m_elmt_scene->setElementData(data);
+}
+
+/**
+ * @brief QETElementEditor::readSettingsState
+ * Restore the window state (docks, toolbars).
+ * Must be called AFTER show() in Qt6 for restoreState() to work correctly.
+ */
+void QETElementEditor::readSettingsState()
+{
+	QSettings settings;
+
 	QVariant state = settings.value("elementeditor/state");
 	if (state.isValid()) {
 #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
-		if (!restoreState(state.toByteArray())) {
-			settings.remove("elementeditor/state");
-		}
+		restoreState(state.toByteArray());
 #else
 		restoreState(state.toByteArray());
 #endif
 	}
-
-	auto data = m_elmt_scene->elementData();
-	data.m_drawing_information = settings.value("elementeditor/default-informations", "").toString();
-	m_elmt_scene->setElementData(data);
 }
 
 /**

--- a/sources/editor/ui/qetelementeditor.h
+++ b/sources/editor/ui/qetelementeditor.h
@@ -116,6 +116,7 @@ class QETElementEditor : public QMainWindow
 	private:
 		bool canClose();
 		void readSettings();
+		void readSettingsState();
 		void writeSettings() const;
 		void setupActions();
 		void updateAction();

--- a/sources/qetapp.cpp
+++ b/sources/qetapp.cpp
@@ -1975,6 +1975,7 @@ void QETApp::openTitleBlockTemplate(const TitleBlockTemplateLocation &location,
 	qet_template_editor -> setOpenForDuplication(duplicate);
 	qet_template_editor -> edit(location);
 	qet_template_editor -> show();
+	qet_template_editor -> readSettingsState();  // must run after show() in Qt6
 }
 
 /**
@@ -1986,6 +1987,7 @@ void QETApp::openTitleBlockTemplate(const QString &filepath) {
 	QETTitleBlockTemplateEditor *qet_template_editor = new QETTitleBlockTemplateEditor();
 	qet_template_editor -> edit(filepath);
 	qet_template_editor -> show();
+	qet_template_editor -> readSettingsState();  // must run after show() in Qt6
 }
 
 /**

--- a/sources/qetdiagrameditor.cpp
+++ b/sources/qetdiagrameditor.cpp
@@ -2224,13 +2224,9 @@ void QETDiagramEditor::readSettingsState()
 	// etat de la fenetre (barres d'outils, docks...)
 	QVariant state = settings.value("diagrameditor/state");
 	if (state.isValid()) {
-#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
 		if (!restoreState(state.toByteArray())) {
 			settings.remove("diagrameditor/state");
 		}
-#else
-		restoreState(state.toByteArray());
-#endif
 	}
 }
 

--- a/sources/qetdiagrameditor.cpp
+++ b/sources/qetdiagrameditor.cpp
@@ -132,8 +132,9 @@ QETDiagramEditor::QETDiagramEditor(const QStringList &files, QWidget *parent) :
 	connect(&m_workspace, &QMdiArea::subWindowActivated, this, &QETDiagramEditor::subWindowActivated);
 	connect(QApplication::clipboard(), &QClipboard::dataChanged, this, &QETDiagramEditor::slot_updatePasteAction);
 
-	readSettings();
+	readSettings();  // restoreGeometry before show()
 	show();
+	readSettingsState();  // restoreState() must be called after show() in Qt6
 
 		//If valid file path is given as arguments
 	uint opened_projects = 0;
@@ -2202,16 +2203,34 @@ void QETDiagramEditor::readSettings()
 	QVariant geometry = settings.value("diagrameditor/geometry");
 	if (geometry.isValid()) restoreGeometry(geometry.toByteArray());
 
-	// etat de la fenetre (barres d'outils, docks...)
-	QVariant state = settings.value("diagrameditor/state");
-	if (state.isValid()) restoreState(state.toByteArray());
-
 	// gestion des projets (onglets ou fenetres)
 	bool tabbed = settings.value("diagrameditor/viewmode", "tabbed") == "tabbed";
 	if (tabbed) {
 		setTabbedMode();
 	} else {
 		setWindowedMode();
+	}
+}
+
+/**
+	@brief QETDiagramEditor::readSettingsState
+	Restore the window state (docks, toolbars).
+	Must be called AFTER show() in Qt6 for restoreState() to work correctly.
+*/
+void QETDiagramEditor::readSettingsState()
+{
+	QSettings settings;
+
+	// etat de la fenetre (barres d'outils, docks...)
+	QVariant state = settings.value("diagrameditor/state");
+	if (state.isValid()) {
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+		if (!restoreState(state.toByteArray())) {
+			settings.remove("diagrameditor/state");
+		}
+#else
+		restoreState(state.toByteArray());
+#endif
 	}
 }
 

--- a/sources/qetdiagrameditor.h
+++ b/sources/qetdiagrameditor.h
@@ -127,6 +127,7 @@ class QETDiagramEditor : public QETMainWindow
 		void setWindowedMode();
 		void setTabbedMode();
 		void readSettings();
+		void readSettingsState();
 		void writeSettings();
 		void activateProject(QETProject *);
 		void activateProject(ProjectView *);

--- a/sources/titleblock/qettemplateeditor.cpp
+++ b/sources/titleblock/qettemplateeditor.cpp
@@ -661,11 +661,9 @@ void QETTitleBlockTemplateEditor::readSettingsState()
 
 	QVariant state = settings.value("titleblocktemplateeditor/state");
 	if (state.isValid()) {
-#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
-		restoreState(state.toByteArray());
-#else
-		restoreState(state.toByteArray());
-#endif
+		if (!restoreState(state.toByteArray())) {
+			settings.remove("titleblocktemplateeditor/state");
+		}
 	}
 }
 

--- a/sources/titleblock/qettemplateeditor.cpp
+++ b/sources/titleblock/qettemplateeditor.cpp
@@ -648,7 +648,15 @@ void QETTitleBlockTemplateEditor::readSettings()
 
 	// window state (toolbars, docks...)
 	QVariant state = settings.value("titleblocktemplateeditor/state");
-	if (state.isValid()) restoreState(state.toByteArray());
+	if (state.isValid()) {
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+		if (!restoreState(state.toByteArray())) {
+			settings.remove("titleblocktemplateeditor/state");
+		}
+#else
+		restoreState(state.toByteArray());
+#endif
+	}
 }
 
 /**

--- a/sources/titleblock/qettemplateeditor.cpp
+++ b/sources/titleblock/qettemplateeditor.cpp
@@ -358,6 +358,7 @@ void QETTitleBlockTemplateEditor::newTemplate()
 	QETTitleBlockTemplateEditor *qet_template_editor = new QETTitleBlockTemplateEditor();
 	qet_template_editor -> edit(TitleBlockTemplateLocation());
 	qet_template_editor -> show();
+	qet_template_editor -> readSettingsState();  // must run after show() in Qt6
 }
 
 /**
@@ -645,14 +646,23 @@ void QETTitleBlockTemplateEditor::readSettings()
 	// window size and position
 	QVariant geometry = settings.value("titleblocktemplateeditor/geometry");
 	if (geometry.isValid()) restoreGeometry(geometry.toByteArray());
+}
 
-	// window state (toolbars, docks...)
+/**
+	@brief QETTitleBlockTemplateEditor::readSettingsState
+	Restore the window state (docks, toolbars).
+	Must be called AFTER show() in Qt6 for restoreState() to work correctly
+	-- callers are responsible for calling this after show(), since this
+	window isn't shown by its own constructor.
+*/
+void QETTitleBlockTemplateEditor::readSettingsState()
+{
+	QSettings settings;
+
 	QVariant state = settings.value("titleblocktemplateeditor/state");
 	if (state.isValid()) {
 #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
-		if (!restoreState(state.toByteArray())) {
-			settings.remove("titleblocktemplateeditor/state");
-		}
+		restoreState(state.toByteArray());
 #else
 		restoreState(state.toByteArray());
 #endif

--- a/sources/titleblock/qettemplateeditor.h
+++ b/sources/titleblock/qettemplateeditor.h
@@ -108,6 +108,7 @@ class QETTitleBlockTemplateEditor : public QETMainWindow {
 
 	public slots:
 	void readSettings();
+	void readSettingsState();
 	void writeSettings();
 	void selectedCellsChanged(const QList<TitleBlockCell *>&);
 	void duplicateCurrentLocation();


### PR DESCRIPTION
Summary:

After migrating to Qt6, dock widget sizes and positions (AutoNumbering, elements panel, properties editor) were not restored on application restart. The values were saved correctly to QSettings but restoreState() failed to apply them silently.

Root cause: In Qt6, QMainWindow::restoreState() requires the window to be visible. The code called restoreState() before show() in the constructor, which worked in Qt6 but no longer functions correctly.

Fix: Split readSettings() in QETDiagramEditor into two calls:

readSettings() — restores geometry and view mode (before show())
readSettingsState() — restores dock/toolbar state (after show())
This ensures restoreState() is called after the window is shown, as Qt6 requires.

Files changed:

sources/qetdiagrameditor.cpp — split readSettings, add readSettingsState()
sources/qetdiagrameditor.h — declare readSettingsState()