### PR TITLE
Fix PLC table: dangling reference warning and row deletion not working

### DIFF
--- a/sources/editor/ui/elementpropertieseditorwidget.cpp
+++ b/sources/editor/ui/elementpropertieseditorwidget.cpp
@@ -690,7 +690,7 @@ void ElementPropertiesEditorWidget::createPlcConfigWidgets()
 	m_plc_table->horizontalHeader()->resizeSection(2, 150);
 	m_plc_table->horizontalHeader()->resizeSection(3, 150);
 	m_plc_table->horizontalHeader()->resizeSection(4, 100);
-	m_plc_table->setSelectionBehavior(QAbstractItemView::SelectItems);
+	m_plc_table->setSelectionBehavior(QAbstractItemView::SelectRows);
 	m_plc_table->setSelectionMode(QAbstractItemView::ExtendedSelection);
 	m_plc_table->setMinimumHeight(200);
 	m_plc_table->setVerticalScrollBarPolicy(Qt::ScrollBarAlwaysOff);

--- a/sources/ui/masterpropertieswidget.cpp
+++ b/sources/ui/masterpropertieswidget.cpp
@@ -999,9 +999,10 @@ void MasterPropertiesWidget::plcUpdateDisplaySettings()
 
 	// Build address -> original IO lookup to correctly reattach terminal data
 	// after row reorder (move up/down) or row removal
+	const auto orig_plc = ed.plcMasterData();
 	QHash<QString, int> addr_to_orig_idx;
-	for (int i = 0; i < ed.plcMasterData().ios.size(); ++i) {
-		addr_to_orig_idx[ed.plcMasterData().ios.at(i).address] = i;
+	for (int i = 0; i < orig_plc.ios.size(); ++i) {
+		addr_to_orig_idx[orig_plc.ios.at(i).address] = i;
 	}
 
 	// Read IOs from table, preserving terminal data from original IOs
@@ -1030,7 +1031,7 @@ void MasterPropertiesWidget::plcUpdateDisplaySettings()
 
 		// Preserve terminal data by looking up original IO via address
 		if (addr_to_orig_idx.contains(io.address)) {
-			const auto orig_io = ed.plcMasterData().ios.at(addr_to_orig_idx.value(io.address));
+			const auto &orig_io = orig_plc.ios.at(addr_to_orig_idx.value(io.address));
 			io.terminalCount = orig_io.terminalCount;
 			io.terminals = orig_io.terminals;
 		}


### PR DESCRIPTION
Two fixes for the PLC master element table:

Fix dangling reference warning in plcUpdateDisplaySettings() (masterpropertieswidget.cpp): Cache the result of plcMasterData() in a local variable instead of calling it repeatedly in loops. The previous code created temporaries whose references became dangling, triggering -Wdangling-reference.
Fix PLC row deletion in the element editor (elementpropertieseditorwidget.cpp): Change table selection behavior from SelectItems to SelectRows. The - button called selectedRows() which always returned empty when only individual cells were selectable, making row deletion silently do nothing.