### PR TITLE
Fix issue #798: element editor crash on scroll-wheel zoom

### DIFF
--- a/ChangeLog_full.md
+++ b/ChangeLog_full.md
@@ -20,6 +20,7 @@ All notable changes to QElectroTech are documented here.
 
 ### 🐛 Bug Fixes
 
+- Fix #798: clamp element-editor and diagram-view zoom to prevent view-transform overflow crash on scroll-wheel zoom ([3ca5d4a](../../commit/3ca5d4ab2))
 - Fix(windows-msi): inject rev into MSI Version Build field ([e19f523](../../commit/e19f5232277efb37435cb65a83563d73333d62ec))
 - Fix #391: use wide-char path for pugixml on Windows to handle Unicode paths ([31edf30](../../commit/31edf30c619213368e9b592b51be6ca8190db831))
 - Fix(#283): restore center alignment when loading table config ([f55ba56](../../commit/f55ba568f68293e06436899bcc831431e9d27295))

--- a/sources/diagramview.cpp
+++ b/sources/diagramview.cpp
@@ -334,6 +334,13 @@ void DiagramView::setSelectionMode()
 */
 void DiagramView::zoom(const qreal zoom_factor)
 {
+	// clamp the resulting scale so a repeated wheel-zoom cannot drive the view
+	// transform to floating-point overflow and crash the editor (issue #798)
+	const qreal target = transform().m11() * zoom_factor;
+	if (target < m_min_zoom || target > m_max_zoom) {
+		return;
+	}
+
 	if (zoom_factor >= 1){
 		scale(zoom_factor, zoom_factor);
 	}

--- a/sources/diagramview.h
+++ b/sources/diagramview.h
@@ -103,6 +103,12 @@ class DiagramView : public QGraphicsView
 		bool mustIntegrateTitleBlockTemplate(const TitleBlockTemplateLocation &) const;
 		bool gestures() const;
 
+		/// Lowest and highest allowed value of the view transform scale (m11).
+		/// Prevents wheel-zoom from driving the transform to overflow, which
+		/// crashes the editor (see GitHub issue #798, same class of bug).
+		static constexpr qreal m_min_zoom = 0.01;
+		static constexpr qreal m_max_zoom = 200.0;
+
 	signals:
 			/// Signal emitted after the selection mode changed
 		void modeChanged();

--- a/sources/editor/elementview.cpp
+++ b/sources/editor/elementview.cpp
@@ -101,12 +101,29 @@ void ElementView::setSelectionMode()
 }
 
 /**
+	Applique un facteur d'echelle a la vue en bornant l'echelle resultante
+	entre m_min_zoom et m_max_zoom. Sans cette borne, un zoom repete (molette)
+	finit par faire deborder la transformation de la vue et fait planter
+	l'editeur (issue #798).
+	@param factor facteur d'echelle a appliquer
+*/
+void ElementView::scaleClamped(qreal factor)
+{
+	const qreal current = transform().m11();
+	const qreal target = current * factor;
+	if (target < m_min_zoom || target > m_max_zoom) {
+		return;
+	}
+	scale(factor, factor);
+}
+
+/**
 	Agrandit le schema (+33% = inverse des -25 % de zoomMoins())
 */
 void ElementView::zoomIn()
 {
 	adjustSceneRect();
-	scale(4.0/3.0, 4.0/3.0);
+	scaleClamped(4.0/3.0);
 }
 
 /**
@@ -115,7 +132,7 @@ void ElementView::zoomIn()
 void ElementView::zoomOut()
 {
 	adjustSceneRect();
-	scale(0.75, 0.75);
+	scaleClamped(0.75);
 }
 
 /**
@@ -123,7 +140,7 @@ void ElementView::zoomOut()
 */
 void ElementView::zoomInSlowly()
 {
-	scale(1.02, 1.02);
+	scaleClamped(1.02);
 }
 
 /**
@@ -131,7 +148,7 @@ void ElementView::zoomInSlowly()
 */
 void ElementView::zoomOutSlowly()
 {
-	scale(0.98, 0.98);
+	scaleClamped(0.98);
 }
 
 /**

--- a/sources/editor/elementview.h
+++ b/sources/editor/elementview.h
@@ -53,6 +53,13 @@ class ElementView : public QGraphicsView {
 	
 	private:
 	QRectF applyMovement(const QRectF &, const QPointF &);
+	void scaleClamped(qreal factor);
+
+	/// Lowest and highest allowed value of the view transform scale (m11).
+	/// Prevents the wheel-zoom from driving the transform to overflow, which
+	/// crashes the editor (bugtracker / GitHub issue #798).
+	static constexpr qreal m_min_zoom = 0.1;
+	static constexpr qreal m_max_zoom = 200.0;
 	
 	public slots:
 	void setVisualisationMode();


### PR DESCRIPTION
## Problem

Issue #798: in the element editor, holding the mouse scroll wheel to zoom in/out closes the application completely (reported on Windows, 0.200.1-r9435).

## Cause

`ElementView::wheelEvent()` calls `zoomIn()` / `zoomOut()` on every wheel notch, and those call `scale()` with no bound on the resulting view transform. `zoomIn()` multiplies the scale by 4/3 each notch; after enough notches the transform scale (`m11`) overflows the `double` range and the `QTransform` becomes non-invertible. `mapToScene()` then returns NaN/inf geometry, which is handed to the raster paint engine on the next `drawBackground()` pass and aborts the editor. `zoomOut()` is symmetric — `adjustSceneRect()` grows the scene rect without limit until it overflows.

The attached diagnostic report is consistent with this: an `EventLoopWatchdog` stall and a paint/glyph error immediately before the log ends, with no C++ exception backtrace.

`DiagramView::zoom()` (the main diagram editor) had the same unbounded `scale()` and is fixed here too.

## Fix

- `ElementView`: new `scaleClamped()` helper that applies the scale factor only while the resulting `m11` stays within `[m_min_zoom, m_max_zoom]` (0.1 .. 200); all four zoom entry points (`zoomIn`, `zoomOut`, `zoomInSlowly`, `zoomOutSlowly`) go through it.
- `DiagramView::zoom()`: same clamp applied inline before the existing scale logic (range 0.01 .. 200).

Zoom behaviour inside the allowed range is unchanged; `zoomReset()` / `zoomFit()` are untouched. Small and self-contained (4 files).