### PR TITLE
Register jump-to-element (Ctrl+G) with ShortcutManager

### DIFF
--- a/sources/qetdiagrameditor.cpp
+++ b/sources/qetdiagrameditor.cpp
@@ -778,7 +778,7 @@ void QETDiagramEditor::setUpActions()
 	});
 
 	m_jump_to_element = new QAction(tr("Atteindre un élément"), this);
-	m_jump_to_element->setShortcut(Qt::CTRL | Qt::Key_G);
+	ShortcutManager::instance().registerAction(m_jump_to_element, "diagrameditor.jump_to_element", tr("Éditeur de schémas"), Qt::CTRL | Qt::Key_G);
 	m_jump_to_element->setStatusTip(tr("Recherche et sélectionne rapidement un élément du folio", "status bar tip"));
 	connect(m_jump_to_element, &QAction::triggered, [this]()
 	{


### PR DESCRIPTION
Fixes #758.

## Problem

`m_jump_to_element` (Édition > Atteindre un élément, `Ctrl+G`) set its
shortcut directly via `setShortcut()` instead of going through
`ShortcutManager::registerAction()`, which every other shortcut in the
app uses. Two consequences:

1. It doesn't appear on the Shortcuts preferences page, so it can't be
   discovered or rebound there.
2. `checkConflicts()` only compares registered entries, so it can't see
   this one — if a user assigns `Ctrl+G` to something else on the
   Shortcuts page, no conflict is reported and the two bindings collide
   silently at runtime.

Of 98 actions carrying a shortcut at runtime, 95 matched a
`registerAction()` call and 2 were Qt built-ins (`Shift+F1`); this was
the only one that was neither. The only other `setShortcut()` call in
the tree clears a shortcut rather than setting one, so this is the sole
instance of the bug.

## Fix

Replace the direct `setShortcut()` call with the same
`ShortcutManager::instance().registerAction(...)` pattern already used
32 other times in this same file, keeping the same default key
(`Ctrl+G`). `registerAction()` applies the shortcut via
`target->setProperty("shortcut", ...)`, which goes through `QAction`'s
own `shortcut` Q_PROPERTY — same effect as the direct call, now
registered, listed, rebindable, and conflict-checked.

## Testing

Builds clean (no new warnings). Verified the action is still
constructed and the window still launches correctly under
`QT_QPA_PLATFORM=offscreen` with a project open (no crash, no
`ShortcutManager`-related warnings). Confirmed `ShortcutsConfigPage`
reads `ShortcutManager::allShortcuts()` directly, so no further UI
change is needed for the entry to appear there.