### PR TITLE
fix problem with PDF-links in files with brackets in name

### DIFF
--- a/sources/pdf_links.cpp
+++ b/sources/pdf_links.cpp
@@ -228,7 +228,7 @@ void convertUriToGoTo(const QString &pdfPath)
 
 			// Find closing ')' of the URI value
 			int uriStart = found + sUri.size();
-			int closeParen = data.indexOf(')', uriStart);
+			int closeParen = data.indexOf(")\n", uriStart);
 			if (closeParen == -1) {
 				// Malformed — copy rest verbatim
 				out.append(data.mid(found));


### PR DESCRIPTION
When I see it correctly, the source of links marked as "/URI (...)" fills the whole line in a PDF.
So when replacing that by a "/GoTo ..." - link we need to search not only for a closing bracket, but for a closing bracket followed by a NewLine "\n".
In this case we can handle filenames with round brackets as well.
This works for me on my Debian GNU/Linux stable and unstable.
Could someone try this with win to confirm the fix?