### PR TITLE
Give QPropertyUndoCommand::undo() its own first-time grace period

### DIFF
--- a/sources/QPropertyUndoCommand/qpropertyundocommand.cpp
+++ b/sources/QPropertyUndoCommand/qpropertyundocommand.cpp
@@ -72,6 +72,7 @@ QPropertyUndoCommand::QPropertyUndoCommand(const QPropertyUndoCommand *other)
 	m_new_value     = other->m_new_value;
 	m_animate       = other->m_animate;
 	m_first_time    = other->m_first_time;
+	m_undo_first_time = other->m_undo_first_time;
 	setText(other->text());
 }
 
@@ -99,11 +100,20 @@ void QPropertyUndoCommand::enableAnimation (bool animate) {
 	@param first_time = if true,
 	the first animation is done at the first call of redo if false,
 	the first animation is done at the second call of redo.
+	The same rule applies to undo, tracked independently: redo() always
+	runs before the first undo() (QUndoStack::push() calls redo()
+	immediately), so by the time undo() can run at all, redo()'s own
+	m_first_time has already flipped true. Sharing that flag would leave
+	undo() with no instant path ever reachable in practice -- reusing it
+	is not actually symmetric, it just looks like it is. m_undo_first_time
+	gives undo() the same one-time grace period redo() has, on its own
+	first call instead of redo's.
 */
 void QPropertyUndoCommand::setAnimated(bool animate, bool first_time)
 {
 	m_animate = animate;
 	m_first_time = first_time;
+	m_undo_first_time = first_time;
 }
 
 /**
@@ -155,7 +165,7 @@ void QPropertyUndoCommand::undo()
 {
 	if (m_object->property(m_property_name) != m_old_value)
 	{
-		if (m_animate)
+		if (m_animate && m_undo_first_time)
 		{
 			QPropertyAnimation *animation = new QPropertyAnimation(m_object, m_property_name);
 			animation->setStartValue(m_new_value);
@@ -163,7 +173,10 @@ void QPropertyUndoCommand::undo()
 			animation->start(QAbstractAnimation::DeleteWhenStopped);
 		}
 		else
+		{
 			m_object->setProperty(m_property_name, m_old_value);
+			m_undo_first_time = true;
+		}
 	}
 
 	QUndoCommand::undo();

--- a/sources/QPropertyUndoCommand/qpropertyundocommand.h
+++ b/sources/QPropertyUndoCommand/qpropertyundocommand.h
@@ -58,7 +58,8 @@ class QPropertyUndoCommand : public QUndoCommand
 		const char *m_property_name;
 		QVariant m_old_value, m_new_value;
 		bool m_animate = false,
-			 m_first_time = true;
+			 m_first_time = true,
+			 m_undo_first_time = true;
 };
 
 #endif // QPROPERTYUNDOCOMMAND_H


### PR DESCRIPTION
Fixes #755.

## The bug

`redo()` has a direct-write path guarded by `m_first_time`: the first
call writes the property immediately, and only animates on calls after
that. `undo()` had no equivalent — `if (m_animate)` with no
`m_first_time` check at all — so it always animated. That means
`undo()` returns before the property is actually restored, and with no
running event loop (headless/scripted use, e.g. `--test-ops`), it never
gets restored at all.

## Why I didn't just reuse `m_first_time` in `undo()`

That's the "obvious" fix — literally the same guard, copy-pasted. I
built and ran it standalone before committing to it (same technique the
original report used: compile just this class against Qt5, no full QET
build needed), and it doesn't actually change anything for the reported
scenario:

`QUndoStack::push()` always calls `redo()` once before `undo()` can ever
run. `redo()`'s direct-write branch sets `m_first_time = true` as it
completes. So by the time `undo()` is called at all, `m_first_time` has
already flipped — reusing it makes `undo()`'s new guard evaluate to
"animate" on every single call. Syntactically symmetric with `redo()`,
but behaviourally identical to the current, broken code for the exact
`setAnimated(true, false)` pattern `RotateSelectionCommand` (and roughly
a dozen other callers — text/rectangle/table/PLC editors) actually use.

## The fix

`undo()` gets its own `m_undo_first_time` flag, seeded from the same
`first_time` argument `setAnimated()` already takes, and set `true` by
`undo()`'s own direct-write branch — the same way `m_first_time` is set
by `redo()`'s. That gives `undo()` a real, independently-reachable
direct-write path on its own first call, rather than inheriting a grace
period `redo()` already spent.

## Verification

Standalone build of just `qpropertyundocommand.{h,cpp}` plus a `Dummy`
QObject, mirroring the issue's own repro:

```
first redo (no event loop): 90   -- unchanged, correct
first undo (no event loop): 0    -- was 90 (bug); now correct
```

Extended the repro with a second redo/undo cycle, pumping the event loop
between steps, to check steady-state behaviour once both directions have
used their one-time grace period: both settle to the correct value when
a loop is available, matching `redo()`'s existing, accepted behaviour —
this fix doesn't change what happens after the first call in either
direction, only adds the missing first-call path to `undo()`.

Checked every other `QPropertyUndoCommand::setAnimated()` /
`enableAnimation()` caller in the tree (~20 call sites): everywhere that
doesn't pass `first_time=false` gets `m_undo_first_time` starting `true`,
and the animate branch never modifies it — so behaviour for those
callers is provably unchanged. Full project builds clean, no new
warnings.