### PR TITLE
Revert #759, so #821 can land instead

### DIFF
--- a/sources/ui/configpage/shortcutsconfigpage.cpp
+++ b/sources/ui/configpage/shortcutsconfigpage.cpp
@@ -56,15 +56,6 @@ static QString normalizedForSearch(const QString &text)
 	return stripped.toCaseFolded();
 }
 
-namespace {
-/// Key a shortcut for conflict detection: two actions collide only when they
-/// share a sequence *within the same category*. See FINDINGS / upstream #757.
-QString conflictKey(const QString &category, const QString &sequence)
-{
-	return category + QLatin1Char('\x1f') + sequence;
-}
-}
-
 /**
 	@brief ShortcutsConfigPage::ShortcutsConfigPage
 	@param parent
@@ -285,27 +276,18 @@ void ShortcutsConfigPage::applyFilter()
 */
 void ShortcutsConfigPage::checkConflicts()
 {
-	// Scope the comparison to the category, not the whole registry.
-	// QElectroTech deliberately registers one key per editor window --
-	// Undo/Redo/New/Open/Save and Ctrl+Shift+S each exist three times, once
-	// for the diagram, element and titleblock editors -- and those are not
-	// collisions: they act on different windows. Comparing globally flagged
-	// 60 of the 95 shipped defaults as conflicts, which made the indicator
-	// meaningless. The category is the registry's existing per-window
-	// grouping, so it is the scope key.
 	QHash<QString, QList<int>> sequence_to_rows;
 	for (int row = 0; row < m_rows.size(); ++row) {
 		const QString sequence_text = m_rows.at(row).edit->keySequence().toString();
 		if (!sequence_text.isEmpty()) {
-			sequence_to_rows[conflictKey(m_rows.at(row).category, sequence_text)] << row;
+			sequence_to_rows[sequence_text] << row;
 		}
 	}
 
 	for (int row = 0; row < m_rows.size(); ++row) {
 		Row &current_row = m_rows[row];
 		const QString sequence_text = current_row.edit->keySequence().toString();
-		const QList<int> &conflicting_rows =
-				sequence_to_rows.value(conflictKey(current_row.category, sequence_text));
+		const QList<int> &conflicting_rows = sequence_to_rows.value(sequence_text);
 		const bool conflicted = !sequence_text.isEmpty() && conflicting_rows.size() > 1;
 
 		current_row.conflicted = conflicted;


### PR DESCRIPTION
Reverts the merge of #759, restoring `shortcutsconfigpage.cpp` to its previous state.

**Why:** #759 and **#821** fix the same issue (#757). #821 was opened on 8 September by @enesgursoy6110 and is the better fix. I merged #759 on 12 September without checking whether a PR for it already existed, and that merge is what currently leaves #821 conflicting with `master`. Reverting is the way to let the right change land.

## Why #821 is the better fix

#759 keys conflict detection on the row's `category`, which is a `tr()` string — `tr("Général")`, `tr("Panneau des éléments")`. #821 keys on the shortcut ID prefix, which is stable and untranslated, and encodes the overlaps a category cannot express.

Checked against the registry rather than by reading — 94 registered actions, plus the four `depth.*` ones registered through `QObject::tr` that a naive grep misses.

On the shipped defaults the two behave identically: all 24 shared sequences are legitimate cross-editor duplicates (`diagrameditor.undo` / `titleblockeditor.undo` / `elementeditor.undo` and so on) and neither flags them. They diverge on shortcuts a user assigns in the preferences page:

| scenario | #759 | #821 |
|---|---|---|
| diagram-editor action given the main-window F1 | **missed** | flagged |
| element-editor action given the main-window F1 | **missed** | flagged |
| diagram action given a `depth.*` sequence | **missed** | flagged |
| element action given a `depth.*` sequence | **missed** | flagged |
| two actions in the same editor collide | flagged | flagged |
| diagram vs title-block editor (legitimate) | not flagged | not flagged |

Those four are real conflicts: the main window is live while an editor is open, and the `depth.*` actions are installed into both the diagram and element editors.

The reason #759 looked adequate is that the scope prefix currently maps one-to-one onto the translated category for all seven scopes, so same-scope detection comes out the same either way. It fails only where scopes genuinely overlap — which is exactly what #821 exists to handle.

## Verified

Qt 6.10.2 / KF 6.10.0, build clean (0 errors), `ctest` 4/4. The file is byte-identical to its state before #759, and #821 merges cleanly on top of this branch (it conflicts with `master` only because of #759).

🤖 Generated with [Claude Code](https://claude.com/claude-code)