### PR TITLE
Include QVariant in bomexport.cpp

### DIFF
--- a/sources/bomexport.cpp
+++ b/sources/bomexport.cpp
@@ -20,6 +20,7 @@
 #include <QSaveFile>
 #include <QSqlQuery>
 #include <QSqlRecord>
+#include <QVariant>
 
 namespace {
 QString csvField(QString value)


### PR DESCRIPTION
`exportBomCsv()` calls `query.value(i).toString()`. `QSqlQuery::value()` returns a `QVariant`, so this file uses the type directly — but never includes it. It compiles only where `QVariant` happens to arrive through another header.

It does not always arrive:

| header | Qt 6.10.2 | Qt 5.15.18 |
|---|---|---|
| `<QSqlQuery>` | provides `QVariant` | does not |
| `<QSqlRecord>` | does not | does not |
| `<QSaveFile>` | does not | does not |

So on Qt6 the file builds today by accident of Qt's header layout rather than by design, and on Qt5 it does not build at all:

```
sources/bomexport.cpp:79:50: error: invalid use of incomplete type ‘class QVariant’
   79 |     values.append(query.value(i).toString());
      |                   ~~~~~~~~~~~^~~
```

**This PR has no effect on a Qt6 build.** I verified that directly: the translation unit compiles clean against Qt 6.10.2 both with and without the include. It is proposed on the narrower ground that a file should declare the types it uses, and that Qt6 has been actively trimming transitive includes between releases — if `qsqlquery.h` ever drops its `QVariant` include, this breaks again with no Qt5 involved.

**How it was tested:** `bomexport.cpp` has no QElectroTech dependencies beyond its own header, so the translation unit was compiled on its own against each Qt:

```
g++ -fsyntax-only -std=c++17 $(pkg-config --cflags-only-I Qt6Core Qt6Sql) -Isources sources/bomexport.cpp   # clean
g++ -fsyntax-only -std=c++17 $(pkg-config --cflags-only-I Qt5Core Qt5Sql) -Isources sources/bomexport.cpp   # fails as above
```

**Also verified the feature works**, not merely that it compiles: `--export-bom` on `examples/industrial.qet` produces correct output through the line in question, including the new smart-device columns.

```
"label";"designation";"manufacturer";"manufacturer_reference";"model";...
"X1";"";"Cabur";"";"";"Mains Input Terminal";...
```

Noticed while rebasing unrelated branches onto current `master` — no criticism of #830 intended; a transitive include is only visible from a differently configured build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)