### PR TITLE
Add position-lock checkbox to element properties (#801)

### DIFF
--- a/sources/qetgraphicsitem/element.cpp
+++ b/sources/qetgraphicsitem/element.cpp
@@ -806,6 +806,7 @@ bool Element::fromXml(QDomElement &e,
 	setZValue(e.attribute(QStringLiteral("z"), QString::number(this->zValue())).toDouble());
 	setFlags(QGraphicsItem::ItemIsMovable
 		 | QGraphicsItem::ItemIsSelectable);
+	is_movable_ = e.attribute(QStringLiteral("is_movable"), QStringLiteral("1")).toInt();
 
 	// orientation
 	bool conv_ok;
@@ -937,6 +938,7 @@ QDomElement Element::toXml(
 	element.setAttribute(QStringLiteral("y"), QString::number(pos().y()));
 	element.setAttribute(QStringLiteral("z"), QString::number(this->zValue()));
 	element.setAttribute(QStringLiteral("orientation"), QString::number(orientation()));
+	element.setAttribute(QStringLiteral("is_movable"), bool(is_movable_));
 
 	/* get the first id to use for the bounds of this element
 	 * recupere le premier id a utiliser pour les bornes de cet element */

--- a/sources/ui/elementpropertieswidget.cpp
+++ b/sources/ui/elementpropertieswidget.cpp
@@ -30,6 +30,7 @@
 #include "masterpropertieswidget.h"
 #include "plclinkwidget.h"
 
+#include <QCheckBox>
 #include <QLabel>
 #include <QUndoStack>
 #include <QVBoxLayout>
@@ -395,6 +396,18 @@ QWidget *ElementPropertiesWidget::generalWidget()
 	label->setWordWrap(true);
 	label->setTextInteractionFlags(Qt::TextEditorInteraction);
 	vlayout_->addWidget(label);
+
+		//checkbox to lock the element position on the diagram
+		//(same mechanism already used by images and drawn shapes)
+	QCheckBox *lock_pos_cb = new QCheckBox(tr("Verrouiller la position"), general_widget);
+	lock_pos_cb->setChecked(!m_element->isMovable());
+	QPointer<Element> element = m_element;
+	connect(lock_pos_cb, &QCheckBox::clicked, this, [element](bool checked) {
+		if (element) {
+			element->setMovable(!checked);
+		}
+	});
+	vlayout_->addWidget(lock_pos_cb);
 
 		//widget for the pixmap
 	QLabel *pix = new QLabel(general_widget);


### PR DESCRIPTION
## Request

#801 — placed elements can't be locked in position the way images and drawn rectangles/shapes already can, so they get accidentally nudged while routing wires nearby.

## Finding

The mechanism already exists: `QetGraphicsItem::isMovable()`/`setMovable()` is inherited by `Element`, `DiagramImageItem`, and `QetShapeItem` alike, and `mouseMoveEvent()` already refuses to move an item when it's not movable. Images and shapes each expose a "lock position" checkbox (`m_lock_pos_cb`) in their properties widget and persist the flag as an `is_movable` XML attribute. Elements had neither — the drag-guard worked, there was just no UI to set it and no persistence.

## Change

- `ElementPropertiesWidget::generalWidget()`: add a "Verrouiller la position" checkbox, same label and behavior as the existing shape/image one, toggling the element's inherited `setMovable()`.
- `Element::toXml()` / `Element::fromXml()`: persist `is_movable`, same attribute name and default-true fallback as `DiagramImageItem`/`QetShapeItem`, so the lock survives save/reload.

## Verification

Built via fastbuild. Headless round-trip: hand-set `is_movable="0"` on one element in `examples/741.qet`, `--resave`d, confirmed the locked element kept `is_movable="0"` and the other 64 elements got `is_movable="1"` written (default-movable, matching files with no attribute at all).

Small and self-contained (2 files, +15/-0).