### PR TITLE
Write embedded title block templates in a stable order

### DIFF
--- a/sources/qetproject.cpp
+++ b/sources/qetproject.cpp
@@ -1043,7 +1043,14 @@ QDomDocument QETProject::toXml()
 	// titleblock templates, if any
 	if (m_titleblocks_collection.templates().count()) {
 		QDomElement titleblocktemplates_elmt = xml_doc.createElement("titleblocktemplates");
-		foreach (QString template_name, m_titleblocks_collection.templates()) {
+			//Sorted, because templates() returns QHash::keys() and Qt
+			//randomises hash order per process. Writing them unsorted put the
+			//<titleblocktemplate> children in a different order on every save,
+			//which is what made a project holding more than one template save
+			//irreproducibly.
+		QStringList template_names = m_titleblocks_collection.templates();
+		template_names.sort();
+		for (const QString &template_name : std::as_const(template_names)) {
 			QDomElement e = m_titleblocks_collection.getTemplateXmlDescription(template_name);
 			titleblocktemplates_elmt.appendChild(xml_doc.importNode(e, true));
 		}


### PR DESCRIPTION
Fifth and last site of the hash-ordering defect fixed in #844, and the one that kept `examples/affuteuse_250h.qet` saving irreproducibly.

`TitleBlockTemplatesProjectCollection::templates()` returns `titleblock_templates_xml_.keys()` — a `QHash` — and `QETProject::toXml()` iterated it directly. A project embedding more than one template wrote the `<titleblocktemplate>` children in a different order on every save.

`affuteuse_250h.qet` embeds three. Two saves of it produced:

```
DIN_A4       A4_1  DIN_A4_copy
DIN_A4_copy  A4_1  DIN_A4
```

## With this, the corpus is as reproducible as it can be

| | reproducible |
|---|---|
| before #844 | 6 / 23 |
| after #844 | 22 / 24 |
| **with this** | **23 / 24** |

The one remaining is `schema_indus.qet`, and it is not an ordering problem. That file stores no `uuid` attribute on any of its 48 placed elements — it predates element uuids — so `Element::fromXml()` mints a fresh one per load and the first save writes them out. It is the only project in the corpus in that state; every other one has full uuid coverage.

That case repairs itself and needs no fix: after a single save the file has 48/48 uuids, and resaving *that* file twice gives byte-identical output. Minting on load is the upgrade path working as intended.

## A correction worth recording

My first reading of the `affuteuse_250h.qet` diff was wrong. Seeing `name="DIN_A4"` on one side and `name="DIN_A4_copy"` on the other, I took it for the save path renaming a template — which would have been considerably worse, since a diagram referencing it by name would have been left pointing at a name that no longer existed. The file simply contains both templates and they had swapped places. Checking the source file rather than trusting the diff is what settled it.

## Verified

Qt 6.10.2 / KF 6.10.0, build clean (0 errors), `ctest` 4/4, and the sweep above. Each project is resaved in **two separate processes** and compared — `QHash` order is randomised per process, so resaving twice within one process hides this class of bug entirely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)