### PR TITLE
Fix folio-report link picker rendering valid candidates as blank rows

### DIFF
--- a/sources/ui/linksingleelementwidget.cpp
+++ b/sources/ui/linksingleelementwidget.cpp
@@ -298,12 +298,37 @@ void LinkSingleElementWidget::buildTree()
 	}
 	
 	else if (m_element->elementData().m_type & ElementData::AllReport)
-	{	
+	{
 		for(const auto &elmt : elmt_vector)
 		{
 			QStringList search_list;
 			QStringList str_list;
-			
+
+				//Identifying columns first: a candidate with no conductor
+				//attached yet (the normal state for a freshly placed report
+				//arrow) would otherwise render as an all-blank row, since
+				//every conductor-property column below can legitimately be
+				//empty. Folio number/position/title never are.
+			if (Diagram *diag = elmt->diagram())
+			{
+				if (settings.value(QStringLiteral("genericpanel/folio"), false).toBool())
+				{
+					autonum::sequentialNumbers seq;
+					QString F =autonum::AssignVariables::formulaToLabel(diag->border_and_titleblock.folio(), seq, diag, elmt);
+					str_list << F;
+				}
+				else
+				{
+					str_list << QString::number(diag->folioIndex() + 1);
+				}
+				str_list << diag->convertPosition(elmt->scenePos()).toString();
+				str_list << diag->title();
+			}
+			else
+			{
+				qDebug() << "In method void LinkSingleElementWidget::updateUi(), provided element must be in a diagram";
+			}
+
 			if (!elmt->conductors().isEmpty())
 			{
 				ConductorProperties cp = elmt->conductors().first()->properties();
@@ -325,32 +350,12 @@ void LinkSingleElementWidget::buildTree()
 			}
 			else
 				str_list << "" << "" << "" << "" << "";
-			
-			if (Diagram *diag = elmt->diagram())
-			{
-				if (settings.value(QStringLiteral("genericpanel/folio"), false).toBool())
-				{
-					autonum::sequentialNumbers seq;
-					QString F =autonum::AssignVariables::formulaToLabel(diag->border_and_titleblock.folio(), seq, diag, elmt);
-					str_list << F;
-				}
-				else
-				{
-					str_list << QString::number(diag->folioIndex() + 1);
-				}
-				str_list << diag->convertPosition(elmt->scenePos()).toString();
-				str_list << diag->title();
-			}
-			else
-			{
-				qDebug() << "In method void LinkSingleElementWidget::updateUi(), provided element must be in a diagram";
-			}
-			
+
 			QTreeWidgetItem *qtwi = new QTreeWidgetItem(ui->m_tree_widget, str_list);
 			m_qtwi_elmt_hash.insert(qtwi, elmt);
 			m_qtwi_strl_hash.insert(qtwi, search_list);
 		}
-		
+
 		QSettings settings;
 		QVariant v = settings.value(QStringLiteral("link-element-widget/report-state"));
 		if(!v.isNull())
@@ -491,25 +496,25 @@ void LinkSingleElementWidget::setUpHeaderLabels()
 	{
 		if (settings.value(QStringLiteral("genericpanel/folio"), false).toBool())
 		{
-			list << tr("N° de fil")
+			list << tr("Label de folio")
+			     << tr("Position")
+			     << tr("Titre de folio")
+			     << tr("N° de fil")
 			     << tr("Fonction")
 			     << tr("Tension / Protocole")
 			     << tr("Couleur du conducteur")
-			     << tr("Section du conducteur")
-			     << tr("Label de folio")
-			     << tr("Position")
-			     << tr("Titre de folio");
+			     << tr("Section du conducteur");
 		}
 		else
 		{
-			list << tr("N° de fil")
+			list << tr("N° de folio")
+			     << tr("Position")
+			     << tr("Titre de folio")
+			     << tr("N° de fil")
 			     << tr("Fonction")
 			     << tr("Tension / Protocole")
 			     << tr("Couleur du conducteur")
-			     << tr("Section du conducteur")
-			     << tr("N° de folio")
-			     << tr("Position")
-			     << tr("Titre de folio");
+			     << tr("Section du conducteur");
 		}
 	}
 	


### PR DESCRIPTION
Fixes #735.

## Problem

In the Report de folio tab of a report arrow's properties
(`LinkSingleElementWidget`, `AllReport` branch), a valid candidate arrow
renders as a completely blank row when it has no conductor attached yet
— the normal state right after placing a new folio-reference arrow.

`buildTree()` was correctly finding the candidate (confirmed in the
original report via temporary instrumentation), but `setUpHeaderLabels()`
put five conductor-property columns first (N° de fil, Fonction, Tension/
Protocole, Couleur, Section), and every one of those is legitimately
empty before a conductor is linked. The three columns that would
actually identify the row — folio number/label, Position, Titre de
folio — were appended last, past the default column widths, so the row
looked entirely empty until clicked.

## Fix

Reorder both `setUpHeaderLabels()` and `buildTree()`'s `AllReport`
branch to lead with the three always-populated columns, matching the
existing `Slave` branch (which leads with `actualLabel()` and doesn't
have this problem). Conductor properties — legitimately blank pre-link
— now trail instead of leading. Column count and the settings-driven
folio-label-vs-number choice are unchanged; only the order moved, and
header/data order were kept in lockstep in both settings branches.

## Testing

Builds clean, no new warnings. Verified by static read that the header
label list and the `str_list` population in `buildTree()` produce the
same 8-column order in both `genericpanel/folio` settings states.

Note for anyone who already has a saved column-width state for this
tree (`link-element-widget/report-state` in QSettings): since the
column count is unchanged, the saved widths still apply positionally,
just to a different column than before the reorder — a one-time
cosmetic adjustment, not a regression.