### PR TITLE
Show folio identity first in report link picker

### DIFF
--- a/sources/ui/linksingleelementwidget.cpp
+++ b/sources/ui/linksingleelementwidget.cpp
@@ -353,8 +353,16 @@ void LinkSingleElementWidget::buildTree()
 		
 		QSettings settings;
 		QVariant v = settings.value(QStringLiteral("link-element-widget/report-state"));
-		if(!v.isNull())
-			ui->m_tree_widget->header()->restoreState(v.toByteArray());
+		auto *header = ui->m_tree_widget->header();
+		if (v.isNull() || !header->restoreState(v.toByteArray()))
+		{
+			// Keep logical column IDs stable for saved layouts, but show the
+			// folio identity first even when the candidate has no conductor.
+			for (int column = 5; column < 8; ++column)
+				header->moveSection(header->visualIndex(column), column - 5);
+			ui->m_tree_widget->resizeColumnToContents(5);
+			ui->m_tree_widget->resizeColumnToContents(6);
+		}
 	}
 	
 	setUpCompleter();


### PR DESCRIPTION
Report-link candidates without a conductor have empty values in the first five logical columns. The folio number, position, and title are present, but appear beyond the initial viewport, making a valid row look blank.

This change moves the three folio identity columns to the front of the default visual order and sizes the first two identity columns to their contents. Logical column IDs are unchanged, so saved header layouts remain compatible and explicitly saved user ordering is still restored.

Validation:

- Built the updated `master` checkout in debug mode with Qt 5.15.19 and MinGW.
- Created a two-folio report-link fixture with no attached conductor and verified that its folio number is the leading visible value.
- Verified that a saved custom header order is restored.

Fixes #735.
