### PR TITLE
Make the slave limit advisory rather than a refusal

### DIFF
--- a/sources/ui/linksingleelementwidget.cpp
+++ b/sources/ui/linksingleelementwidget.cpp
@@ -17,7 +17,6 @@
 */
 #include "linksingleelementwidget.h"
 #include "contactgroupselectiondialog.h"
-#include "../qetgraphicsitem/masterelement.h"
 #include "../qetgraphicsitem/conductor.h"
 #include "../diagram.h"
 #include "../diagramposition.h"
@@ -418,11 +417,12 @@ QVector <QPointer<Element>> LinkSingleElementWidget::availableElements()
 				continue;
 			}
 
-			// If the master is full, we'll remove it from the list!
-			MasterElement *master = static_cast<MasterElement*>(elmt);
-			if (master->isFull()) {
-				elmt_vector.removeAt(i);
-			}
+				// A master at its declared limit stays in the list. Removing
+				// it made a full master indistinguishable from one that does
+				// not exist: the candidate simply was not there, with nothing
+				// to say why. The limit is advisory -- see the prompt in
+				// MasterPropertiesWidget::on_link_button_clicked() -- so the
+				// user decides, rather than the list deciding for them.
 		}
 	}
 	return elmt_vector;

--- a/sources/ui/masterpropertieswidget.cpp
+++ b/sources/ui/masterpropertieswidget.cpp
@@ -307,15 +307,24 @@ void MasterPropertiesWidget::on_link_button_clicked()
 		int max_slaves = max_slaves_variant.toInt();
 		int current_slaves = ui->m_link_tree_widget->topLevelItemCount();
 
-		// If a limit is set and reached
+			// If a limit is set and reached, say so but let the user decide.
+			// The limit records how many contacts the part is expected to
+			// carry; it is not a rule the drawing has to obey, and refusing
+			// the link obstructs drawing a schematic before the hardware has
+			// been chosen.
 		if (max_slaves != -1 && current_slaves >= max_slaves) {
 
-
 			// Show a message box with the actual window as parent to ensure it's on top
-			QMessageBox::warning(this->window(),
-								 tr("Nombre maximal d'esclaves atteint."),
-								 tr("Cet élément maître ne peut plus accepter aucun nouveau contact esclave, la limite fixée a été atteinte (Limite: %1).").arg(max_slaves));
-			return;
+			const auto answer = QMessageBox::warning(
+						this->window(),
+						tr("Nombre maximal d'esclaves atteint."),
+						tr("La limite fixée pour cet élément maître est atteinte (Limite: %1).\n\n"
+						   "Voulez-vous tout de même lier ce contact esclave ?").arg(max_slaves),
+						QMessageBox::Yes | QMessageBox::No,
+						QMessageBox::Yes);
+			if (answer != QMessageBox::Yes) {
+				return;
+			}
 		}
 	}
 


### PR DESCRIPTION
Last piece of the contact work from #819, after #825, #826 and #827.

> **Please read the "on consent" note at the end before merging.** This is built on what you and @IBSYSLevi said about how you work, not on an explicit yes to a direct question, and it is easy to drop if I have read that wrong.

## Why

`max_slaves` records how many contacts a part is expected to carry. It was enforced as a rule the drawing must obey, which cuts across the workflow both of you described in #819 — draw the schematic first, choose the physical hardware afterwards. A limit that *refuses* a link forces the hardware decision up front, which is the thing that was said to get in the way.

@IBSYSLevi in #819:

> So if the “max_slaves” property strictly prevented me from specifying more slaves, that would be a hindrance.

## What changes

Two changes, both in the UI. `MasterElement::isFull()` is untouched — it stays a query, and the callers decide what to do with the answer.

**`MasterPropertiesWidget::on_link_button_clicked()`** now reports that the limit is reached and asks whether to link anyway, defaulting to yes, instead of refusing outright.

**`LinkSingleElementWidget`** no longer removes a full master from the candidate list. This was the worse half of the old behaviour: a master at its limit was simply *not there*, indistinguishable from one that does not exist, with nothing to explain why. It now stays selectable and the user decides.

## What deliberately does not change

**PLC masters.** Their limit is the number of declared IO slots, which is structural rather than advisory — a link past it would have no IO index to map to. `PlcLinkWidget` also already tells the user when it hides one, through `m_hidden_masters_label`, so it never had the silent-disappearance problem in the first place.

## Scope

Only masters that opt into a limit are affected. `max_slaves` defaults to `-1`, and no project in `examples/` sets it, so for every existing project this changes nothing.

## Testing

- Builds clean on Qt 5.15.18, Ubuntu 26.04, gcc 15.2.0.
- 22 of the 23 projects in `examples/` load and export (`--export-bom`) with no crash or hang; the 23rd is `schema_indus.qet`, which hangs on any headless verb for the unrelated reason in #661.
- `tst_contactusage` still passes.
- Removed a `masterelement.h` include that the second change left unused.

## On consent

@scorpio810 — I asked in #819 whether the cap should warn rather than refuse, and did not get an explicit answer, so I have inferred it from your and @IBSYSLevi's comments about drawing before choosing hardware. That inference may be wrong, and this is a behaviour change to something that has worked one way until now.

If you would rather keep the hard limit, say so and I will close this; nothing else in the merged stack depends on it. If you would rather keep the refusal but fix only the silent disappearance in the candidate list, that is a smaller change and I am happy to reduce it to just that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
