### PR TITLE
Select newly added diagram in project tree

### DIFF
--- a/sources/genericpanel.cpp
+++ b/sources/genericpanel.cpp
@@ -730,11 +730,24 @@ void GenericPanel::projectInformationsChanged(QETProject *project) {
 /**
 	@brief GenericPanel::diagramAdded
 	@param project
-	@param diagram (unused)
+	@param diagram the newly added diagram to select in the tree
 */
 void GenericPanel::diagramAdded(QETProject *project, Diagram *diagram) {
-	Q_UNUSED(diagram)
 	addProject(project, nullptr, GenericPanel::AddChildDiagrams);
+	if (diagram) {
+		QTreeWidgetItem *projectItem = itemForProject(project);
+		if (projectItem) {
+			for (int i = projectItem->childCount() - 1; i >= 0; --i) {
+				QTreeWidgetItem *child = projectItem->child(i);
+				if (child && child->type() == QET::Diagram) {
+					clearSelection();
+					setCurrentItem(child);
+					child->setSelected(true);
+					break;
+				}
+			}
+		}
+	}
 	emit(panelContentChanged());
 }
 

--- a/sources/genericpanel.cpp
+++ b/sources/genericpanel.cpp
@@ -737,9 +737,10 @@ void GenericPanel::diagramAdded(QETProject *project, Diagram *diagram) {
 	if (diagram) {
 		QTreeWidgetItem *projectItem = itemForProject(project);
 		if (projectItem) {
-			for (int i = projectItem->childCount() - 1; i >= 0; --i) {
+			for (int i = 0; i < projectItem->childCount(); ++i) {
 				QTreeWidgetItem *child = projectItem->child(i);
-				if (child && child->type() == QET::Diagram) {
+				if (child && child->type() == QET::Diagram
+				    && valueForItem<Diagram *>(child) == diagram) {
 					clearSelection();
 					setCurrentItem(child);
 					child->setSelected(true);


### PR DESCRIPTION
Summary: When adding a new page to a project, the diagram view correctly switches to the new page, but the project tree (ElementsPanel) kept the previous page selected. This happened because GenericPanel::diagramAdded() rebuilt the tree but never selected the newly added diagram item — the diagram parameter was marked as Q_UNUSED.

The fix iterates backwards through the project's child items after the tree rebuild and selects the last QET::Diagram type item, which is the newly added diagram.