### PR TITLE
Use QLabel::pixmap()'s non-deprecated by-value form on Qt5

### DIFF
--- a/sources/ui/imagetransparentcolordialog.cpp
+++ b/sources/ui/imagetransparentcolordialog.cpp
@@ -66,8 +66,11 @@ ClickableImageLabel::ClickableImageLabel(const QImage &sourceImage, QWidget *par
 void ClickableImageLabel::mousePressEvent(QMouseEvent *event)
 {
 		// QLabel::pixmap() returns a pointer in Qt5 and a value in Qt6.
+		// Qt 5.15 offers the by-value form behind Qt::ReturnByValue; the
+		// pointer overload is deprecated there, so take the by-value one
+		// on both and the difference reduces to the argument.
 #if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
-	const QPixmap label_pixmap = pixmap() ? *pixmap() : QPixmap();
+	const QPixmap label_pixmap = pixmap(Qt::ReturnByValue);
 #else
 	const QPixmap label_pixmap = pixmap();
 #endif


### PR DESCRIPTION
Small follow-up to #824, tidying up after myself.

That PR fixed the Qt5 build by reading the pixmap through `QLabel::pixmap()`'s pointer overload — but Qt 5.15 deprecates that overload, so the fix compiled with two deprecation warnings of its own. Qt 5.15 provides the by-value form behind `Qt::ReturnByValue`, so both branches can take the same overload and the difference reduces to the argument.

```diff
 #if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
-	const QPixmap label_pixmap = pixmap() ? *pixmap() : QPixmap();
+	const QPixmap label_pixmap = pixmap(Qt::ReturnByValue);
 #else
 	const QPixmap label_pixmap = pixmap();
 #endif
```

**Equivalent, not merely similar:** the pointer overload returns `nullptr` when no pixmap is set, which the old expression converted into a null `QPixmap`; `pixmap(Qt::ReturnByValue)` returns a null `QPixmap` directly. Same value, and the null check disappears, so the Qt5 branch becomes a single expression.

## Testing

A change inside a `#if` is only half tested if one branch is built, so both were:

| | Result |
|---|---|
| Qt 5.15.18 — deprecation warnings for this file | **2 → 0** |
| Qt 5.15.18 — build | clean, binary runs (`0.200.1-dev`) |
| Qt 6.10.2 — build | clean, 488/488, links |
| 22 projects in `examples/` — load and export (`--export-bom`) | no crash, no hang |

Ubuntu 26.04, gcc 15.2.0.

@scorpio810 — this is the first thing I will merge myself with the write access you granted. It seemed a reasonable one to start with: one line, in code I added yesterday, where the compiler decides whether it is right rather than my judgement. Say the word if you would rather I left merges to you, and I will.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
