### PR TITLE
Wiring list: numeric wire-number order, UTF-8 BOM and atomic write

### DIFF
--- a/sources/cli_export.cpp
+++ b/sources/cli_export.cpp
@@ -564,7 +564,14 @@ int exportWiring(QETProject &project, const QString &output)
 
 	QSqlQuery query = project.dataBase()->newQuery(
 		"SELECT " % columns.join(", ") %
-		" FROM wiring_list_view ORDER BY diagram_position, wire_number");
+		" FROM wiring_list_view"
+		//Wire numbers are text, so a plain sort puts "10" before "9".
+		//Numeric ones first, ordered by value; anything non-numeric after,
+		//ordered as text. The trailing wire_number keeps ties stable.
+		" ORDER BY diagram_position,"
+		" CASE WHEN wire_number GLOB '[0-9]*' THEN 0 ELSE 1 END,"
+		" CAST(wire_number AS INTEGER),"
+		" wire_number");
 	if (!query.exec()) {
 		err << "Wiring list query failed: " << query.lastError().text() << "\n";
 		return 1;

--- a/sources/cli_export.cpp
+++ b/sources/cli_export.cpp
@@ -39,6 +39,7 @@
 #include <QDomDocument>
 #include <QDate>
 #include <QFile>
+#include <QSaveFile>
 #include <QFileInfo>
 #include <QJsonArray>
 #include <QJsonDocument>
@@ -587,14 +588,23 @@ int exportWiring(QETProject &project, const QString &output)
 		++rows;
 	}
 
-	QFile file(output);
-	if (!file.open(QIODevice::WriteOnly | QIODevice::Text)) {
+		//Written through QSaveFile so a failure part-way leaves the previous
+		//file intact rather than a truncated one, and with a UTF-8 byte order
+		//mark: without it Excel opens a .csv as the local 8-bit codepage and
+		//mangles any accented element label. Qt writes UTF-8 by default, so
+		//the bytes were already right -- the mark is what tells Excel so.
+	QSaveFile file(output);
+	if (!file.open(QIODevice::WriteOnly)) {
 		err << "Cannot open '" << output << "' for writing.\n";
 		return 1;
 	}
-	QTextStream fout(&file);
-	fout << csv;
-	file.close();
+	static const char utf8_bom[] = "\xEF\xBB\xBF";
+	file.write(utf8_bom, 3);
+	file.write(csv.toUtf8());
+	if (!file.commit()) {
+		err << "Cannot write '" << output << "': " << file.errorString() << "\n";
+		return 1;
+	}
 	out << "Exported " << rows << " conductor(s) -> " << output << "\n";
 	return 0;
 }

--- a/sources/ui/wiringlistdialog.cpp
+++ b/sources/ui/wiringlistdialog.cpp
@@ -52,7 +52,14 @@ WiringListDialog::WiringListDialog(QETProject *project, QWidget *parent) :
 				"SELECT wire_number, from_element_label, from_terminal,"
 				" to_element_label, to_terminal, diagram_position"
 				" FROM wiring_list_view"
-				" ORDER BY diagram_position, wire_number"),
+				//Wire numbers are text, so a plain sort puts "10" before "9".
+				//Numeric ones first, ordered by value; anything non-numeric
+				//after, ordered as text. The trailing wire_number keeps ties
+				//stable.
+				" ORDER BY diagram_position,"
+				" CASE WHEN wire_number GLOB '[0-9]*' THEN 0 ELSE 1 END,"
+				" CAST(wire_number AS INTEGER),"
+				" wire_number"),
 			m_project->dataBase()->database());
 
 	model->setHeaderData(0, Qt::Horizontal, tr("Fil", "column title"));


### PR DESCRIPTION
Both of the **Minor** points from your review on merging #630.

## 1. Wire numbers sorted as text

> `ORDER BY diagram_position, wire_number` sorts wire numbers as text, so "10" comes before "9".

Confirmed against the corpus before fixing: `perceuse.qet` put **111 before 12**, and `affuteuse_250h.qet` put **45 before 5**. `industrial.qet` looked correct only because its wire numbers happen to be uniform width, which is presumably why it went unnoticed.

Wire numbers are free text and not always numeric — `perceuse.qet` also carries an unresolved `%sequ_1` — so the ordering has to handle both. Numeric values first, ordered by value; anything else after, ordered as text; the trailing `wire_number` keeps ties stable.

**Fixed in both places the query appears:** the CLI exporter and the wiring list dialog. They carried the same `ORDER BY`, so fixing one alone would have made the dialog and `--export-wiring` disagree about the order of identical data.

## 2. No UTF-8 mark, non-atomic write

> Once #830 is in, it could optionally reuse `BomExport::writeCsv()` to get a BOM, which Excel needs to detect UTF-8 when opening the file directly, and an atomic write.

Done directly rather than waiting on #830, since neither half depends on it.

The bytes were already UTF-8; what was missing is the mark that tells Excel so. Without it Excel falls back to the local 8-bit codepage and mangles accented element labels. `QSaveFile` replaces `QFile` so a failure part-way leaves the previous file intact rather than truncated — already the codebase's pattern in `QET::writeToFile()`.

I left the other CLI exporters alone. They share the pattern, but adding a BOM to `exportBom()` output would change what existing scripts already consume, which is beyond this note.

## Verified

- `perceuse`, `affuteuse_250h`, `industrial`, `tremie_vibrante`: **zero out-of-order numeric pairs**, row counts unchanged, `%sequ_1` now sorts after the numbers rather than among them.
- Folio 3 of `perceuse.qet` now reads `0 1 2 3 4 4 5 5 6 6 7 7 12 12`.
- Output starts `ef bb bf`, header intact, all 156 rows preserved, parses as `utf-8-sig`.
- Pointing the exporter at a missing project leaves an existing target file untouched, where before it was truncated.
- Builds clean on Qt 6.10.2, gcc 15.2.0, Ubuntu 26.04.

No rush on review — this is tidy-up behind a merge, not something blocking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
