### PR TITLE
Fix Qt5 build: QLabel::pixmap() returns a pointer, not a value

### DIFF
--- a/sources/ui/imagetransparentcolordialog.cpp
+++ b/sources/ui/imagetransparentcolordialog.cpp
@@ -65,7 +65,14 @@ ClickableImageLabel::ClickableImageLabel(const QImage &sourceImage, QWidget *par
 */
 void ClickableImageLabel::mousePressEvent(QMouseEvent *event)
 {
-	if (event->button() != Qt::LeftButton || pixmap().isNull())
+		// QLabel::pixmap() returns a pointer in Qt5 and a value in Qt6.
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+	const QPixmap label_pixmap = pixmap() ? *pixmap() : QPixmap();
+#else
+	const QPixmap label_pixmap = pixmap();
+#endif
+
+	if (event->button() != Qt::LeftButton || label_pixmap.isNull())
 		return;
 
 	// The label may be larger than its pixmap (layout stretching); the
@@ -73,9 +80,9 @@ void ClickableImageLabel::mousePressEvent(QMouseEvent *event)
 	// so the click has to be re-based against the pixmap's own rect
 	// within the label, not the label's own top-left.
 	const QRect pixmapRect(
-			(width() - pixmap().width()) / 2,
-			(height() - pixmap().height()) / 2,
-			pixmap().width(), pixmap().height());
+			(width() - label_pixmap.width()) / 2,
+			(height() - label_pixmap.height()) / 2,
+			label_pixmap.width(), label_pixmap.height());
 	if (!pixmapRect.contains(event->pos()))
 		return;
 


### PR DESCRIPTION
`ClickableImageLabel::mousePressEvent()` calls `pixmap().isNull()` and `pixmap().width()`. That is the Qt6 signature — in Qt5 `QLabel::pixmap()` returns `const QPixmap *`, so the code does not compile:

```
sources/ui/imagetransparentcolordialog.cpp:68:59: error: request for member 'isNull' in
'((ClickableImageLabel*)this)->ClickableImageLabel::QLabel.QLabel::pixmap()',
which is of pointer type 'const QPixmap*' (maybe you meant to use '->' ?)
```

`CMakeLists.txt` defaults `QT_VERSION_MAJOR` to 5 when it is not specified:

```cmake
if(NOT DEFINED QT_VERSION_MAJOR)
    set(QT_VERSION_MAJOR 5)
```

so **a default configuration of master has not built since 6b577ee75** (5 errors, all in this one function).

## Fix

Read the pixmap once into a local, version-guarded the way the rest of the codebase already handles this split (`qgimanager.cpp`, `exportpropertieswidget.cpp`). That also removes four repeated `pixmap()` calls from the same expression.

## Testing

Qt 5.15.18, Ubuntu 26.04, gcc 15.2.0: master fails with 5 errors before the change and builds clean after it. The built binary starts and reports its version. No behaviour change on Qt6, where `pixmap()` already returned a value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
