### PR TITLE
Reject non-finite coordinates while loading XML

### DIFF
--- a/sources/qet.cpp
+++ b/sources/qet.cpp
@@ -239,7 +239,7 @@ bool QET::attributeIsAReal(
 	// verifie la validite de l'attribut
 	bool ok;
 	qreal tmp = e.attribute(nom_attribut).toDouble(&ok);
-	if (!ok) return(false);
+	if (!ok || !qIsFinite(tmp)) return(false);
 	if (reel != nullptr) *reel = tmp;
 	return(true);
 }

--- a/sources/qetgraphicsitem/ViewItem/qetgraphicstableitem.cpp
+++ b/sources/qetgraphicsitem/ViewItem/qetgraphicstableitem.cpp
@@ -626,12 +626,8 @@ void QetGraphicsTableItem::fromXml(const QDomElement &dom_element)
 	}
 
 	this->setPos(
-				dom_element.attribute(
-					"x",
-					QString::number(10)).toDouble(),
-				dom_element.attribute(
-					"y",
-					QString::number(10)).toDouble());
+				QETXML::finiteAttribute(dom_element, "x", 10),
+				QETXML::finiteAttribute(dom_element, "y", 10));
 	//Size is not set now because will change during the whole process of opening a project from the xml
 	m_pending_size = QSize(
 				dom_element.attribute(

--- a/sources/qetgraphicsitem/conductor.cpp
+++ b/sources/qetgraphicsitem/conductor.cpp
@@ -16,6 +16,7 @@
 	along with QElectroTech.  If not, see <http://www.gnu.org/licenses/>.
 */
 #include "../qetgraphicsitem/conductor.h"
+#include "../qetxml.h"
 #include "../qetproject.h"
 #include "../QPropertyUndoCommand/qpropertyundocommand.h"
 #include "../autoNum/numerotationcontextcommands.h"
@@ -1022,8 +1023,8 @@ bool Conductor::fromXml(QDomElement &dom_element)
 		m_uuid = QUuid::createUuid();
 	}
 
-	setPos(dom_element.attribute("x", nullptr).toDouble(),
-		   dom_element.attribute("y", nullptr).toDouble());
+	setPos(QETXML::finiteAttribute(dom_element, "x"),
+		   QETXML::finiteAttribute(dom_element, "y"));
 
 	bool retval = pathFromXml(dom_element);
 
@@ -1152,7 +1153,7 @@ bool Conductor::pathFromXml(const QDomElement &e) {
 		// cette longueur doit etre un reel
 		bool ok;
 		qreal segment_length = current_segment.attribute("length").toDouble(&ok);
-		if (!ok) continue;
+		if (!ok || !qIsFinite(segment_length)) continue;
 
 		if (current_segment.attribute("orientation") == "horizontal") {
 			segments_x << segment_length;

--- a/sources/qetgraphicsitem/conductortextitem.cpp
+++ b/sources/qetgraphicsitem/conductortextitem.cpp
@@ -16,6 +16,7 @@
 	along with QElectroTech.  If not, see <http://www.gnu.org/licenses/>.
 */
 #include "conductortextitem.h"
+#include "../qetxml.h"
 
 #include "../diagram.h"
 #include "../diagramcommands.h"
@@ -70,12 +71,12 @@ Conductor *ConductorTextItem::parentConductor() const
 */
 void ConductorTextItem::fromXml(const QDomElement &e) {
 	if (e.hasAttribute("userx")) {
-		setPos(e.attribute("userx").toDouble(),
-			   e.attribute("usery").toDouble());
+		setPos(QETXML::finiteAttribute(e, "userx"),
+			   QETXML::finiteAttribute(e, "usery"));
 		moved_by_user_ = true;
 	}
 	if (e.hasAttribute("rotation")) {
-		setRotation(e.attribute("rotation").toDouble());
+		setRotation(QETXML::finiteAttribute(e, "rotation"));
 		rotate_by_user_ = true;
 	}
 }

--- a/sources/qetgraphicsitem/diagramimageitem.cpp
+++ b/sources/qetgraphicsitem/diagramimageitem.cpp
@@ -16,6 +16,7 @@
 	along with QElectroTech.  If not, see <http://www.gnu.org/licenses/>.
 */
 #include "diagramimageitem.h"
+#include "../qetxml.h"
 
 #include "../PropertiesEditor/propertieseditordialog.h"
 #include "../QPropertyUndoCommand/qpropertyundocommand.h"
@@ -1409,8 +1410,8 @@ bool DiagramImageItem::fromXml(const QDomElement &e)
 	// <transform> element (independent scaleX/scaleY, and/or a custom
 	// pivot), the same two-tier fallback QetShapeItem's own fromXml()
 	// already uses for its identical <transform> element.
-	m_transform.rotation = e.attribute("rotation").toDouble();
-	m_transform.scaleX = e.attribute("size").toDouble();
+	m_transform.rotation = QETXML::finiteAttribute(e, "rotation");
+	m_transform.scaleX = QETXML::finiteAttribute(e, "size", 1);
 	m_transform.scaleY = m_transform.scaleX;
 	m_transform.pivot = boundingRect().center();
 	m_pivotIsCustom = false;
@@ -1418,20 +1419,20 @@ bool DiagramImageItem::fromXml(const QDomElement &e)
 	const QDomElement transformElement = e.firstChildElement("transform");
 	if (!transformElement.isNull())
 	{
-		m_transform.rotation = transformElement.attribute("rotation", "0").toDouble();
-		m_transform.skewX    = transformElement.attribute("skewX", "0").toDouble();
-		m_transform.skewY    = transformElement.attribute("skewY", "0").toDouble();
-		m_transform.scaleX   = transformElement.attribute("scaleX", "1").toDouble();
-		m_transform.scaleY   = transformElement.attribute("scaleY", "1").toDouble();
-		m_transform.pivot    = QPointF(transformElement.attribute("pivotX", "0").toDouble(),
-		                                transformElement.attribute("pivotY", "0").toDouble());
+		m_transform.rotation = QETXML::finiteAttribute(transformElement, "rotation");
+		m_transform.skewX    = QETXML::finiteAttribute(transformElement, "skewX");
+		m_transform.skewY    = QETXML::finiteAttribute(transformElement, "skewY");
+		m_transform.scaleX   = QETXML::finiteAttribute(transformElement, "scaleX", 1);
+		m_transform.scaleY   = QETXML::finiteAttribute(transformElement, "scaleY", 1);
+		m_transform.pivot    = QPointF(QETXML::finiteAttribute(transformElement, "pivotX"),
+		                                QETXML::finiteAttribute(transformElement, "pivotY"));
 		m_pivotIsCustom = true;
 	}
 	setTransform(m_transform.toMatrix());
 
 		//We directly call setPos from QGraphicsObject, because QetGraphicsItem will snap to grid
-	QGraphicsObject::setPos(e.attribute("x").toDouble(), e.attribute("y").toDouble());
-	setZValue(e.attribute("z", QString::number(this->zValue())).toDouble());
+	QGraphicsObject::setPos(QETXML::finiteAttribute(e, "x"), QETXML::finiteAttribute(e, "y"));
+	setZValue(QETXML::finiteAttribute(e, QStringLiteral("z"), this->zValue()));
 	is_movable_ = (e.attribute("is_movable").toInt());
 
 	return (true);

--- a/sources/qetgraphicsitem/dynamicelementtextitem.cpp
+++ b/sources/qetgraphicsitem/dynamicelementtextitem.cpp
@@ -16,6 +16,7 @@
 	along with QElectroTech.  If not, see <http://www.gnu.org/licenses/>.
 */
 #include "dynamicelementtextitem.h"
+#include "../qetxml.h"
 #include "../qetproject.h"
 #include "../QPropertyUndoCommand/qpropertyundocommand.h"
 #include "../diagram.h"
@@ -163,7 +164,7 @@ void DynamicElementTextItem::fromXml(const QDomElement &dom_elmt)
 		return;
 	}
 	
-	QGraphicsTextItem::setRotation(dom_elmt.attribute("rotation", QString::number(0)).toDouble());
+	QGraphicsTextItem::setRotation(QETXML::finiteAttribute(dom_elmt, "rotation"));
 	setKeepVisualRotation(dom_elmt.attribute("keep_visual_rotation", "true") == "true"? true : false);
 	setRotationPointCenter(dom_elmt.attribute("rotation_point_center", "false") == "true"? true : false);
 
@@ -183,7 +184,7 @@ void DynamicElementTextItem::fromXml(const QDomElement &dom_elmt)
 
 	m_uuid = QUuid(dom_elmt.attribute("uuid", QUuid::createUuid().toString()));
 	setFrame(dom_elmt.attribute("frame", "false") == "true"? true : false);
-	setTextWidth(dom_elmt.attribute("text_width", QString::number(-1)).toDouble());
+	setTextWidth(QETXML::finiteAttribute(dom_elmt, "text_width", -1));
 	
 		//Text from
 	QMetaEnum me = textFromMetaEnum();
@@ -221,8 +222,8 @@ void DynamicElementTextItem::fromXml(const QDomElement &dom_elmt)
 		//Force the update of the displayed text
 	setTextFrom(m_text_from);
 	
-	QGraphicsTextItem::setPos(dom_elmt.attribute("x", QString::number(0)).toDouble(),
-							  dom_elmt.attribute("y", QString::number(0)).toDouble());
+	QGraphicsTextItem::setPos(QETXML::finiteAttribute(dom_elmt, "x"),
+							  QETXML::finiteAttribute(dom_elmt, "y"));
 }
 
 /**

--- a/sources/qetgraphicsitem/element.cpp
+++ b/sources/qetgraphicsitem/element.cpp
@@ -514,8 +514,8 @@ bool Element::buildFromXml(const QDomElement &xml_def_elmt, int *state)
 
 				// Store plc_table positions for runtime rendering
 				if (qde.tagName() == QLatin1String("plc_table")) {
-					qreal x = qde.attribute("x", "0").toDouble();
-					qreal y = qde.attribute("y", "0").toDouble();
+					qreal x = QETXML::finiteAttribute(qde, "x");
+					qreal y = QETXML::finiteAttribute(qde, "y");
 					m_plc_table_positions.append(QPointF(x, y));
 				}
 
@@ -595,8 +595,7 @@ bool Element::parseInput(const QDomElement &dom_element)
 		font.setPointSize(dom_element.attribute(QStringLiteral("size"),
 							QString::number(9)).toInt());
 		deti->setFont(font);
-		deti->setRotation(dom_element.attribute(QStringLiteral("rotation"),
-							QString::number(0)).toDouble());
+		deti->setRotation(QETXML::finiteAttribute(dom_element, QStringLiteral("rotation")));
 
 		if(dom_element.attribute(QStringLiteral("tagg"), QStringLiteral("none")) != QLatin1String("none"))
 		{
@@ -609,17 +608,14 @@ bool Element::parseInput(const QDomElement &dom_element)
 			//We need to use a QTransform to find the pos of this text from the saved pos of text item
 		QTransform transform;
 			//First make the rotation
-		transform.rotate(dom_element.attribute(QStringLiteral("rotation"),
-											   QStringLiteral("0")).toDouble());
+		transform.rotate(QETXML::finiteAttribute(dom_element, QStringLiteral("rotation")));
 		QPointF pos = transform.map(
 						  QPointF(0,
 								  -deti->boundingRect().height()/2));
 		transform.reset();
 			//Second translate to the pos
-		QPointF p(dom_element.attribute(QStringLiteral("x"),
-										QString::number(0)).toDouble(),
-				  dom_element.attribute(QStringLiteral("y"),
-										QString::number(0)).toDouble());
+		QPointF p(QETXML::finiteAttribute(dom_element, QStringLiteral("x")),
+				  QETXML::finiteAttribute(dom_element, QStringLiteral("y")));
 		transform.translate(p.x(), p.y());
 		deti->setPos(transform.map(pos));
 		m_dynamic_text_list.append(deti);
@@ -801,9 +797,9 @@ bool Element::fromXml(QDomElement &e,
 
 		//Position and selection.
 		//We directly call setPos from QGraphicsObject, because QetGraphicsItem will snap to grid
-	QGraphicsObject::setPos(e.attribute(QStringLiteral("x")).toDouble(),
-							e.attribute(QStringLiteral("y")).toDouble());
-	setZValue(e.attribute(QStringLiteral("z"), QString::number(this->zValue())).toDouble());
+	QGraphicsObject::setPos(QETXML::finiteAttribute(e, QStringLiteral("x")),
+							QETXML::finiteAttribute(e, QStringLiteral("y")));
+	setZValue(QETXML::finiteAttribute(e, QStringLiteral("z"), this->zValue()));
 	setFlags(QGraphicsItem::ItemIsMovable
 		 | QGraphicsItem::ItemIsSelectable);
 	is_movable_ = e.attribute(QStringLiteral("is_movable"), QStringLiteral("1")).toInt();

--- a/sources/qetgraphicsitem/elementtextitemgroup.cpp
+++ b/sources/qetgraphicsitem/elementtextitemgroup.cpp
@@ -16,6 +16,7 @@
 	along with QElectroTech.  If not, see <http://www.gnu.org/licenses/>.
 */
 #include "elementtextitemgroup.h"
+#include "../qetxml.h"
 #include "../qetproject.h"
 #include "../QPropertyUndoCommand/qpropertyundocommand.h"
 #include "../diagram.h"
@@ -472,10 +473,10 @@ void ElementTextItemGroup::fromXml(QDomElement &dom_element)
 					)
 				);
 
-	setPos(dom_element.attribute("x", QString::number(0)).toDouble(),
-		   dom_element.attribute("y", QString::number(0)).toDouble());
+	setPos(QETXML::finiteAttribute(dom_element, "x"),
+		   QETXML::finiteAttribute(dom_element, "y"));
 	
-	setRotation(dom_element.attribute("rotation", QString::number(0)).toDouble());
+	setRotation(QETXML::finiteAttribute(dom_element, "rotation"));
 	setVerticalAdjustment(dom_element.attribute("vertical_adjustment").toInt());
 	setFrame(dom_element.attribute("frame", "false") == "true"? true : false);
 	

--- a/sources/qetgraphicsitem/independenttextitem.cpp
+++ b/sources/qetgraphicsitem/independenttextitem.cpp
@@ -16,6 +16,7 @@
 	along with QElectroTech.  If not, see <http://www.gnu.org/licenses/>.
 */
 #include "independenttextitem.h"
+#include "../qetxml.h"
 
 #include "../diagram.h"
 #include "../diagramcommands.h"
@@ -63,9 +64,9 @@ IndependentTextItem::~IndependentTextItem()
 	@param e L'element XML representant le champ de texte
 */
 void IndependentTextItem::fromXml(const QDomElement &e) {
-	setPos(e.attribute("x").toDouble(), e.attribute("y").toDouble());
+	setPos(QETXML::finiteAttribute(e, "x"), QETXML::finiteAttribute(e, "y"));
 	setHtml(e.attribute("text"));
-	setRotation(e.attribute("rotation").toDouble());
+	setRotation(QETXML::finiteAttribute(e, "rotation"));
 	if (e.hasAttribute("font"))
 	{
 		QFont font;

--- a/sources/qetgraphicsitem/qetshapeitem.cpp
+++ b/sources/qetgraphicsitem/qetshapeitem.cpp
@@ -2910,15 +2910,15 @@ bool QetShapeItem::fromXml(const QDomElement &e)
 
 	if (m_shapeType != Polygon && m_shapeType != Path)
 	{
-		m_P1.setX(e.attribute("x1", nullptr).toDouble());
-		m_P1.setY(e.attribute("y1", nullptr).toDouble());
-		m_P2.setX(e.attribute("x2", nullptr).toDouble());
-		m_P2.setY(e.attribute("y2", nullptr).toDouble());
+		m_P1.setX(QETXML::finiteAttribute(e, "x1"));
+		m_P1.setY(QETXML::finiteAttribute(e, "y1"));
+		m_P2.setX(QETXML::finiteAttribute(e, "x2"));
+		m_P2.setY(QETXML::finiteAttribute(e, "y2"));
 
 		if (m_shapeType == Rectangle)
 		{
-			setXRadius(e.attribute("rx", "0").toDouble());
-			setYRadius(e.attribute("ry", "0").toDouble());
+			setXRadius(QETXML::finiteAttribute(e, "rx"));
+			setYRadius(QETXML::finiteAttribute(e, "ry"));
 		}
 	}
 	if (m_shapeType == Polygon)
@@ -2933,7 +2933,7 @@ bool QetShapeItem::fromXml(const QDomElement &e)
 		// edit.
 		m_polygon.clear();
 		for(const QDomElement& de : QET::findInDomElement(e, "points", "point")) {
-			m_polygon << QPointF(de.attribute("x", nullptr).toDouble(), de.attribute("y", nullptr).toDouble());
+			m_polygon << QPointF(QETXML::finiteAttribute(de, "x"), QETXML::finiteAttribute(de, "y"));
 		}
 	}
 	else if (m_shapeType == Path)
@@ -2942,17 +2942,17 @@ bool QetShapeItem::fromXml(const QDomElement &e)
 		for (const QDomElement &nodeElement : QET::findInDomElement(e, "nodes", "node"))
 		{
 			PathNode node;
-			node.anchor = QPointF(nodeElement.attribute("x").toDouble(), nodeElement.attribute("y").toDouble());
+			node.anchor = QPointF(QETXML::finiteAttribute(nodeElement, "x"), QETXML::finiteAttribute(nodeElement, "y"));
 			const QString kind = nodeElement.attribute("kind", "corner");
 			node.kind = (kind == "smooth") ? NodeKind::Smooth
 			          : (kind == "symmetric") ? NodeKind::Symmetric
 			          : NodeKind::Corner;
 			QDomElement in = nodeElement.firstChildElement("in");
 			if (!in.isNull())
-				node.inHandle = QPointF(in.attribute("dx").toDouble(), in.attribute("dy").toDouble());
+				node.inHandle = QPointF(QETXML::finiteAttribute(in, "dx"), QETXML::finiteAttribute(in, "dy"));
 			QDomElement out = nodeElement.firstChildElement("out");
 			if (!out.isNull())
-				node.outHandle = QPointF(out.attribute("dx").toDouble(), out.attribute("dy").toDouble());
+				node.outHandle = QPointF(QETXML::finiteAttribute(out, "dx"), QETXML::finiteAttribute(out, "dy"));
 			m_nodes << node;
 		}
 	}
@@ -2960,13 +2960,13 @@ bool QetShapeItem::fromXml(const QDomElement &e)
 	QDomElement transformElement = e.firstChildElement("transform");
 	if (!transformElement.isNull())
 	{
-		m_transform.rotation = transformElement.attribute("rotation", "0").toDouble();
-		m_transform.skewX    = transformElement.attribute("skewX", "0").toDouble();
-		m_transform.skewY    = transformElement.attribute("skewY", "0").toDouble();
-		m_transform.scaleX   = transformElement.attribute("scaleX", "1").toDouble();
-		m_transform.scaleY   = transformElement.attribute("scaleY", "1").toDouble();
-		m_transform.pivot    = QPointF(transformElement.attribute("pivotX", "0").toDouble(),
-		                                transformElement.attribute("pivotY", "0").toDouble());
+		m_transform.rotation = QETXML::finiteAttribute(transformElement, "rotation");
+		m_transform.skewX    = QETXML::finiteAttribute(transformElement, "skewX");
+		m_transform.skewY    = QETXML::finiteAttribute(transformElement, "skewY");
+		m_transform.scaleX   = QETXML::finiteAttribute(transformElement, "scaleX", 1);
+		m_transform.scaleY   = QETXML::finiteAttribute(transformElement, "scaleY", 1);
+		m_transform.pivot    = QPointF(QETXML::finiteAttribute(transformElement, "pivotX"),
+		                                QETXML::finiteAttribute(transformElement, "pivotY"));
 		m_pivotIsCustom = true;
 	}
 	else
@@ -2980,19 +2980,19 @@ bool QetShapeItem::fromXml(const QDomElement &e)
 	QDomElement arcElement = e.firstChildElement("arc");
 	if (!arcElement.isNull() && m_shapeType == Ellipse)
 	{
-		m_startAngle = arcElement.attribute("startAngle", "0").toDouble();
-		m_endAngle   = m_startAngle + arcElement.attribute("spanAngle", "360").toDouble();
+		m_startAngle = QETXML::finiteAttribute(arcElement, "startAngle");
+		m_endAngle   = m_startAngle + QETXML::finiteAttribute(arcElement, "spanAngle", 360);
 		const QString closure = arcElement.attribute("closure", "none");
 		m_arcClosure = (closure == "chord") ? Chord : (closure == "pie") ? Pie : NoClosure;
 	}
 
 	if (e.hasAttribute("posX") || e.hasAttribute("posY"))
 	{
-		QGraphicsItem::setPos(e.attribute("posX", "0").toDouble(),
-		                      e.attribute("posY", "0").toDouble());
+		QGraphicsItem::setPos(QETXML::finiteAttribute(e, "posX"),
+		                      QETXML::finiteAttribute(e, "posY"));
 	}
 
-	setZValue(e.attribute("z", QString::number(this->zValue())).toDouble());
+	setZValue(QETXML::finiteAttribute(e, QStringLiteral("z"), this->zValue()));
 
 	// fromXml() can change anything about the shape -- geometry, node
 	// count, even shapeType() itself (undoing a Rectangle->Polygon

--- a/sources/qetxml.cpp
+++ b/sources/qetxml.cpp
@@ -21,9 +21,27 @@
 #include "utils/qetutils.h"
 
 #include <QDir>
+#include <QDebug>
 #include <QFont>
 #include <QGraphicsItem>
 #include <QPen>
+
+double QETXML::finiteAttribute(const QDomElement &element, const QString &name,
+							  double default_value)
+{
+	if (!element.hasAttribute(name))
+		return default_value;
+
+	bool ok = false;
+	const QString text = element.attribute(name);
+	const double value = text.toDouble(&ok);
+	if (ok && qIsFinite(value))
+		return value;
+
+	qWarning() << "Invalid numeric XML attribute" << element.tagName()
+			   << name << text << "- using" << default_value;
+	return default_value;
+}
 
 /**
 	@brief QETXML::penToXml
@@ -85,7 +103,7 @@ QPen QETXML::penFromXml(const QDomElement &element)
 	else                                pen.setStyle(Qt::DashLine);
 
 	pen.setColor(QColor(element.attribute("color", "#000000")));
-	pen.setWidthF(element.attribute("widthF", "1").toDouble());
+	pen.setWidthF(finiteAttribute(element, QStringLiteral("widthF"), 1.0));
 	return pen;
 }
 
@@ -945,8 +963,8 @@ bool qGraphicsItemPosFromXml(QGraphicsItem *item, const QDomElement &xml_elmt)
 {
 	if (xml_elmt.tagName() == QLatin1String("pos"))
 	{
-		item->setX(xml_elmt.attribute(QStringLiteral("x"), QStringLiteral("0")).toDouble());
-		item->setY(xml_elmt.attribute(QStringLiteral("y"), QStringLiteral("0")).toDouble());
+		item->setX(finiteAttribute(xml_elmt, QStringLiteral("x")));
+		item->setY(finiteAttribute(xml_elmt, QStringLiteral("y")));
 		item->setZValue(xml_elmt.attribute(QStringLiteral("z"), QStringLiteral("0")).toInt());
 
 		return true;

--- a/sources/qetxml.h
+++ b/sources/qetxml.h
@@ -33,6 +33,10 @@ class QGraphicsItem;
 */
 namespace QETXML
 {
+	// Read geometry without allowing NaN/Inf to reach Qt's path algorithms.
+	double finiteAttribute(const QDomElement &element, const QString &name,
+						   double default_value = 0.0);
+
 	QDomElement penToXml(QDomDocument &parent_document, const QPen& pen);
 	QPen penFromXml (const QDomElement &element);
 


### PR DESCRIPTION
Non-finite XML coordinates currently pass through Qt's numeric conversion. An element with an `x="nan"` value can then reach `QPainterPath` collision handling while conductors are loaded and keep the application busy indefinitely.

This change adds a shared finite-number reader for graphical XML attributes. Invalid or non-finite values fall back to the same defaults used for missing attributes and produce a diagnostic containing the tag, attribute, and rejected value. The reader is applied to element positions, text items, groups, shapes, images, table positions, pen widths, and conductor positions. Required real-valued definition attributes now reject non-finite values, and invalid conductor segment lengths are ignored so the existing automatic routing fallback can run.

Validation:

- Built the updated `master` checkout in debug mode with Qt 5.15.19 and MinGW.
- Resaved the shipped `grafcet.qet` example after mutating element and dynamic-text coordinates to `nan`, `inf`, and `-inf`.
- All six malformed fixtures completed within the timeout and retained their element and conductor counts.
- Covered defaults, finite values, text rotation/width, polygon coordinates, and transforms with local Qt tests.

Fixes #781.
Fixes #782.
