### PR TITLE
Fix PLC table dangling reference warning and row deletion

### DIFF
--- a/sources/editor/ui/elementpropertieseditorwidget.cpp
+++ b/sources/editor/ui/elementpropertieseditorwidget.cpp
@@ -690,7 +690,7 @@ void ElementPropertiesEditorWidget::createPlcConfigWidgets()
 	m_plc_table->horizontalHeader()->resizeSection(2, 150);
 	m_plc_table->horizontalHeader()->resizeSection(3, 150);
 	m_plc_table->horizontalHeader()->resizeSection(4, 100);
-	m_plc_table->setSelectionBehavior(QAbstractItemView::SelectItems);
+	m_plc_table->setSelectionBehavior(QAbstractItemView::SelectRows);
 	m_plc_table->setSelectionMode(QAbstractItemView::ExtendedSelection);
 	m_plc_table->setMinimumHeight(200);
 	m_plc_table->setVerticalScrollBarPolicy(Qt::ScrollBarAlwaysOff);

--- a/sources/ui/masterpropertieswidget.cpp
+++ b/sources/ui/masterpropertieswidget.cpp
@@ -976,7 +976,8 @@ void MasterPropertiesWidget::plcUpdateDisplaySettings()
 
 	// Preserve existing display settings
 	ElementData ed = m_element->elementData();
-	ElementData::PlcMasterData plc_data = ed.plcMasterData();
+	const auto orig_plc = ed.plcMasterData();
+	ElementData::PlcMasterData plc_data = orig_plc;
 	plc_data.ios.clear();
 
 	// Read IOs from table, preserving terminal data from original IOs by row index
@@ -1007,8 +1008,8 @@ void MasterPropertiesWidget::plcUpdateDisplaySettings()
 		// This avoids address-based lookup which fails when all addresses
 		// are empty (common in PLC masters) — a hash collision would cause
 		// only the last IO's terminals to be used for all rows.
-		if (row < ed.plcMasterData().ios.size()) {
-			const auto &orig_io = ed.plcMasterData().ios.at(row);
+		if (row < orig_plc.ios.size()) {
+			const auto &orig_io = orig_plc.ios.at(row);
 			io.terminalCount = orig_io.terminalCount;
 			io.terminals = orig_io.terminals;
 		}


### PR DESCRIPTION
Two fixes for the PLC master element table:

Fix dangling reference warning (masterpropertieswidget.cpp): Cache the result of plcMasterData() in a local variable to avoid creating temporaries in the loop. The previous code took a const reference to an element of a temporary that was destroyed at the end of the expression, triggering -Wdangling-reference.
Fix row deletion in the element editor (elementpropertieseditorwidget.cpp): Change setSelectionBehavior from SelectItems to SelectRows. The - button called selectedRows() which always returned empty when only individual cells were selectable, making row deletion silently do nothing.