### PR TITLE
Local/slave element informations merge

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -22,8 +22,9 @@ Since 0.100, development has centered on a new headless command-line workflow, t
 - **BOM / Nomenclature**
 - Specific elements can now be excluded from the Bill of Materials (Nomenclature).
 - Slave labels can inherit their linked Master's label while retaining a local
-  suffix (for example `K1-A1` or `PLC1-CH3`); inheritance is enabled by default
-  and can be disabled in the placed element's Informations tab.
+  suffix (for example `K1-A1` or `PLC1-CH3`). Each cross-reference type defines
+  whether inheritance is enabled by default and which separator is used; a
+  placed Slave can still override inheritance in its Informations tab.
 - **Terminal & cross-reference (Xref) work**
 - Continued iteration on a `max_slaves` limit for Master elements (added, tuned, briefly reverted, then re-implemented with proper save/load handling).
 - New "potential isolation" option for terminals, and new No/Nc/Common contact types for switch (SW) terminals.

--- a/ChangeLog
+++ b/ChangeLog
@@ -52,6 +52,11 @@ Since 0.100, development has centered on a new headless command-line workflow, t
 - Fixed a crash when destroying a `QETProject` before its asynchronous backup had finished.
 - Fixed regional system locale sometimes loading the wrong translation.
 - Fixed dynamic element text shifting/jumping when duplicating diagrams, and a wiring-list filter/timing issue.
+- Fixed an idle repaint loop caused by linked coil cross-reference geometry
+  being invalidated from its paint path.
+- Reusing an element UUID from an external collection now places an identical
+  embedded definition directly; a changed definition with the same UUID uses
+  the existing overwrite/ignore/rename dialog.
 - Various smaller fixes: a first-click spurious element move right after selecting a tool, an -Wreorder compiler warning, and several translation corrections (German, French, Chinese).
 
 ### macOS

--- a/ChangeLog
+++ b/ChangeLog
@@ -21,6 +21,9 @@ Since 0.100, development has centered on a new headless command-line workflow, t
 - Diagrams/folios can now be duplicated along with all their metadata and embedded elements.
 - **BOM / Nomenclature**
 - Specific elements can now be excluded from the Bill of Materials (Nomenclature).
+- Slave labels can inherit their linked Master's label while retaining a local
+  suffix (for example `K1-A1` or `PLC1-CH3`); inheritance is enabled by default
+  and can be disabled in the placed element's Informations tab.
 - **Terminal & cross-reference (Xref) work**
 - Continued iteration on a `max_slaves` limit for Master elements (added, tuned, briefly reverted, then re-implemented with proper save/load handling).
 - New "potential isolation" option for terminals, and new No/Nc/Common contact types for switch (SW) terminals.

--- a/ChangeLog_full.md
+++ b/ChangeLog_full.md
@@ -20,6 +20,7 @@ All notable changes to QElectroTech are documented here.
 
 ### 🐛 Bug Fixes
 
+- Open filesystem element definitions before parsing them as XML, restoring drag-and-drop insertion from file-backed collections.
 - Keep Slave element information editable and persistent in element-source XML, and include Slave rows and metadata in the internal project database.
 - Fix #798: clamp element-editor and diagram-view zoom to prevent view-transform overflow crash on scroll-wheel zoom ([3ca5d4a](../../commit/3ca5d4ab2))
 - Fix(windows-msi): inject rev into MSI Version Build field ([e19f523](../../commit/e19f5232277efb37435cb65a83563d73333d62ec))
@@ -1085,4 +1086,3 @@ All notable changes to QElectroTech are documented here.
 - Added element-descriptions and elements ([337a2a4](../../commit/337a2a45b441cab77ca96ab3618cf6aaa658792a))
 - Added/fixed translations and added elements ([fcab774](../../commit/fcab77420d44edb545e21888b958d4b2c18b9741))
 - Add a push button to automatically reorder the terminal strip ([1699ad9](../../commit/1699ad9dd884d07aef7a0dc93508c52a20421724))
-

--- a/ChangeLog_full.md
+++ b/ChangeLog_full.md
@@ -21,7 +21,7 @@ All notable changes to QElectroTech are documented here.
 ### 🐛 Bug Fixes
 
 - Open filesystem element definitions before parsing them as XML, restoring drag-and-drop insertion from file-backed collections.
-- Keep Slave element information editable in both the element editor and diagram properties, persistent in element-source XML, and included in the internal project database.
+- Keep Slave element information editable in both the element editor and diagram properties, persistent in element-source XML, and included in the internal project database; Slave elements now default to exclusion from BOM unless explicitly opted in.
 - Fix #798: clamp element-editor and diagram-view zoom to prevent view-transform overflow crash on scroll-wheel zoom ([3ca5d4a](../../commit/3ca5d4ab2))
 - Fix(windows-msi): inject rev into MSI Version Build field ([e19f523](../../commit/e19f5232277efb37435cb65a83563d73333d62ec))
 - Fix #391: use wide-char path for pugixml on Windows to handle Unicode paths ([31edf30](../../commit/31edf30c619213368e9b592b51be6ca8190db831))

--- a/ChangeLog_full.md
+++ b/ChangeLog_full.md
@@ -21,7 +21,7 @@ All notable changes to QElectroTech are documented here.
 ### 🐛 Bug Fixes
 
 - Open filesystem element definitions before parsing them as XML, restoring drag-and-drop insertion from file-backed collections.
-- Keep Slave element information editable and persistent in element-source XML, and include Slave rows and metadata in the internal project database.
+- Keep Slave element information editable in both the element editor and diagram properties, persistent in element-source XML, and included in the internal project database.
 - Fix #798: clamp element-editor and diagram-view zoom to prevent view-transform overflow crash on scroll-wheel zoom ([3ca5d4a](../../commit/3ca5d4ab2))
 - Fix(windows-msi): inject rev into MSI Version Build field ([e19f523](../../commit/e19f5232277efb37435cb65a83563d73333d62ec))
 - Fix #391: use wide-char path for pugixml on Windows to handle Unicode paths ([31edf30](../../commit/31edf30c619213368e9b592b51be6ca8190db831))

--- a/ChangeLog_full.md
+++ b/ChangeLog_full.md
@@ -20,6 +20,7 @@ All notable changes to QElectroTech are documented here.
 
 ### 🐛 Bug Fixes
 
+- Keep Slave element information editable and persistent in element-source XML, and include Slave rows and metadata in the internal project database.
 - Fix #798: clamp element-editor and diagram-view zoom to prevent view-transform overflow crash on scroll-wheel zoom ([3ca5d4a](../../commit/3ca5d4ab2))
 - Fix(windows-msi): inject rev into MSI Version Build field ([e19f523](../../commit/e19f5232277efb37435cb65a83563d73333d62ec))
 - Fix #391: use wide-char path for pugixml on Windows to handle Unicode paths ([31edf30](../../commit/31edf30c619213368e9b592b51be6ca8190db831))
@@ -1084,5 +1085,4 @@ All notable changes to QElectroTech are documented here.
 - Added element-descriptions and elements ([337a2a4](../../commit/337a2a45b441cab77ca96ab3618cf6aaa658792a))
 - Added/fixed translations and added elements ([fcab774](../../commit/fcab77420d44edb545e21888b958d4b2c18b9741))
 - Add a push button to automatically reorder the terminal strip ([1699ad9](../../commit/1699ad9dd884d07aef7a0dc93508c52a20421724))
-
 

--- a/dev_doc/slave-element-information-roundtrip.md
+++ b/dev_doc/slave-element-information-roundtrip.md
@@ -117,3 +117,17 @@ Dragging an element from a file-backed collection could emit
 This was not a `/tmp` or company-collection permission problem:
 `ElementsLocation::xml()` passed its `QFile` to `QDomDocument::setContent()`
 without opening it. The file is now opened read-only before XML parsing.
+
+The follow-up duplicate-import regression was UUID-related. Import now searches
+the embedded project collection by UUID independently of the external
+collection path. If the stored and dragged XML definitions are equivalent, the
+stored definition is reused and another instance can be placed. If their XML
+differs, the existing overwrite/ignore/rename dialog is shown.
+
+## Cross-reference idle CPU regression
+
+The cross-reference paint functions recalculated their bounding geometry and
+called `prepareGeometryChange()` during every paint. A visible linked coil could
+therefore continuously invalidate the scene and keep the GUI repainting while
+idle. Geometry is now updated only from `CrossRefItem::updateLabel()`; ordinary
+paint calls use the cached bounding rectangle and shape.

--- a/dev_doc/slave-element-information-roundtrip.md
+++ b/dev_doc/slave-element-information-roundtrip.md
@@ -1,0 +1,82 @@
+# Slave element information is not persisted consistently
+
+## Problem
+
+`Slave` elements already own an `ElementData::m_informations` context. Project
+XML loading and saving also round-trip that context for every element basetype,
+and dynamic element text can read values such as `quantity_auxiliary4` from a
+Slave instance.
+
+The remaining write and database paths were inconsistent:
+
+- the element editor hid and disabled the Informations tree for Slave elements;
+- `ElementScene::toXml()` omitted `<elementInformations>` when saving a Slave
+  element definition;
+- full internal-database rebuilds excluded Slave elements from both `element`
+  and `element_info`;
+- the incremental database path and the full rebuild derived `element.sub_type`
+  differently, so a Slave subtype could disappear after `updateDB()`.
+
+This made manually inserted information work in a `.qet` project while the
+same data could not be authored and preserved consistently through the UI and
+could not be queried reliably from the internal project database.
+
+## Reproduction
+
+1. Create or open a Slave element containing a dynamic text bound to
+   `quantity_auxiliary4`.
+2. Add this information manually to a placed instance in project XML:
+
+   ```xml
+   <elementInformation name="quantity_auxiliary4" show="1">this is quantity_auxiliary4</elementInformation>
+   ```
+
+3. Open and re-save the project. The dynamic text renders and the project
+   instance keeps the value.
+4. Open the element definition in the element editor. On an unmodified build,
+   the Informations tab is unavailable for Slave elements and the definition
+   writer does not serialize the context.
+5. Rebuild the internal database. On an unmodified build, the Slave is absent
+   from `element`, `element_info`, and consequently
+   `element_nomenclature_view`.
+
+## Expected behavior
+
+- Slave information can be edited in the same Informations tree used by other
+  supported basetypes.
+- Saving and reopening a Slave `.elmt` definition preserves non-empty
+  `<elementInformation>` entries.
+- The internal database represents every supported placed element, including
+  Slave instances, and preserves their Slave subtype across incremental and
+  full rebuild paths.
+- BOM inclusion remains independently controllable through
+  `exclude_from_bom`.
+
+## Implementation
+
+- Enable and show the Informations tree for `ElementData::Slave`.
+- Add `ElementData::Slave` to the `ElementScene::toXml()` information write
+  condition.
+- Add `ElementData::Slave` to both internal-database population masks.
+- Use one basetype-aware subtype conversion for incremental insertion and full
+  database rebuilds.
+
+## Compatibility and behavior change
+
+Project XML parsing and instance serialization already accept Slave
+information, so no project format migration is required.
+
+Because `element_nomenclature_view` reads all rows from the internal `element`
+and `element_info` tables except rows marked `exclude_from_bom = 'true'`, Slave
+elements now become visible to unfiltered nomenclature and BOM queries. Projects
+that use Slave elements only as subordinate contacts can mark them
+`exclude_from_bom` when they should not be listed separately.
+
+## Test fixture
+
+`dev_doc/test_cases/qet_quantity_auxiliary4_slave_minimal.qet` is an anonymized
+one-folio project
+with two identical PLC Slave instances. Both contain a dynamic text bound to
+`quantity_auxiliary4`; only one instance contains the corresponding XML value.
+It can be used to verify rendering, project round-trip, and internal-database
+population without project-specific tags or manufacturer data.

--- a/dev_doc/slave-element-information-roundtrip.md
+++ b/dev_doc/slave-element-information-roundtrip.md
@@ -55,6 +55,9 @@ could not be queried reliably from the internal project database.
   full rebuild paths.
 - BOM inclusion remains independently controllable through
   `exclude_from_bom`, with Slave elements excluded by default.
+- Slave label inheritance is enabled by default and can be disabled per placed
+  Slave. An inherited label combines the Master and local Slave labels with a
+  hyphen, for example `K1-A1` or `PLC1-CH3`.
 
 ## Implementation
 
@@ -68,6 +71,12 @@ could not be queried reliably from the internal project database.
   database rebuilds.
 - Normalize a missing, null, or empty `exclude_from_bom` to `true` for Slave
   definitions and placed instances while preserving an explicit `false`.
+- Normalize a missing, null, or empty `inherit_label` to `true`, expose it as a
+  Slave-only checkbox, and calculate the displayed label without overwriting
+  the Slave's own XML `label` value.
+- Migrate a legacy PLC Slave label that exactly duplicates its linked Master's
+  label to an empty local suffix, avoiding duplicated or stale labels after a
+  Master rename.
 
 ## Compatibility and behavior change
 
@@ -80,6 +89,11 @@ elements are excluded from unfiltered nomenclature and BOM queries by default.
 This also applies to legacy Slave XML where the key is missing or empty. An
 explicit `exclude_from_bom=false` remains the opt-in for listing a Slave as a
 separate BOM item.
+
+Legacy Slave XML without `inherit_label` defaults to inheritance. Explicit
+`inherit_label=false` preserves a standalone Slave label. PLC link data remains
+Master-driven, but the channel's own label is no longer destroyed by linking or
+unlinking.
 
 ## Test fixture
 

--- a/dev_doc/slave-element-information-roundtrip.md
+++ b/dev_doc/slave-element-information-roundtrip.md
@@ -54,7 +54,7 @@ could not be queried reliably from the internal project database.
   Slave instances, and preserves their Slave subtype across incremental and
   full rebuild paths.
 - BOM inclusion remains independently controllable through
-  `exclude_from_bom`.
+  `exclude_from_bom`, with Slave elements excluded by default.
 
 ## Implementation
 
@@ -66,6 +66,8 @@ could not be queried reliably from the internal project database.
 - Add `ElementData::Slave` to both internal-database population masks.
 - Use one basetype-aware subtype conversion for incremental insertion and full
   database rebuilds.
+- Normalize a missing, null, or empty `exclude_from_bom` to `true` for Slave
+  definitions and placed instances while preserving an explicit `false`.
 
 ## Compatibility and behavior change
 
@@ -74,9 +76,10 @@ information, so no project format migration is required.
 
 Because `element_nomenclature_view` reads all rows from the internal `element`
 and `element_info` tables except rows marked `exclude_from_bom = 'true'`, Slave
-elements now become visible to unfiltered nomenclature and BOM queries. Projects
-that use Slave elements only as subordinate contacts can mark them
-`exclude_from_bom` when they should not be listed separately.
+elements are excluded from unfiltered nomenclature and BOM queries by default.
+This also applies to legacy Slave XML where the key is missing or empty. An
+explicit `exclude_from_bom=false` remains the opt-in for listing a Slave as a
+separate BOM item.
 
 ## Test fixture
 

--- a/dev_doc/slave-element-information-roundtrip.md
+++ b/dev_doc/slave-element-information-roundtrip.md
@@ -10,6 +10,8 @@ Slave instance.
 The remaining write and database paths were inconsistent:
 
 - the element editor hid and disabled the Informations tree for Slave elements;
+- the diagram/folio element-properties dialog omitted its Informations tab for
+  Slave instances;
 - `ElementScene::toXml()` omitted `<elementInformations>` when saving a Slave
   element definition;
 - full internal-database rebuilds excluded Slave elements from both `element`
@@ -44,6 +46,8 @@ could not be queried reliably from the internal project database.
 
 - Slave information can be edited in the same Informations tree used by other
   supported basetypes.
+- Placed Slave instances expose an Informations tab in the diagram/folio
+  element-properties dialog without replacing their PLC/link tab.
 - Saving and reopening a Slave `.elmt` definition preserves non-empty
   `<elementInformation>` entries.
 - The internal database represents every supported placed element, including
@@ -55,6 +59,8 @@ could not be queried reliably from the internal project database.
 ## Implementation
 
 - Enable and show the Informations tree for `ElementData::Slave`.
+- Add `ElementInfoWidget` to the diagram/folio properties tabs for
+  `Element::Slave`.
 - Add `ElementData::Slave` to the `ElementScene::toXml()` information write
   condition.
 - Add `ElementData::Slave` to both internal-database population masks.

--- a/dev_doc/slave-element-information-roundtrip.md
+++ b/dev_doc/slave-element-information-roundtrip.md
@@ -80,3 +80,11 @@ with two identical PLC Slave instances. Both contain a dynamic text bound to
 `quantity_auxiliary4`; only one instance contains the corresponding XML value.
 It can be used to verify rendering, project round-trip, and internal-database
 population without project-specific tags or manufacturer data.
+
+## Related UI test failure
+
+Dragging an element from a file-backed collection could emit
+`QDomDocument called with unopened QIODevice` and fail to create the object.
+This was not a `/tmp` or company-collection permission problem:
+`ElementsLocation::xml()` passed its `QFile` to `QDomDocument::setContent()`
+without opening it. The file is now opened read-only before XML parsing.

--- a/dev_doc/slave-element-information-roundtrip.md
+++ b/dev_doc/slave-element-information-roundtrip.md
@@ -56,8 +56,10 @@ could not be queried reliably from the internal project database.
 - BOM inclusion remains independently controllable through
   `exclude_from_bom`, with Slave elements excluded by default.
 - Slave label inheritance is enabled by default and can be disabled per placed
-  Slave. An inherited label combines the Master and local Slave labels with a
-  hyphen, for example `K1-A1` or `PLC1-CH3`.
+  Slave. Each project cross-reference profile (`coil`, `protection`,
+  `commutator`, and `plc`) controls its default and separator. An inherited
+  label therefore combines the Master and local Slave labels as `K1-A1` or,
+  with a custom separator, for example `K1:A1`.
 
 ## Implementation
 
@@ -71,9 +73,12 @@ could not be queried reliably from the internal project database.
   database rebuilds.
 - Normalize a missing, null, or empty `exclude_from_bom` to `true` for Slave
   definitions and placed instances while preserving an explicit `false`.
-- Normalize a missing, null, or empty `inherit_label` to `true`, expose it as a
-  Slave-only checkbox, and calculate the displayed label without overwriting
-  the Slave's own XML `label` value.
+- Resolve a missing, null, or empty `inherit_label` from the linked Master's
+  project cross-reference profile (whose backward-compatible default is
+  `true`), expose it as a Slave-only checkbox, and calculate the displayed
+  label without overwriting the Slave's own XML `label` value.
+- Persist the inheritance default and separator in both application settings
+  and project `<xref>` XML for all four Master types.
 - Migrate a legacy PLC Slave label that exactly duplicates its linked Master's
   label to an empty local suffix, avoiding duplicated or stale labels after a
   Master rename.
@@ -90,10 +95,11 @@ This also applies to legacy Slave XML where the key is missing or empty. An
 explicit `exclude_from_bom=false` remains the opt-in for listing a Slave as a
 separate BOM item.
 
-Legacy Slave XML without `inherit_label` defaults to inheritance. Explicit
-`inherit_label=false` preserves a standalone Slave label. PLC link data remains
-Master-driven, but the channel's own label is no longer destroyed by linking or
-unlinking.
+Legacy Slave XML without `inherit_label` follows its project profile; legacy
+profiles have the compatible defaults `inherit_label=true` and
+`label_separator="-"`. Explicit `inherit_label=false` preserves a standalone
+Slave label. PLC link data remains Master-driven, but the channel's own label
+is no longer destroyed by linking or unlinking.
 
 ## Test fixture
 

--- a/dev_doc/test_cases/qet_quantity_auxiliary4_slave_minimal.qet
+++ b/dev_doc/test_cases/qet_quantity_auxiliary4_slave_minimal.qet
@@ -1,0 +1,151 @@
+<?xml version='1.0' encoding='utf-8'?>
+<project title="Minimal quantity_auxiliary4 Slave reproduction" version="0.200.1">
+    <properties />
+    <newdiagrams>
+        <border rowsize="80" rows="8" displaycols="true" cols="17" colsize="60" displayrows="true" />
+        <inset author="" auto_page_num="" date="" displayAt="bottom" filename="" folio="%id/%total" indexrev="" locmach="" plant="" title="" version="" />
+        <conductors type="multi" num="" formula="" displaytext="0" numsize="9" condsize="1" bicolor="false" color2="#000000" text_color="#000000" />
+        <report label="%f-%l%c" />
+        <xrefs />
+        <conductors_autonums freeze_new_conductors="false" current_autonum="" />
+        <folio_autonums />
+        <element_autonums freeze_new_elements="false" current_autonum="" />
+    </newdiagrams>
+    <diagram author="" auto_page_num="" cols="17" colsize="60" date="" displayAt="bottom" displaycols="true" displayrows="true" filename="" folio="%id/%total" freezeNewConductor="false" freezeNewElement="false" height="660" indexrev="" locmach="" order="1" plant="" rows="8" rowsize="80" title="quantity_auxiliary4 minimal reproduction" version="0.200.1-dev">
+        <defaultconductor type="multi" num="" formula="" displaytext="0" numsize="9" condsize="1" bicolor="false" color2="#000000" text_color="#000000" />
+        <elements>
+            <element freezeLabel="false" is_movable="1" orientation="0" prefix="" type="embed://generic/single-channel-slave.elmt" uuid="{6be0d5b9-a786-579f-a6c0-5b18cc52df7e}" x="260" y="260" z="10">
+                <terminals>
+                    <terminal id="0" orientation="2" x="0" y="-4" />
+                    <terminal id="1" orientation="2" x="20" y="-4" />
+                    <terminal id="2" orientation="2" x="40" y="-4" />
+                    <terminal id="3" orientation="2" x="60" y="-4" />
+                </terminals>
+                <inputs />
+                <elementInformations>
+                    <elementInformation name="quantity_auxiliary4" show="1">this is quantity_auxiliary4</elementInformation>
+                </elementInformations>
+                <dynamic_texts>
+                    <dynamic_elmt_text Halignment="AlignLeft" Valignment="AlignTop" font="Liberation Sans,9,-1,5,50,0,0,0,0,0,Regular" frame="true" keep_visual_rotation="false" rotation="0" rotation_point_center="false" text_from="UserText" text_width="-1" uuid="{e954d1f9-aa22-5695-a10f-aa4ec2f24992}" x="-5" y="-115">
+                        <text>WITH XML FIELD</text>
+                    </dynamic_elmt_text>
+                    <dynamic_elmt_text Halignment="AlignLeft" Valignment="AlignTop" font="Liberation Sans,9,-1,5,50,0,0,0,0,0,Regular" frame="true" keep_visual_rotation="false" rotation="0" rotation_point_center="false" text_from="ElementInfo" text_width="-1" uuid="{6c17fe7c-7758-5f0f-b9fe-8f759730e88f}" x="-5" y="-95">
+                        <info_name>quantity_auxiliary4</info_name>
+                    </dynamic_elmt_text>
+                </dynamic_texts>
+                <texts_groups />
+            </element>
+            <element freezeLabel="false" is_movable="1" orientation="0" prefix="" type="embed://generic/single-channel-slave.elmt" uuid="{77ecdd83-8a40-5feb-bb2c-d0024bfb69da}" x="560" y="260" z="10">
+                <terminals>
+                    <terminal id="4" orientation="2" x="0" y="-4" />
+                    <terminal id="5" orientation="2" x="20" y="-4" />
+                    <terminal id="6" orientation="2" x="40" y="-4" />
+                    <terminal id="7" orientation="2" x="60" y="-4" />
+                </terminals>
+                <inputs />
+                <elementInformations />
+                <dynamic_texts>
+                    <dynamic_elmt_text Halignment="AlignLeft" Valignment="AlignTop" font="Liberation Sans,9,-1,5,50,0,0,0,0,0,Regular" frame="true" keep_visual_rotation="false" rotation="0" rotation_point_center="false" text_from="UserText" text_width="-1" uuid="{6aa27a94-4361-56d6-afb6-bf68d109e6d8}" x="-5" y="-115">
+                        <text>WITHOUT XML FIELD</text>
+                    </dynamic_elmt_text>
+                    <dynamic_elmt_text Halignment="AlignLeft" Valignment="AlignTop" font="Liberation Sans,9,-1,5,50,0,0,0,0,0,Regular" frame="true" keep_visual_rotation="false" rotation="0" rotation_point_center="false" text_from="ElementInfo" text_width="-1" uuid="{e3e7d4a5-1f86-5cea-bff4-81826da5ea08}" x="-5" y="-95">
+                        <text />
+                        <info_name>quantity_auxiliary4</info_name>
+                    </dynamic_elmt_text>
+                </dynamic_texts>
+                <texts_groups />
+            </element>
+        </elements>
+        <conductors />
+        <inputs />
+        <shapes />
+        <images />
+    </diagram>
+    <collection>
+        <category name="generic">
+            <names>
+                <name lang="en">Generic</name>
+            </names>
+            <element name="single-channel-slave.elmt">
+                <definition height="90" hotspot_x="10" hotspot_y="84" link_type="slave" type="element" version="0.200.1" width="90">
+                    <uuid uuid="{01558f72-0d06-50bd-828f-680c98b7601d}" />
+                    <names>
+                        <name lang="en">Generic PLC single-channel Slave</name>
+                    </names>
+                    <kindInformations>
+                        <kindInformation name="type">plc</kindInformation>
+                        <kindInformation name="state">Other</kindInformation>
+                        <kindInformation name="number">1</kindInformation>
+                    </kindInformations>
+                    <description>
+                        <dynamic_text Halignment="AlignLeft" Valignment="AlignTop" font="Liberation Sans,7,-1,0,50,0,0,0,0,0,Regular" frame="false" keep_visual_rotation="false" rotation="0" text_from="UserText" text_width="-1" uuid="{5a71a440-cc68-50ac-8399-f68ab03f2b07}" x="58" y="-17" z="1">
+                            <text>13</text>
+                        </dynamic_text>
+                        <line antialias="false" end1="none" end2="none" length1="1.5" length2="1.5" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="0" x2="0" y1="-30" y2="-3" />
+                        <line antialias="false" end1="none" end2="none" length1="1.5" length2="1.5" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="40" x2="40" y1="-30" y2="-3" />
+                        <text color="#000000" font="Liberation Sans,5,-1,0,50,0,0,0,0,0,Regular" rotation="0" text="Ic+" x="42" y="-15" />
+                        <line antialias="false" end1="none" end2="none" length1="1.5" length2="1.5" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="43" x2="47" y1="-33" y2="-33" />
+                        <circle antialias="false" diameter="6" style="line-style:normal;line-weight:normal;filling:none;color:black" x="4" y="-51" />
+                        <text color="#000000" font="Liberation Sans,5,-1,0,50,0,0,0,0,0,Regular" rotation="0" text="Ic-" x="62" y="-15" />
+                        <text color="#000000" font="Liberation Sans,5,-1,0,50,0,0,0,0,0,Regular" rotation="0" text="M-" x="22" y="-15" />
+                        <text color="#000000" font="Liberation Sans,5,-1,0,50,0,0,0,0,0,Regular" rotation="0" text="M+" x="2" y="-15" />
+                        <line antialias="false" end1="none" end2="none" length1="1.5" length2="1.5" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="60" x2="60" y1="-30" y2="-3" />
+                        <line antialias="false" end1="none" end2="none" length1="1.5" length2="1.5" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="20" x2="20" y1="-30" y2="-3" />
+                        <rect antialias="false" height="7.8" rx="0" ry="0" style="line-style:normal;line-weight:normal;filling:none;color:black" width="7.8" x="26" y="-67" />
+                        <text color="#000000" font="Liberation Sans,6,-1,0,50,0,0,0,0,0,Regular" rotation="270" text="Logic" x="55" y="-45" />
+                        <circle antialias="false" diameter="3" style="line-style:normal;line-weight:normal;filling:none;color:black" x="58.5" y="-2.5" />
+                        <circle antialias="false" diameter="3" style="line-style:normal;line-weight:normal;filling:none;color:black" x="38.5" y="-2.5" />
+                        <line antialias="false" end1="none" end2="none" length1="1.5" length2="1.5" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="32.6" x2="26" y1="-67" y2="-60.4" />
+                        <circle antialias="false" diameter="3" style="line-style:normal;line-weight:normal;filling:none;color:black" x="18.5" y="-2.5" />
+                        <circle antialias="false" diameter="3" style="line-style:normal;line-weight:normal;filling:none;color:black" x="-1.5" y="-2.5" />
+                        <line antialias="false" end1="none" end2="none" length1="1.5" length2="1.5" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="27.2" x2="33.8" y1="-59.2" y2="-65.8" />
+                        <dynamic_text Halignment="AlignLeft" Valignment="AlignTop" font="Liberation Sans,9,-1,0,50,0,0,0,0,0,Regular" frame="false" keep_visual_rotation="false" rotation="0" text_from="ElementInfo" text_width="-1" uuid="{2aee6f97-ec3f-5800-bf26-8b9cd9378322}" x="-7" y="-85" z="22">
+                            <text />
+                            <info_name>label</info_name>
+                        </dynamic_text>
+                        <dynamic_text Halignment="AlignLeft" Valignment="AlignTop" font="Liberation Sans,7,-1,0,50,0,0,0,0,0,Regular" frame="false" keep_visual_rotation="false" rotation="0" text_from="UserText" text_width="-1" uuid="{b4ffd762-4e14-51c3-9295-2cb5a45ce7e2}" x="38" y="-17" z="23">
+                            <text>9</text>
+                        </dynamic_text>
+                        <dynamic_text Halignment="AlignLeft" Valignment="AlignTop" font="Liberation Sans,7,-1,0,50,0,0,0,0,0,Regular" frame="false" keep_visual_rotation="false" rotation="0" text_from="UserText" text_width="-1" uuid="{7a682416-b407-5c6e-bc8c-a0eed69629b2}" x="-2" y="-17" z="24">
+                            <text>1</text>
+                        </dynamic_text>
+                        <rect antialias="false" height="10" rx="0" ry="0" style="line-style:normal;line-weight:normal;filling:none;color:black" width="64" x="-2" y="-40" />
+                        <dynamic_text Halignment="AlignLeft" Valignment="AlignTop" font="Liberation Sans,7,-1,0,50,0,0,0,0,0,Regular" frame="false" keep_visual_rotation="false" rotation="0" text_from="UserText" text_width="-1" uuid="{582db34d-fa45-5511-92fd-04cd7f87de6b}" x="47" y="-83" z="25">
+                            <text>1</text>
+                        </dynamic_text>
+                        <dynamic_text Halignment="AlignLeft" Valignment="AlignTop" font="Liberation Sans,7,-1,0,50,0,0,0,0,0,Regular" frame="false" keep_visual_rotation="false" rotation="0" text_from="UserText" text_width="-1" uuid="{483ad320-61aa-550b-b756-dcad92081a13}" x="18" y="-17" z="26">
+                            <text>5</text>
+                        </dynamic_text>
+                        <text color="#000000" font="Liberation Sans,7,-1,0,50,0,0,0,0,0,Regular" rotation="0" text="CH" x="37" y="-70" />
+                        <text color="#000000" font="Liberation Sans,6,-1,0,50,0,0,0,0,0,Regular" rotation="0" text="MUX" x="11" y="-32" />
+                        <rect antialias="false" height="13" rx="0" ry="0" style="line-style:normal;line-weight:normal;filling:none;color:black" width="13" x="-3" y="-67" />
+                        <line antialias="false" end1="none" end2="none" length1="1.5" length2="1.5" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="8" x2="-3" y1="-67" y2="-56" />
+                        <line antialias="false" end1="none" end2="none" length1="1.5" length2="1.5" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-1" x2="10" y1="-54" y2="-65" />
+                        <circle antialias="false" diameter="6" style="line-style:normal;line-weight:normal;filling:none;color:black" x="8" y="-51" />
+                        <line antialias="false" end1="none" end2="none" length1="1.5" length2="1.5" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="2" x2="2" y1="-48" y2="-54" />
+                        <rect antialias="false" height="11" rx="0" ry="0" style="line-style:normal;line-weight:normal;filling:none;color:black" width="20" x="20" y="-55" />
+                        <line antialias="false" end1="none" end2="none" length1="1.5" length2="1.5" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="31" x2="35" y1="-33" y2="-33" />
+                        <line antialias="false" end1="none" end2="none" length1="1.5" length2="1.5" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="35" x2="44" y1="-33" y2="-37" />
+                        <line antialias="false" end1="none" end2="none" length1="1.5" length2="1.5" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="30" x2="30" y1="-44" y2="-40" />
+                        <line antialias="false" end1="none" end2="none" length1="1.5" length2="1.5" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="4" x2="2" y1="-48" y2="-48" />
+                        <line antialias="false" end1="none" end2="none" length1="1.5" length2="1.5" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="14" x2="20" y1="-48" y2="-48" />
+                        <text color="#000000" font="Liberation Sans,6,-1,0,50,0,0,0,0,0,Regular" rotation="0" text="ADC" x="22" y="-47" />
+                        <rect antialias="false" height="23" rx="0" ry="0" style="line-style:normal;line-weight:normal;filling:none;color:black" width="14" x="46" y="-66" />
+                        <line antialias="false" end1="none" end2="none" length1="1.5" length2="1.5" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="34" x2="46" y1="-62" y2="-62" />
+                        <rect antialias="false" height="80" rx="0" ry="0" style="line-style:normal;line-weight:normal;filling:none;color:black" width="80" x="-5" y="-80" />
+                        <line antialias="false" end1="none" end2="none" length1="1.5" length2="1.5" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="30" x2="30" y1="-59" y2="-55" />
+                        <line antialias="false" end1="none" end2="none" length1="1.5" length2="1.5" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="10" x2="17" y1="-57" y2="-57" />
+                        <line antialias="false" end1="none" end2="none" length1="1.5" length2="1.5" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="17" x2="17" y1="-57" y2="-62" />
+                        <line antialias="false" end1="none" end2="none" length1="1.5" length2="1.5" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="19" x2="15" y1="-62" y2="-62" />
+                        <line antialias="false" end1="none" end2="none" length1="1.5" length2="1.5" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="15" x2="17" y1="-62" y2="-67" />
+                        <line antialias="false" end1="none" end2="none" length1="1.5" length2="1.5" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="19" x2="17" y1="-62" y2="-67" />
+                        <terminal name="" orientation="s" type="Generic" uuid="{d595235b-4e7d-51a1-b5f2-b23c3b525fb9}" x="0" y="0" />
+                        <terminal name="" orientation="s" type="Generic" uuid="{624b2ee4-724a-5e86-860b-3c8fb9edfef0}" x="20" y="0" />
+                        <terminal name="" orientation="s" type="Generic" uuid="{006b4ef0-2c99-57d5-bc98-5e3aa1302a03}" x="40" y="0" />
+                        <terminal name="" orientation="s" type="Generic" uuid="{431d9124-33f5-5942-aff6-fdd49aa4f5b1}" x="60" y="0" />
+                    </description>
+                </definition>
+            </element>
+        </category>
+    </collection>
+</project>

--- a/lang/qet_en.ts
+++ b/lang/qet_en.ts
@@ -2247,6 +2247,11 @@ The element&apos;s display name is edited separately in the element properties.<
         <source>Exclure de la nomenclature</source>
         <translation>Exclude from the bill of materials</translation>
     </message>
+    <message>
+        <location filename="../sources/ui/elementinfowidget.cpp" line="243"/>
+        <source>Hériter le label</source>
+        <translation>Inherit label</translation>
+    </message>
 </context>
 <context>
     <name>ElementPropertiesEditorWidget</name>

--- a/lang/qet_en.ts
+++ b/lang/qet_en.ts
@@ -16161,6 +16161,16 @@ associer le nom &quot;volta&quot; et la valeur &quot;1745&quot; remplacera %{vol
         <translation>Label cross reference</translation>
     </message>
     <message>
+        <location filename="../sources/ui/xrefpropertieswidget.ui" line="214"/>
+        <source>Hériter le label par défaut</source>
+        <translation>Inherit label by default</translation>
+    </message>
+    <message>
+        <location filename="../sources/ui/xrefpropertieswidget.ui" line="228"/>
+        <source>Séparateur du label hérité</source>
+        <translation>Inherited label separator</translation>
+    </message>
+    <message>
         <location filename="../sources/ui/xrefpropertieswidget.ui" line="161"/>
         <source>Maitre</source>
         <translation>Master</translation>

--- a/lang/qet_hu.ts
+++ b/lang/qet_hu.ts
@@ -16163,6 +16163,16 @@ associer le nom &quot;volta&quot; et la valeur &quot;1745&quot; remplacera %{vol
         <translation>Kereszthivatkozás címkéje</translation>
     </message>
     <message>
+        <location filename="../sources/ui/xrefpropertieswidget.ui" line="214"/>
+        <source>Hériter le label par défaut</source>
+        <translation>Címke öröklése alapértelmezés szerint</translation>
+    </message>
+    <message>
+        <location filename="../sources/ui/xrefpropertieswidget.ui" line="228"/>
+        <source>Séparateur du label hérité</source>
+        <translation>Örökölt címke elválasztója</translation>
+    </message>
+    <message>
         <location filename="../sources/ui/xrefpropertieswidget.ui" line="161"/>
         <source>Maitre</source>
         <translation>Mester</translation>

--- a/lang/qet_hu.ts
+++ b/lang/qet_hu.ts
@@ -2255,6 +2255,11 @@ Az elem megjelenítési nevét külön lehet szerkeszteni az elem tulajdonságok
         <source>Exclure de la nomenclature</source>
         <translation>Kizárás az anyagjegyzékből</translation>
     </message>
+    <message>
+        <location filename="../sources/ui/elementinfowidget.cpp" line="243"/>
+        <source>Hériter le label</source>
+        <translation>Címke öröklése</translation>
+    </message>
 </context>
 <context>
     <name>ElementPropertiesEditorWidget</name>

--- a/sources/ElementsCollection/elementslocation.cpp
+++ b/sources/ElementsCollection/elementslocation.cpp
@@ -654,7 +654,8 @@ QDomElement ElementsLocation::xml() const
 	{
 		QFile file (m_file_system_path);
 		QDomDocument docu;
-		if (docu.setContent(&file))
+		if (file.open(QIODevice::ReadOnly | QIODevice::Text)
+			&& docu.setContent(&file))
 			return docu.documentElement();
 	}
 	else

--- a/sources/dataBase/projectdatabase.cpp
+++ b/sources/dataBase/projectdatabase.cpp
@@ -33,6 +33,21 @@
 #include <QSqlDriver>
 #include <sqlite3.h>
 
+namespace {
+
+QString elementSubTypeToString(const ElementData &data)
+{
+	if (data.m_type == ElementData::Master) {
+		return data.masterTypeToString();
+	}
+	if (data.m_type == ElementData::Slave) {
+		return ElementData::slaveTypeToString(data.m_slave_type);
+	}
+	return QString();
+} // namespace
+
+}
+
 
 /**
 	@brief projectDataBase::projectDataBase
@@ -125,8 +140,9 @@ void projectDataBase::addElement(Element *element)
 	m_insert_elements_query.bindValue(":uuid", element->uuid().toString());
 	m_insert_elements_query.bindValue(":diagram_uuid", element->diagram()->uuid().toString());
 	m_insert_elements_query.bindValue(":pos", element->diagram()->convertPosition(element->scenePos()).toString());
-	m_insert_elements_query.bindValue(":type", element->elementData().typeToString());
-	m_insert_elements_query.bindValue(":sub_type", element->kindInformations()["type"].toString());
+	const auto element_data = element->elementData();
+	m_insert_elements_query.bindValue(":type", element_data.typeToString());
+	m_insert_elements_query.bindValue(":sub_type", elementSubTypeToString(element_data));
 	if (!m_insert_elements_query.exec()) {
 		qDebug() << "projectDataBase::addElement insert element error : " << m_insert_elements_query.lastError();
 	}
@@ -649,7 +665,11 @@ void projectDataBase::populateElementTable()
 	for (auto diagram : m_project->diagrams())
 	{
 		const ElementProvider ep(diagram);
-		const auto elmt_vector = ep.find(ElementData::Simple | ElementData::Terminal | ElementData::Master | ElementData::Thumbnail);
+		const auto elmt_vector = ep.find(ElementData::Simple |
+									 ElementData::Terminal |
+									 ElementData::Master |
+									 ElementData::Slave |
+									 ElementData::Thumbnail);
 			//Insert all values into the database
 		for (const auto &elmt : elmt_vector)
 		{
@@ -658,7 +678,7 @@ void projectDataBase::populateElementTable()
 			m_insert_elements_query.bindValue(":diagram_uuid", diagram->uuid().toString());
 			m_insert_elements_query.bindValue(":pos", diagram->convertPosition(elmt->scenePos()).toString());
 			m_insert_elements_query.bindValue(":type", elmt_data.typeToString());
-			m_insert_elements_query.bindValue(":sub_type", elmt_data.masterTypeToString());
+			m_insert_elements_query.bindValue(":sub_type", elementSubTypeToString(elmt_data));
 			if (!m_insert_elements_query.exec()) {
 				qDebug() << "projectDataBase::populateElementTable insert error : " << m_insert_elements_query.lastError();
 			}
@@ -678,7 +698,11 @@ void projectDataBase::populateElementInfoTable()
 	for (const auto &diagram : m_project->diagrams())
 	{
 		const ElementProvider ep(diagram);
-		const auto elmt_vector = ep.find(ElementData::Simple | ElementData::Terminal | ElementData::Master | ElementData::Thumbnail);
+		const auto elmt_vector = ep.find(ElementData::Simple |
+									 ElementData::Terminal |
+									 ElementData::Master |
+									 ElementData::Slave |
+									 ElementData::Thumbnail);
 
 			//Insert all values into the database
 		for (const auto &elmt : elmt_vector)

--- a/sources/editor/elementscene.cpp
+++ b/sources/editor/elementscene.cpp
@@ -481,6 +481,7 @@ const QDomDocument ElementScene::toXml(bool all_parts)
 
 	if (type_ == ElementData::Simple ||
 		type_ == ElementData::Master ||
+		type_ == ElementData::Slave ||
 		type_ == ElementData::Terminal ||
 		type_ == ElementData::Thumbnail)
 	{

--- a/sources/editor/ui/elementpropertieseditorwidget.cpp
+++ b/sources/editor/ui/elementpropertieseditorwidget.cpp
@@ -292,7 +292,7 @@ void ElementPropertiesEditorWidget::updateTree()
 			ui->m_tree->setEnabled(true);
 			break;
 		case ElementData::Slave:
-			ui->m_tree->setDisabled(true);
+			ui->m_tree->setEnabled(true);
 			break;
 		case ElementData::Terminal:
 			ui->m_tree->setEnabled(true);
@@ -425,7 +425,9 @@ void ElementPropertiesEditorWidget::on_m_base_type_cb_currentIndexChanged(int in
 
 	ui->tabWidget->setTabVisible(1,
 								 (type_ == ElementData::Simple ||
-								  type_ == ElementData::Master));
+								  type_ == ElementData::Master ||
+								  type_ == ElementData::Slave ||
+								  type_ == ElementData::Terminal));
 
 	updateTree();
 }

--- a/sources/editor/ui/elementpropertieseditorwidget.cpp
+++ b/sources/editor/ui/elementpropertieseditorwidget.cpp
@@ -399,6 +399,7 @@ void ElementPropertiesEditorWidget::on_m_buttonBox_accepted()
 		m_data.m_informations.addValue(qtwi->data(0, Qt::UserRole).toString(),
 									   txt);
 	}
+	ElementData::applyInformationDefaults(m_data.m_type, m_data.m_informations);
 	
 	this->close();
 }

--- a/sources/properties/elementdata.cpp
+++ b/sources/properties/elementdata.cpp
@@ -54,6 +54,7 @@ bool ElementData::fromXml(const QDomElement &xml_element)
 	kindInfoFromXml(xml_element);
 	m_informations.fromXml(xml_element.firstChildElement(QStringLiteral("elementInformations")),
 						   QStringLiteral("elementInformation"));
+	applyInformationDefaults(m_type, m_informations);
 	m_names_list.fromXml(xml_element);
 
 	auto xml_draw_info = xml_element.firstChildElement(QStringLiteral("informations"));
@@ -62,6 +63,28 @@ bool ElementData::fromXml(const QDomElement &xml_element)
 	}
 
 	return true;
+}
+
+/**
+ * @brief ElementData::applyInformationDefaults
+ * Apply basetype-specific defaults without overriding an explicit value.
+ * Legacy Slave definitions and instances did not store exclude_from_bom;
+ * treat a missing, null, or empty value as excluded while preserving an
+ * explicit false opt-in.
+ */
+void ElementData::applyInformationDefaults(
+		ElementData::Type type,
+		DiagramContext &informations)
+{
+	const QString key = QStringLiteral("exclude_from_bom");
+	const QVariant value = informations.value(key);
+	if (type == ElementData::Slave
+		&& (!informations.contains(key)
+			|| value.isNull()
+			|| value.toString().trimmed().isEmpty()))
+	{
+		informations.addValue(key, QStringLiteral("true"));
+	}
 }
 
 QDomElement ElementData::kindInfoToXml(QDomDocument &document)

--- a/sources/properties/elementdata.cpp
+++ b/sources/properties/elementdata.cpp
@@ -80,8 +80,7 @@ void ElementData::applyInformationDefaults(
 		return;
 
 	const QStringList default_true_keys = {
-		QStringLiteral("exclude_from_bom"),
-		QStringLiteral("inherit_label")
+		QStringLiteral("exclude_from_bom")
 	};
 	for (const QString &key : default_true_keys)
 	{

--- a/sources/properties/elementdata.cpp
+++ b/sources/properties/elementdata.cpp
@@ -68,22 +68,30 @@ bool ElementData::fromXml(const QDomElement &xml_element)
 /**
  * @brief ElementData::applyInformationDefaults
  * Apply basetype-specific defaults without overriding an explicit value.
- * Legacy Slave definitions and instances did not store exclude_from_bom;
- * treat a missing, null, or empty value as excluded while preserving an
+ * Legacy Slave definitions and instances did not store these boolean fields.
+ * Treat a missing, null, or empty value as enabled while preserving an
  * explicit false opt-in.
  */
 void ElementData::applyInformationDefaults(
 		ElementData::Type type,
 		DiagramContext &informations)
 {
-	const QString key = QStringLiteral("exclude_from_bom");
-	const QVariant value = informations.value(key);
-	if (type == ElementData::Slave
-		&& (!informations.contains(key)
-			|| value.isNull()
-			|| value.toString().trimmed().isEmpty()))
+	if (type != ElementData::Slave)
+		return;
+
+	const QStringList default_true_keys = {
+		QStringLiteral("exclude_from_bom"),
+		QStringLiteral("inherit_label")
+	};
+	for (const QString &key : default_true_keys)
 	{
-		informations.addValue(key, QStringLiteral("true"));
+		const QVariant value = informations.value(key);
+		if (!informations.contains(key)
+			|| value.isNull()
+			|| value.toString().trimmed().isEmpty())
+		{
+			informations.addValue(key, QStringLiteral("true"));
+		}
 	}
 }
 

--- a/sources/properties/elementdata.h
+++ b/sources/properties/elementdata.h
@@ -218,6 +218,9 @@ class ElementData : public PropertiesInterface
 		void fromSettings(const QSettings &settings,  const QString prefix = QString()) override;
 		QDomElement toXml(QDomDocument &xml_element) const override;
 		bool fromXml(const QDomElement &xml_element) override;
+		static void applyInformationDefaults(
+				ElementData::Type type,
+				DiagramContext &informations);
 		QDomElement kindInfoToXml(QDomDocument &document);
 	QDomElement plcMasterDataToXml(QDomDocument &document) const;
 	void plcMasterDataFromXml(const QDomElement &xml_plc);

--- a/sources/properties/xrefproperties.cpp
+++ b/sources/properties/xrefproperties.cpp
@@ -35,6 +35,8 @@ XRefProperties::XRefProperties()
 	m_prefix_keys << "power" << "delay" << "switch";
 	m_master_label = "%f-%l%c";
 	m_slave_label = "(%f-%l%c)";
+	m_inherit_label_by_default = true;
+	m_label_separator = QStringLiteral("-");
 	m_offset = 0;
 	m_xref_pos = Qt::AlignBottom;
 }
@@ -60,6 +62,8 @@ void XRefProperties::toSettings(QSettings &settings,
 	settings.setValue(prefix % "master_label", master_label);
 	QString slave_label = m_slave_label;
 	settings.setValue(prefix % "slave_label", slave_label);
+	settings.setValue(prefix % "inherit_label", m_inherit_label_by_default);
+	settings.setValue(prefix % "label_separator", m_label_separator);
 
 
 	QMetaEnum var = QMetaEnum::fromType<Qt::Alignment>();
@@ -88,6 +92,8 @@ void XRefProperties::fromSettings(const QSettings &settings,
 	m_offset = settings.value(prefix % "offset", "0").toInt();
 	m_master_label = settings.value(prefix % "master_label", "%f-%l%c").toString();
 	m_slave_label = settings.value(prefix % "slave_label", "(%f-%l%c)").toString();
+	m_inherit_label_by_default = settings.value(prefix % "inherit_label", true).toBool();
+	m_label_separator = settings.value(prefix % "label_separator", QStringLiteral("-")).toString();
 
 	QMetaEnum var = QMetaEnum::fromType<Qt::Alignment>();
 	m_xref_pos = Qt::AlignmentFlag(var.keyToValue((settings.value(prefix % "xrefpos", "AlignBottom").toString()).toStdString().data()));
@@ -127,6 +133,8 @@ QDomElement XRefProperties::toXml(QDomDocument &xml_document) const
 	xml_element.setAttribute("master_label", master_label);
 	QString slave_label = m_slave_label;
 	xml_element.setAttribute("slave_label", slave_label);
+	xml_element.setAttribute("inherit_label", m_inherit_label_by_default ? "true" : "false");
+	xml_element.setAttribute("label_separator", m_label_separator);
 	foreach (QString key, m_prefix.keys()) {
 		xml_element.setAttribute(key % "prefix", m_prefix.value(key));
 	}
@@ -159,6 +167,8 @@ bool XRefProperties::fromXml(const QDomElement &xml_element) {
 	m_offset = xml_element.attribute("offset", "0").toInt();
 	m_master_label = xml_element.attribute("master_label", "%f-%l%c");
 	m_slave_label = xml_element.attribute("slave_label","(%f-%l%c)");
+	m_inherit_label_by_default = xml_element.attribute("inherit_label", "true") == QLatin1String("true");
+	m_label_separator = xml_element.attribute("label_separator", QStringLiteral("-"));
 	foreach (QString key, m_prefix_keys) {
 		m_prefix.insert(key, xml_element.attribute(key % "prefix"));
 	}
@@ -200,12 +210,13 @@ bool XRefProperties::operator ==(const XRefProperties &xrp) const{
 			&& m_master_label== xrp.m_master_label
 			&& m_offset      == xrp.m_offset
 			&& m_xref_pos    == xrp.m_xref_pos
-			&& m_slave_label == xrp.m_slave_label);
+			&& m_slave_label == xrp.m_slave_label
+			&& m_inherit_label_by_default == xrp.m_inherit_label_by_default
+			&& m_label_separator == xrp.m_label_separator);
 }
 
 bool XRefProperties::operator !=(const XRefProperties &xrp) const
 {
 	return (! (*this == xrp));
 }
-
 

--- a/sources/properties/xrefproperties.h
+++ b/sources/properties/xrefproperties.h
@@ -77,6 +77,12 @@ class XRefProperties : public PropertiesInterface
 	void setSlaveLabel(const QString slave) {m_slave_label = slave;}
 	QString slaveLabel () const				{return m_slave_label;}
 
+	void setInheritLabelByDefault(bool inherit) {m_inherit_label_by_default = inherit;}
+	bool inheritLabelByDefault() const {return m_inherit_label_by_default;}
+
+	void setLabelSeparator(const QString &separator) {m_label_separator = separator;}
+	QString labelSeparator() const {return m_label_separator;}
+
 	void setOffset(const int offset) {m_offset = offset;}
 	int offset() const				 {return m_offset;}
 
@@ -92,6 +98,8 @@ class XRefProperties : public PropertiesInterface
 	QStringList m_prefix_keys;
 	QString m_master_label;
 	QString m_slave_label;
+	bool m_inherit_label_by_default;
+	QString m_label_separator;
 	int     m_offset;
 	QString m_key;
 };

--- a/sources/qetgraphicsitem/crossrefitem.cpp
+++ b/sources/qetgraphicsitem/crossrefitem.cpp
@@ -704,8 +704,11 @@ void CrossRefItem::setUpCrossBoundingRect(QPainter &painter)
 */
 void CrossRefItem::drawAsCross(QPainter &painter)
 {
-	//calculate the size of the cross
-	setUpCrossBoundingRect(painter);
+	// Geometry is calculated by updateLabel() with m_update_map enabled.
+	// Calling prepareGeometryChange() from paint() continuously invalidates the
+	// scene and creates an idle repaint loop as soon as a linked coil is shown.
+	if (m_update_map)
+		setUpCrossBoundingRect(painter);
 	m_drawed_contacts = 0;
 	if (m_update_map) m_hovered_contacts_map.clear();
 
@@ -767,10 +770,13 @@ void CrossRefItem::drawAsContacts(QPainter &painter)
 		}
 	}
 
-	bounding_rect.adjust(-30, -4, 4, 4);
-	prepareGeometryChange();
-	m_bounding_rect = bounding_rect;
-	m_shape_path.addRect(bounding_rect);
+	if (m_update_map)
+	{
+		bounding_rect.adjust(-30, -4, 4, 4);
+		prepareGeometryChange();
+		m_bounding_rect = bounding_rect;
+		m_shape_path.addRect(bounding_rect);
+	}
 }
 
 /**

--- a/sources/qetgraphicsitem/dynamicelementtextitem.cpp
+++ b/sources/qetgraphicsitem/dynamicelementtextitem.cpp
@@ -382,6 +382,8 @@ void DynamicElementTextItem::setTextFrom(DynamicElementTextItem::TextFrom text_f
 		{
 			setupFormulaConnection();
 			updateLabel();
+			if (old_text_from == UserText && parentElement() != elementUseForInfo())
+				connect(parentElement(), &Element::elementInfoChange, this, &DynamicElementTextItem::elementInfoChanged);
 		}
 		else
 			setPlainText(elementUseForInfo()->elementInformations().value(m_info_name).toString());
@@ -395,6 +397,8 @@ void DynamicElementTextItem::setTextFrom(DynamicElementTextItem::TextFrom text_f
 		{
 			setupFormulaConnection();
 			updateLabel();
+			if (old_text_from == UserText && parentElement() != elementUseForInfo())
+				connect(parentElement(), &Element::elementInfoChange, this, &DynamicElementTextItem::elementInfoChanged);
 		}
 		else
 			setPlainText(autonum::AssignVariables::replaceVariable(m_composite_text, elementUseForInfo()->elementInformations()));
@@ -846,7 +850,9 @@ void DynamicElementTextItem::elementInfoChanged()
 			setupFormulaConnection();
 
 			if (element) {
-				final_text = element->actualLabel();
+				Element *label_element = parentElement() && parentElement()->linkType() == Element::Slave
+					? parentElement() : element;
+				final_text = label_element->actualLabel();
 			}
 		}
 		else {
@@ -860,6 +866,11 @@ void DynamicElementTextItem::elementInfoChanged()
 		if (m_composite_text.contains("%{label}"))
 			setupFormulaConnection();
 		
+		if (element && m_composite_text.contains(QStringLiteral("%{label}"))) {
+			Element *label_element = parentElement() && parentElement()->linkType() == Element::Slave
+				? parentElement() : element;
+			dc.addValue(QStringLiteral("label"), label_element->actualLabel());
+		}
 		final_text = autonum::AssignVariables::replaceVariable(m_composite_text, dc);
 	}
 	else if (m_text_from  == UserText)
@@ -1118,9 +1129,16 @@ void DynamicElementTextItem::updateLabel()
 		
 
 		if(m_text_from == ElementInfo && element) {
-			setPlainText(element->actualLabel());
+			Element *label_element = parentElement() && parentElement()->linkType() == Element::Slave
+				? parentElement() : element;
+			setPlainText(label_element->actualLabel());
 		}
 		else if (m_text_from == CompositeText) {
+			if (element) {
+				Element *label_element = parentElement() && parentElement()->linkType() == Element::Slave
+					? parentElement() : element;
+				dc.addValue(QStringLiteral("label"), label_element->actualLabel());
+			}
 			setPlainText(autonum::AssignVariables::replaceVariable(m_composite_text, dc));
 		}
 	}

--- a/sources/qetgraphicsitem/dynamicelementtextitem.cpp
+++ b/sources/qetgraphicsitem/dynamicelementtextitem.cpp
@@ -762,6 +762,12 @@ QVariant DynamicElementTextItem::itemChange(QGraphicsItem::GraphicsItemChange ch
 			connect(m_parent_element.data(), &Element::elementInfoChange,
 				this, &DynamicElementTextItem::elementInfoChanged,
 				Qt::UniqueConnection);
+			if (m_parent_element.data()->diagram() && m_parent_element.data()->diagram()->project())
+			{
+				connect(m_parent_element.data()->diagram()->project(), &QETProject::XRefPropertiesChanged,
+					this, &DynamicElementTextItem::updateLabel,
+					Qt::UniqueConnection);
+			}
 				//The parent is already linked, wa call master changed for init the connection
 			if(!m_parent_element.data()->linkedElements().isEmpty())
 				masterChanged();

--- a/sources/qetgraphicsitem/dynamicelementtextitem.cpp
+++ b/sources/qetgraphicsitem/dynamicelementtextitem.cpp
@@ -759,6 +759,9 @@ QVariant DynamicElementTextItem::itemChange(QGraphicsItem::GraphicsItemChange ch
 		if(m_parent_element.data()->linkType() == Element::Slave)
 		{
 			connect(m_parent_element.data(), &Element::linkedElementChanged, this, &DynamicElementTextItem::masterChanged);
+			connect(m_parent_element.data(), &Element::elementInfoChange,
+				this, &DynamicElementTextItem::elementInfoChanged,
+				Qt::UniqueConnection);
 				//The parent is already linked, wa call master changed for init the connection
 			if(!m_parent_element.data()->linkedElements().isEmpty())
 				masterChanged();
@@ -895,9 +898,22 @@ void DynamicElementTextItem::masterChanged()
 		updateXref();
 	}
 	
-	if(elementUseForInfo())
+	Element *linked_master = nullptr;
+	if (parentElement() && parentElement()->linkType() == Element::Slave)
 	{
-		m_master_element = elementUseForInfo();
+		for (Element *linked : parentElement()->linkedElements())
+		{
+			if (linked && linked->linkType() == Element::Master)
+			{
+				linked_master = linked;
+				break;
+			}
+		}
+	}
+
+	if(linked_master)
+	{
+		m_master_element = linked_master;
 		if(m_text_from == ElementInfo || m_text_from == CompositeText)
 			connect(m_master_element.data(), &Element::elementInfoChange, this, &DynamicElementTextItem::elementInfoChanged);
 		

--- a/sources/qetgraphicsitem/element.cpp
+++ b/sources/qetgraphicsitem/element.cpp
@@ -1738,12 +1738,11 @@ QString Element::actualLabel()
 				this);
 	}
 
-	if (m_data.m_type != ElementData::Slave ||
-		m_data.m_informations.value(QStringLiteral("inherit_label")).toString() != QLatin1String("true"))
+	if (m_data.m_type != ElementData::Slave || !inheritsLabel())
 		return own_label;
 
 	Element *master = nullptr;
-	for (Element *linked : linkedElements()) {
+	for (Element *linked : std::as_const(connected_elements)) {
 		if (linked && linked->linkType() == Element::Master) {
 			master = linked;
 			break;
@@ -1757,7 +1756,54 @@ QString Element::actualLabel()
 		return own_label;
 	if (own_label.isEmpty())
 		return master_label;
-	return master_label + QStringLiteral("-") + own_label;
+	return master_label + labelInheritanceSeparator() + own_label;
+}
+
+/**
+ * @brief Element::inheritsLabel
+ * Return the explicit per-Slave choice, or the linked Master's project XRef
+ * default when the element has no explicit override.
+ */
+bool Element::inheritsLabel() const
+{
+	if (m_data.m_type != ElementData::Slave)
+		return false;
+
+	const QVariant explicit_value = m_data.m_informations.value(QStringLiteral("inherit_label"));
+	if (m_data.m_informations.contains(QStringLiteral("inherit_label")) &&
+		!explicit_value.isNull() && !explicit_value.toString().trimmed().isEmpty())
+	{
+		return explicit_value.toString() == QLatin1String("true");
+	}
+
+	QString type = m_data.m_slave_type == ElementData::PLCSlave
+		? QStringLiteral("plc") : QStringLiteral("coil");
+	for (Element *linked : connected_elements) {
+		if (linked && linked->linkType() == Element::Master) {
+			type = linked->kindInformations().value(QStringLiteral("type")).toString();
+			break;
+		}
+	}
+	return !diagram() || !diagram()->project()
+		? true : diagram()->project()->defaultXRefProperties(type).inheritLabelByDefault();
+}
+
+/**
+ * @brief Element::labelInheritanceSeparator
+ * Return the separator configured for the linked Master's XRef type.
+ */
+QString Element::labelInheritanceSeparator() const
+{
+	QString type = m_data.m_slave_type == ElementData::PLCSlave
+		? QStringLiteral("plc") : QStringLiteral("coil");
+	for (Element *linked : connected_elements) {
+		if (linked && linked->linkType() == Element::Master) {
+			type = linked->kindInformations().value(QStringLiteral("type")).toString();
+			break;
+		}
+	}
+	return !diagram() || !diagram()->project()
+		? QStringLiteral("-") : diagram()->project()->defaultXRefProperties(type).labelSeparator();
 }
 
 /**

--- a/sources/qetgraphicsitem/element.cpp
+++ b/sources/qetgraphicsitem/element.cpp
@@ -1424,31 +1424,12 @@ void Element::setElementInformations(DiagramContext dc)
 	m_data.m_informations = dc;
 
 	const auto actual_label{actualLabel()};
-	if (!actual_label.isEmpty()) {
+	if (m_data.m_type != ElementData::Slave &&
+		!m_data.m_informations.value(QStringLiteral("formula")).toString().isEmpty() &&
+		!actual_label.isEmpty()) {
 		m_data.m_informations.addValue(QStringLiteral("label"), actual_label); //Update the label if there is a formula
 	}
 	emit elementInfoChange(old_info, m_data.m_informations);
-
-	// Propagate label change to linked PLC slaves (label is changed via
-	// setElementInformations through the undo stack, not via setElementData)
-	if (m_data.m_type == ElementData::Master && m_data.m_master_type == ElementData::PLC)
-	{
-		if (!m_group_index_map.isEmpty())
-		{
-			const QString new_label = actualLabel();
-			for (auto it = m_group_index_map.constBegin(); it != m_group_index_map.constEnd(); ++it)
-			{
-				Element *slave = it.key();
-				if (!slave)
-					continue;
-				if (slave->elementInformations().value(QETInformation::ELMT_LABEL).toString() == new_label)
-					continue;
-				DiagramContext ctx = slave->elementInformations();
-				ctx.addValue(QETInformation::ELMT_LABEL, new_label);
-				slave->setElementInformations(ctx);
-			}
-		}
-	}
 }
 
 /**
@@ -1474,7 +1455,8 @@ void Element::setElementData(ElementData data)
 	m_data = data;
 
 	if (old_info != m_data.m_informations) {
-		m_data.m_informations.addValue(QStringLiteral("label"), actualLabel()); //Update the label if there is a formula
+		if (m_data.m_type != ElementData::Slave)
+			m_data.m_informations.addValue(QStringLiteral("label"), actualLabel()); //Update the label if there is a formula
 		if (diagram()) {
 			diagram()->project()->dataBase()->elementInfoChanged(this);
 		}
@@ -1486,9 +1468,7 @@ void Element::setElementData(ElementData data)
 	{
 		const auto &new_plc = m_data.plcMasterData();
 		bool plc_changed = (old_plc.ios != new_plc.ios);
-		bool label_changed = (old_info.value(QStringLiteral("label")) !=
-			m_data.m_informations.value(QStringLiteral("label")));
-		if (!m_group_index_map.isEmpty() && (plc_changed || label_changed))
+		if (!m_group_index_map.isEmpty() && plc_changed)
 		{
 			for (auto it = m_group_index_map.constBegin(); it != m_group_index_map.constEnd(); ++it)
 			{
@@ -1516,7 +1496,6 @@ void Element::setElementData(ElementData data)
 							return autonum::AssignVariables::formulaToLabel(
 								xrp.slaveLabel(), seq, diagram(), this);
 						}());
-					ctx.addValue(QETInformation::ELMT_LABEL, actualLabel());
 					ctx.addValue(QETInformation::ELMT_PLC_TC,
 						QString::number(io.terminalCount));
 					for (int t = 0; t < io.terminalCount && t < 4; ++t)
@@ -1541,13 +1520,6 @@ void Element::setElementData(ElementData data)
 							slave_terms.at(t)->setUseMasterLabel(false);
 						}
 					}
-				}
-				if (label_changed)
-				{
-					// Only label changed, update the label on the slave
-					DiagramContext ctx = slave->elementInformations();
-					ctx.addValue(QETInformation::ELMT_LABEL, actualLabel());
-					slave->setElementInformations(ctx);
 				}
 			}
 		}
@@ -1754,16 +1726,38 @@ void Element::freezeNewAddedElement()
 */
 QString Element::actualLabel()
 {
+	QString own_label;
 	if (m_data.m_informations.value(QStringLiteral("formula")).toString().isEmpty()) {
-		return m_data.m_informations.value(QStringLiteral("label")).toString();
+		own_label = m_data.m_informations.value(QStringLiteral("label")).toString();
 	} else {
-	return autonum::AssignVariables::formulaToLabel(
+		own_label = autonum::AssignVariables::formulaToLabel(
 				m_data.m_informations.value(
 					QStringLiteral("formula")).toString(),
 				m_autoNum_seq,
 				diagram(),
 				this);
 	}
+
+	if (m_data.m_type != ElementData::Slave ||
+		m_data.m_informations.value(QStringLiteral("inherit_label")).toString() != QLatin1String("true"))
+		return own_label;
+
+	Element *master = nullptr;
+	for (Element *linked : linkedElements()) {
+		if (linked && linked->linkType() == Element::Master) {
+			master = linked;
+			break;
+		}
+	}
+	if (!master)
+		return own_label;
+
+	const QString master_label = master->actualLabel();
+	if (master_label.isEmpty() || master_label == own_label)
+		return own_label;
+	if (own_label.isEmpty())
+		return master_label;
+	return master_label + QStringLiteral("-") + own_label;
 }
 
 /**

--- a/sources/qetgraphicsitem/element.cpp
+++ b/sources/qetgraphicsitem/element.cpp
@@ -849,6 +849,7 @@ bool Element::fromXml(QDomElement &e,
 	DiagramContext dc;
 	dc.fromXml(e.firstChildElement(QStringLiteral("elementInformations")),
 			   QStringLiteral("elementInformation"));
+	ElementData::applyInformationDefaults(m_data.m_type, dc);
 
 		//Load override properties (For now, only used when the element is a terminal)
 	if (m_data.m_type == ElementData::Terminal)

--- a/sources/qetgraphicsitem/element.h
+++ b/sources/qetgraphicsitem/element.h
@@ -150,6 +150,8 @@ class Element : public QetGraphicsItem
 		bool isFreezeLabel() const {return m_freeze_label;}
 		void freezeNewAddedElement();
 		QString actualLabel();
+		bool inheritsLabel() const;
+		QString labelInheritanceSeparator() const;
 
 		QString name() const override;
 		ElementsLocation location() const;

--- a/sources/qetgraphicsitem/masterelement.cpp
+++ b/sources/qetgraphicsitem/masterelement.cpp
@@ -69,7 +69,20 @@ void MasterElement::linkToElement(Element *elmt)
 
 		// For PLC masters, connect slave position changes to trigger master repaint
 		if (m_data.m_master_type == ElementData::PLC)
+		{
+			// Older PLC projects stored the master's label directly in the
+			// Slave label. With real inheritance that value would later become
+			// a stale suffix (for example PLC2-PLC1), so migrate only the exact
+			// duplicate to an empty local label when the link is established.
+			DiagramContext ctx = elmt->elementInformations();
+			if (ctx.value(QStringLiteral("inherit_label")).toString() == QLatin1String("true") &&
+				ctx.value(QETInformation::ELMT_LABEL).toString() == actualLabel())
+			{
+				ctx.remove(QETInformation::ELMT_LABEL);
+				elmt->setElementInformations(ctx);
+			}
 			connectSlavePositionUpdates(elmt);
+		}
 
 		emit linkedElementChanged();
 		aboutDeleteXref();
@@ -110,7 +123,6 @@ void MasterElement::unlinkElement(Element *elmt)
 			ctx.remove(QETInformation::ELMT_PLC_FUNCTION);
 			ctx.remove(QETInformation::ELMT_PLC_COMMENT);
 			ctx.remove(QETInformation::ELMT_PLC_CROSSREF);
-			ctx.remove(QETInformation::ELMT_LABEL);
 			elmt->setElementInformations(ctx);
 
 			setGroupIndexForElement(elmt, -1);

--- a/sources/qetgraphicsitem/masterelement.cpp
+++ b/sources/qetgraphicsitem/masterelement.cpp
@@ -75,7 +75,7 @@ void MasterElement::linkToElement(Element *elmt)
 			// a stale suffix (for example PLC2-PLC1), so migrate only the exact
 			// duplicate to an empty local label when the link is established.
 			DiagramContext ctx = elmt->elementInformations();
-			if (ctx.value(QStringLiteral("inherit_label")).toString() == QLatin1String("true") &&
+			if (elmt->inheritsLabel() &&
 				ctx.value(QETInformation::ELMT_LABEL).toString() == actualLabel())
 			{
 				ctx.remove(QETInformation::ELMT_LABEL);

--- a/sources/qetinformation.cpp
+++ b/sources/qetinformation.cpp
@@ -195,7 +195,8 @@ QStringList QETInformation::elementInfoKeys()
 						 ELMT_PLC_FUNCTION,
 						 ELMT_PLC_COMMENT,
 						 ELMT_PLC_CROSSREF,
-						 "exclude_from_bom" };
+						 "exclude_from_bom",
+						 "inherit_label" };
 	return list;
 }
 

--- a/sources/qetproject.cpp
+++ b/sources/qetproject.cpp
@@ -45,6 +45,62 @@
 
 static int BACKUP_INTERVAL = 1200000; //interval in ms of backup = 20min
 
+namespace {
+
+bool equivalentElementXml(const QDomNode &left, const QDomNode &right)
+{
+	if (left.nodeType() != right.nodeType())
+		return false;
+
+	if (left.isElement())
+	{
+		const QDomElement left_element = left.toElement();
+		const QDomElement right_element = right.toElement();
+		if (left_element.tagName() != right_element.tagName())
+			return false;
+
+		const QDomNamedNodeMap left_attributes = left_element.attributes();
+		const QDomNamedNodeMap right_attributes = right_element.attributes();
+		if (left_attributes.count() != right_attributes.count())
+			return false;
+		for (int i = 0; i < left_attributes.count(); ++i)
+		{
+			const QDomAttr attribute = left_attributes.item(i).toAttr();
+			if (!right_element.hasAttribute(attribute.name()) ||
+				right_element.attribute(attribute.name()) != attribute.value())
+				return false;
+		}
+	}
+	else if (left.isText())
+	{
+		return left.nodeValue() == right.nodeValue();
+	}
+
+	auto meaningfulChildren = [](const QDomNode &node) {
+		QList<QDomNode> children;
+		for (QDomNode child = node.firstChild(); !child.isNull(); child = child.nextSibling())
+		{
+			if (child.isComment() || (child.isText() && child.nodeValue().trimmed().isEmpty()))
+				continue;
+			children << child;
+		}
+		return children;
+	};
+
+	const QList<QDomNode> left_children = meaningfulChildren(left);
+	const QList<QDomNode> right_children = meaningfulChildren(right);
+	if (left_children.size() != right_children.size())
+		return false;
+	for (int i = 0; i < left_children.size(); ++i)
+	{
+		if (!equivalentElementXml(left_children.at(i), right_children.at(i)))
+			return false;
+	}
+	return true;
+}
+
+}
+
 bool QETProject::m_backup_enabled = true;
 
 void QETProject::setBackupEnabled(bool enabled)
@@ -1219,6 +1275,7 @@ ElementsLocation QETProject::importElement(ElementsLocation &location)
 
 	//Get the path where the element must be imported
 	QString import_path;
+	bool changed_definition_with_same_uuid = false;
 	if (location.isFileSystem()) {
 		import_path = "import/" % location.collectionPath(false);
 	}
@@ -1230,12 +1287,32 @@ ElementsLocation QETProject::importElement(ElementsLocation &location)
 		import_path = location.collectionPath(false);
 	}
 
+	// An element definition is identified by its UUID, not by the collection
+	// path it was dragged from. Reuse an identical embedded definition from any
+	// path. If the external definition changed while retaining its UUID, route
+	// through the existing overwrite/ignore/rename dialog below.
+	const QUuid source_uuid = location.uuid();
+	if (!source_uuid.isNull())
+	{
+		for (const ElementsLocation &candidate : m_elements_collection->elementsLocation())
+		{
+			if (candidate.uuid() != source_uuid)
+				continue;
+			if (equivalentElementXml(candidate.xml(), location.xml()))
+				return candidate;
+			import_path = candidate.collectionPath(false);
+			changed_definition_with_same_uuid = true;
+			break;
+		}
+	}
+
 	//Element already exist in the embedded collection, we ask what to do to user
 	if (m_elements_collection->exist(import_path)) {
 		ElementsLocation existing_location(import_path, this);
 
 		//existing_location and location have the same uuid, so it is the same element
-		if (existing_location.uuid() == location.uuid()) {
+		if (existing_location.uuid() == location.uuid() &&
+			!changed_definition_with_same_uuid) {
 			return existing_location;
 		}
 
@@ -1266,7 +1343,8 @@ ElementsLocation QETProject::importElement(ElementsLocation &location)
 					}
 				}
 				ElementsLocation parent_loc = existing_location.parent();
-				return m_elements_collection->copy(location, parent_loc);
+				return m_elements_collection->copy(
+					location, parent_loc, existing_location.fileName());
 			}
 			//Add the new element with an other name.
 			else if (action == QET::Rename) {

--- a/sources/ui/elementinfowidget.cpp
+++ b/sources/ui/elementinfowidget.cpp
@@ -393,8 +393,7 @@ void ElementInfoWidget::updateUi()
 		m_exclude_from_bom_cb->setChecked(exclude_bom_value == QLatin1String("true"));
 	}
 	if (m_inherit_label_cb) {
-		const QString inherit_value = element_info.value(QStringLiteral("inherit_label")).toString();
-		m_inherit_label_cb->setChecked(inherit_value == QLatin1String("true"));
+		m_inherit_label_cb->setChecked(m_element->inheritsLabel());
 	}
 
 	if (m_live_edit) {

--- a/sources/ui/elementinfowidget.cpp
+++ b/sources/ui/elementinfowidget.cpp
@@ -171,6 +171,9 @@ void ElementInfoWidget::enableLiveEdit()
 	if (m_exclude_from_bom_cb) {
 		connect(m_exclude_from_bom_cb, &QCheckBox::clicked, this, &ElementInfoWidget::apply);
 	}
+	if (m_inherit_label_cb) {
+		connect(m_inherit_label_cb, &QCheckBox::clicked, this, &ElementInfoWidget::apply);
+	}
 }
 
 /**
@@ -188,6 +191,9 @@ void ElementInfoWidget::disableLiveEdit()
 	}
 	if (m_exclude_from_bom_cb) {
 		disconnect(m_exclude_from_bom_cb, &QCheckBox::clicked, this, &ElementInfoWidget::apply);
+	}
+	if (m_inherit_label_cb) {
+		disconnect(m_inherit_label_cb, &QCheckBox::clicked, this, &ElementInfoWidget::apply);
 	}
 }
 
@@ -211,6 +217,7 @@ void ElementInfoWidget::buildInterface()
 		//has no entry for it that row carries no label at all - an anonymous
 		//line that currentInfo() then fills with "true"/"false".
 	keys.removeAll(QStringLiteral("exclude_from_bom"));
+	keys.removeAll(QStringLiteral("inherit_label"));
 
 	for (auto str : keys)
 	{
@@ -232,15 +239,20 @@ void ElementInfoWidget::buildInterface()
 	// English: Initialize and style the BOM exclusion checkbox
 	m_exclude_from_bom_cb = new QCheckBox(tr("Exclure de la nomenclature"), this);
 	m_exclude_from_bom_cb->setStyleSheet(QStringLiteral("margin: 5px; font-weight: bold;"));
+	m_inherit_label_cb = new QCheckBox(tr("Hériter le label"), this);
+	m_inherit_label_cb->setStyleSheet(QStringLiteral("margin: 5px; font-weight: bold;"));
 
 	if (QVBoxLayout *mainLayout = qobject_cast<QVBoxLayout*>(this->layout())) {
 		mainLayout->insertWidget(1, m_potential_isolating_cb);
 		// English: Insert the new checkbox into the main vertical layout
 		mainLayout->insertWidget(2, m_exclude_from_bom_cb);
+		mainLayout->insertWidget(3, m_inherit_label_cb);
 	}
 
 	// English: BOM exclusion applies to all elements, so it's always visible
 	m_exclude_from_bom_cb->setVisible(true);
+	m_inherit_label_cb->setVisible(
+		m_element.data()->elementData().m_type == ElementData::Slave);
 
 	// Show checkbox only if the element is a terminal
 	if (m_element.data()->elementData().m_type == ElementData::Terminal) {
@@ -267,7 +279,8 @@ QStringList ElementInfoWidget::predefinedKeys() const
 
 	keys << QStringLiteral("auto_num_locked")
 		 << QStringLiteral("potential_isolating")
-		 << QStringLiteral("exclude_from_bom");
+		 << QStringLiteral("exclude_from_bom")
+		 << QStringLiteral("inherit_label");
 
 	return keys;
 }
@@ -379,6 +392,10 @@ void ElementInfoWidget::updateUi()
 		QString exclude_bom_value = element_info.value(QStringLiteral("exclude_from_bom")).toString();
 		m_exclude_from_bom_cb->setChecked(exclude_bom_value == QLatin1String("true"));
 	}
+	if (m_inherit_label_cb) {
+		const QString inherit_value = element_info.value(QStringLiteral("inherit_label")).toString();
+		m_inherit_label_cb->setChecked(inherit_value == QLatin1String("true"));
+	}
 
 	if (m_live_edit) {
 		enableLiveEdit();
@@ -428,6 +445,10 @@ DiagramContext ElementInfoWidget::currentInfo() const
 
 	if (m_exclude_from_bom_cb) {
 		info_.addValue(QStringLiteral("exclude_from_bom"), m_exclude_from_bom_cb->isChecked() ? QStringLiteral("true") : QStringLiteral("false"));
+	}
+	if (m_inherit_label_cb &&
+		m_element->elementData().m_type == ElementData::Slave) {
+		info_.addValue(QStringLiteral("inherit_label"), m_inherit_label_cb->isChecked() ? QStringLiteral("true") : QStringLiteral("false"));
 	}
 	return info_;
 }

--- a/sources/ui/elementinfowidget.h
+++ b/sources/ui/elementinfowidget.h
@@ -81,6 +81,7 @@ class ElementInfoWidget : public AbstractElementPropertiesEditorWidget
 		QPushButton                     *m_add_custom_property_btn = nullptr;
 		QCheckBox                       *m_potential_isolating_cb = nullptr;
 		QCheckBox                        *m_exclude_from_bom_cb = nullptr;
+		QCheckBox                        *m_inherit_label_cb = nullptr;
 		bool m_first_activation;
 		bool m_ui_builded = false;
 };

--- a/sources/ui/elementpropertieswidget.cpp
+++ b/sources/ui/elementpropertieswidget.cpp
@@ -309,6 +309,7 @@ void ElementPropertiesWidget::updateUi()
 				m_list_editor << new PlcLinkWidget(m_element, this);
 			else
 				m_list_editor << new LinkSingleElementWidget(m_element, this);
+			m_list_editor << new ElementInfoWidget(m_element, this);
 			break;
 		case Element::Terminale:
 			m_list_editor << new ElementInfoWidget(m_element, this);

--- a/sources/ui/xrefpropertieswidget.cpp
+++ b/sources/ui/xrefpropertieswidget.cpp
@@ -146,6 +146,8 @@ void XRefPropertiesWidget::saveProperties(int index) {
 	xrp.setPrefix("switch", ui->m_switch_prefix_le->text());
 	xrp.setMasterLabel(ui->m_master_le->text());
 	xrp.setSlaveLabel(ui->m_slave_le->text());
+	xrp.setInheritLabelByDefault(ui->m_inherit_label_cb->isChecked());
+	xrp.setLabelSeparator(ui->m_label_separator_le->text());
 	xrp.setOffset(ui->m_offset_sb->value());
 
 	m_properties.insert(type, xrp);
@@ -173,6 +175,8 @@ void XRefPropertiesWidget::updateDisplay()
 
 	QString slave = xrp.slaveLabel();
 	ui->m_slave_le->setText(slave);
+	ui->m_inherit_label_cb->setChecked(xrp.inheritLabelByDefault());
+	ui->m_label_separator_le->setText(xrp.labelSeparator());
 
 	int offset = xrp.offset();
 	ui->m_offset_sb->setValue(offset);

--- a/sources/ui/xrefpropertieswidget.ui
+++ b/sources/ui/xrefpropertieswidget.ui
@@ -208,6 +208,37 @@
             </layout>
            </item>
            <item>
+            <widget class="QCheckBox" name="m_inherit_label_cb">
+             <property name="text">
+              <string>Hériter le label par défaut</string>
+             </property>
+             <property name="checked">
+              <bool>true</bool>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <layout class="QHBoxLayout" name="horizontalLayout_inherit_separator">
+             <item>
+              <widget class="QLabel" name="label_inherit_separator">
+               <property name="text">
+                <string>Séparateur du label hérité</string>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QLineEdit" name="m_label_separator_le">
+               <property name="text">
+                <string>-</string>
+               </property>
+               <property name="maxLength">
+                <number>1</number>
+               </property>
+              </widget>
+             </item>
+            </layout>
+           </item>
+           <item>
             <widget class="QLabel" name="label_8">
              <property name="text">
               <string>Créer votre propre texte en vous aidant des variables suivantes :

--- a/sources/undocommand/linkelementcommand.cpp
+++ b/sources/undocommand/linkelementcommand.cpp
@@ -448,8 +448,6 @@ void LinkElementCommand::makeLink(const QList<Element *> &element_list)
 							ctx.addValue(QETInformation::ELMT_PLC_COMMENT, io.comment);
 							ctx.addValue(QETInformation::ELMT_PLC_CROSSREF,
 								plcCrossRefText(elmt, m_element));
-							ctx.addValue(QETInformation::ELMT_LABEL,
-								elmt->actualLabel());
 							ctx.addValue(QETInformation::ELMT_PLC_TC,
 								QString::number(io.terminalCount));
 							const QStringList eff_terms = io.effectiveTerminals();
@@ -565,8 +563,6 @@ void LinkElementCommand::makeLink(const QList<Element *> &element_list)
 						ctx.addValue(QETInformation::ELMT_PLC_COMMENT, io.comment);
 						ctx.addValue(QETInformation::ELMT_PLC_CROSSREF,
 							plcCrossRefText(m_element, slave));
-						ctx.addValue(QETInformation::ELMT_LABEL,
-							m_element->actualLabel());
 						ctx.addValue(QETInformation::ELMT_PLC_TC,
 							QString::number(io.terminalCount));
 						const QStringList eff_terms = io.effectiveTerminals();


### PR DESCRIPTION
For transparency: most of the code in this PoC was generated with AI assistance (Codex). I reviewed the changes and tested the resulting implementation, but I am still far too new to the QET codebase to claim that I fully understand all of its internals or that these changes follow the best architectural approach.

This PoC is what I can reasonably provide: a working implementation of the behavior I had in mind when I originally suggested enabling the Information Tab for Slave elements.

On my local build it works as intended, and I have included the source history, combined patch, technical notes, import instructions, and a test project so that the implementation can be inspected and reproduced independently.

This is only a demonstration of the direction I had in mind, not a proposal to treat all of these changes as part of https://github.com/qelectrotech/qelectrotech-source-mirror/issues/806 or to merge the complete PoC as one change.

The implementation covers:

    enabling the Information UI for Slave definitions and placed Slave elements;
    including Slave information in the internal SQLite population and existing SQL-view source data;
    defaulting a missing Slave exclude_from_bom value to true while preserving an explicit false;
    optional Master-Slave label inheritance without overwriting the stored local Slave label;
    per-XRef-type inheritance defaults and separator configuration;
    opening file-backed collection XML before parsing (bugfix for current main);
    allowing an already embedded UUID to be placed again from an external collection, while changed XML still reaches the overwrite/ignore/rename flow;
    removing a CrossRefItem geometry update from the steady-state paint path, which stopped the linked-coil idle repaint loop observed during testing.

Interactive results on the local build:

    repeated placement of the same external collection UUID works;
    linked-coil idle CPU returned to the observed 0-2% range for the full system;
    Slave metadata and inherited labels survive save and reload;
    no warning or error related to these modifications showed up in the logs.