### PR TITLE
Restore Qt5 no-KF qmake builds

### DIFF
--- a/qelectrotech.pro
+++ b/qelectrotech.pro
@@ -256,7 +256,7 @@ QT += xml svg network sql widgets printsupport concurrent gui-private
 # sources/ui/nokde is only added to the include path in that configuration, so
 # a normal KF5 build is unaffected.
 no_kf5 {
-    DEFINES     += BUILD_WITHOUT_KF5
+    DEFINES     += BUILD_WITHOUT_KF BUILD_WITHOUT_KF5
     INCLUDEPATH += sources/ui/nokde
     HEADERS     += $$files(sources/ui/nokde/*.h)
     SOURCES     += $$files(sources/ui/nokde/*.cpp)

--- a/sources/ui/imagetransparentcolordialog.cpp
+++ b/sources/ui/imagetransparentcolordialog.cpp
@@ -65,7 +65,7 @@ ClickableImageLabel::ClickableImageLabel(const QImage &sourceImage, QWidget *par
 */
 void ClickableImageLabel::mousePressEvent(QMouseEvent *event)
 {
-	if (event->button() != Qt::LeftButton || pixmap().isNull())
+	if (event->button() != Qt::LeftButton || m_displayImage.isNull())
 		return;
 
 	// The label may be larger than its pixmap (layout stretching); the
@@ -73,9 +73,9 @@ void ClickableImageLabel::mousePressEvent(QMouseEvent *event)
 	// so the click has to be re-based against the pixmap's own rect
 	// within the label, not the label's own top-left.
 	const QRect pixmapRect(
-			(width() - pixmap().width()) / 2,
-			(height() - pixmap().height()) / 2,
-			pixmap().width(), pixmap().height());
+			(width() - m_displayImage.width()) / 2,
+			(height() - m_displayImage.height()) / 2,
+			m_displayImage.width(), m_displayImage.height());
 	if (!pixmapRect.contains(event->pos()))
 		return;
 


### PR DESCRIPTION
The supported Qt 5 no-KF qmake configuration currently fails for two independent reasons:

- `CONFIG+=no_kf5` defines `BUILD_WITHOUT_KF5`, while the no-KF compatibility code is guarded by `BUILD_WITHOUT_KF`.
- On Qt 5, `QLabel::pixmap()` returns a pointer, but the transparent-color dialog uses the Qt 6 value-returning API.

This change defines both compatibility macros for the no-KF build and uses the dialog's existing `m_displayImage` value for null and dimensions checks. That representation is already the pixmap being displayed and avoids API differences between Qt 5 and Qt 6.

Validation:

- Configured with Qt 5.15.19, MinGW, `CONFIG+=debug CONFIG+=no_kf5 CONFIG-=release`.
- Built the debug application successfully.
