### PR TITLE
Do not install PugiXML and Googletest static libraries. 

### DIFF
--- a/cmake/fetch_pugixml.cmake
+++ b/cmake/fetch_pugixml.cmake
@@ -26,7 +26,7 @@ if(BUILD_PUGIXML)
     pugixml
     GIT_REPOSITORY https://github.com/zeux/pugixml.git
     GIT_TAG        v1.15)
-
+  set(PUGIXML_INSTALL OFF CACHE INTERNAL "")
   FetchContent_MakeAvailable(pugixml)
 else()
   find_package(pugixml REQUIRED)

--- a/tests/googlemock/CMakeLists.txt
+++ b/tests/googlemock/CMakeLists.txt
@@ -65,7 +65,7 @@ FetchContent_Declare(
   GTest
   GIT_REPOSITORY https://github.com/google/googletest.git
   GIT_TAG        release-1.10.0)
-
+set(INSTALL_GTEST OFF CACHE INTERNAL "")
 FetchContent_MakeAvailable(GTest)
 
 include(../../cmake/fetch_kdeaddons.cmake)

--- a/tests/googletest/CMakeLists.txt
+++ b/tests/googletest/CMakeLists.txt
@@ -65,7 +65,7 @@ FetchContent_Declare(
   GTest
   GIT_REPOSITORY https://github.com/google/googletest.git
   GIT_TAG        v1.17.0)
-
+set(INSTALL_GTEST OFF CACHE INTERNAL "")
 FetchContent_MakeAvailable(GTest)
 
 include(../../cmake/fetch_kdeaddons.cmake)


### PR DESCRIPTION
Do not install 3rd party libs which are only used as static libs. Basically the libs folder in the install order vanishes.