### PR TITLE
Set a bundle identifier so macOS file dialogs work

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -163,7 +163,22 @@ else()
 endif()
 
 if(APPLE)
-    set_target_properties(${PROJECT_NAME} PROPERTIES MACOSX_BUNDLE TRUE)
+    # CFBundleIdentifier must not be empty. CMake's default Info.plist
+    # template fills it from MACOSX_BUNDLE_GUI_IDENTIFIER; with that unset
+    # the bundle ships an empty identifier, LaunchServices never registers
+    # the .app, and AppKit's open/save panel service (which is keyed on the
+    # client's bundle id) silently presents nothing -- every
+    # QFileDialog::getOpenFileName()/getSaveFileName() call returns an empty
+    # string without a panel ever appearing, so File > Open and File > Save
+    # as do nothing at all.
+    set_target_properties(${PROJECT_NAME} PROPERTIES
+        MACOSX_BUNDLE TRUE
+        MACOSX_BUNDLE_GUI_IDENTIFIER "org.qelectrotech.QElectroTech"
+        MACOSX_BUNDLE_BUNDLE_NAME "QElectroTech"
+        MACOSX_BUNDLE_BUNDLE_VERSION "${PROJECT_VERSION}"
+        MACOSX_BUNDLE_SHORT_VERSION_STRING "${PROJECT_VERSION}"
+        MACOSX_BUNDLE_COPYRIGHT "Copyright 2006-2026 The QElectroTech Team"
+    )
 endif()
 
 # The default build only compiles the tracked .ts files to .qm (lrelease).


### PR DESCRIPTION
## Problem

On macOS, **File > Open and File > Save as do nothing**. No panel appears, no error is shown.

`CMakeLists.txt` marks the target as `MACOSX_BUNDLE` but never sets `MACOSX_BUNDLE_GUI_IDENTIFIER`, so CMake's default `Info.plist` template substitutes an empty string:

```console
$ /usr/libexec/PlistBuddy -c "Print :CFBundleIdentifier" qelectrotech.app/Contents/Info.plist
        # empty
$ lsappinfo info -only bundleid <pid>
    bundleID=""    bundle path=[ NULL ]
```

An `.app` with an empty identifier is never registered by LaunchServices. AppKit runs the open/save panel in an XPC service keyed on the client's bundle identifier — the service is spawned on every request, but presents no window. `QFileDialog::getOpenFileName()` and `getSaveFileName()` therefore return an empty string with no panel ever appearing, and `QETDiagramEditor::openProject()` returns at its `if (filepath.isEmpty())` guard.

This affects every macOS CMake build since the target became a bundle. `File > New` is unaffected, since it needs no dialog — which is what makes the failure look like a broken menu action rather than a packaging problem.

## Fix

Fill in the identifier along with the other bundle metadata CMake's template expects.

`org.qelectrotech.QElectroTech` is the identifier Qt already derives from `setOrganizationDomain("qelectrotech.org")` and `setApplicationName("QElectroTech")` for the app's own settings file (`~/Library/Preferences/org.qelectrotech.QElectroTech.plist`), so the bundle now agrees with what the app writes at runtime.

## Verification

macOS 27, Qt 6.11.2, CMake build.

- Before: File > Open and File > Save as present nothing; the panel XPC service spawns and exits.
- After: both panels open normally.
- Confirmed causally in both directions — hand-patching `CFBundleIdentifier` into an existing broken bundle makes the panel appear, and reverting to an empty identifier makes it vanish again.

No code signing step is required. The linker's ad-hoc signature still reports the executable name as its identifier (`codesign -dv` → `Identifier=qelectrotech`) and the panels work regardless, once the plist is correct.

## Scope

Deliberately minimal — the identifier and the metadata fields around it, nothing else. Two related macOS packaging gaps are left alone and can follow separately if wanted:

- the app icon is not copied into the bundle (`MACOSX_BUNDLE_ICON_FILE` alone does not do it)
- there is no document-type association, so Finder offers no "Open With QElectroTech" for `.qet` / `.elmt` / `.titleblock`