### PR TITLE
Doxygen: drop call graphs and emit SVG, 1012 MB -> 211 MB

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -2658,7 +2658,7 @@ INCLUDED_BY_GRAPH      = YES
 # The default value is: NO.
 # This tag requires that the tag HAVE_DOT is set to YES.
 
-CALL_GRAPH             = YES
+CALL_GRAPH             = NO
 
 # If the CALLER_GRAPH tag is set to YES then Doxygen will generate a caller
 # dependency graph for every global function or class method.
@@ -2670,7 +2670,7 @@ CALL_GRAPH             = YES
 # The default value is: NO.
 # This tag requires that the tag HAVE_DOT is set to YES.
 
-CALLER_GRAPH           = YES
+CALLER_GRAPH           = NO
 
 # If the GRAPHICAL_HIERARCHY tag is set to YES then Doxygen will graphical
 # hierarchy of all classes instead of a textual one.
@@ -2711,7 +2711,7 @@ DIR_GRAPH_MAX_DEPTH    = 1
 # The default value is: png.
 # This tag requires that the tag HAVE_DOT is set to YES.
 
-DOT_IMAGE_FORMAT       = png
+DOT_IMAGE_FORMAT       = svg
 
 # If DOT_IMAGE_FORMAT is set to svg, then this option can be set to YES to
 # enable generation of interactive SVG images that allow zooming and panning.


### PR DESCRIPTION
Follows the measurements in #824. @scorpio810 asked for a lighter Doxyfile; this is the middle option from that table.

**Independent of #832** — that one removes the `.qch`/LFS path, this one trims the HTML. They touch different parts of the `Doxyfile` (line 1586 vs 2661+) and can merge in either order.

## The numbers

Doxygen 1.15.0, graphviz 14.1.2, Ubuntu 26.04, current `master`. Each row is a full clean run; only the named settings differ:

| Settings | Size | Time | Images |
|---|---|---|---|
| as shipped | 1012 MB | 134 s | 8 574 |
| `CALL_GRAPH=NO` `CALLER_GRAPH=NO` | 405 MB | 43 s | 1 852 |
| **↑ plus `DOT_IMAGE_FORMAT=svg`** ← this PR | **211 MB** | **22 s** | 3 528 |
| `HAVE_DOT=NO` (no graphs at all) | 74 MB | 8 s | 343 |

That baseline of 1012 MB corresponds to the 985 MB @scorpio810 measured — different doxygen and graphviz versions, same ballpark.

## What changes, and why these three lines

**`CALL_GRAPH=NO`, `CALLER_GRAPH=NO`.** These are generated *per function*, so they dominate both size and time: on their own they take 1012 MB → 405 MB and 134 s → 43 s. They are also the least-read graphs in a codebase this size, where the call graph for anything central is unreadably dense.

**`DOT_IMAGE_FORMAT=svg`.** Halves it again, 405 MB → 211 MB, and the diagrams become vector rather than fixed-resolution bitmaps. `INTERACTIVE_SVG` is already `YES` in the Doxyfile and has been inert while the format was `png`; it now takes effect, so the remaining diagrams pan and zoom.

**What stays:** class, collaboration, include, included-by, hierarchy and directory graphs — the diagrams that are actually read.

## Why not go further

`HAVE_DOT=NO` reaches 74 MB, but the class and collaboration diagrams are the most useful part of a doxygen build, so that felt like the wrong trade. If you would rather keep call graphs in reduced form instead, `DOT_GRAPH_MAX_NODES` (currently 50) and `MAX_DOT_GRAPH_DEPTH` (currently 0, unlimited) are the softer dials and I am happy to measure some combinations.

## Testing

Ran doxygen with this exact Doxyfile:

- **211 MB**, matching the measurement above
- `doc/html/index.html` present
- 3 526 `.svg` and 2 `.png`

Also worth recording, since it came up in #824: **there is no lighter Doxyfile in the history to return to.** `Doxyfile` has exactly one commit, `a8e2a7acf`, which added it whole at 2838 lines. Measuring forward was the only option.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
