### PR TITLE
Remove dead exclude_from_bom clause from ElementQueryWidget

### DIFF
--- a/sources/dataBase/ui/elementquerywidget.cpp
+++ b/sources/dataBase/ui/elementquerywidget.cpp
@@ -378,10 +378,10 @@ QString ElementQueryWidget::queryStr() const
 		where.clear();
 	}
 
-	QString exclude_condition = "(exclude_from_bom IS NULL OR exclude_from_bom != '1')";
-
-	filter_ += " AND " + exclude_condition;
-	// -------------------------------------------------------------
+	// exclude_from_bom is already filtered by element_nomenclature_view
+	// (see createElementNomenclatureView() in projectdatabase.cpp); this
+	// widget's query reads FROM that view, so a flagged element never
+	// reaches this point in the first place.
 
 	if (where.isEmpty() && !filter_.isEmpty()) {
 		filter_.remove(0, 4); //Remove the first " AND" of filter.


### PR DESCRIPTION
## Problem

`ElementQueryWidget::queryStr()` reads `FROM element_nomenclature_view`, and
that view already excludes flagged elements in its own `WHERE` clause (see
`createElementNomenclatureView()` in `projectdatabase.cpp`). This widget then
added a second condition on top: `exclude_from_bom IS NULL OR
exclude_from_bom != '1'` — but nothing anywhere ever writes the literal
string `"1"` to this key (the only writer stores `"true"`/`"false"`), so the
clause is true for every row that could possibly reach this point and does
nothing.

## Fix

Removed the dead clause, with a comment pointing at the view that actually
does the filtering.

## Verification

Confirmed dead by measurement rather than by reading: reading the value only
ever comes back `"true"` or `"false"` (never `"1"`), and an
`exclude_from_bom="1"` element still appeared in `--export-bom` output on a
test fixture (checked as part of qelectrotech#765's review).

`ElementQueryWidget` backs the BOM export dialog and the diagram table
properties widget; neither has a headless CLI equivalent, so this couldn't
be verified end-to-end through `--export-bom` the way a database-level fix
could. Verified instead: the file compiles clean, and a
load/resave/`--export-bom` smoke test on `examples/tremie_vibrante.qet`
shows no change in app behaviour (98 components, matching baseline —
expected, since `--export-bom` doesn't go through this widget at all).
