### PR TITLE
Fix paste breaking existing conductors

### DIFF
--- a/sources/diagramcommands.cpp
+++ b/sources/diagramcommands.cpp
@@ -17,9 +17,7 @@
 */
 #include "diagramcommands.h"
 
-#include "autobreakconductor.h"
 #include "diagram.h"
-#include "qetproject.h"
 #include "qetgraphicsitem/conductortextitem.h"
 #include "qetgraphicsitem/element.h"
 #include "qetgraphicsitem/elementtextitemgroup.h"
@@ -50,7 +48,6 @@ PasteDiagramCommand::PasteDiagramCommand( Diagram *dia, const DiagramContent &c,
 PasteDiagramCommand::~PasteDiagramCommand()
 {
 	diagram -> qgiManager().release(content.items(filter));
-	delete m_break_cmd;
 }
 
 /**
@@ -60,10 +57,6 @@ PasteDiagramCommand::~PasteDiagramCommand()
 void PasteDiagramCommand::undo()
 {
 	diagram -> showMe();
-
-		//Undo auto-break before removing items, so terminals are still on scene
-	if (m_break_cmd)
-		m_break_cmd->undo();
 
 	foreach(QGraphicsItem *item, content.items(filter))
 		diagram->removeItem(item);
@@ -116,27 +109,6 @@ void PasteDiagramCommand::redo()
 				}
 			}
 		}
-
-			//Auto-break conductors on first paste. Items are already on the
-			//scene at this point (added before this command was created).
-		if (diagram->project()->autoBreakConductor())
-		{
-			m_break_cmd = new QUndoCommand();
-			QList<Conductor *> conductors_handled;
-			QSet<Terminal *> used_terminals;
-			for (Element *e : content.m_elements) {
-				autoBreakConductors(diagram, e, m_break_cmd,
-						    conductors_handled, used_terminals);
-			}
-			if (m_break_cmd->childCount() == 0) {
-				delete m_break_cmd;
-				m_break_cmd = nullptr;
-			}
-			else
-			{
-				m_break_cmd->redo();
-			}
-		}
 	}
 	else
 	{
@@ -144,10 +116,6 @@ void PasteDiagramCommand::redo()
 		for (QGraphicsItem *item : qgis_list) {
 			diagram->addItem(item);
 		}
-
-			//Re-execute the stored break commands (items are back on scene)
-		if (m_break_cmd)
-			m_break_cmd->redo();
 	}
 
 	const QList<QGraphicsItem *> qgis_list = content.items();

--- a/sources/diagramcommands.h
+++ b/sources/diagramcommands.h
@@ -53,8 +53,6 @@ class PasteDiagramCommand : public QUndoCommand {
 	int filter;
 	/// prevent the first call to redo()
 	bool first_redo;
-	/// auto-break conductor sub-commands (created on first redo)
-	QUndoCommand *m_break_cmd = nullptr;
 };
 
 /**


### PR DESCRIPTION
Copying a component and pasting it on the same page broke existing conductors and reconnected them through the pasted element. This was unwanted behavior — the pasted element should be completely independent.

Root cause: autoBreakConductors() was called in PasteDiagramCommand::redo() (added in commit 39b1e836b). When pasting at the same position, the pasted element's terminals overlap with the original's conductor endpoints, causing autoBreakConductors() to detect those conductors as "needing a break" and reconnecting them through the new element.

Fix: Removed the autoBreakConductors() call from PasteDiagramCommand. This function is only needed when placing new elements from the collection (DiagramEventAddElement, ElementsMover), not when pasting copied elements. This restores the pre-39b1e836b behavior where pasted elements are fully independent.