### PR TITLE
Add configurable distance between label and slave XRef

### DIFF
--- a/sources/editor/ui/dynamictextfieldeditor.cpp
+++ b/sources/editor/ui/dynamictextfieldeditor.cpp
@@ -245,7 +245,8 @@ void DynamicTextFieldEditor::fillInfoComboBox()
 	else {
 		strl = QETInformation::elementInfoKeys();
 
-		bool is_plc_slave = (type == ElementData::Slave
+		bool is_slave = (type == ElementData::Slave);
+		bool is_plc_slave = (is_slave
 							 && ed.m_slave_type == ElementData::PLCSlave);
 
 		if (is_plc_slave) {
@@ -273,6 +274,10 @@ void DynamicTextFieldEditor::fillInfoComboBox()
 			strl.removeAll(QETInformation::ELMT_PLC_T2);
 			strl.removeAll(QETInformation::ELMT_PLC_T3);
 			strl.removeAll(QETInformation::ELMT_PLC_T4);
+		}
+
+		if (is_slave) {
+			strl.prepend(QETInformation::ELMT_XREF);
 		}
 	}
 

--- a/sources/properties/xrefproperties.cpp
+++ b/sources/properties/xrefproperties.cpp
@@ -36,6 +36,7 @@ XRefProperties::XRefProperties()
 	m_master_label = "%f-%l%c";
 	m_slave_label = "(%f-%l%c)";
 	m_offset = 0;
+	m_slave_offset = 0;
 	m_xref_pos = Qt::AlignBottom;
 }
 
@@ -56,6 +57,8 @@ void XRefProperties::toSettings(QSettings &settings,
 	settings.setValue(prefix % "snapto", snap);
 	int offset = m_offset;
 	settings.setValue(prefix % "offset", offset);
+	int slave_offset = m_slave_offset;
+	settings.setValue(prefix % "slave_offset", slave_offset);
 	QString master_label = m_master_label;
 	settings.setValue(prefix % "master_label", master_label);
 	QString slave_label = m_slave_label;
@@ -86,6 +89,7 @@ void XRefProperties::fromSettings(const QSettings &settings,
 	QString snap = settings.value(prefix % "snapto", "label").toString();
 	snap == "bottom"? m_snap_to = Bottom : m_snap_to = Label;
 	m_offset = settings.value(prefix % "offset", "0").toInt();
+	m_slave_offset = settings.value(prefix % "slave_offset", "0").toInt();
 	m_master_label = settings.value(prefix % "master_label", "%f-%l%c").toString();
 	m_slave_label = settings.value(prefix % "slave_label", "(%f-%l%c)").toString();
 
@@ -123,6 +127,7 @@ QDomElement XRefProperties::toXml(QDomDocument &xml_document) const
 
 	int offset = m_offset;
 	xml_element.setAttribute("offset", QString::number(offset));
+	xml_element.setAttribute("slave_offset", QString::number(m_slave_offset));
 	QString master_label = m_master_label;
 	xml_element.setAttribute("master_label", master_label);
 	QString slave_label = m_slave_label;
@@ -157,6 +162,7 @@ bool XRefProperties::fromXml(const QDomElement &xml_element) {
 		m_xref_pos = Qt::AlignBottom;
 
 	m_offset = xml_element.attribute("offset", "0").toInt();
+	m_slave_offset = xml_element.attribute("slave_offset", "0").toInt();
 	m_master_label = xml_element.attribute("master_label", "%f-%l%c");
 	m_slave_label = xml_element.attribute("slave_label","(%f-%l%c)");
 	foreach (QString key, m_prefix_keys) {
@@ -199,6 +205,7 @@ bool XRefProperties::operator ==(const XRefProperties &xrp) const{
 			&& m_prefix      == xrp.m_prefix
 			&& m_master_label== xrp.m_master_label
 			&& m_offset      == xrp.m_offset
+			&& m_slave_offset== xrp.m_slave_offset
 			&& m_xref_pos    == xrp.m_xref_pos
 			&& m_slave_label == xrp.m_slave_label);
 }

--- a/sources/properties/xrefproperties.h
+++ b/sources/properties/xrefproperties.h
@@ -80,6 +80,9 @@ class XRefProperties : public PropertiesInterface
 	void setOffset(const int offset) {m_offset = offset;}
 	int offset() const				 {return m_offset;}
 
+	void setSlaveOffset(const int offset) {m_slave_offset = offset;}
+	int slaveOffset() const				 {return m_slave_offset;}
+
 	void setKey(QString& key) {m_key = key;}
 
 	private:
@@ -93,6 +96,7 @@ class XRefProperties : public PropertiesInterface
 	QString m_master_label;
 	QString m_slave_label;
 	int     m_offset;
+	int     m_slave_offset;
 	QString m_key;
 };
 

--- a/sources/qetgraphicsitem/dynamicelementtextitem.cpp
+++ b/sources/qetgraphicsitem/dynamicelementtextitem.cpp
@@ -1387,7 +1387,7 @@ void DynamicElementTextItem::updateXref()
 				}
 				else
 					m_slave_Xref_item->setPlainText(xref_label);
-				setXref_item(xrp.getXrefPos());
+				setXref_item(xrp.getXrefPos(), xrp.slaveOffset());
 				return;
 			}
 		}
@@ -1453,7 +1453,7 @@ void DynamicElementTextItem::setPlainText(const QString &text)
 			? nullptr : m_parent_element.data()->linkedElements().first();
 		if (master_elmt) {
 			XRefProperties xrp = diagram()->project()->defaultXRefProperties(master_elmt->kindInformations()["type"].toString());
-			setXref_item(xrp.getXrefPos());
+			setXref_item(xrp.getXrefPos(), xrp.slaveOffset());
 		}
 	}
 }
@@ -1465,44 +1465,44 @@ void DynamicElementTextItem::setTextWidth(qreal width)
 	emit textWidthChanged(width);
 }
 
-void DynamicElementTextItem::setXref_item(Qt::AlignmentFlag m_exHrefPos)
+void DynamicElementTextItem::setXref_item(Qt::AlignmentFlag m_exHrefPos, int slave_offset)
 {
 	QRectF r = boundingRect();
 	QPointF pos;
 	//QPointF pos(r.center().x() - m_slave_Xref_item->boundingRect().width()/2,r.top());
 	if (m_exHrefPos == Qt::AlignBottom)
 	{
-		pos = QPointF(r.center().x() - m_slave_Xref_item->boundingRect().width()/2,r.bottom());
+		pos = QPointF(r.center().x() - m_slave_Xref_item->boundingRect().width()/2,r.bottom() + slave_offset);
 	}
 	else if (m_exHrefPos == Qt::AlignTop)
 	{
-		pos = QPointF(r.center().x() - m_slave_Xref_item->boundingRect().width()/2,r.top() - m_slave_Xref_item->boundingRect().height());
+		pos = QPointF(r.center().x() - m_slave_Xref_item->boundingRect().width()/2,r.top() - m_slave_Xref_item->boundingRect().height() - slave_offset);
 	}
 	else if (m_exHrefPos == Qt::AlignLeft)  //
 	{
-		pos = QPointF(r.left() -  m_slave_Xref_item->boundingRect().width(),r.center().y() - m_slave_Xref_item->boundingRect().height()/2);
+		pos = QPointF(r.left() -  m_slave_Xref_item->boundingRect().width() - slave_offset,r.center().y() - m_slave_Xref_item->boundingRect().height()/2);
 	}
 	else if (m_exHrefPos == Qt::AlignRight)  //
 	{
-		pos = QPointF(r.right() ,r.center().y() - m_slave_Xref_item->boundingRect().height()/2);
+		pos = QPointF(r.right() + slave_offset ,r.center().y() - m_slave_Xref_item->boundingRect().height()/2);
 	}
 	else if (m_exHrefPos == Qt::AlignBaseline)  //
 	{
 		if(this->alignment() &Qt::AlignBottom)
 		{
-			pos = QPointF(r.center().x() - m_slave_Xref_item->boundingRect().width()/2,r.bottom());
+			pos = QPointF(r.center().x() - m_slave_Xref_item->boundingRect().width()/2,r.bottom() + slave_offset);
 		}
 		else if(this->alignment() &Qt::AlignTop)
 		{
-			pos = QPointF(r.center().x() - m_slave_Xref_item->boundingRect().width()/2,r.top() - m_slave_Xref_item->boundingRect().height());
+			pos = QPointF(r.center().x() - m_slave_Xref_item->boundingRect().width()/2,r.top() - m_slave_Xref_item->boundingRect().height() - slave_offset);
 		}
 		else if(this->alignment() &Qt::AlignLeft)
 		{
-			pos = QPointF(r.left() -  m_slave_Xref_item->boundingRect().width(),r.center().y() - m_slave_Xref_item->boundingRect().height()/2);
+			pos = QPointF(r.left() -  m_slave_Xref_item->boundingRect().width() - slave_offset,r.center().y() - m_slave_Xref_item->boundingRect().height()/2);
 		}
 		else if(this->alignment() &Qt::AlignRight)
 		{
-			pos = QPointF(r.right() ,r.center().y() - m_slave_Xref_item->boundingRect().height()/2);
+			pos = QPointF(r.right() + slave_offset ,r.center().y() - m_slave_Xref_item->boundingRect().height()/2);
 		}
 	}
 	m_slave_Xref_item->setPos(pos);

--- a/sources/qetgraphicsitem/dynamicelementtextitem.cpp
+++ b/sources/qetgraphicsitem/dynamicelementtextitem.cpp
@@ -1359,36 +1359,68 @@ void DynamicElementTextItem::updateXref()
 				!m_parent_element.data()->linkedElements().isEmpty())
 		{
 			Element *master_elmt = m_parent_element.data()->linkedElements().first();
-			if(master_elmt && !parentGroup() &&
-			   (
+			if(master_elmt && !parentGroup())
+			{
+				XRefProperties xrp = diagram()->project()->defaultXRefProperties(master_elmt->kindInformations()["type"].toString());
+
+				//Champ de texte: store xref in element informations
+				if(xrp.getXrefPos() == Qt::AlignHCenter)
+				{
+					if(m_text_from == DynamicElementTextItem::ElementInfo && m_info_name == "xref")
+					{
+						QString xref_label = xrp.slaveLabel();
+						xref_label = autonum::AssignVariables::formulaToLabel(xref_label, master_elmt->rSequenceStruct(), master_elmt->diagram(), master_elmt);
+
+						DiagramContext dc = m_parent_element->elementInformations();
+						if(dc.value("xref").toString() != xref_label)
+						{
+							dc.addValue("xref", xref_label);
+							m_parent_element->setElementInformations(dc);
+						}
+
+						//Set up connections for future updates
+						if(m_update_slave_Xref_connection.isEmpty())
+						{
+							m_update_slave_Xref_connection << connect(master_elmt, &Element::xChanged,                       this, &DynamicElementTextItem::updateXref);
+							m_update_slave_Xref_connection << connect(master_elmt, &Element::yChanged,                       this, &DynamicElementTextItem::updateXref);
+							m_update_slave_Xref_connection << connect(master_elmt, &Element::elementInfoChange,              this, &DynamicElementTextItem::updateXref);
+							m_update_slave_Xref_connection << connect(diagram(), &Diagram::diagramInformationChanged,                    this, &DynamicElementTextItem::updateXref);
+							m_update_slave_Xref_connection << connect(diagram()->project(),    &QETProject::projectDiagramsOrderChanged, this, &DynamicElementTextItem::updateXref);
+							m_update_slave_Xref_connection << connect(diagram()->project(),    &QETProject::diagramRemoved,              this, &DynamicElementTextItem::updateXref);
+							m_update_slave_Xref_connection << connect(diagram()->project(),    &QETProject::XRefPropertiesChanged,       this, &DynamicElementTextItem::updateXref);
+						}
+						return;
+					}
+					//For label/composite text: fall through to cleanup (delete m_slave_Xref_item)
+				}
+				else if(
 				   (m_text_from == DynamicElementTextItem::ElementInfo && m_info_name == "label") ||
 				   (m_text_from == DynamicElementTextItem::CompositeText && m_composite_text.contains("%{label}"))
 			   )
-			  )
-			{
-				XRefProperties xrp = diagram()->project()->defaultXRefProperties(master_elmt->kindInformations()["type"].toString());
-				QString xref_label = xrp.slaveLabel();
-				xref_label = autonum::AssignVariables::formulaToLabel(xref_label, master_elmt->rSequenceStruct(), master_elmt->diagram(), master_elmt);
-				
-				if(!m_slave_Xref_item)
 				{
-					m_slave_Xref_item = new QGraphicsTextItem(xref_label, this);
-					m_slave_Xref_item->setFont(QETApp::diagramTextsFont(5));
-					m_slave_Xref_item->setDefaultTextColor(Qt::black);
-					m_slave_Xref_item->installSceneEventFilter(this);
+					QString xref_label = xrp.slaveLabel();
+					xref_label = autonum::AssignVariables::formulaToLabel(xref_label, master_elmt->rSequenceStruct(), master_elmt->diagram(), master_elmt);
 					
-					m_update_slave_Xref_connection << connect(master_elmt, &Element::xChanged,                       this, &DynamicElementTextItem::updateXref);
-					m_update_slave_Xref_connection << connect(master_elmt, &Element::yChanged,                       this, &DynamicElementTextItem::updateXref);
-					m_update_slave_Xref_connection << connect(master_elmt, &Element::elementInfoChange,              this, &DynamicElementTextItem::updateXref);
-					m_update_slave_Xref_connection << connect(diagram(), &Diagram::diagramInformationChanged,                    this, &DynamicElementTextItem::updateXref);
-					m_update_slave_Xref_connection << connect(diagram()->project(),    &QETProject::projectDiagramsOrderChanged, this, &DynamicElementTextItem::updateXref);
-					m_update_slave_Xref_connection << connect(diagram()->project(),    &QETProject::diagramRemoved,              this, &DynamicElementTextItem::updateXref);
-					m_update_slave_Xref_connection << connect(diagram()->project(),    &QETProject::XRefPropertiesChanged,       this, &DynamicElementTextItem::updateXref);
+					if(!m_slave_Xref_item)
+					{
+						m_slave_Xref_item = new QGraphicsTextItem(xref_label, this);
+						m_slave_Xref_item->setFont(QETApp::diagramTextsFont(5));
+						m_slave_Xref_item->setDefaultTextColor(Qt::black);
+						m_slave_Xref_item->installSceneEventFilter(this);
+						
+						m_update_slave_Xref_connection << connect(master_elmt, &Element::xChanged,                       this, &DynamicElementTextItem::updateXref);
+						m_update_slave_Xref_connection << connect(master_elmt, &Element::yChanged,                       this, &DynamicElementTextItem::updateXref);
+						m_update_slave_Xref_connection << connect(master_elmt, &Element::elementInfoChange,              this, &DynamicElementTextItem::updateXref);
+						m_update_slave_Xref_connection << connect(diagram(), &Diagram::diagramInformationChanged,                    this, &DynamicElementTextItem::updateXref);
+						m_update_slave_Xref_connection << connect(diagram()->project(),    &QETProject::projectDiagramsOrderChanged, this, &DynamicElementTextItem::updateXref);
+						m_update_slave_Xref_connection << connect(diagram()->project(),    &QETProject::diagramRemoved,              this, &DynamicElementTextItem::updateXref);
+						m_update_slave_Xref_connection << connect(diagram()->project(),    &QETProject::XRefPropertiesChanged,       this, &DynamicElementTextItem::updateXref);
+					}
+					else
+						m_slave_Xref_item->setPlainText(xref_label);
+					setXref_item(xrp.getXrefPos(), xrp.slaveOffset());
+					return;
 				}
-				else
-					m_slave_Xref_item->setPlainText(xref_label);
-				setXref_item(xrp.getXrefPos(), xrp.slaveOffset());
-				return;
 			}
 		}
 	}
@@ -1405,6 +1437,29 @@ void DynamicElementTextItem::updateXref()
 		delete m_slave_Xref_item;
 		m_slave_Xref_item = nullptr;
 		m_update_slave_Xref_connection.clear();
+
+		//If position changed to Champ de texte, store xref in element info
+		if(m_parent_element->linkType() == Element::Slave &&
+		   !m_parent_element->linkedElements().isEmpty())
+		{
+			Element *master_elmt = m_parent_element->linkedElements().first();
+			if(master_elmt && diagram())
+			{
+				XRefProperties xrp = diagram()->project()->defaultXRefProperties(master_elmt->kindInformations()["type"].toString());
+				if(xrp.getXrefPos() == Qt::AlignHCenter)
+				{
+					QString xref_label = xrp.slaveLabel();
+					xref_label = autonum::AssignVariables::formulaToLabel(xref_label, master_elmt->rSequenceStruct(), master_elmt->diagram(), master_elmt);
+
+					DiagramContext dc = m_parent_element->elementInformations();
+					if(dc.value("xref").toString() != xref_label)
+					{
+						dc.addValue("xref", xref_label);
+						m_parent_element->setElementInformations(dc);
+					}
+				}
+			}
+		}
 	}
 }
 

--- a/sources/qetgraphicsitem/dynamicelementtextitem.h
+++ b/sources/qetgraphicsitem/dynamicelementtextitem.h
@@ -112,7 +112,7 @@ class DynamicElementTextItem : public DiagramTextItem
 		void updateXref();
 		void setPlainText(const QString &text);
 		void setTextWidth(qreal width);
-		void setXref_item(Qt::AlignmentFlag m_exHrefPos);
+		void setXref_item(Qt::AlignmentFlag m_exHrefPos, int slave_offset = 0);
 
 		void setKeepVisualRotation(bool set);
 		bool keepVisualRotation() const;

--- a/sources/qetgraphicsitem/elementtextitemgroup.cpp
+++ b/sources/qetgraphicsitem/elementtextitemgroup.cpp
@@ -263,7 +263,16 @@ void ElementTextItemGroup::updateAlignment()
 	if(m_Xref_item)
 		m_Xref_item->autoPos();
 	if(m_slave_Xref_item)
-		adjustSlaveXrefPos();
+	{
+		int slave_offset = 0;
+		Element *master_elmt = m_parent_element->linkedElements().isEmpty()
+			? nullptr : m_parent_element->linkedElements().first();
+		if (master_elmt && m_parent_element->diagram()) {
+			XRefProperties xrp = m_parent_element->diagram()->project()->defaultXRefProperties(master_elmt->kindInformations()["type"].toString());
+			slave_offset = xrp.slaveOffset();
+		}
+		adjustSlaveXrefPos(slave_offset);
+	}
 	if(m_hold_to_bottom_of_page)
 		autoPos();
 }

--- a/sources/qetgraphicsitem/elementtextitemgroup.cpp
+++ b/sources/qetgraphicsitem/elementtextitemgroup.cpp
@@ -810,7 +810,7 @@ void ElementTextItemGroup::updateXref()
 					else
 						m_slave_Xref_item->setPlainText(xref_label);
 					
-					adjustSlaveXrefPos();
+					adjustSlaveXrefPos(xrp.slaveOffset());
 					return;
 				}
 			}
@@ -833,11 +833,11 @@ void ElementTextItemGroup::updateXref()
 	}
 }
 
-void ElementTextItemGroup::adjustSlaveXrefPos()
+void ElementTextItemGroup::adjustSlaveXrefPos(int slave_offset)
 {
 	QRectF r = boundingRect();
 	QPointF pos(r.center().x() - m_slave_Xref_item->boundingRect().width()/2,
-				r.bottom());
+				r.bottom() + slave_offset);
 	m_slave_Xref_item->setPos(pos);
 }
 

--- a/sources/qetgraphicsitem/elementtextitemgroup.cpp
+++ b/sources/qetgraphicsitem/elementtextitemgroup.cpp
@@ -795,12 +795,46 @@ void ElementTextItemGroup::updateXref()
 				!m_parent_element->linkedElements().isEmpty())
 		{
 			Element *master_elmt = m_parent_element->linkedElements().first();
+			XRefProperties xrp = project->defaultXRefProperties(master_elmt->kindInformations()["type"].toString());
+
+			//Champ de texte: store xref in element informations
+			if(xrp.getXrefPos() == Qt::AlignHCenter)
+			{
+				for(DynamicElementTextItem *deti : texts())
+				{
+					if(deti->textFrom() == DynamicElementTextItem::ElementInfo && deti->infoName() == "xref")
+					{
+						QString xref_label = xrp.slaveLabel();
+						xref_label = autonum::AssignVariables::formulaToLabel(xref_label, master_elmt->rSequenceStruct(), master_elmt->diagram(), master_elmt);
+
+						DiagramContext dc = m_parent_element->elementInformations();
+						if(dc.value("xref").toString() != xref_label)
+						{
+							dc.addValue("xref", xref_label);
+							m_parent_element->setElementInformations(dc);
+						}
+
+						//Set up connections for future updates
+						if(m_update_slave_Xref_connection.isEmpty())
+						{
+							m_update_slave_Xref_connection << connect(master_elmt, &Element::xChanged,                       this, &ElementTextItemGroup::updateXref);
+							m_update_slave_Xref_connection << connect(master_elmt, &Element::yChanged,                       this, &ElementTextItemGroup::updateXref);
+							m_update_slave_Xref_connection << connect(master_elmt, &Element::elementInfoChange,              this, &ElementTextItemGroup::updateXref);
+							m_update_slave_Xref_connection << connect(project,     &QETProject::projectDiagramsOrderChanged, this, &ElementTextItemGroup::updateXref);
+							m_update_slave_Xref_connection << connect(project,     &QETProject::diagramRemoved,              this, &ElementTextItemGroup::updateXref);
+							m_update_slave_Xref_connection << connect(project,     &QETProject::XRefPropertiesChanged,       this, &ElementTextItemGroup::updateXref);
+						}
+						return;
+					}
+				}
+				//No "xref" text found: fall through to cleanup
+			}
+
 			for(DynamicElementTextItem *deti : texts())
 			{
 				if((deti->textFrom() == DynamicElementTextItem::ElementInfo && deti->infoName() == "label") ||
 				   (deti->textFrom() == DynamicElementTextItem::CompositeText && deti->compositeText().contains("%{label")))
 				{
-					XRefProperties xrp = project->defaultXRefProperties(master_elmt->kindInformations()["type"].toString());
 					QString xref_label = xrp.slaveLabel();
 					xref_label = autonum::AssignVariables::formulaToLabel(xref_label, master_elmt->rSequenceStruct(), master_elmt->diagram(), master_elmt);
 					
@@ -839,6 +873,30 @@ void ElementTextItemGroup::updateXref()
 		delete m_slave_Xref_item;
 		m_slave_Xref_item = nullptr;
 		m_update_slave_Xref_connection.clear();
+
+		//If position changed to Champ de texte, store xref in element info
+		if(m_parent_element->linkType() == Element::Slave &&
+		   !m_parent_element->linkedElements().isEmpty() &&
+		   m_parent_element->diagram())
+		{
+			Element *master_elmt = m_parent_element->linkedElements().first();
+			if(master_elmt)
+			{
+				XRefProperties xrp = m_parent_element->diagram()->project()->defaultXRefProperties(master_elmt->kindInformations()["type"].toString());
+				if(xrp.getXrefPos() == Qt::AlignHCenter)
+				{
+					QString xref_label = xrp.slaveLabel();
+					xref_label = autonum::AssignVariables::formulaToLabel(xref_label, master_elmt->rSequenceStruct(), master_elmt->diagram(), master_elmt);
+
+					DiagramContext dc = m_parent_element->elementInformations();
+					if(dc.value("xref").toString() != xref_label)
+					{
+						dc.addValue("xref", xref_label);
+						m_parent_element->setElementInformations(dc);
+					}
+				}
+			}
+		}
 	}
 }
 

--- a/sources/qetgraphicsitem/elementtextitemgroup.h
+++ b/sources/qetgraphicsitem/elementtextitemgroup.h
@@ -104,7 +104,7 @@ class ElementTextItemGroup : public QObject, public  QGraphicsItemGroup
 		
 	private:
 		void updateXref();
-		void adjustSlaveXrefPos();
+		void adjustSlaveXrefPos(int slave_offset = 0);
 		void autoPos();
 
 	private:

--- a/sources/qetinformation.cpp
+++ b/sources/qetinformation.cpp
@@ -194,8 +194,9 @@ QStringList QETInformation::elementInfoKeys()
 						 ELMT_PLC_ADDRESS,
 						 ELMT_PLC_FUNCTION,
 						 ELMT_PLC_COMMENT,
-						 ELMT_PLC_CROSSREF,
-						 "exclude_from_bom" };
+					 ELMT_PLC_CROSSREF,
+					 ELMT_XREF,
+					 "exclude_from_bom" };
 	return list;
 }
 
@@ -316,6 +317,7 @@ QString QETInformation::translatedInfoKey(const QString &info)
 	else if (info == ELMT_PLC_FUNCTION)                      return QObject::tr("Fonction PLC");
 	else if (info == ELMT_PLC_COMMENT)                       return QObject::tr("Commentaire PLC");
 	else if (info == ELMT_PLC_CROSSREF)                      return QObject::tr("Réf. croisée PLC");
+	else if (info == ELMT_XREF)                          return QObject::tr("Réf. croisée");
 	else return QString();
 }
 

--- a/sources/qetinformation.h
+++ b/sources/qetinformation.h
@@ -83,6 +83,7 @@ namespace QETInformation
 	static QString ELMT_SUPPLIER_AUX4                     = "supplier_auxiliary4";
 	static QString ELMT_QUANTITY_AUX4                     = "quantity_auxiliary4";
 	static QString ELMT_UNITY_AUX4                        = "unity_auxiliary4";
+	static QString ELMT_XREF                         = "xref";
 
 
 	/** Default information related to conductor **/

--- a/sources/ui/xrefpropertieswidget.cpp
+++ b/sources/ui/xrefpropertieswidget.cpp
@@ -147,6 +147,7 @@ void XRefPropertiesWidget::saveProperties(int index) {
 	xrp.setMasterLabel(ui->m_master_le->text());
 	xrp.setSlaveLabel(ui->m_slave_le->text());
 	xrp.setOffset(ui->m_offset_sb->value());
+	xrp.setSlaveOffset(ui->m_slave_offset_sb->value());
 
 	m_properties.insert(type, xrp);
 }
@@ -176,6 +177,9 @@ void XRefPropertiesWidget::updateDisplay()
 
 	int offset = xrp.offset();
 	ui->m_offset_sb->setValue(offset);
+
+	int slave_offset = xrp.slaveOffset();
+	ui->m_slave_offset_sb->setValue(slave_offset);
 
 	if (xrp.snapTo() == XRefProperties::Bottom){
 		 ui->m_snap_to_cb->setCurrentIndex(ui->m_snap_to_cb->findData("bottom"));

--- a/sources/ui/xrefpropertieswidget.cpp
+++ b/sources/ui/xrefpropertieswidget.cpp
@@ -111,6 +111,7 @@ void XRefPropertiesWidget::buildUi()
 	ui -> m_xrefpos_cb -> addItem(tr("Left"),"left");
 	ui -> m_xrefpos_cb -> addItem(tr("Right"),"right");
 	ui -> m_xrefpos_cb -> addItem(tr("Text alignment"),"alignment");
+	ui -> m_xrefpos_cb -> addItem(tr("Champ de texte"),"text_field");
 	m_previous_type_index = ui -> m_type_cb -> currentIndex();
 }
 
@@ -139,6 +140,7 @@ void XRefPropertiesWidget::saveProperties(int index) {
 	else if(ui->m_xrefpos_cb->itemData(ui->m_xrefpos_cb->currentIndex()).toString() == "left") xrp.setXrefPos(Qt::AlignLeft);
 	else if(ui->m_xrefpos_cb->itemData(ui->m_xrefpos_cb->currentIndex()).toString() == "right") xrp.setXrefPos(Qt::AlignRight);
 	else if(ui->m_xrefpos_cb->itemData(ui->m_xrefpos_cb->currentIndex()).toString() == "alignment") xrp.setXrefPos(Qt::AlignBaseline);
+	else if(ui->m_xrefpos_cb->itemData(ui->m_xrefpos_cb->currentIndex()).toString() == "text_field") xrp.setXrefPos(Qt::AlignHCenter);
 	xrp.setShowPowerContac(ui->m_show_power_cb->isChecked());
 	xrp.setShowTerminalName(ui->m_show_terminal_name_cb->isChecked());
 	xrp.setPrefix("power",  ui->m_power_prefix_le->text());
@@ -195,6 +197,7 @@ void XRefPropertiesWidget::updateDisplay()
 	else if(xrp.getXrefPos() == Qt::AlignRight) ui->m_xrefpos_cb->setCurrentIndex(ui->m_xrefpos_cb->findData("right"));
 	else if(xrp.getXrefPos() == Qt::AlignBaseline) ui->m_xrefpos_cb->setCurrentIndex(ui->m_xrefpos_cb->findData("alignment"));
 	else if(xrp.getXrefPos() == Qt::AlignBottom) ui->m_xrefpos_cb->setCurrentIndex(ui->m_xrefpos_cb->findData("bottom"));
+	else if(xrp.getXrefPos() == Qt::AlignHCenter) ui->m_xrefpos_cb->setCurrentIndex(ui->m_xrefpos_cb->findData("text_field"));
 	ui->m_show_power_cb->setChecked(xrp.showPowerContact());
 	ui->m_show_terminal_name_cb->setChecked(xrp.showTerminalName());
 	ui->m_power_prefix_le-> setText(xrp.prefix("power"));

--- a/sources/ui/xrefpropertieswidget.ui
+++ b/sources/ui/xrefpropertieswidget.ui
@@ -90,20 +90,56 @@
         </item>
        </layout>
       </item>
-      <item>
-       <layout class="QHBoxLayout" name="horizontalLayout_6">
-        <item>
-         <widget class="QLabel" name="label_10">
-          <property name="text">
-           <string>XRef slave position</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QComboBox" name="m_xrefpos_cb"/>
-        </item>
-       </layout>
-      </item>
+       <item>
+        <layout class="QHBoxLayout" name="horizontalLayout_6">
+         <item>
+          <widget class="QLabel" name="label_10">
+           <property name="text">
+            <string>XRef slave position</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QComboBox" name="m_xrefpos_cb"/>
+         </item>
+        </layout>
+       </item>
+       <item>
+        <layout class="QHBoxLayout" name="horizontalLayout_8">
+         <item>
+          <widget class="QLabel" name="label_11">
+           <property name="text">
+            <string>Distance label - slave :</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QSpinBox" name="m_slave_offset_sb">
+           <property name="toolTip">
+            <string>Distance in pixels between the label and the slave cross reference</string>
+           </property>
+           <property name="suffix">
+            <string notr="true">px</string>
+           </property>
+           <property name="correctionMode">
+            <enum>QAbstractSpinBox::CorrectToNearestValue</enum>
+           </property>
+           <property name="minimum">
+            <number>-50</number>
+           </property>
+           <property name="maximum">
+            <number>100</number>
+           </property>
+           <property name="singleStep">
+            <number>1</number>
+           </property>
+           <property name="value">
+            <number>0</number>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
       <item>
        <layout class="QHBoxLayout" name="horizontalLayout_3">
         <item>


### PR DESCRIPTION
Add a SpinBox to the XRef properties widget to allow users to configure
the distance (in pixels) between the element label and the slave cross
reference text. The offset applies to all 5 position modes (Top, Bottom,
Left, Right, Text alignment).

Previously the distance was hardcoded to 0 with no way to adjust it.
The new setting ranges from -50px to +100px (default 0), is stored in
both project XML and QSettings, and is available per element type
(coil, protection, commutator, PLC).

Changed files:
- xrefproperties.h/cpp: add m_slave_offset property with serialization
- xrefpropertieswidget.ui/cpp: add SpinBox for the new property
- dynamicelementtextitem.h/cpp: apply slave_offset in setXref_item()
- elementtextitemgroup.h/cpp: apply slave_offset in adjustSlaveXrefPos()