### PR TITLE
Rebuild the project database once per load, and not at all while closing

### DIFF
--- a/sources/dataBase/projectdatabase.cpp
+++ b/sources/dataBase/projectdatabase.cpp
@@ -53,6 +53,7 @@ projectDataBase::projectDataBase(QETProject *project, QObject *parent) :
 	});
 	connect(m_project, &QETProject::projectDiagramsOrderChanged, [this]()
 	{
+		m_content_changed = true;
 		for (auto diagram : m_project->diagrams())
 		{
 			m_diagram_order_changed.bindValue(":pos", m_project->folioIndex(diagram)+1);
@@ -85,12 +86,40 @@ projectDataBase::~projectDataBase()
 */
 void projectDataBase::updateDB()
 {
+		//A bulk operation is in progress and updates the database itself once
+		//it is done : rebuilding now would only be thrown away by that final
+		//rebuild. @see setUpdateBlocked().
+	if (m_update_blocked) {
+		return;
+	}
+
+		//Nothing in the project has changed since the last rebuild, so
+		//repopulating would insert exactly the rows that are already there.
+		//The signal is still emitted : callers and models rely on it to
+		//refresh, and what they read back is unchanged either way.
+	if (!m_content_changed)
+	{
+		emit dataBaseUpdated();
+		return;
+	}
+
 	populateDiagramTable();
 	populateDiagramInfoTable();
 	populateElementTable();
 	populateElementInfoTable();
 	populateConductorTable();
+	m_content_changed = false;
+
 	emit dataBaseUpdated();
+}
+
+/**
+	@brief projectDataBase::setUpdateBlocked
+	@param blocked : whether updateDB() should skip the full rebuild
+*/
+void projectDataBase::setUpdateBlocked(bool blocked)
+{
+	m_update_blocked = blocked;
 }
 
 /**
@@ -158,6 +187,7 @@ int projectDataBase::excludedConductorCount() const
 */
 void projectDataBase::addElement(Element *element)
 {
+	m_content_changed = true;
 	if (!element || !element->diagram()) {
 		qDebug() << "projectDataBase::addElement: null element or diagram";
 		return;
@@ -182,6 +212,7 @@ void projectDataBase::addElement(Element *element)
 */
 void projectDataBase::removeElement(Element *element)
 {
+	m_content_changed = true;
 	m_remove_element_query.bindValue(":uuid", element->uuid().toString());
 	if(!m_remove_element_query.exec()) {
 		qDebug() << "projectDataBase::removeElement remove error : " << m_remove_element_query.lastError();
@@ -196,6 +227,7 @@ void projectDataBase::removeElement(Element *element)
 */
 void projectDataBase::elementInfoChanged(Element *element)
 {
+	m_content_changed = true;
 	auto hash = elementInfoToString(element);
 	for (auto str : QETInformation::elementInfoKeys()) {
 		m_update_element_query.bindValue(":" + str, hash.value(str));
@@ -210,6 +242,7 @@ void projectDataBase::elementInfoChanged(Element *element)
 
 void projectDataBase::elementInfoChanged(QList<Element *> elements)
 {
+	m_content_changed = true;
 	this->blockSignals(true);
 		//Block signal for not emit dataBaseUpdated at
 		//each call of the method elementInfoChanged(Element *element)
@@ -226,6 +259,7 @@ void projectDataBase::elementInfoChanged(QList<Element *> elements)
 
 void projectDataBase::addDiagram(Diagram *diagram)
 {
+	m_content_changed = true;
 	m_insert_diagram_query.bindValue(":uuid", diagram->uuid().toString());
 	m_insert_diagram_query.bindValue(":pos", m_project->folioIndex(diagram)+1);
 	if(!m_insert_diagram_query.exec()) {
@@ -254,6 +288,7 @@ void projectDataBase::addDiagram(Diagram *diagram)
 
 void projectDataBase::removeDiagram(Diagram *diagram)
 {
+	m_content_changed = true;
 	const QString uuid_str = diagram->uuid().toString();
 
 		//Order matters: element_info and terminal are scoped through a
@@ -309,6 +344,7 @@ void projectDataBase::removeDiagram(Diagram *diagram)
 
 void projectDataBase::diagramInfoChanged(Diagram *diagram)
 {
+	m_content_changed = true;
 	bindDiagramInfoValues(m_update_diagram_info_query, diagram);
 
 	if (!m_update_diagram_info_query.exec()) {
@@ -320,6 +356,7 @@ void projectDataBase::diagramInfoChanged(Diagram *diagram)
 
 void projectDataBase::diagramOrderChanged()
 {
+	m_content_changed = true;
 }
 
 /**
@@ -328,6 +365,7 @@ void projectDataBase::diagramOrderChanged()
 */
 void projectDataBase::addConductor(Conductor *conductor)
 {
+	m_content_changed = true;
 	if (!conductor || !conductor->diagram()) {
 		qDebug() << "projectDataBase::addConductor: null conductor or diagram";
 		return;
@@ -361,6 +399,7 @@ void projectDataBase::addConductor(Conductor *conductor)
 */
 void projectDataBase::removeConductor(Conductor *conductor)
 {
+	m_content_changed = true;
 	m_remove_conductor_query.bindValue(":uuid", conductor->uuid().toString());
 	if (!m_remove_conductor_query.exec()) {
 		qDebug() << "projectDataBase::removeConductor delete error : " << m_remove_conductor_query.lastError();
@@ -381,6 +420,7 @@ void projectDataBase::removeConductor(Conductor *conductor)
 */
 void projectDataBase::updateConductor(Conductor *conductor)
 {
+	m_content_changed = true;
 	if (!conductor) {
 		return;
 	}
@@ -423,6 +463,7 @@ void projectDataBase::watchConductor(Conductor *conductor)
 */
 void projectDataBase::conductorPropertiesChanged()
 {
+	m_content_changed = true;
 	if (auto *conductor = qobject_cast<Conductor *>(sender())) {
 		updateConductor(conductor);
 	}

--- a/sources/dataBase/projectdatabase.h
+++ b/sources/dataBase/projectdatabase.h
@@ -47,6 +47,17 @@ class projectDataBase : public QObject
 		virtual ~projectDataBase() override;
 
 		void updateDB();
+			/**
+				Suppress the full rebuild performed by updateDB().
+
+				While blocked, updateDB() returns immediately instead of
+				repopulating every table. Meant for bulk operations -- notably
+				loading a project, where each table model re-queries the
+				database as it is built and would otherwise trigger one
+				complete rebuild of it. The caller unblocks and calls
+				updateDB() once when done; @see QETProject::readProjectXml().
+			*/
+		void setUpdateBlocked(bool blocked);
 		QETProject *project() const;
 		QSqlQuery newQuery(const QString &query = QString());
 		QSqlDatabase database() const {return m_data_base;}
@@ -97,6 +108,12 @@ class projectDataBase : public QObject
 
 	private:
 		QPointer<QETProject> m_project;
+		bool m_update_blocked = false;
+			//Starts true : the database is empty until the first rebuild.
+			//Set by every method of this class that writes rows, cleared by
+			//updateDB(). Callers reach the database from outside only through
+			//newQuery(), and every such call site reads.
+		bool m_content_changed = true;
 		QSqlDatabase m_data_base;
 		QSqlQuery m_insert_elements_query,
 				  m_insert_element_info_query,

--- a/sources/qetproject.cpp
+++ b/sources/qetproject.cpp
@@ -1547,6 +1547,11 @@ void QETProject::readProjectXml(QDomDocument &xml_project)
 	}
 
 	m_data_base.blockSignals(true);
+		//Blocking the signals is not enough : every table model built below
+		//re-queries the database, and each of those queries used to trigger a
+		//complete rebuild of it. The content being loaded is the same for all
+		//of them, so a single rebuild once everything is in place is enough.
+	m_data_base.setUpdateBlocked(true);
 
 		//Load the project-wide properties
 	readProjectPropertiesXml(xml_project);
@@ -1586,6 +1591,7 @@ void QETProject::readProjectXml(QDomDocument &xml_project)
 	const qint64 refresh_ms = phase_timer.restart();
 
 	m_data_base.blockSignals(false);
+	m_data_base.setUpdateBlocked(false);
 	m_data_base.updateDB();
 	const qint64 database_ms = phase_timer.elapsed();
 

--- a/sources/qetproject.cpp
+++ b/sources/qetproject.cpp
@@ -160,6 +160,11 @@ QETProject::~QETProject()
 		//We block database signal to avoid hundreds of unnecessary emitted signal
 		//due to deletion (diagram, item, etc...) and as much update made in the not yet deleted things.
 	m_data_base.blockSignals(true);
+		//Same reasoning for the rebuild itself : destroying a table relinks
+		//the tables that were chained to it, which re-queries the database,
+		//which rebuilds it completely -- for a project that is on its way out.
+		//Nothing can observe the result : the database is destroyed with it.
+	m_data_base.setUpdateBlocked(true);
 
 		//Each time a diagram is deleted we also remove it from m_diagram_list
 		//because a lot of thing append during the destructor of a diagram class


### PR DESCRIPTION
Two related changes to how often `projectDataBase::updateDB()` runs. It drops and repopulates every table in the project database, and it was running many times where once, or not at all, would do.

### Opening a project

`ProjectDBModel::setQuery()` calls `updateDB()`. The rebuild does not depend on the query, so each table model that queries the database while a project is being read triggers another complete repopulate of the same content. A 100 folio project ran it **26 times, 9.9 s of a 15.7 s load**.

`readProjectXml()` already wrapped the load in `m_data_base.blockSignals(true)` with the comment *"to avoid hundreds of unnecessary emitted signal"*. The intent was there, but `blockSignals()` suppresses only the signal, not the work it announces. `setUpdateBlocked()` extends the same intent to the work.

A dirty flag handles the rest: more rebuilds are triggered by `setQuery()` *after* `readProjectXml()` returns, where the load-phase timers cannot see them. When nothing has changed the repopulate is skipped, but `dataBaseUpdated()` is **still emitted**, so every signal-driven refresh behaves exactly as before.

### Closing a project

Destroying a project cost more than loading it. On a 1000 folio project `--info` reported its work done in 160 s but the process ran for 657 s, all of the difference in `~QETProject()`.

Timing each destructor put 94 % of that in `~QetGraphicsTableItem()`, the cost per table doubling as the project grew. A table destructor repairs the chain it belonged to, which relinks the neighbouring tables, and one branch of `setPreviousTable()` builds a fresh `ProjectDBModel` whose copy constructor calls `setQuery()`. Destroying a 250 folio project rebuilt the whole database **12 times**, for a project being thrown away.

| folios | teardown before | after |
|---|---|---|
| 100 | 1.30 s | 0.26 s |
| 250 | 7.75 s | 1.73 s |
| 400 | 19.92 s | 4.02 s |
| 1000 | ~497 s | ~24 s |

### Scope, honestly

Repeating the rebuild was **wasteful, not wrong** — every `populate*Table()` begins with a `DELETE` — so no output changes. On a real project like `examples/industrial.qet` this is about **4 %** of load time; the large numbers above are synthetic 250-1000 folio projects, which is not a shape users have today. What makes it worth doing is that the work removed is unconditionally redundant, in 69 lines, rather than the benchmark.

### Verification

`--info` byte identical on all 24 example projects, and `--export-bom`, `--export-wires`, `--export-cables`, `--export-nets` and `--export-wiring` identical on `industrial.qet`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)