### PR TITLE
Fix crash when expanding templates/macros tree (Qt6 regression)

### DIFF
--- a/sources/ElementsCollection/elementscollectionmodel.cpp
+++ b/sources/ElementsCollection/elementscollectionmodel.cpp
@@ -63,6 +63,7 @@ QVariant ElementsCollectionModel::data(const QModelIndex &index, int role) const
 {
 	if (role == Qt::DecorationRole) {
 		QStandardItem *item = itemFromIndex(index);
+		if (!item) return QStandardItemModel::data(index, role);
 
 		if (item->type() == FileElementCollectionItem::Type)
 			static_cast<FileElementCollectionItem*>(item)->setUpIcon();
@@ -330,7 +331,6 @@ void ElementsCollectionModel::loadMacrosCollection()
 void ElementsCollectionModel::addMacrosCollection(bool set_data)
 {
 	QString macrosPath = QETApp::userMacrosDir();
-	qDebug() << "=== MAKRO PFAD CHECK ===" << macrosPath;
 	if (macrosPath.endsWith("/")) {
 		macrosPath.remove(macrosPath.length() - 1, 1);
 	}

--- a/sources/ElementsCollection/fileelementcollectionitem.cpp
+++ b/sources/ElementsCollection/fileelementcollectionitem.cpp
@@ -430,7 +430,7 @@ void FileElementCollectionItem::setUpData()
  */
 void FileElementCollectionItem::setUpIcon()
 {
-		// Must return unconditionally once an icon is set: setIcon() calls
+		// Must return unconditionally once setUpIcon has run: setIcon() calls
 		// setData(), which emits dataChanged() regardless of whether the new
 		// icon differs from the old one (QIcon has no meaningful equality).
 		// QTreeView responds to dataChanged() by recomputing the row's size
@@ -438,13 +438,18 @@ void FileElementCollectionItem::setUpIcon()
 		// guard, any repeated setIcon() here recurses until the stack
 		// overflows. Confirmed by crash report on PR #633.
 		//
+		// We use a dedicated bool instead of icon().isNull() because
+		// some items intentionally keep a null icon (e.g. .qetmak),
+		// which would bypass a null-based guard and still recurse.
+		//
 		// This item's m_qet_directory_unreadable is already final by the time
 		// this can run at all: ElementsCollectionModel only attaches itself
 		// to the tree view (making data() reachable) from loadingFinished(),
 		// which fires after the QtConcurrent::map over every item -- this one
 		// included -- has completed. So there is no race to work around here.
-	if (!icon().isNull())
+	if (m_icon_initialized)
 		return;
+	m_icon_initialized = true;
 
 	if (isCollectionRoot()) {
 		QString macrosPath = QETApp::userMacrosDir();

--- a/sources/ElementsCollection/fileelementcollectionitem.h
+++ b/sources/ElementsCollection/fileelementcollectionitem.h
@@ -69,6 +69,7 @@ class FileElementCollectionItem : public ElementCollectionItem
 			/// rather than acted on in localName(), because setUpData() resets
 			/// the tooltip afterwards and would otherwise discard it.
 		bool m_qet_directory_unreadable = false;
+		bool m_icon_initialized = false;
 };
 
 #endif // FILEELEMENTCOLLECTIONITEM2_H


### PR DESCRIPTION
Problem
When expanding folders in the templates (Vorlagen) tab, QElectroTech crashes with a stack overflow. The crash occurs specifically when:

Opening the templates tab
Expanding the "Vorlagen" root node
Expanding a subfolder containing .qetmak files
This is a Qt6 regression — the crash does not occur on Qt5.

Root Cause
FileElementCollectionItem::setUpIcon() uses icon().isNull() as a recursion guard. For .qetmak files, the icon is intentionally left empty (setIcon(QIcon())), which produces a null QIcon. Since the guard never triggers for null icons, every call to setUpIcon() sets a null icon, which emits dataChanged(), causing the tree view to re-query data(), which calls setUpIcon() again — resulting in infinite recursion and a stack overflow.

Fix
Replace the icon().isNull() guard in setUpIcon() with a dedicated bool m_icon_initialized flag. This allows .qetmak files to keep their intentionally empty icon while reliably preventing recursion.
Add a null-pointer check for itemFromIndex() in ElementsCollectionModel::data() to prevent crashes from invalid indices during tree expansion.
Remove leftover debug output ("=== MAKRO PFAD CHECK ===").