### PR TITLE
Fix command-line tools hanging on the table limitation dialog

### DIFF
--- a/sources/qetgraphicsitem/ViewItem/qetgraphicstableitem.cpp
+++ b/sources/qetgraphicsitem/ViewItem/qetgraphicstableitem.cpp
@@ -21,6 +21,7 @@
 #include "../../createdxf.h"
 #include "../../diagram.h"
 #include "../../elementprovider.h"
+#include "../../qetmessagebox.h"
 #include "../../qetxml.h"
 #include "../../utils/qetutils.h"
 #include "projectdbmodel.h"
@@ -119,7 +120,7 @@ void QetGraphicsTableItem::checkInsufficientRowsCount(
 			text = tr("Les information à afficher sont supérieurs à la quantité maximal pouvant être affiché par le tableau.\n"
 					  "Veuillez ajouter un nouveau tableau ou regler le tableau existant afin d'afficher l'integralité des informations.");
 		}
-		QMessageBox::information(parent, tr("Limitation de tableau"), text);
+		QET::QetMessageBox::information(parent, tr("Limitation de tableau"), text);
 	}
 
 }


### PR DESCRIPTION
When a placed nomenclature or summary table cannot display every row its model holds, `QetGraphicsTableItem::checkInsufficientRowsCount()` informs the user with a modal message box. It used `QMessageBox` directly rather than `QET::QetMessageBox`, so it ignored the non-interactive mode `main.cpp` sets for the command-line verbs, and every headless verb (`--info`, `--resave`, `--export-*`) blocked forever on a dialog nobody could answer.

This is the same defect fixed in e3d11a499 for the other modals reachable from the command line; this call site was missed.

**How it was found:** a `--info` run that never returned. A gdb backtrace showed the process parked in `QDialog::exec()` under this function.

**Reproduction:** any project where a placed table's configured row capacity is exceeded by the data. The projects shipped in `examples/` are all small enough not to trigger it, which is why it has gone unnoticed.

**Verification:** `--info` output byte identical on all 24 example projects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)