### PR TITLE
Fix terminal and contact blocks missing from the parts list

### DIFF
--- a/sources/bomexport.cpp
+++ b/sources/bomexport.cpp
@@ -59,8 +59,27 @@ QStringList BomExport::defaultColumns()
 
 QString BomExport::defaultQuery()
 {
+		//Slaves and terminals are included because both are routinely
+		//separately orderable hardware. A circuit breaker can carry ten or
+		//twenty auxiliary blocks, each with its own order code, and a
+		//terminal block is a purchased part in its own right. Neither shares
+		//a line with its master: the query is ungrouped, one row per element,
+		//so each appears as the distinct item it is.
+		//
+		//Anything that should not be ordered is kept out by setting
+		//exclude_from_bom on the element, which the view already honours --
+		//a relay's own auxiliary contact, say.
+		//
+		//Thumbnails are deliberately left out for now even though ten of
+		//them in the shipped examples carry manufacturer and reference data
+		//(the assembly-plan mounting-plate symbols), because that has not
+		//been asked for and is a separate question. The folio report arrows
+		//and the conductor definition stay out because they are not hardware.
+		//
+		//See discussion #847.
 	return QStringLiteral("SELECT %1 FROM element_nomenclature_view "
-						  "WHERE ( element_type = 'simple' OR element_type = 'master') "
+						  "WHERE element_type IN "
+						  "('simple', 'master', 'slave', 'terminal') "
 						  "ORDER BY diagram_position, position, label")
 			.arg(defaultColumns().join(QStringLiteral(", ")));
 }

--- a/sources/dataBase/projectdatabase.cpp
+++ b/sources/dataBase/projectdatabase.cpp
@@ -711,7 +711,14 @@ void projectDataBase::createElementNomenclatureView()
 							//the table's. Kept identical to the mask populateElementTable()
 							//used to apply, so what this view returns does not change --
 							//a slave element (a relay contact) is still not a line item.
-						 " AND e.type IN ('simple', 'terminal', 'master', 'thumbnail')");
+							 //Slave is here because an auxiliary contact block is
+							 //separately orderable hardware with its own part
+							 //number, even though it shares its master's BMK.
+							 //Anything that should not be ordered -- a relay's
+							 //own auxiliary contact, say -- is kept out by
+							 //exclude_from_bom above, not by its base type.
+							 //See discussion #847.
+						 " AND e.type IN ('simple', 'terminal', 'master', 'slave', 'thumbnail')");
 
 	QSqlQuery query(m_data_base);
 	if (!query.exec(create_view)) {

--- a/tests/qttest/tst_smart_device.cpp
+++ b/tests/qttest/tst_smart_device.cpp
@@ -92,9 +92,17 @@ void SmartDeviceTest::defaultQueryAndCsv()
 					QStringLiteral("日本電機")));
 		QVERIFY(add(QStringLiteral("-K1"), QStringLiteral("master"), 1, 2,
 					QStringLiteral("Müller")));
+		//A slave and a terminal are both separately orderable hardware -- an
+		//auxiliary contact block has its own order code, and so does a
+		//terminal block -- so both belong in the bill of materials. See
+		//discussion #847. Anything that should not be ordered is kept out by
+		//exclude_from_bom rather than by its base type.
 		QVERIFY(add(QStringLiteral("-K1.1"), QStringLiteral("slave"), 1, 3,
-					QStringLiteral("Must not be exported")));
+					QStringLiteral("Aux contact block")));
 		QVERIFY(add(QStringLiteral("X1"), QStringLiteral("terminal"), 1, 4,
+					QStringLiteral("Terminal block")));
+		//Still filtered out: a folio report arrow is not hardware.
+		QVERIFY(add(QStringLiteral(">1"), QStringLiteral("next_report"), 1, 5,
 					QStringLiteral("Must not be exported")));
 
 		QSqlQuery query(db);
@@ -103,11 +111,13 @@ void SmartDeviceTest::defaultQueryAndCsv()
 		int rows = 0;
 		const auto csv = BomExport::toCsv(
 				query, BomExport::defaultColumns(), true, &rows);
-		QCOMPARE(rows, 2);
+		QCOMPARE(rows, 4);
 		QVERIFY(csv.startsWith("\xEF\xBB\xBF\"label\";\"designation\";"));
 		QVERIFY(csv.contains(QStringLiteral("Müller").toUtf8()));
 		QVERIFY(csv.contains(QStringLiteral("日本電機").toUtf8()));
 		QVERIFY(csv.contains("\"Quoted \"\"note\"\"\nnext line\""));
+		QVERIFY(csv.contains("Aux contact block"));
+		QVERIFY(csv.contains("Terminal block"));
 		QVERIFY(!csv.contains("Must not be exported"));
 		QVERIFY(csv.indexOf("-K1") < csv.indexOf("-K2"));
 	}


### PR DESCRIPTION
When you buy a circuit breaker, the auxiliary contact blocks that clip onto it are ordered separately — each has its own part number, and a big breaker might carry ten or twenty of them. Terminal blocks are the same: a Phoenix Contact PTTB 2,5 is a part you purchase.

In QElectroTech, those are drawn as slave and terminal elements. You could type their manufacturer and part number in, but they never appeared in the parts list the project exports, so anyone building an order from that list had to add them by hand.

This puts them in. Decided by @ispyisail in #847, on @IBSYSLevi's reasoning and @jozi332's use cases.

Existing exports get longer — `examples/industrial.qet` goes from 258 rows to 395, its 96 terminals and 41 slaves now appearing with their label and folio. Most carry no part number yet, because that only became settable on the symbol itself in #721 and #765.

---

**Two filters had to change:** `BomExport::defaultQuery()` and the `WHERE` clause of `element_nomenclature_view`. Changing only the query moves terminals but not slaves.

Folio report arrows and the conductor definition stay excluded. `exclude_from_bom` still removes anything else.

## @enesgursoy6110 — your test says the opposite

Your test in #830 checks that slave and terminal rows stay out of the export. This PR puts them in, so the test now expects them.

If you had a reason to keep them out, say so and I'll revert.

Qt 6.10.2, build clean, ctest 4/4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)