### PR TITLE
Pin Preferences default tab to Appearance in code

### DIFF
--- a/sources/ui/configpage/generalconfigurationpage.cpp
+++ b/sources/ui/configpage/generalconfigurationpage.cpp
@@ -36,7 +36,12 @@ GeneralConfigurationPage::GeneralConfigurationPage(QWidget *parent) :
 	ui(new Ui::GeneralConfigurationPage)
 {
 	ui->setupUi(this);
-	
+
+	// Pin the default tab in code: Qt Designer rewrites the .ui file's
+	// currentIndex to whatever tab was open in the editor on last save,
+	// so relying on that value alone lets it silently drift (see #468).
+	ui->tabWidget->setCurrentIndex(0);
+
 	QSettings settings;
 	
 		//Appearance tab


### PR DESCRIPTION
## Summary
- Preferences currently opens on whatever tab `.ui`'s `currentIndex` happens to hold, which Qt Designer silently rewrites to "whatever tab was open in the editor" on any unrelated save of `generalconfigurationpage.ui` (this file's history shows it flip 0→2→0→1→5→2→0 across otherwise-unrelated commits).
- Pins the default explicitly in `GeneralConfigurationPage`'s constructor (`ui->tabWidget->setCurrentIndex(0)`), so the default tab no longer depends on Designer XML state.

Fixes #468

## Test plan
- [x] Built via CMake/Qt6 (`-DQT_VERSION_MAJOR=6`)
- [x] Ran the app, opened Preferences (Cmd+,), confirmed it opens on **Apparence** (first tab)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FFJW2zoGKU2sVy4vbeL3J7