### PR TITLE
Fix: avoid crash when opening a project without a folio (diagram).

### DIFF
--- a/sources/projectview.cpp
+++ b/sources/projectview.cpp
@@ -210,10 +210,14 @@ void ProjectView::changeFirstTab()
 }
 
 /**
-	@return first folio of current project
+	@return first folio of current project, or nullptr if the project
+	has no diagram.
 */
 DiagramView *ProjectView::firstDiagram()
 {
+	if (m_diagram_ids.isEmpty()) {
+		return(nullptr);
+	}
 	return(m_diagram_ids.first());
 }
 


### PR DESCRIPTION
A new project is created with an empty page but it is possible to delete all exisiting pages and to save the project as a valid(?) .qet file. When opening the program crashes due to an invalid access. The fix here allows to open it properly.

To be considered whether it would make sense to block the deletion of the last page.

I ran it through clang-tidy and there might be more risky access operations which are not safeguarded by checking for empty(). To be addressed later.