### PR TITLE
Add unit test locking in Diagram::toXml() coordinate sort order

### DIFF
--- a/sources/diagram.cpp
+++ b/sources/diagram.cpp
@@ -40,30 +40,13 @@
 #include "undocommand/addelementtextcommand.h"
 #include "qetinformation.h"
 #include "qetproject.h"
+#include "diagramsortkeys.h"
 #include <algorithm>
 #include <cassert>
 #include <math.h>
 
 namespace {
-	/// Format a coordinate as a string that sorts the same way the number
-	/// does. Plain fixed-precision formatting ("%.4f") does NOT do this --
-	/// e.g. "15.0000" sorts before "5.0000" as text even though 15 > 5 --
-	/// so shift into a non-negative range and zero-pad to a fixed width
-	/// before comparing.
-	QString coordinateKey(double v)
-	{
-			//Diagram coordinates are nowhere near this range; the offset and
-			//width just need to be big enough that shifted values are always
-			//non-negative and always the same digit count.
-		constexpr double offset = 1e9;
-		qint64 scaled = qint64(qRound64((v + offset) * 10000.0));
-		return QStringLiteral("%1").arg(scaled, 20, 10, QLatin1Char('0'));
-	}
-
-	QString positionKey(const QPointF &pos)
-	{
-		return coordinateKey(pos.x()) + QLatin1Char('|') + coordinateKey(pos.y());
-	}
+	using DiagramSortKeys::positionKey;
 
 	/// Sort key for Diagram::toXml()'s <elements> block: the element's own
 	/// diagram-local position, exactly what it's already saved as (x/y),

--- a/sources/diagramsortkeys.h
+++ b/sources/diagramsortkeys.h
@@ -1,0 +1,53 @@
+/*
+	Copyright 2006-2026 The QElectroTech Team
+	This file is part of QElectroTech.
+
+	QElectroTech is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 2 of the License, or
+	(at your option) any later version.
+
+	QElectroTech is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with QElectroTech.  If not, see <http://www.gnu.org/licenses/>.
+*/
+#ifndef DIAGRAMSORTKEYS_H
+#define DIAGRAMSORTKEYS_H
+
+#include <QPointF>
+#include <QString>
+#include <QtGlobal>
+
+/// Sort-key helpers used by Diagram::toXml() to serialize elements and
+/// conductors in a deterministic order. Pulled into their own header
+/// (instead of an anonymous namespace in diagram.cpp) so they can be
+/// unit-tested directly -- see tests/qttest/tst_diagramsortkeys.cpp.
+namespace DiagramSortKeys {
+
+	/// Format a coordinate as a string that sorts the same way the number
+	/// does. Plain fixed-precision formatting ("%.4f") does NOT do this --
+	/// e.g. "15.0000" sorts before "5.0000" as text even though 15 > 5 --
+	/// so shift into a non-negative range and zero-pad to a fixed width
+	/// before comparing.
+	inline QString coordinateKey(double v)
+	{
+			//Diagram coordinates are nowhere near this range; the offset and
+			//width just need to be big enough that shifted values are always
+			//non-negative and always the same digit count.
+		constexpr double offset = 1e9;
+		qint64 scaled = qint64(qRound64((v + offset) * 10000.0));
+		return QStringLiteral("%1").arg(scaled, 20, 10, QLatin1Char('0'));
+	}
+
+	inline QString positionKey(const QPointF &pos)
+	{
+		return coordinateKey(pos.x()) + QLatin1Char('|') + coordinateKey(pos.y());
+	}
+
+}
+
+#endif

--- a/tests/qttest/CMakeLists.txt
+++ b/tests/qttest/CMakeLists.txt
@@ -77,3 +77,11 @@ target_link_libraries(
   ${KF_PRIVATE_LIBRARIES}
   ${QET_PRIVATE_LIBRARIES})
 
+# diagramsortkeys.h is a header-only helper (no QET link deps needed
+# beyond Qt itself), so this test builds independently of the rest of
+# the QET sources.
+add_executable(tst_diagramsortkeys tst_diagramsortkeys.cpp)
+add_test(NAME tst_diagramsortkeys COMMAND tst_diagramsortkeys)
+target_include_directories(tst_diagramsortkeys PRIVATE ${QET_DIR}/sources)
+target_link_libraries(tst_diagramsortkeys PRIVATE Qt::Test)
+

--- a/tests/qttest/tst_diagramsortkeys.cpp
+++ b/tests/qttest/tst_diagramsortkeys.cpp
@@ -1,0 +1,39 @@
+#include <QtTest>
+
+#include "diagramsortkeys.h"
+
+class tst_diagramsortkeys : public QObject
+{
+	Q_OBJECT
+
+private slots:
+	// positionKey() must sort the same way the underlying coordinates do,
+	// including across differing integer-part digit widths and across the
+	// negative/positive boundary. A previous implementation formatted
+	// coordinates with plain "%.4f" and compared the resulting strings
+	// directly, which sorted "15.0000" before "5.0000".
+	void sortsLikeNumbers_data()
+	{
+		QTest::addColumn<QPointF>("smaller");
+		QTest::addColumn<QPointF>("larger");
+
+		QTest::newRow("single vs double digit")   << QPointF(5.0, 0.0)   << QPointF(15.0, 0.0);
+		QTest::newRow("double vs triple digit")   << QPointF(0.0, 99.0)  << QPointF(0.0, 100.0);
+		QTest::newRow("negative vs negative")     << QPointF(-15.0, 0.0) << QPointF(-5.0, 0.0);
+		QTest::newRow("negative vs positive")     << QPointF(-1.0, 0.0)  << QPointF(1.0, 0.0);
+		QTest::newRow("negative vs zero")         << QPointF(0.0, -0.0001) << QPointF(0.0, 0.0);
+		QTest::newRow("fractional precision")     << QPointF(1.0001, 0.0) << QPointF(1.001, 0.0);
+	}
+
+	void sortsLikeNumbers()
+	{
+		QFETCH(QPointF, smaller);
+		QFETCH(QPointF, larger);
+
+		QVERIFY(DiagramSortKeys::positionKey(smaller) < DiagramSortKeys::positionKey(larger));
+	}
+};
+
+QTEST_APPLESS_MAIN(tst_diagramsortkeys)
+
+#include "tst_diagramsortkeys.moc"


### PR DESCRIPTION
## Summary

Follow-up to the `positionKey()` fix merged directly in #779 (b2f4ef5d2). Per [review feedback on that fix](https://github.com/qelectrotech/qelectrotech-source-mirror/pull/779#issuecomment-5567651799), this adds a small regression test so the underlying bug class can't silently reappear: plain fixed-precision `"%.4f"` formatting compares out of numeric order once the integer part's digit count differs (e.g. `"15.0000"` sorted before `"5.0000"`).

- `positionKey()`/`coordinateKey()` move out of `diagram.cpp`'s anonymous namespace into a small header-only `sources/diagramsortkeys.h`, so the test links against the exact same code `Diagram::toXml()` uses rather than duplicating the algorithm. No behavior change.
- `tests/qttest/tst_diagramsortkeys.cpp` covers single- vs double-digit, double- vs triple-digit, negative-vs-negative, negative-vs-positive, and negative-vs-zero coordinate pairs, plus sub-precision deltas.

## Test plan

- [x] `qelectrotech.dir/sources/diagram.cpp.o` builds cleanly with the refactor
- [x] New test target builds and all 6 cases pass:
```
Totals: 8 passed, 0 failed, 0 skipped, 0 blacklisted, 1ms
```

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)