### PR TITLE
Cache the drawing of element definitions that have no uuid

### DIFF
--- a/sources/factory/elementpicturefactory.cpp
+++ b/sources/factory/elementpicturefactory.cpp
@@ -37,6 +37,33 @@
 ElementPictureFactory* ElementPictureFactory::m_factory = nullptr;
 
 /**
+	@brief ElementPictureFactory::cacheKey
+	@param location
+	@return the key under which the drawing of the element at location is
+	cached.
+
+	An element definition normally carries its own uuid, and that is used
+	directly. Definitions saved before uuids were written do not have one --
+	a good share of the shipped example projects are still in that state --
+	and they all presented the same null uuid as a key. The drawing of such
+	an element was therefore either rebuilt for every instance placed, or
+	stored under a key it shared with every other element lacking a uuid.
+	Derive a stable key from the location for those instead:
+	ElementsLocation::toString() qualifies an embedded path with the id of
+	the project that owns it, and project ids come from an ever-increasing
+	counter and are never reused, so the derived key cannot collide with an
+	element of another project.
+*/
+QUuid ElementPictureFactory::cacheKey(const ElementsLocation &location)
+{
+	const QUuid uuid = location.uuid();
+	if (!uuid.isNull()) {
+		return uuid;
+	}
+	return QUuid::createUuidV5(QUuid(), location.toString().toUtf8());
+}
+
+/**
 	@brief ElementPictureFactory::getPictures
 	Set the picture of the element at location.
 	Note, picture can be null
@@ -50,12 +77,7 @@ void ElementPictureFactory::getPictures(const ElementsLocation &location, QPictu
 		return;
 	}
 
-	QUuid uuid = location.uuid();
-	if(Q_UNLIKELY(uuid.isNull()))
-	{
-		build(location, &picture, &low_picture);
-		return;
-	}
+	const QUuid uuid = cacheKey(location);
 
 	if(m_pictures_H.contains(uuid))
 	{
@@ -80,7 +102,7 @@ void ElementPictureFactory::getPictures(const ElementsLocation &location, QPictu
 */
 QPixmap ElementPictureFactory::pixmap(const ElementsLocation &location)
 {
-	QUuid uuid = location.uuid();
+	const QUuid uuid = cacheKey(location);
 
 	if (m_pixmap_H.contains(uuid)) {
 		return m_pixmap_H.value(uuid);
@@ -114,9 +136,7 @@ QPixmap ElementPictureFactory::pixmap(const ElementsLocation &location)
 		painter.translate(hsx, hsy);
 		painter.drawPicture(0, 0, m_pictures_H.value(uuid));
 
-		if (!uuid.isNull()) {
-			m_pixmap_H.insert(uuid, pix);
-		}
+		m_pixmap_H.insert(uuid, pix);
 		return pix;
 	}
 
@@ -132,10 +152,11 @@ QPixmap ElementPictureFactory::pixmap(const ElementsLocation &location)
 ElementPictureFactory::primitives ElementPictureFactory::getPrimitives(
 		const ElementsLocation &location)
 {
-	if(!m_primitives_H.contains(location.uuid()))
+	const QUuid uuid = cacheKey(location);
+	if(!m_primitives_H.contains(uuid))
 		build(location);
 
-	return m_primitives_H.value(location.uuid());
+	return m_primitives_H.value(uuid);
 }
 
 ElementPictureFactory::~ElementPictureFactory()
@@ -270,7 +291,7 @@ bool ElementPictureFactory::build(const ElementsLocation &location,
 	painter.end();
 	low_painter.end();
 
-	const auto uuid_ = location.uuid();
+	const auto uuid_ = cacheKey(location);
 	if (!picture) {
 		m_pictures_H.insert(uuid_, pic);
 		m_primitives_H.insert(uuid_, primitives_);

--- a/sources/factory/elementpicturefactory.h
+++ b/sources/factory/elementpicturefactory.h
@@ -92,6 +92,7 @@ class ElementPictureFactory
 		ElementPictureFactory operator= (const ElementPictureFactory &);
 		~ElementPictureFactory();
 		
+		static QUuid cacheKey(const ElementsLocation &location);
 		bool build(const ElementsLocation &location, QPicture *picture=nullptr, QPicture *low_picture=nullptr);
 		void parseElement(const QDomElement &dom, QPainter &painter, primitives &prim) const;
 		void parseLine   (const QDomElement &dom, QPainter &painter, primitives &prim) const;


### PR DESCRIPTION
`ElementPictureFactory` caches the `QPicture` it builds for an element definition, keyed by that definition's uuid. Definitions saved before uuids were written do not have one, and every one of them presents the same null uuid. `getPictures()` spotted the null and took an **uncached** path, so the drawing was rebuilt from the XML for every instance the project placed.

Counted with a counter in `getPictures()`:

| project | `getPictures` calls | uncached builds | cache hits |
|---|---|---|---|
| `m_000.qet` | 831 | **831** | 0 |
| `affuteuse_250h.qet` | 256 | **256** | 0 |
| `industrial.qet` | 618 | 0 | 553 |
| `perceuse.qet` | 552 | 0 | 495 |

`m_000.qet` built 831 pictures for **97** distinct definitions. **13 of the 24 shipped example projects** have definitions without a uuid, so this is most of the corpus rather than an edge case.

### The key

When the definition has no uuid of its own, derive one from the location. `ElementsLocation::toString()` qualifies an embedded path with the id of the project that owns it, and `QETApp::registerProject()` hands ids out of an ever-increasing counter and never reuses them — so the derived key cannot collide with an element of a different project. That was checked before relying on it, since a reused id would have meant serving one project's drawing for another's element.

### Measurements

Instruction counts rather than seconds, because they are deterministic. Measured on **Qt 6.10.2** (KF 6.10.0), opening `examples/affuteuse_250h.qet`:

| | instructions |
|---|---|
| master | 5,140,207,309 |
| this branch | 4,643,634,064 (**−9.7 %**) |
| `ElementPictureFactory::build` inclusive | 975 M (18.98 %) → 457 M (9.85 %) |

The halving of `build()` is predicted independently by the counters: 106 definitions against 256 instances is 41 %, and the cost fell to 47 %. The same measurement on Qt 5.15.18 gives −10.7 %, so the win is marginally smaller on Qt6 but the mechanism is unchanged.

### A latent bug retired, not a demonstrated one

`build()` inserted into `m_primitives_H` under `location.uuid()` with no null guard, so every uuid-less definition wrote to the **same** null key and `getPrimitives()` read back through it — those entries could only ever have belonged to whichever element was built last. Its only caller is `exportdialog.cpp`, which the command line never reaches, so **no wrong output could be demonstrated** and none is claimed here.

### Verification

Builds clean on Qt 6.10.2 and Qt 5.15.18. `--info` byte identical to master on all 24 example projects on both, and the SVG export of `affuteuse_250h.qet` — a project whose definitions *all* lack uuids — byte identical too.

### Note for review

Companion PR **#841** makes `setPainterStyle` cheaper per call; this one calls it far less often. Separately they measure −9.7 % and −9.4 %; **together they are −15.1 %, not −19.1 %**. Whichever merges second will measure smaller than its own description claims.

🤖 Generated with [Claude Code](https://claude.com/claude-code)