### PR TITLE
Fix segfault when a project is destroyed with a diagram still pending deleteLater()

### DIFF
--- a/sources/qetproject.cpp
+++ b/sources/qetproject.cpp
@@ -174,6 +174,30 @@ QETProject::~QETProject()
 		delete  diagram;
 		m_diagrams_list.removeOne(diagram);
 	}
+
+		//A diagram can be detached from this project (detachDiagram(), used by
+		//both removeDiagram() and RemoveDiagramCommand::redo()) and scheduled
+		//for deferred deletion via deleteLater(), without that deletion having
+		//actually run yet -- deleteLater() only fires on the next event-loop
+		//iteration, and nothing guarantees one runs before this destructor
+		//does. Such a diagram is no longer in m_diagrams_list (so the loop
+		//above never touches it) but is still a QObject child of this project
+		//(Diagram's constructor passes `project` straight to QGraphicsScene's
+		//parent argument). Left alone, it is destroyed later by QObject's own
+		//automatic child cleanup in ~QObject(), which runs AFTER m_data_base
+		//(a plain value member, destroyed by ordinary C++ member teardown)
+		//has already been destroyed -- and Diagram's destructor calls back
+		//into dataBase()->removeElement() for each of its elements, so that
+		//ordering is a use-after-free (confirmed by crash: SIGSEGV in
+		//QSqlResult::exec(), called from Diagram::~Diagram() by way of
+		//Diagram::removeItem(), by way of QObjectPrivate::deleteChildren()).
+		//Delete any such stragglers now, synchronously, while m_data_base is
+		//still alive. The deleteLater() event, if it is ever processed
+		//afterward, is a safe no-op on an already-deleted QObject.
+	const auto orphaned_diagrams = findChildren<Diagram *>(QString(), Qt::FindDirectChildrenOnly);
+	for (Diagram *diagram : orphaned_diagrams) {
+		delete diagram;
+	}
 }
 
 /**


### PR DESCRIPTION
## Problem

`QETProject::removeDiagram(Diagram*)` detaches a diagram from
`m_diagrams_list` and schedules it for destruction via `deleteLater()`.
That deferred delete only actually runs on a future Qt event-loop
iteration.

If `~QETProject()` runs before that iteration happens — e.g. a
headless/CLI caller that never enters `QCoreApplication::exec()`, or a
project closed immediately after `removeDiagram()` in the same call
stack — the diagram is still a live `QObject` child of the project
(`Diagram`'s constructor passes `project` straight through to
`QGraphicsScene`'s parent argument). It then gets destroyed later by
`QObject`'s own automatic child cleanup in the base `~QObject()`
destructor, which runs *after* `m_data_base` — a plain C++ value
member — has already been torn down by ordinary member destruction
order.

`Diagram::~Diagram()` calls back into `dataBase()->removeElement()`
for each of its elements, so that ordering is a use-after-free:

```
Thread 1 "qelectrotech" received signal SIGSEGV, Segmentation fault.
0x00007ffff696d72d in QString::operator=(QString const&) () from libQt5Core.so.5
#0  QString::operator=(QString const&) ()
#1  QSqlResult::exec() ()
#2  projectDataBase::removeElement(Element*) ()
#3  Diagram::removeItem(QGraphicsItem*) ()
#4  Diagram::~Diagram() ()
#5  Diagram::~Diagram() ()
#6  QObjectPrivate::deleteChildren() ()
#7  QObject::~QObject() ()
#8  CLIExport::run(QStringList const&) ()
#9  main ()
```

Minimal repro (no editing, no undo stack):

```cpp
QETProject project(input);   // stack-allocated
project.removeDiagram(project.diagrams().first());
// project's destructor runs here as the enclosing scope exits --
// no QCoreApplication::processEvents() in between
```

`removeDiagram()` itself has no production callers today (UI code goes
through the undoable `ProjectView::removeDiagram()` /
`RemoveDiagramCommand` path instead), which is presumably why this has
gone unnoticed, but it's public API and the same shape of bug could
resurface anywhere a diagram is detached-and-deferred without a
guaranteed event-loop pump before project teardown.

## Fix

In `~QETProject()`, after the existing loop that deletes every diagram
still in `m_diagrams_list`, add a second pass that finds any `Diagram`
still parented to the project (i.e. detached from the list but not yet
reaped by its pending `deleteLater()`) and deletes it synchronously,
while `m_data_base` is still alive. The original `deleteLater()` event,
if it does still fire afterward, is a safe no-op on an already-deleted
`QObject`.

## Testing

Verified with a temporary CLI probe (not included in this diff)
reproducing the exact original crash conditions — a stack-local
`QETProject`, `removeDiagram()` called, no event-loop iteration before
scope exit, matching `CLIExport::run()`'s real code path — against
several real example projects. All crashed reliably before this patch
and exit cleanly after it. The normal teardown path (diagram still in
`m_diagrams_list`, no `removeDiagram()` call) was also re-verified
unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)