### PR TITLE
Compile the element style pattern once instead of once per primitive

### DIFF
--- a/sources/factory/elementpicturefactory.cpp
+++ b/sources/factory/elementpicturefactory.cpp
@@ -621,7 +621,11 @@ void ElementPictureFactory::setPainterStyle(const QDomElement &dom, QPainter &pa
 		//Get the couples style/value
 	const QStringList styles = dom.attribute("style").split(";", Qt::SkipEmptyParts);
 
-	QRegularExpression rx("^(?<name>[a-z-]+):(?<value>[a-zA-Z-]+)$");
+		//Built once : this runs for every primitive of every element
+		//instance a project places, and recompiling the pattern each time
+		//was the single largest cost of opening a project.
+	static const QRegularExpression rx(
+				QStringLiteral("^(?<name>[a-z-]+):(?<value>[a-zA-Z-]+)$"));
 	if (!rx.isValid())
 	{
 		qWarning() <<QObject::tr("this is an error in the code")


### PR DESCRIPTION
`ElementPictureFactory::setPainterStyle()` built its `QRegularExpression` as a local, so the pattern was compiled from scratch on every call — and it is called once per graphics primitive, of every element instance a project places.

A callgrind profile of opening `examples/affuteuse_250h.qet` put **27 % of all instructions inside libpcre2**, and 11 % of the whole run inside this one function.

Making it `static const` compiles the pattern once for the life of the process. Same pattern, same matching, same named captures.

### Measurements

Instruction counts rather than seconds, because they are deterministic and do not depend on what else the machine is doing. Measured on **Qt 6.10.2** (KF 6.10.0), opening `examples/affuteuse_250h.qet`:

| | instructions |
|---|---|
| master | 5,140,207,309 |
| this branch | 4,656,769,110 (**−9.4 %**) |
| `setPainterStyle` inclusive | 590 M (11.49 %) → 86 M (1.85 %) |
| libpcre2, whole run | 27.1 % → 19.3 % |

The same measurement on Qt 5.15.18 gives −10.5 %, so the win is marginally smaller on Qt6 but the mechanism is unchanged.

### Verification

Builds clean on Qt 6.10.2 and Qt 5.15.18. `--info` byte identical to master on all 24 example projects on both, and every SVG produced for `industrial.qet` is byte identical — that being the output that would change if the styles were parsed any differently.

### Note for review

There is a companion PR, **#842**, which caches element drawings that have no uuid. The two overlap: this one makes `setPainterStyle` cheaper per call, that one calls it far less often. Separately they measure −9.4 % and −9.7 %; **together they are −15.1 %, not −19.1 %**. Whichever merges second will measure smaller than its own description claims.

### Still open, not addressed here

libpcre2 remains **19.3 %** of the run after this change, so other regular expressions in the load path are also hot. Not investigated yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)