### PR TITLE
Make auto_num_locked/potential_isolating/exclude_from_bom case-insensitive

### DIFF
--- a/sources/dataBase/projectdatabase.cpp
+++ b/sources/dataBase/projectdatabase.cpp
@@ -583,7 +583,10 @@ void projectDataBase::createElementNomenclatureView()
 						 "di.folio AS folio,"
 						 "e.pos AS position "
 						 " FROM element_info ei, diagram_info di, element e, diagram d"
-						 " WHERE ei.element_uuid = e.uuid AND e.diagram_uuid = d.uuid AND di.diagram_uuid = d.uuid AND (ei.exclude_from_bom IS NOT 'true')");
+						 // COLLATE NOCASE: the writer always stores lowercase "true"/"false",
+						 // but a hand-authored file can spell it "True"/"TRUE" -- those used
+						 // to compare unequal to 'true' and stay in the BOM silently.
+						 " WHERE ei.element_uuid = e.uuid AND e.diagram_uuid = d.uuid AND di.diagram_uuid = d.uuid AND (ei.exclude_from_bom COLLATE NOCASE IS NOT 'true')");
 
 	QSqlQuery query(m_data_base);
 	if (!query.exec(create_view)) {

--- a/sources/qetgraphicsitem/terminal.cpp
+++ b/sources/qetgraphicsitem/terminal.cpp
@@ -24,6 +24,7 @@
 #include "../qetgraphicsitem/conductor.h"
 #include "../qetgraphicsitem/element.h"
 #include "conductortextitem.h"
+#include "../qetinformation.h"
 
 #include <utility>
 
@@ -976,7 +977,7 @@ QList<Terminal *> relatedPotentialTerminal (
 	else if (terminal -> parentElement() -> linkType() & Element::Terminale)
 	{
 		// English: Check if the user activated the potential isolation checkbox for this terminal
-		if (terminal->parentElement()->elementInformations().value(QStringLiteral("potential_isolating")).toString() == QLatin1String("true")) {
+		if (QETInformation::isInfoFlagTrue(terminal->parentElement()->elementInformations().value(QStringLiteral("potential_isolating")).toString())) {
 			// English: Potential is isolated. Return an empty list so it does not propagate to the other side.
 			return QList<Terminal *>();
 		}

--- a/sources/qetinformation.cpp
+++ b/sources/qetinformation.cpp
@@ -385,3 +385,13 @@ QStringList QETInformation::terminalElementInfoKeys()
 						 ELMT_SUPPLIER };
 	return list;
 }
+
+/**
+ * @brief QETInformation::isInfoFlagTrue
+ * @param value
+ * @return see header for the rationale.
+ */
+bool QETInformation::isInfoFlagTrue(const QString &value)
+{
+	return value.compare(QLatin1String("true"), Qt::CaseInsensitive) == 0;
+}

--- a/sources/qetinformation.h
+++ b/sources/qetinformation.h
@@ -159,6 +159,22 @@ namespace QETInformation
 
 	QString infoToVar(const QString &info);
 	QString translatedInfoKey(const QString &info);
+
+	/**
+	 * @brief isInfoFlagTrue
+	 * @param value : an elementInformation value read for a boolean-style
+	 * flag (auto_num_locked, potential_isolating, exclude_from_bom).
+	 * @return true if @value spells "true" case-insensitively.
+	 *
+	 * These three keys are stored as plain text, and the only writer
+	 * (the checkbox in ElementInfoWidget / ElementPropertiesEditorWidget)
+	 * always writes lowercase "true"/"false" -- but the value can also come
+	 * from a hand-authored .elmt/.qet file, where "True", "TRUE" or "1" read
+	 * as plausible spellings of yes and silently do nothing, because every
+	 * comparison site up to now has been a case-sensitive `== "true"`. Route
+	 * every read through here instead of repeating the comparison.
+	 */
+	bool isInfoFlagTrue(const QString &value);
 }
 
 #endif // QETINFORMATION_H

--- a/sources/ui/elementinfowidget.cpp
+++ b/sources/ui/elementinfowidget.cpp
@@ -366,18 +366,18 @@ void ElementInfoWidget::updateUi()
 	// Load the lock status for auto numbering
 	if (m_element->elementData().m_type == ElementData::Terminal) {
 		QString lock_value = element_info.value(QStringLiteral("auto_num_locked")).toString();
-		ui->m_auto_num_locked_cb->setChecked(lock_value == QLatin1String("true"));
+		ui->m_auto_num_locked_cb->setChecked(QETInformation::isInfoFlagTrue(lock_value));
 
 		// English: Load the potential isolating status from the element information mapping
 		if (m_potential_isolating_cb) {
 			QString isolating_value = element_info.value(QStringLiteral("potential_isolating")).toString();
-			m_potential_isolating_cb->setChecked(isolating_value == QLatin1String("true"));
+			m_potential_isolating_cb->setChecked(QETInformation::isInfoFlagTrue(isolating_value));
 		}
 	}
 	// English: Load the BOM exclusion status from the element information mapping
 	if (m_exclude_from_bom_cb) {
 		QString exclude_bom_value = element_info.value(QStringLiteral("exclude_from_bom")).toString();
-		m_exclude_from_bom_cb->setChecked(exclude_bom_value == QLatin1String("true"));
+		m_exclude_from_bom_cb->setChecked(QETInformation::isInfoFlagTrue(exclude_bom_value));
 	}
 
 	if (m_live_edit) {

--- a/sources/ui/terminalnumberingdialog.cpp
+++ b/sources/ui/terminalnumberingdialog.cpp
@@ -4,6 +4,7 @@
 #include "../diagram.h"
 #include "../qetgraphicsitem/element.h"
 #include "../undocommand/changeelementinformationcommand.h"
+#include "../qetinformation.h"
 #include <QUndoCommand>
 #include <QCheckBox>
 #include <QVBoxLayout>
@@ -34,7 +35,7 @@ TerminalNumberingDialog::TerminalNumberingDialog(QWidget *parent, QETProject *pr
                     if (elmt->elementData().m_type == ElementData::Terminal) {
                         // Ignore locked terminals
                         DiagramContext info = elmt->elementInformations();
-                        if (info.value(QStringLiteral("auto_num_locked")).toString() == QLatin1String("true")) {
+                        if (QETInformation::isInfoFlagTrue(info.value(QStringLiteral("auto_num_locked")).toString())) {
                             continue;
                         }
 
@@ -158,7 +159,7 @@ QUndoCommand* TerminalNumberingDialog::getUndoCommand(QETProject *project) const
                     DiagramContext info = elmt->elementInformations();
 
                     // Ignore locked terminals (if the user checked a 'lock' property)
-                    if (info.value(QStringLiteral("auto_num_locked")).toString() == QLatin1String("true")) {
+                    if (QETInformation::isInfoFlagTrue(info.value(QStringLiteral("auto_num_locked")).toString())) {
                         continue;
                     }
 


### PR DESCRIPTION
## Problem

`auto_num_locked`, `potential_isolating` and `exclude_from_bom` are stored as
plain text and compared against the literal `"true"` everywhere they are
read — a SQL predicate in `element_nomenclature_view`, and case-sensitive
`==` checks in `terminal.cpp`, `terminalnumberingdialog.cpp` and
`elementinfowidget.cpp`. The only writer (the checkbox in
`ElementInfoWidget`) always writes lowercase `"true"`/`"false"`, so this is
invisible from the GUI. But the value can also come from a hand-authored
`.elmt`/`.qet` file, where `"True"`, `"TRUE"` or `"tRuE"` read as entirely
plausible spellings of yes and silently do nothing — no error, no warning,
the checkbox just never takes effect.

## Fix

Added `QETInformation::isInfoFlagTrue()` as the one place this comparison is
made, used at all four C++ read sites, so a future fifth site can't
reintroduce the case-sensitivity. The SQL side (`element_nomenclature_view`)
gets `COLLATE NOCASE`, since a C++ helper can't reach into a view definition.

## Verification

Built and tested against `examples/tremie_vibrante.qet` (98 components) via
`--export-bom`:

| stored value | BOM rows | before this fix |
|---|---|---|
| *(absent)* | 98 | 98 |
| `false` | 98 | 98 |
| `true` | **93** | 93 |
| `True` | **93** | 98 *(no effect)* |
| `TRUE` | **93** | 98 *(no effect)* |
| `tRuE` | **93** | 98 *(no effect)* |
| `FALSE` | 98 | 98 |
| `False` | 98 | 98 |

Marking 5 elements `exclude_from_bom="True"` had no effect before this
change (98 rows, unchanged) and now correctly excludes them (93 rows). Same
for `TRUE`/`tRuE`; the `false`-family variants correctly remain no-ops.

Full corpus regression: `--export-bom` output is byte-identical to master on
21 of 22 comparable example projects (`schema_indus.qet` excluded — a known,
unrelated startup-modal hang). The one difference, on `photovoltaique.qet`,
is three rows tied on `ORDER BY label` landing in a different order — same
row count, empty diff once sorted, and a pre-existing non-determinism (the
query has never defined a tiebreaker) unrelated to this change.
